### PR TITLE
[wrangler] Add `wrangler flagship` commands

### DIFF
--- a/.changeset/flagship-cli-commands.md
+++ b/.changeset/flagship-cli-commands.md
@@ -1,0 +1,7 @@
+---
+"wrangler": minor
+---
+
+Add `wrangler flagship` commands for managing Flagship apps and feature flags.
+
+The new `wrangler flagship apps` and `wrangler flagship flags` command groups let you create, list, get, inspect, update, set, split, rollout, enable, disable, evaluate, and delete Flagship apps and flags from the CLI, including targeting rules, variations, percentage rollouts, evaluation context, and flag changelogs.

--- a/packages/wrangler/src/__tests__/flagship.test.ts
+++ b/packages/wrangler/src/__tests__/flagship.test.ts
@@ -1,4 +1,8 @@
-import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
+import {
+	readWranglerConfig,
+	runInTempDir,
+	writeWranglerConfig,
+} from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
 import { afterEach, beforeEach, describe, it } from "vitest";
 import { mockAccountId, mockApiToken } from "./helpers/mock-account-id";
@@ -115,6 +119,7 @@ describe("flagship", () => {
 			expect(std.out).toContain("Created Flagship app");
 			expect(std.out).toContain("checkout");
 			expect(std.out).toContain("app-1");
+			expect(std.out).toContain("To access your new Flagship");
 		});
 
 		it("sends a JSON content-type so the API parses the body", async ({
@@ -126,6 +131,42 @@ describe("flagship", () => {
 			});
 			await runWrangler("flagship apps create checkout");
 			await expect(contentType).resolves.toContain("application/json");
+		});
+
+		it("adds a created app to wrangler.jsonc when given a binding", async ({
+			expect,
+		}) => {
+			writeWranglerConfig({}, "./wrangler.jsonc");
+			const body = captureBody("post", "apps", {
+				id: "app-1",
+				name: "checkout",
+				created_at: "2026-01-01",
+				updated_at: "2026-01-02",
+				updated_by: "dev@cloudflare.com",
+			});
+			await runWrangler("flagship apps create checkout --binding FLAGS");
+			await expect(body).resolves.toEqual({ name: "checkout" });
+			expect(readWranglerConfig("./wrangler.jsonc")).toMatchObject({
+				flagship: [{ binding: "FLAGS", app_id: "app-1" }],
+			});
+		});
+
+		it("does not update config when creating an app with --json", async ({
+			expect,
+		}) => {
+			writeWranglerConfig({}, "./wrangler.jsonc");
+			msw.use(
+				http.post("*/accounts/:accountId/flagship/apps", () =>
+					HttpResponse.json(
+						createFetchResult({ id: "app-1", name: "checkout" }, true)
+					)
+				)
+			);
+			await runWrangler("flagship apps create checkout --binding FLAGS --json");
+			expect(JSON.parse(std.out)).toEqual({ id: "app-1", name: "checkout" });
+			expect(readWranglerConfig("./wrangler.jsonc")).not.toHaveProperty(
+				"flagship"
+			);
 		});
 
 		it("lists apps", async ({ expect }) => {

--- a/packages/wrangler/src/__tests__/flagship.test.ts
+++ b/packages/wrangler/src/__tests__/flagship.test.ts
@@ -534,7 +534,10 @@ describe("flagship", () => {
 			await expect(
 				runWrangler("flagship flags delete app-1 new-ui --json")
 			).rejects.toThrowError(/Pass --force/);
-			expect(std.out).toBe("");
+			expect(JSON.parse(std.out)).toEqual({
+				error:
+					"Pass --force to skip the confirmation prompt when using --json.",
+			});
 		});
 
 		it("continues deleting after a failure and reports it", async ({
@@ -565,6 +568,37 @@ describe("flagship", () => {
 			expect(deleted).toEqual(["alpha", "gamma"]);
 			expect(std.out).toContain("Deleted flag 'alpha'");
 			expect(std.out).toContain("Deleted flag 'gamma'");
+		});
+
+		it("reports bulk failures as JSON when using --json", async ({
+			expect,
+		}) => {
+			msw.use(
+				http.delete(
+					"*/accounts/:accountId/flagship/apps/app-1/flags/:flagKey",
+					({ params }) => {
+						const key = String(params.flagKey);
+						if (key === "beta") {
+							return HttpResponse.json(
+								createFetchResult(null, false, [
+									{ code: 1000, message: "flag is locked" },
+								]),
+								{ status: 500 }
+							);
+						}
+						return HttpResponse.json(createFetchResult({ key }, true));
+					}
+				)
+			);
+			await expect(
+				runWrangler(
+					"flagship flags delete app-1 alpha beta gamma --force --json"
+				)
+			).rejects.toThrowError(/Failed to process 1 of the requested items/);
+			expect(JSON.parse(std.out)).toMatchObject({
+				results: [{ key: "alpha" }, { key: "gamma" }],
+				failures: [{ target: "beta" }],
+			});
 		});
 
 		it("shows the flag changelog", async ({ expect }) => {

--- a/packages/wrangler/src/__tests__/flagship.test.ts
+++ b/packages/wrangler/src/__tests__/flagship.test.ts
@@ -1436,6 +1436,34 @@ describe("flagship", () => {
 			});
 		});
 
+		it("renumbers rules after deleting a middle priority", async ({
+			expect,
+		}) => {
+			mockGet("apps/app-1/flags/new-ui", {
+				key: "new-ui",
+				enabled: true,
+				default_variation: "off",
+				variations: { on: true, off: false, beta: true },
+				rules: [
+					{ priority: 1, serve_variation: "on", conditions: [] },
+					{ priority: 2, serve_variation: "off", conditions: [] },
+					{ priority: 3, serve_variation: "beta", conditions: [] },
+				],
+			});
+			const body = captureBody("put", "apps/app-1/flags/new-ui", {
+				key: "new-ui",
+			});
+			await runWrangler(
+				"flagship flags rules delete app-1 new-ui --priority 2"
+			);
+			await expect(body).resolves.toMatchObject({
+				rules: [
+					{ priority: 1, serve_variation: "on" },
+					{ priority: 2, serve_variation: "beta" },
+				],
+			});
+		});
+
 		it("reorders rules by existing priority", async ({ expect }) => {
 			mockGet("apps/app-1/flags/new-ui", {
 				key: "new-ui",

--- a/packages/wrangler/src/__tests__/flagship.test.ts
+++ b/packages/wrangler/src/__tests__/flagship.test.ts
@@ -1,0 +1,1549 @@
+import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
+import { http, HttpResponse } from "msw";
+import { afterEach, beforeEach, describe, it } from "vitest";
+import { mockAccountId, mockApiToken } from "./helpers/mock-account-id";
+import { mockConsoleMethods } from "./helpers/mock-console";
+import { clearDialogs, mockConfirm } from "./helpers/mock-dialogs";
+import { useMockIsTTY } from "./helpers/mock-istty";
+import { createFetchResult, msw } from "./helpers/msw";
+import { runWrangler } from "./helpers/run-wrangler";
+
+type JsonResponseBody = Parameters<typeof HttpResponse.json>[0];
+
+function mockGet(
+	path: string,
+	result: unknown,
+	resultInfo?: Record<string, unknown>
+) {
+	msw.use(
+		http.get(
+			`*/accounts/:accountId/flagship/${path}`,
+			() =>
+				HttpResponse.json(createFetchResult(result, true, [], [], resultInfo)),
+			{ once: true }
+		)
+	);
+}
+
+function mockPaged(
+	path: string,
+	pages: Array<{ items: unknown[]; cursor: string | null }>
+) {
+	msw.use(
+		http.get(`*/accounts/:accountId/flagship/${path}`, ({ request }) => {
+			const cursor = new URL(request.url).searchParams.get("cursor");
+			const index = cursor
+				? pages.findIndex((page, i) => i > 0 && pages[i - 1].cursor === cursor)
+				: 0;
+			const page = pages[index] ?? pages[pages.length - 1];
+			return HttpResponse.json(
+				createFetchResult(page.items, true, [], [], {
+					count: page.items.length,
+					cursor: page.cursor,
+				})
+			);
+		})
+	);
+}
+
+function mockRawGet(path: string, result: JsonResponseBody) {
+	msw.use(
+		http.get(
+			`*/accounts/:accountId/flagship/${path}`,
+			() => HttpResponse.json(result),
+			{ once: true }
+		)
+	);
+}
+
+function captureBody(
+	method: "post" | "put" | "delete",
+	path: string,
+	result: unknown
+): Promise<unknown> {
+	return new Promise((resolve) => {
+		msw.use(
+			http[method](
+				`*/accounts/:accountId/flagship/${path}`,
+				async ({ request }) => {
+					resolve(request.body ? await request.json().catch(() => null) : null);
+					return HttpResponse.json(createFetchResult(result, true));
+				},
+				{ once: true }
+			)
+		);
+	});
+}
+
+function captureContentType(
+	method: "post" | "put",
+	path: string,
+	result: unknown
+): Promise<string | null> {
+	return new Promise((resolve) => {
+		msw.use(
+			http[method](
+				`*/accounts/:accountId/flagship/${path}`,
+				({ request }) => {
+					resolve(request.headers.get("content-type"));
+					return HttpResponse.json(createFetchResult(result, true));
+				},
+				{ once: true }
+			)
+		);
+	});
+}
+
+describe("flagship", () => {
+	mockAccountId();
+	mockApiToken();
+	runInTempDir();
+	const { setIsTTY } = useMockIsTTY();
+	const std = mockConsoleMethods();
+
+	beforeEach(() => setIsTTY(true));
+	afterEach(() => clearDialogs());
+
+	describe("apps", () => {
+		it("creates an app", async ({ expect }) => {
+			const body = captureBody("post", "apps", {
+				id: "app-1",
+				name: "checkout",
+			});
+			await runWrangler("flagship apps create checkout");
+			await expect(body).resolves.toEqual({ name: "checkout" });
+			expect(std.out).toContain("Created Flagship app");
+			expect(std.out).toContain("checkout");
+			expect(std.out).toContain("app-1");
+		});
+
+		it("sends a JSON content-type so the API parses the body", async ({
+			expect,
+		}) => {
+			const contentType = captureContentType("post", "apps", {
+				id: "app-1",
+				name: "checkout",
+			});
+			await runWrangler("flagship apps create checkout");
+			await expect(contentType).resolves.toContain("application/json");
+		});
+
+		it("lists apps", async ({ expect }) => {
+			mockGet("apps", [
+				{
+					id: "app-1",
+					name: "checkout",
+					created_at: "2026-01-01",
+					updated_at: "2026-01-02",
+					updated_by: "dev@cloudflare.com",
+				},
+			]);
+			await runWrangler("flagship apps list");
+			expect(std.out).toContain("app-1");
+			expect(std.out).toContain("checkout");
+		});
+
+		it("updates an app", async ({ expect }) => {
+			const body = captureBody("put", "apps/app-1", {
+				id: "app-1",
+				name: "renamed",
+			});
+			await runWrangler("flagship apps update app-1 --name renamed");
+			await expect(body).resolves.toEqual({ name: "renamed" });
+			expect(std.out).toContain("Updated Flagship app");
+			expect(std.out).toContain("renamed");
+		});
+
+		it("deletes an app with confirmation", async ({ expect }) => {
+			mockConfirm({
+				text: "Are you sure you want to delete the Flagship app 'app-1'? This also deletes all of its flags.",
+				result: true,
+			});
+			const body = captureBody("delete", "apps/app-1", { id: "app-1" });
+			await runWrangler("flagship apps delete app-1");
+			await expect(body).resolves.toBeNull();
+			expect(std.out).toContain("Deleted Flagship app 'app-1'");
+		});
+
+		it("deletes an app with --json (skips prompt, outputs result)", async ({
+			expect,
+		}) => {
+			msw.use(
+				http.delete(
+					"*/accounts/:accountId/flagship/apps/app-1",
+					() => HttpResponse.json(createFetchResult({ id: "app-1" }, true)),
+					{ once: true }
+				)
+			);
+			await runWrangler("flagship apps delete app-1 --force --json");
+			expect(JSON.parse(std.out)).toEqual({ id: "app-1" });
+		});
+
+		it("deletes multiple apps", async ({ expect }) => {
+			const deleted: string[] = [];
+			msw.use(
+				http.delete(
+					"*/accounts/:accountId/flagship/apps/:appId",
+					({ params }) => {
+						const appId = String(params.appId);
+						deleted.push(appId);
+						return HttpResponse.json(createFetchResult({ id: appId }, true));
+					}
+				)
+			);
+			await runWrangler("flagship apps delete app-1 app-2 --force --json");
+			expect(deleted).toEqual(["app-1", "app-2"]);
+			expect(JSON.parse(std.out)).toEqual([{ id: "app-1" }, { id: "app-2" }]);
+		});
+	});
+
+	describe("flags", () => {
+		it("creates a boolean flag with a targeting rule", async ({ expect }) => {
+			const body = captureBody("post", "apps/app-1/flags", {
+				key: "new-ui",
+				type: "boolean",
+				enabled: true,
+				default_variation: "off",
+				variations: { on: true, off: false },
+				rules: [],
+			});
+			await runWrangler(
+				`flagship flags create app-1 new-ui --variation on=true --variation off=false --default-variation off --rule "priority=1; serve=on; when=plan equals pro AND country in [US,CA]; rollout=30%@user_id"`
+			);
+			await expect(body).resolves.toEqual({
+				key: "new-ui",
+				description: undefined,
+				enabled: true,
+				default_variation: "off",
+				variations: { on: true, off: false },
+				rules: [
+					{
+						priority: 1,
+						serve_variation: "on",
+						conditions: [
+							{ attribute: "plan", operator: "equals", value: "pro" },
+							{ attribute: "country", operator: "in", value: ["US", "CA"] },
+						],
+						rollout: { percentage: 30, attribute: "user_id" },
+					},
+				],
+			});
+			expect(std.out).toContain("Created flag");
+			expect(std.out).toContain("new-ui");
+		});
+
+		it("accepts a rule provided as JSON", async ({ expect }) => {
+			const body = captureBody("post", "apps/app-1/flags", { key: "f" });
+			await runWrangler(
+				`flagship flags create app-1 f --variation on=true --variation off=false --default-variation off --rule-json '{"priority":1,"serve_variation":"on","conditions":[{"logical_operator":"OR","clauses":[{"attribute":"beta","operator":"equals","value":true}]}]}'`
+			);
+			await expect(body).resolves.toMatchObject({
+				rules: [
+					{
+						priority: 1,
+						serve_variation: "on",
+						conditions: [
+							{
+								logical_operator: "OR",
+								clauses: [
+									{ attribute: "beta", operator: "equals", value: true },
+								],
+							},
+						],
+					},
+				],
+			});
+		});
+
+		it("preserves condition values that contain the operator name", async ({
+			expect,
+		}) => {
+			const body = captureBody("post", "apps/app-1/flags", { key: "f" });
+			await runWrangler(
+				`flagship flags create app-1 f --variation on=true --variation off=false --default-variation off --rule "priority=1; serve=on; when=msg equals a equals b"`
+			);
+			await expect(body).resolves.toMatchObject({
+				rules: [
+					{
+						conditions: [
+							{ attribute: "msg", operator: "equals", value: "a equals b" },
+						],
+					},
+				],
+			});
+		});
+
+		it("parses JSON-style arrays for in operators", async ({ expect }) => {
+			const body = captureBody("post", "apps/app-1/flags", { key: "f" });
+			await runWrangler(
+				`flagship flags create app-1 f --variation on=true --variation off=false --default-variation off --rule 'serve=on; when=country in ["US","CA"]'`
+			);
+			await expect(body).resolves.toMatchObject({
+				rules: [
+					{
+						conditions: [
+							{ attribute: "country", operator: "in", value: ["US", "CA"] },
+						],
+					},
+				],
+			});
+		});
+
+		it("rejects empty and malformed condition expressions", async ({
+			expect,
+		}) => {
+			await expect(
+				runWrangler(
+					`flagship flags create app-1 f --variation on=true --variation off=false --default-variation off --rule "serve=on; when="`
+				)
+			).rejects.toThrowError(/Condition expression is empty/);
+			await expect(
+				runWrangler(
+					`flagship flags create app-1 f --variation on=true --variation off=false --default-variation off --rule "serve=on; when=plan equals pro OR"`
+				)
+			).rejects.toThrowError(
+				/Logical operators must appear between conditions/
+			);
+		});
+
+		it("rejects malformed rule JSON", async ({ expect }) => {
+			await expect(
+				runWrangler(
+					`flagship flags create app-1 f --variation on=true --variation off=false --default-variation off --rule-json '{"conditions":[]}'`
+				)
+			).rejects.toThrowError(/serve_variation/);
+		});
+
+		it("defaults new flags to boolean on/off variations", async ({
+			expect,
+		}) => {
+			const body = captureBody("post", "apps/app-1/flags", {
+				key: "simple-flag",
+				type: "boolean",
+				enabled: true,
+				default_variation: "off",
+				variations: { on: true, off: false },
+				rules: [],
+			});
+			await runWrangler("flagship flags create app-1 simple-flag");
+			await expect(body).resolves.toMatchObject({
+				default_variation: "off",
+				variations: { on: true, off: false },
+			});
+		});
+
+		it("lists flags and surfaces the next cursor", async ({ expect }) => {
+			mockGet(
+				"apps/app-1/flags",
+				[
+					{
+						key: "new-ui",
+						type: "boolean",
+						enabled: true,
+						default_variation: "off",
+						variations: { on: true, off: false },
+						rules: [],
+					},
+				],
+				{ count: 1, cursor: "next-key" }
+			);
+			await runWrangler("flagship flags list app-1");
+			expect(std.out).toContain("new-ui");
+			expect(std.out).toContain("Next cursor: next-key");
+		});
+
+		it("renders a flag with variations and rules", async ({ expect }) => {
+			mockGet("apps/app-1/flags/new-ui", {
+				key: "new-ui",
+				type: "boolean",
+				description: "Roll out the new UI",
+				enabled: true,
+				default_variation: "off",
+				variations: { on: true, off: false },
+				rules: [
+					{
+						priority: 1,
+						serve_variation: "on",
+						conditions: [
+							{ attribute: "plan", operator: "equals", value: "pro" },
+						],
+						rollout: { percentage: 30, attribute: "user_id" },
+					},
+				],
+			});
+			await runWrangler("flagship flags get app-1 new-ui");
+			expect(std.out).toContain("new-ui");
+			expect(std.out).toContain("enabled");
+			expect(std.out).toContain("off  false  default");
+			expect(std.out).toContain('serve "on" when plan equals "pro"');
+			expect(std.out).toContain("30% rollout by user_id");
+		});
+
+		it("evaluates a flag with context", async ({ expect }) => {
+			let url = "";
+			msw.use(
+				http.get(
+					"*/accounts/:accountId/flagship/apps/app-1/evaluate",
+					({ request }) => {
+						url = request.url;
+						return HttpResponse.json({
+							flagKey: "new-ui",
+							value: true,
+							variant: "on",
+							reason: "TARGETING_MATCH",
+						});
+					},
+					{ once: true }
+				)
+			);
+			await runWrangler(
+				"flagship flags evaluate app-1 new-ui --context plan=pro --targeting-key user-1"
+			);
+			expect(url).toContain("flagKey=new-ui");
+			expect(url).toContain("plan=pro");
+			expect(url).toContain("targetingKey=user-1");
+			expect(std.out).toContain("evaluated");
+			expect(std.out).toContain("TARGETING_MATCH");
+		});
+
+		it("does not let context override the flag key", async ({ expect }) => {
+			let url = "";
+			msw.use(
+				http.get(
+					"*/accounts/:accountId/flagship/apps/app-1/evaluate",
+					({ request }) => {
+						url = request.url;
+						return HttpResponse.json({ flagKey: "new-ui", value: true });
+					},
+					{ once: true }
+				)
+			);
+			await runWrangler(
+				"flagship flags evaluate app-1 new-ui --context flagKey=wrong"
+			);
+			const params = new URL(url).searchParams;
+			expect(params.getAll("flagKey")).toEqual(["new-ui"]);
+		});
+
+		it("supports inspect, history, and eval aliases", async ({ expect }) => {
+			mockGet("apps/app-1/flags/new-ui", {
+				key: "new-ui",
+				enabled: true,
+				default_variation: "off",
+				variations: { on: true, off: false },
+				rules: [],
+			});
+			await runWrangler("flagship flags inspect app-1 new-ui");
+			expect(std.out).toContain("new-ui");
+
+			mockGet("apps/app-1/flags/new-ui/changelog", []);
+			await runWrangler("flagship flags history app-1 new-ui");
+			expect(std.out).toContain("No changelog entries");
+
+			mockRawGet("apps/app-1/evaluate", { flagKey: "new-ui", value: false });
+			await runWrangler("flagship flags eval app-1 new-ui");
+			expect(std.out).toContain("new-ui");
+		});
+
+		it("toggles a flag via read-modify-write", async ({ expect }) => {
+			mockGet("apps/app-1/flags/new-ui", {
+				key: "new-ui",
+				enabled: true,
+				default_variation: "off",
+				variations: { on: true, off: false },
+				rules: [{ priority: 1, serve_variation: "on", conditions: [] }],
+			});
+			const body = captureBody("put", "apps/app-1/flags/new-ui", {
+				key: "new-ui",
+				type: "boolean",
+				enabled: false,
+				default_variation: "off",
+				variations: { on: true, off: false },
+				rules: [{ priority: 1, serve_variation: "on", conditions: [] }],
+			});
+			await runWrangler("flagship flags update app-1 new-ui --disable");
+			await expect(body).resolves.toEqual({
+				key: "new-ui",
+				description: undefined,
+				enabled: false,
+				default_variation: "off",
+				variations: { on: true, off: false },
+				rules: [{ priority: 1, serve_variation: "on", conditions: [] }],
+			});
+			expect(std.out).toContain("Updated flag");
+			expect(std.out).toContain("disabled");
+		});
+
+		it("deletes a flag with confirmation", async ({ expect }) => {
+			mockConfirm({
+				text: "Are you sure you want to delete the flag 'new-ui'?",
+				result: true,
+			});
+			const body = captureBody("delete", "apps/app-1/flags/new-ui", {
+				key: "new-ui",
+			});
+			await runWrangler("flagship flags delete app-1 new-ui");
+			await expect(body).resolves.toBeNull();
+			expect(std.out).toContain("Deleted flag 'new-ui'");
+		});
+
+		it("deletes a flag with --json (skips prompt, outputs result)", async ({
+			expect,
+		}) => {
+			msw.use(
+				http.delete(
+					"*/accounts/:accountId/flagship/apps/app-1/flags/new-ui",
+					() => HttpResponse.json(createFetchResult({ key: "new-ui" }, true)),
+					{ once: true }
+				)
+			);
+			await runWrangler("flagship flags delete app-1 new-ui --force --json");
+			expect(JSON.parse(std.out)).toEqual({ key: "new-ui" });
+		});
+
+		it("deletes multiple flags given an app id and multiple keys", async ({
+			expect,
+		}) => {
+			const deleted: string[] = [];
+			msw.use(
+				http.delete(
+					"*/accounts/:accountId/flagship/apps/app-1/flags/:flagKey",
+					({ params }) => {
+						const key = String(params.flagKey);
+						deleted.push(key);
+						return HttpResponse.json(createFetchResult({ key }, true));
+					}
+				)
+			);
+			await runWrangler(
+				"flagship flags delete app-1 alpha beta --force --json"
+			);
+			expect(deleted).toEqual(["alpha", "beta"]);
+			expect(JSON.parse(std.out)).toEqual([{ key: "alpha" }, { key: "beta" }]);
+		});
+
+		it("requires an app id and at least one flag key", async ({ expect }) => {
+			await expect(
+				runWrangler("flagship flags delete app-1 --force")
+			).rejects.toThrowError(
+				/An app ID and at least one flag key are required/
+			);
+		});
+
+		it("requires --force to delete with --json", async ({ expect }) => {
+			await expect(
+				runWrangler("flagship flags delete app-1 new-ui --json")
+			).rejects.toThrowError(/Pass --force/);
+			expect(std.out).toBe("");
+		});
+
+		it("continues deleting after a failure and reports it", async ({
+			expect,
+		}) => {
+			const deleted: string[] = [];
+			msw.use(
+				http.delete(
+					"*/accounts/:accountId/flagship/apps/app-1/flags/:flagKey",
+					({ params }) => {
+						const key = String(params.flagKey);
+						if (key === "beta") {
+							return HttpResponse.json(
+								createFetchResult(null, false, [
+									{ code: 1000, message: "flag is locked" },
+								]),
+								{ status: 500 }
+							);
+						}
+						deleted.push(key);
+						return HttpResponse.json(createFetchResult({ key }, true));
+					}
+				)
+			);
+			await expect(
+				runWrangler("flagship flags delete app-1 alpha beta gamma --force")
+			).rejects.toThrowError(/Failed to process 1 of the requested items/);
+			expect(deleted).toEqual(["alpha", "gamma"]);
+			expect(std.out).toContain("Deleted flag 'alpha'");
+			expect(std.out).toContain("Deleted flag 'gamma'");
+		});
+
+		it("shows the flag changelog", async ({ expect }) => {
+			mockGet("apps/app-1/flags/new-ui/changelog", [
+				{
+					flag_key: "new-ui",
+					event: "create",
+					after: {
+						key: "new-ui",
+						enabled: true,
+						default_variation: "off",
+						variations: { on: true, off: false },
+						rules: [],
+						updated_at: "2026-01-02",
+						updated_by: "dev@cloudflare.com",
+					},
+				},
+			]);
+			await runWrangler("flagship flags changelog app-1 new-ui");
+			expect(std.out).toContain("create");
+			expect(std.out).toContain("dev@cloudflare.com");
+		});
+
+		it("enables a flag without re-specifying its definition", async ({
+			expect,
+		}) => {
+			mockGet("apps/app-1/flags/new-ui", {
+				key: "new-ui",
+				enabled: false,
+				default_variation: "off",
+				variations: { on: true, off: false },
+				rules: [],
+			});
+			const body = captureBody("put", "apps/app-1/flags/new-ui", {
+				key: "new-ui",
+				enabled: true,
+				default_variation: "off",
+				variations: { on: true, off: false },
+				rules: [],
+			});
+			await runWrangler("flagship flags enable app-1 new-ui");
+			await expect(body).resolves.toMatchObject({ enabled: true });
+			expect(std.out).toContain("Enabled flag");
+		});
+
+		it("disables multiple flags", async ({ expect }) => {
+			const updated: string[] = [];
+			msw.use(
+				http.get(
+					"*/accounts/:accountId/flagship/apps/app-1/flags/:flagKey",
+					({ params }) =>
+						HttpResponse.json(
+							createFetchResult(
+								{
+									key: String(params.flagKey),
+									enabled: true,
+									default_variation: "off",
+									variations: { on: true, off: false },
+									rules: [],
+								},
+								true
+							)
+						)
+				),
+				http.put(
+					"*/accounts/:accountId/flagship/apps/app-1/flags/:flagKey",
+					async ({ params, request }) => {
+						const body = await request.json();
+						expect(body).toMatchObject({ enabled: false });
+						updated.push(String(params.flagKey));
+						return HttpResponse.json(createFetchResult(body, true));
+					}
+				)
+			);
+			await runWrangler("flagship flags disable app-1 alpha beta --json");
+			expect(updated).toEqual(["alpha", "beta"]);
+			expect(JSON.parse(std.out)).toMatchObject([
+				{ key: "alpha", enabled: false },
+				{ key: "beta", enabled: false },
+			]);
+		});
+
+		it("reports failures when a bulk toggle partially fails", async ({
+			expect,
+		}) => {
+			msw.use(
+				http.get(
+					"*/accounts/:accountId/flagship/apps/app-1/flags/:flagKey",
+					({ params }) => {
+						const key = String(params.flagKey);
+						if (key === "missing") {
+							return HttpResponse.json(
+								createFetchResult(null, false, [
+									{ code: 1001, message: "flag not found" },
+								]),
+								{ status: 404 }
+							);
+						}
+						return HttpResponse.json(
+							createFetchResult(
+								{
+									key,
+									enabled: true,
+									default_variation: "off",
+									variations: { on: true, off: false },
+									rules: [],
+								},
+								true
+							)
+						);
+					}
+				),
+				http.put(
+					"*/accounts/:accountId/flagship/apps/app-1/flags/:flagKey",
+					async ({ request }) =>
+						HttpResponse.json(createFetchResult(await request.json(), true))
+				)
+			);
+			await expect(
+				runWrangler("flagship flags disable app-1 alpha missing")
+			).rejects.toThrowError(/Failed to process 1 of the requested items/);
+			expect(std.out).toContain("Disabled flag");
+		});
+
+		it("sets the default variation", async ({ expect }) => {
+			mockGet("apps/app-1/flags/new-ui", {
+				key: "new-ui",
+				enabled: true,
+				default_variation: "off",
+				variations: { on: true, off: false },
+				rules: [{ priority: 1, serve_variation: "on", conditions: [] }],
+			});
+			const body = captureBody("put", "apps/app-1/flags/new-ui", {
+				key: "new-ui",
+				enabled: true,
+				default_variation: "on",
+				variations: { on: true, off: false },
+				rules: [],
+			});
+			await runWrangler(
+				"flagship flags set app-1 new-ui --variation=on --clear-rules"
+			);
+			await expect(body).resolves.toMatchObject({
+				default_variation: "on",
+				rules: [],
+			});
+			expect(std.out).toContain('Set default variation to "on"');
+		});
+
+		it("clears the description when passed an empty string", async ({
+			expect,
+		}) => {
+			mockGet("apps/app-1/flags/new-ui", {
+				key: "new-ui",
+				enabled: true,
+				description: "old description",
+				default_variation: "off",
+				variations: { on: true, off: false },
+				rules: [],
+			});
+			const body = captureBody("put", "apps/app-1/flags/new-ui", {
+				key: "new-ui",
+			});
+			await runWrangler('flagship flags update app-1 new-ui --description ""');
+			await expect(body).resolves.toMatchObject({ description: null });
+		});
+
+		it("configures a weighted split", async ({ expect }) => {
+			mockGet("apps/app-1/flags/model", {
+				key: "model",
+				enabled: true,
+				default_variation: "stable",
+				variations: { stable: "v1", candidate: "v2" },
+				rules: [],
+			});
+			const body = captureBody("put", "apps/app-1/flags/model", {
+				key: "model",
+				enabled: true,
+				default_variation: "stable",
+				variations: { stable: "v1", candidate: "v2" },
+				rules: [],
+			});
+			await runWrangler(
+				"flagship flags split app-1 model --by user_id --weight stable=95 --weight candidate=5"
+			);
+			await expect(body).resolves.toMatchObject({
+				rules: [
+					{
+						priority: 1,
+						serve_variation: "stable",
+						rollout: { percentage: 95, attribute: "user_id" },
+					},
+					{
+						priority: 2,
+						serve_variation: "candidate",
+						rollout: { percentage: 100, attribute: "user_id" },
+					},
+				],
+			});
+			expect(std.out).toContain("Updated split");
+		});
+
+		it("configures a single rollout", async ({ expect }) => {
+			mockGet("apps/app-1/flags/new-ui", {
+				key: "new-ui",
+				enabled: true,
+				default_variation: "off",
+				variations: { on: true, off: false },
+				rules: [],
+			});
+			const body = captureBody("put", "apps/app-1/flags/new-ui", {
+				key: "new-ui",
+				enabled: true,
+				default_variation: "off",
+				variations: { on: true, off: false },
+				rules: [],
+			});
+			await runWrangler(
+				"flagship flags rollout app-1 new-ui --to on --percentage 25 --by user_id"
+			);
+			await expect(body).resolves.toMatchObject({
+				rules: [
+					{
+						priority: 1,
+						serve_variation: "on",
+						rollout: { percentage: 25, attribute: "user_id" },
+					},
+				],
+			});
+			expect(std.out).toContain("Updated rollout");
+		});
+
+		it("removes the rollout without changing the default when percentage is 0", async ({
+			expect,
+		}) => {
+			mockGet("apps/app-1/flags/new-ui", {
+				key: "new-ui",
+				enabled: true,
+				default_variation: "off",
+				variations: { on: true, off: false },
+				rules: [
+					{
+						priority: 1,
+						serve_variation: "on",
+						conditions: [],
+						rollout: { percentage: 25, attribute: "user_id" },
+					},
+				],
+			});
+			const body = captureBody("put", "apps/app-1/flags/new-ui", {
+				key: "new-ui",
+			});
+			await runWrangler(
+				"flagship flags rollout app-1 new-ui --to on --percentage 0 --from on"
+			);
+			await expect(body).resolves.toMatchObject({
+				default_variation: "off",
+				rules: [],
+			});
+		});
+
+		it("asks for confirmation before a rollout replaces targeting rules with conditions", async ({
+			expect,
+		}) => {
+			mockGet("apps/app-1/flags/new-ui", {
+				key: "new-ui",
+				enabled: true,
+				default_variation: "off",
+				variations: { on: true, off: false },
+				rules: [
+					{
+						priority: 1,
+						serve_variation: "on",
+						conditions: [
+							{ attribute: "plan", operator: "equals", value: "pro" },
+						],
+					},
+				],
+			});
+			mockConfirm({
+				text: "This flag has existing targeting rule(s) with conditions. Continuing will replace them with this rollout. Continue?",
+				result: false,
+			});
+			await runWrangler(
+				"flagship flags rollout app-1 new-ui --to on --percentage 25"
+			);
+			expect(std.out).toContain("Aborting rollout");
+		});
+
+		it("skips the rollout confirmation with --force", async ({ expect }) => {
+			mockGet("apps/app-1/flags/new-ui", {
+				key: "new-ui",
+				enabled: true,
+				default_variation: "off",
+				variations: { on: true, off: false },
+				rules: [
+					{
+						priority: 1,
+						serve_variation: "on",
+						conditions: [
+							{ attribute: "plan", operator: "equals", value: "pro" },
+						],
+					},
+				],
+			});
+			const body = captureBody("put", "apps/app-1/flags/new-ui", {
+				key: "new-ui",
+			});
+			await runWrangler(
+				"flagship flags rollout app-1 new-ui --to on --percentage 25 --force"
+			);
+			await expect(body).resolves.toMatchObject({
+				rules: [{ priority: 1, serve_variation: "on" }],
+			});
+		});
+
+		it("requires --force to replace targeting rules with --json", async ({
+			expect,
+		}) => {
+			mockGet("apps/app-1/flags/new-ui", {
+				key: "new-ui",
+				enabled: true,
+				default_variation: "off",
+				variations: { on: true, off: false },
+				rules: [
+					{
+						priority: 1,
+						serve_variation: "on",
+						conditions: [
+							{ attribute: "plan", operator: "equals", value: "pro" },
+						],
+					},
+				],
+			});
+			await expect(
+				runWrangler(
+					"flagship flags rollout app-1 new-ui --to on --percentage 25 --json"
+				)
+			).rejects.toThrowError(/Pass --force to confirm/);
+		});
+
+		it("asks for confirmation before a split replaces targeting rules with conditions", async ({
+			expect,
+		}) => {
+			mockGet("apps/app-1/flags/model", {
+				key: "model",
+				enabled: true,
+				default_variation: "stable",
+				variations: { stable: "v1", candidate: "v2" },
+				rules: [
+					{
+						priority: 1,
+						serve_variation: "stable",
+						conditions: [
+							{ attribute: "plan", operator: "equals", value: "pro" },
+						],
+					},
+				],
+			});
+			mockConfirm({
+				text: "This flag has existing targeting rule(s) with conditions. Continuing will replace them with this split. Continue?",
+				result: false,
+			});
+			await runWrangler(
+				"flagship flags split app-1 model -w stable=50 -w candidate=50"
+			);
+			expect(std.out).toContain("Aborting split");
+		});
+
+		it("supports the ls alias", async ({ expect }) => {
+			mockGet("apps/app-1/flags", []);
+			await runWrangler("flagship flags ls app-1");
+			expect(std.out).toContain("No flags in this app yet");
+		});
+	});
+
+	describe("rule parsing and validation", () => {
+		it("detects the operator by position, not list order", async ({
+			expect,
+		}) => {
+			const body = captureBody("post", "apps/app-1/flags", { key: "f" });
+			await runWrangler(
+				`flagship flags create app-1 f -V on=true -V off=false --default off --rule "serve=on; when=desc contains x equals y"`
+			);
+			await expect(body).resolves.toMatchObject({
+				rules: [
+					{
+						conditions: [
+							{ attribute: "desc", operator: "contains", value: "x equals y" },
+						],
+					},
+				],
+			});
+		});
+
+		it("parses OR groups into a nested condition", async ({ expect }) => {
+			const body = captureBody("post", "apps/app-1/flags", { key: "f" });
+			await runWrangler(
+				`flagship flags create app-1 f -V on=true -V off=false --default off --rule "serve=on; when=plan equals pro OR plan equals team"`
+			);
+			await expect(body).resolves.toMatchObject({
+				rules: [
+					{
+						conditions: [
+							{
+								logical_operator: "OR",
+								clauses: [
+									{ attribute: "plan", operator: "equals", value: "pro" },
+									{ attribute: "plan", operator: "equals", value: "team" },
+								],
+							},
+						],
+					},
+				],
+			});
+		});
+
+		it("gives AND higher precedence than OR", async ({ expect }) => {
+			const body = captureBody("post", "apps/app-1/flags", { key: "f" });
+			await runWrangler(
+				`flagship flags create app-1 f -V on=true -V off=false --default off --rule "serve=on; when=a equals 1 AND b equals 2 OR c equals 3"`
+			);
+			await expect(body).resolves.toMatchObject({
+				rules: [
+					{
+						conditions: [
+							{
+								logical_operator: "OR",
+								clauses: [
+									{
+										logical_operator: "AND",
+										clauses: [
+											{ attribute: "a", operator: "equals", value: 1 },
+											{ attribute: "b", operator: "equals", value: 2 },
+										],
+									},
+									{ attribute: "c", operator: "equals", value: 3 },
+								],
+							},
+						],
+					},
+				],
+			});
+		});
+
+		it("auto-assigns rule priorities by declaration order", async ({
+			expect,
+		}) => {
+			const body = captureBody("post", "apps/app-1/flags", { key: "f" });
+			await runWrangler(
+				`flagship flags create app-1 f -V on=true -V off=false --default off --rule "serve=on; when=plan equals pro" --rule "serve=off; when=plan equals free"`
+			);
+			await expect(body).resolves.toMatchObject({
+				rules: [
+					{ priority: 1, serve_variation: "on" },
+					{ priority: 2, serve_variation: "off" },
+				],
+			});
+		});
+
+		it("rejects duplicate rule priorities", async ({ expect }) => {
+			await expect(
+				runWrangler(
+					`flagship flags create app-1 f -V on=true -V off=false --default off --rule "priority=1; serve=on; when=plan equals pro" --rule "priority=1; serve=off; when=plan equals free"`
+				)
+			).rejects.toThrowError(/Duplicate rule priority 1/);
+		});
+
+		it("rejects a default variation that is not defined", async ({
+			expect,
+		}) => {
+			await expect(
+				runWrangler(
+					"flagship flags create app-1 f -V on=true -V off=false --default nope"
+				)
+			).rejects.toThrowError(/Default variation "nope" is not one of/);
+		});
+
+		it("rejects a rule that serves an unknown variation", async ({
+			expect,
+		}) => {
+			await expect(
+				runWrangler(
+					`flagship flags create app-1 f -V on=true -V off=false --default off --rule "serve=maybe; when=plan equals pro"`
+				)
+			).rejects.toThrowError(/serves unknown variation "maybe"/);
+		});
+
+		it("treats lowercase and/or inside a value literally", async ({
+			expect,
+		}) => {
+			const body = captureBody("post", "apps/app-1/flags", { key: "f" });
+			await runWrangler(
+				`flagship flags create app-1 f -V on=true -V off=false --default off --rule "serve=on; when=name equals tom and jerry"`
+			);
+			await expect(body).resolves.toMatchObject({
+				rules: [
+					{
+						conditions: [
+							{
+								attribute: "name",
+								operator: "equals",
+								value: "tom and jerry",
+							},
+						],
+					},
+				],
+			});
+		});
+
+		it("keeps numeric-looking values that do not round-trip as strings", async ({
+			expect,
+		}) => {
+			const body = captureBody("post", "apps/app-1/flags", { key: "f" });
+			await runWrangler(
+				`flagship flags create app-1 f -V on=true -V off=false --default off --rule "serve=on; when=code equals 007"`
+			);
+			await expect(body).resolves.toMatchObject({
+				rules: [
+					{
+						conditions: [
+							{ attribute: "code", operator: "equals", value: "007" },
+						],
+					},
+				],
+			});
+		});
+
+		it("treats quoted values literally, including reserved words", async ({
+			expect,
+		}) => {
+			const body = captureBody("post", "apps/app-1/flags", { key: "f" });
+			await runWrangler(
+				`flagship flags create app-1 f -V on=true -V off=false --default off --rule 'serve=on; when=title equals "WAR AND PEACE" OR title equals "tom; jerry"'`
+			);
+			await expect(body).resolves.toMatchObject({
+				rules: [
+					{
+						conditions: [
+							{
+								logical_operator: "OR",
+								clauses: [
+									{
+										attribute: "title",
+										operator: "equals",
+										value: "WAR AND PEACE",
+									},
+									{
+										attribute: "title",
+										operator: "equals",
+										value: "tom; jerry",
+									},
+								],
+							},
+						],
+					},
+				],
+			});
+		});
+
+		it("does not split on AND/OR inside a bracketed list", async ({
+			expect,
+		}) => {
+			const body = captureBody("post", "apps/app-1/flags", { key: "f" });
+			await runWrangler(
+				`flagship flags create app-1 f -V on=true -V off=false --default off --rule 'serve=on; when=country in ["AND","OR"]'`
+			);
+			await expect(body).resolves.toMatchObject({
+				rules: [
+					{
+						conditions: [
+							{ attribute: "country", operator: "in", value: ["AND", "OR"] },
+						],
+					},
+				],
+			});
+		});
+
+		it("rejects an unterminated quote in a condition", async ({ expect }) => {
+			await expect(
+				runWrangler(
+					`flagship flags create app-1 f -V on=true -V off=false --default off --rule 'serve=on; when=title equals "oops'`
+				)
+			).rejects.toThrowError(/Unterminated double quote/);
+		});
+
+		it("rejects a malformed bracketed list", async ({ expect }) => {
+			await expect(
+				runWrangler(
+					`flagship flags create app-1 f -V on=true -V off=false --default off --rule "serve=on; when=country in [US,CA"`
+				)
+			).rejects.toThrowError(/Unterminated "\["/);
+		});
+
+		it("rejects an empty list item", async ({ expect }) => {
+			await expect(
+				runWrangler(
+					`flagship flags create app-1 f -V on=true -V off=false --default off --rule "serve=on; when=country in [US,,CA]"`
+				)
+			).rejects.toThrowError(/List items must not be empty/);
+		});
+
+		it("rejects a condition with no value", async ({ expect }) => {
+			await expect(
+				runWrangler(
+					`flagship flags create app-1 f -V on=true -V off=false --default off --rule "serve=on; when=plan equals"`
+				)
+			).rejects.toThrowError(/Could not find a valid operator|missing a value/);
+		});
+
+		it("rejects a rollout with multiple @ separators", async ({ expect }) => {
+			await expect(
+				runWrangler(
+					`flagship flags create app-1 f -V on=true -V off=false --default off --rule "serve=on; rollout=30%@user@id"`
+				)
+			).rejects.toThrowError(/single non-empty attribute/);
+		});
+
+		it("rejects duplicate variation names", async ({ expect }) => {
+			await expect(
+				runWrangler(
+					"flagship flags create app-1 f -V on=true -V on=false --default on"
+				)
+			).rejects.toThrowError(/Duplicate variation "on"/);
+		});
+
+		it("rejects a non-finite number variation", async ({ expect }) => {
+			await expect(
+				runWrangler(
+					"flagship flags create app-1 f --type number -V big=Infinity --default big"
+				)
+			).rejects.toThrowError(/not a valid finite number/);
+		});
+
+		it("rejects variations with inconsistent inferred types", async ({
+			expect,
+		}) => {
+			await expect(
+				runWrangler(
+					"flagship flags create app-1 f -V a=true -V b=5 --default a"
+				)
+			).rejects.toThrowError(
+				/Variation "b" is number but variation "a" is boolean/
+			);
+		});
+
+		it("rejects --set-variation introducing an inconsistent type", async ({
+			expect,
+		}) => {
+			mockGet("apps/app-1/flags/f", {
+				key: "f",
+				enabled: true,
+				default_variation: "on",
+				variations: { on: true, off: false },
+				rules: [],
+			});
+			await expect(
+				runWrangler("flagship flags update app-1 f --set-variation extra=5")
+			).rejects.toThrowError(
+				/Variation "extra" is number but variation "on" is boolean/
+			);
+		});
+
+		it("rejects unknown fields in --rule-json", async ({ expect }) => {
+			await expect(
+				runWrangler(
+					`flagship flags create app-1 f -V on=true -V off=false --default off --rule-json '{"serve_variation":"on","conditions":[],"bogus":1}'`
+				)
+			).rejects.toThrowError(/Unexpected field "bogus"/);
+		});
+
+		it("rejects a --rule-json condition mixing logical and base fields", async ({
+			expect,
+		}) => {
+			await expect(
+				runWrangler(
+					`flagship flags create app-1 f -V on=true -V off=false --default off --rule-json '{"serve_variation":"on","conditions":[{"logical_operator":"AND","clauses":[],"attribute":"x"}]}'`
+				)
+			).rejects.toThrowError(/Unexpected field "attribute"/);
+		});
+	});
+
+	describe("split validation", () => {
+		it("rejects duplicate split weights", async ({ expect }) => {
+			mockGet("apps/app-1/flags/model", {
+				key: "model",
+				enabled: true,
+				default_variation: "a",
+				variations: { a: "1", b: "2" },
+				rules: [],
+			});
+			await expect(
+				runWrangler("flagship flags split app-1 model -w a=10 -w a=90")
+			).rejects.toThrowError(/Duplicate weight for variation "a"/);
+		});
+
+		it("rejects a non-finite split weight", async ({ expect }) => {
+			mockGet("apps/app-1/flags/model", {
+				key: "model",
+				enabled: true,
+				default_variation: "a",
+				variations: { a: "1", b: "2" },
+				rules: [],
+			});
+			await expect(
+				runWrangler("flagship flags split app-1 model -w a=Infinity -w b=10")
+			).rejects.toThrowError(/non-negative finite number/);
+		});
+	});
+
+	describe("incremental rule editing", () => {
+		it("appends a rule with --add-rule, keeping existing rules", async ({
+			expect,
+		}) => {
+			mockGet("apps/app-1/flags/new-ui", {
+				key: "new-ui",
+				enabled: true,
+				default_variation: "off",
+				variations: { on: true, off: false },
+				rules: [{ priority: 1, serve_variation: "on", conditions: [] }],
+			});
+			const body = captureBody("put", "apps/app-1/flags/new-ui", {
+				key: "new-ui",
+			});
+			await runWrangler(
+				`flagship flags update app-1 new-ui --add-rule "serve=off; when=plan equals free"`
+			);
+			await expect(body).resolves.toMatchObject({
+				rules: [
+					{ priority: 1, serve_variation: "on" },
+					{
+						priority: 2,
+						serve_variation: "off",
+						conditions: [
+							{ attribute: "plan", operator: "equals", value: "free" },
+						],
+					},
+				],
+			});
+		});
+
+		it("rejects replacing and appending rules in the same command", async ({
+			expect,
+		}) => {
+			mockGet("apps/app-1/flags/new-ui", {
+				key: "new-ui",
+				enabled: true,
+				default_variation: "off",
+				variations: { on: true, off: false },
+				rules: [],
+			});
+			await expect(
+				runWrangler(
+					`flagship flags update app-1 new-ui --rule "serve=on; when=plan equals pro" --add-rule "serve=off; when=plan equals free"`
+				)
+			).rejects.toThrowError(/Cannot replace rules .* and append rules/);
+		});
+
+		it("lists rules for a flag", async ({ expect }) => {
+			mockGet("apps/app-1/flags/new-ui", {
+				key: "new-ui",
+				enabled: true,
+				default_variation: "off",
+				variations: { on: true, off: false },
+				rules: [
+					{
+						priority: 1,
+						serve_variation: "on",
+						conditions: [
+							{ attribute: "plan", operator: "equals", value: "pro" },
+						],
+						rollout: { percentage: 25, attribute: "user_id" },
+					},
+				],
+			});
+			await runWrangler("flagship flags rules list app-1 new-ui");
+			expect(std.out).toContain("priority");
+			expect(std.out).toContain("25%@user_id");
+			expect(std.out).toContain("plan equals");
+		});
+
+		it("updates one rule rollout by priority", async ({ expect }) => {
+			mockGet("apps/app-1/flags/new-ui", {
+				key: "new-ui",
+				enabled: true,
+				default_variation: "off",
+				variations: { on: true, off: false },
+				rules: [
+					{
+						priority: 1,
+						serve_variation: "on",
+						conditions: [],
+						rollout: { percentage: 25, attribute: "user_id" },
+					},
+					{ priority: 2, serve_variation: "off", conditions: [] },
+				],
+			});
+			const body = captureBody("put", "apps/app-1/flags/new-ui", {
+				key: "new-ui",
+			});
+			await runWrangler(
+				"flagship flags rules update app-1 new-ui --priority 1 --rollout 50%@user_id"
+			);
+			await expect(body).resolves.toMatchObject({
+				rules: [
+					{
+						priority: 1,
+						serve_variation: "on",
+						rollout: { percentage: 50, attribute: "user_id" },
+					},
+					{ priority: 2, serve_variation: "off" },
+				],
+			});
+		});
+
+		it("deletes one rule by priority", async ({ expect }) => {
+			mockGet("apps/app-1/flags/new-ui", {
+				key: "new-ui",
+				enabled: true,
+				default_variation: "off",
+				variations: { on: true, off: false },
+				rules: [
+					{ priority: 1, serve_variation: "on", conditions: [] },
+					{ priority: 2, serve_variation: "off", conditions: [] },
+				],
+			});
+			const body = captureBody("put", "apps/app-1/flags/new-ui", {
+				key: "new-ui",
+			});
+			await runWrangler(
+				"flagship flags rules delete app-1 new-ui --priority 2"
+			);
+			await expect(body).resolves.toMatchObject({
+				rules: [{ priority: 1, serve_variation: "on" }],
+			});
+		});
+
+		it("reorders rules by existing priority", async ({ expect }) => {
+			mockGet("apps/app-1/flags/new-ui", {
+				key: "new-ui",
+				enabled: true,
+				default_variation: "off",
+				variations: { on: true, off: false },
+				rules: [
+					{ priority: 1, serve_variation: "on", conditions: [] },
+					{ priority: 2, serve_variation: "off", conditions: [] },
+				],
+			});
+			const body = captureBody("put", "apps/app-1/flags/new-ui", {
+				key: "new-ui",
+			});
+			await runWrangler(
+				"flagship flags rules reorder app-1 new-ui --order 2,1"
+			);
+			await expect(body).resolves.toMatchObject({
+				rules: [
+					{ priority: 1, serve_variation: "off" },
+					{ priority: 2, serve_variation: "on" },
+				],
+			});
+		});
+
+		it("rejects invalid reorder entries", async ({ expect }) => {
+			mockGet("apps/app-1/flags/new-ui", {
+				key: "new-ui",
+				enabled: true,
+				default_variation: "off",
+				variations: { on: true, off: false },
+				rules: [
+					{ priority: 1, serve_variation: "on", conditions: [] },
+					{ priority: 2, serve_variation: "off", conditions: [] },
+				],
+			});
+			await expect(
+				runWrangler("flagship flags rules reorder app-1 new-ui --order 1,wat,2")
+			).rejects.toThrowError(/Invalid --order/);
+		});
+	});
+
+	describe("pagination", () => {
+		it("allows --limit without treating default --all=false as a conflict", async ({
+			expect,
+		}) => {
+			mockGet(
+				"apps/app-1/flags/new-ui/changelog",
+				[
+					{
+						flag_key: "new-ui",
+						event: "create",
+						after: { updated_by: "a@b.c" },
+					},
+				],
+				{ count: 1, cursor: null }
+			);
+			await runWrangler("flagship flags changelog app-1 new-ui --limit 3");
+			expect(std.out).toContain("create");
+		});
+
+		it("rejects --all with explicit pagination options", async ({ expect }) => {
+			await expect(
+				runWrangler("flagship flags changelog app-1 new-ui --all --limit 3")
+			).rejects.toThrowError(/Cannot use --all together with --limit/);
+		});
+
+		it("rejects invalid pagination limits", async ({ expect }) => {
+			await expect(
+				runWrangler("flagship flags list app-1 --limit 0")
+			).rejects.toThrowError(/Invalid --limit/);
+			await expect(
+				runWrangler("flagship flags changelog app-1 new-ui --limit 201")
+			).rejects.toThrowError(/Invalid --limit/);
+		});
+
+		it("follows the cursor with --all when listing flags", async ({
+			expect,
+		}) => {
+			mockPaged("apps/app-1/flags", [
+				{
+					items: [
+						{ key: "a", enabled: true, default_variation: "off", rules: [] },
+					],
+					cursor: "page-2",
+				},
+				{
+					items: [
+						{ key: "b", enabled: true, default_variation: "off", rules: [] },
+					],
+					cursor: null,
+				},
+			]);
+			await runWrangler("flagship flags list app-1 --all");
+			expect(std.out).toContain("a");
+			expect(std.out).toContain("b");
+			expect(std.out).not.toContain("Next cursor");
+		});
+
+		it("follows the cursor with --all when reading the changelog", async ({
+			expect,
+		}) => {
+			mockPaged("apps/app-1/flags/new-ui/changelog", [
+				{
+					items: [
+						{
+							flag_key: "new-ui",
+							event: "create",
+							after: { updated_by: "a@b.c" },
+						},
+					],
+					cursor: "page-2",
+				},
+				{
+					items: [
+						{
+							flag_key: "new-ui",
+							event: "delete",
+							after: { updated_by: "d@e.f" },
+						},
+					],
+					cursor: null,
+				},
+			]);
+			await runWrangler("flagship flags changelog app-1 new-ui --all");
+			expect(std.out).toContain("create");
+			expect(std.out).toContain("delete");
+			expect(std.out).not.toContain("Next cursor");
+		});
+	});
+
+	describe("app id is required", () => {
+		it("requires an app id for flags list", async ({ expect }) => {
+			await expect(runWrangler("flagship flags list")).rejects.toThrowError(
+				"Not enough non-option arguments: got 0, need at least 1"
+			);
+		});
+
+		it("requires an app id for apps get", async ({ expect }) => {
+			await expect(runWrangler("flagship apps get")).rejects.toThrowError(
+				"Not enough non-option arguments: got 0, need at least 1"
+			);
+		});
+	});
+});

--- a/packages/wrangler/src/__tests__/flagship.test.ts
+++ b/packages/wrangler/src/__tests__/flagship.test.ts
@@ -143,6 +143,38 @@ describe("flagship", () => {
 			expect(std.out).toContain("checkout");
 		});
 
+		it("follows app list cursors", async ({ expect }) => {
+			mockPaged("apps", [
+				{
+					items: [
+						{
+							id: "app-1",
+							name: "checkout",
+							created_at: "2026-01-01",
+							updated_at: "2026-01-02",
+							updated_by: "dev@cloudflare.com",
+						},
+					],
+					cursor: "page-2",
+				},
+				{
+					items: [
+						{
+							id: "app-2",
+							name: "experiments",
+							created_at: "2026-01-01",
+							updated_at: "2026-01-03",
+							updated_by: "dev@cloudflare.com",
+						},
+					],
+					cursor: null,
+				},
+			]);
+			await runWrangler("flagship apps list");
+			expect(std.out).toContain("app-1");
+			expect(std.out).toContain("app-2");
+		});
+
 		it("updates an app", async ({ expect }) => {
 			const body = captureBody("put", "apps/app-1", {
 				id: "app-1",
@@ -379,6 +411,34 @@ describe("flagship", () => {
 			expect(std.out).toContain("30% rollout by user_id");
 		});
 
+		it("encodes flag keys in API paths", async ({ expect }) => {
+			let url = "";
+			msw.use(
+				http.get(
+					"*/accounts/:accountId/flagship/apps/app-1/flags/:flagKey",
+					({ params, request }) => {
+						url = request.url;
+						expect(params.flagKey).toBe("foo/bar");
+						return HttpResponse.json(
+							createFetchResult(
+								{
+									key: "foo/bar",
+									enabled: true,
+									default_variation: "off",
+									variations: { on: true, off: false },
+									rules: [],
+								},
+								true
+							)
+						);
+					},
+					{ once: true }
+				)
+			);
+			await runWrangler('flagship flags get app-1 "foo/bar"');
+			expect(url).toContain("/flags/foo%2Fbar");
+		});
+
 		it("evaluates a flag with context", async ({ expect }) => {
 			let url = "";
 			msw.use(
@@ -404,6 +464,19 @@ describe("flagship", () => {
 			expect(url).toContain("targetingKey=user-1");
 			expect(std.out).toContain("evaluated");
 			expect(std.out).toContain("TARGETING_MATCH");
+		});
+
+		it("evaluates a flag from a standard API envelope", async ({ expect }) => {
+			mockGet("apps/app-1/evaluate", {
+				flagKey: "new-ui",
+				value: true,
+				variant: "on",
+				reason: "DEFAULT",
+			});
+			await runWrangler("flagship flags evaluate app-1 new-ui");
+			expect(std.out).toContain("new-ui");
+			expect(std.out).toContain("true");
+			expect(std.out).toContain("DEFAULT");
 		});
 
 		it("does not let context override the flag key", async ({ expect }) => {
@@ -525,9 +598,7 @@ describe("flagship", () => {
 		it("requires an app id and at least one flag key", async ({ expect }) => {
 			await expect(
 				runWrangler("flagship flags delete app-1 --force")
-			).rejects.toThrowError(
-				/An app ID and at least one flag key are required/
-			);
+			).rejects.toThrowError(/Not enough non-option arguments/);
 		});
 
 		it("requires --force to delete with --json", async ({ expect }) => {
@@ -829,6 +900,14 @@ describe("flagship", () => {
 				],
 			});
 			expect(std.out).toContain("Updated rollout");
+		});
+
+		it("rejects a non-finite rollout percentage", async ({ expect }) => {
+			await expect(
+				runWrangler(
+					"flagship flags rollout app-1 new-ui --to on --percentage NaN"
+				)
+			).rejects.toThrowError(/--percentage must be between 0 and 100/);
 		});
 
 		it("removes the rollout without changing the default when percentage is 0", async ({
@@ -1217,6 +1296,14 @@ describe("flagship", () => {
 			).rejects.toThrowError(/single non-empty attribute/);
 		});
 
+		it("rejects a rollout with an empty percentage", async ({ expect }) => {
+			await expect(
+				runWrangler(
+					`flagship flags create app-1 f -V on=true -V off=false --default off --rule "serve=on; rollout=@user_id"`
+				)
+			).rejects.toThrowError(/Expected a percentage between 0 and 100/);
+		});
+
 		it("rejects duplicate variation names", async ({ expect }) => {
 			await expect(
 				runWrangler(
@@ -1503,6 +1590,28 @@ describe("flagship", () => {
 			await expect(
 				runWrangler("flagship flags rules reorder app-1 new-ui --order 1,wat,2")
 			).rejects.toThrowError(/Invalid --order/);
+		});
+
+		it("rejects duplicate and extra reorder priorities", async ({ expect }) => {
+			const flag = {
+				key: "new-ui",
+				enabled: true,
+				default_variation: "off",
+				variations: { on: true, off: false },
+				rules: [
+					{ priority: 1, serve_variation: "on", conditions: [] },
+					{ priority: 2, serve_variation: "off", conditions: [] },
+				],
+			};
+			mockGet("apps/app-1/flags/new-ui", flag);
+			await expect(
+				runWrangler("flagship flags rules reorder app-1 new-ui --order 1,2,1")
+			).rejects.toThrowError(/must contain each existing rule priority/);
+
+			mockGet("apps/app-1/flags/new-ui", flag);
+			await expect(
+				runWrangler("flagship flags rules reorder app-1 new-ui --order 1,2,3")
+			).rejects.toThrowError(/must contain each existing rule priority/);
 		});
 	});
 

--- a/packages/wrangler/src/__tests__/index.test.ts
+++ b/packages/wrangler/src/__tests__/index.test.ts
@@ -65,6 +65,7 @@ describe("wrangler", () => {
 				  wrangler deployments            🚢 List and view the current and past deployments for your Worker
 				  wrangler dev [script]           👂 Start a local server for developing your Worker
 				  wrangler dispatch-namespace     🏗️ Manage dispatch namespaces
+				  wrangler flagship               🚩 Manage Flagship apps and feature flags [open beta]
 				  wrangler init [name]            📥 Initialize a basic Worker
 				  wrangler pages                  ⚡️ Configure Cloudflare Pages
 				  wrangler preview [script]       👀 Create a Preview deployment of the current Worker [private beta]
@@ -165,6 +166,7 @@ describe("wrangler", () => {
 				  wrangler deployments            🚢 List and view the current and past deployments for your Worker
 				  wrangler dev [script]           👂 Start a local server for developing your Worker
 				  wrangler dispatch-namespace     🏗️ Manage dispatch namespaces
+				  wrangler flagship               🚩 Manage Flagship apps and feature flags [open beta]
 				  wrangler init [name]            📥 Initialize a basic Worker
 				  wrangler pages                  ⚡️ Configure Cloudflare Pages
 				  wrangler preview [script]       👀 Create a Preview deployment of the current Worker [private beta]

--- a/packages/wrangler/src/core/teams.d.ts
+++ b/packages/wrangler/src/core/teams.d.ts
@@ -27,4 +27,5 @@ export type Teams =
 	| "Product: Tunnels"
 	| "Product: Email Service"
 	| "Product: Browser Run"
-	| "Product: Artifacts";
+	| "Product: Artifacts"
+	| "Product: Flagship";

--- a/packages/wrangler/src/flagship/apps/create.ts
+++ b/packages/wrangler/src/flagship/apps/create.ts
@@ -1,6 +1,10 @@
-import { dim } from "@cloudflare/cli-shared-helpers/colors";
 import { createCommand } from "../../core/create-command";
 import { logger } from "../../logger";
+import {
+	createdResourceConfig,
+	sharedResourceCreationArgs,
+} from "../../utils/add-created-resource-config";
+import { getValidBindingName } from "../../utils/getValidBindingName";
 import { createApp } from "../client";
 import { renderApp } from "../render";
 
@@ -24,9 +28,11 @@ export const flagshipAppsCreateCommand = createCommand({
 			default: false,
 			description: "Return output as JSON",
 		},
+		...sharedResourceCreationArgs,
 	},
 	positionalArgs: ["name"],
-	async handler({ name, json }, { config }) {
+	async handler(args, { config }) {
+		const { name, json } = args;
 		const app = await createApp(config, name);
 		if (json) {
 			logger.json(app);
@@ -34,15 +40,16 @@ export const flagshipAppsCreateCommand = createCommand({
 		}
 		logger.log(`✅ Created Flagship app\n`);
 		logger.log(renderApp(app));
-		logger.log(
-			`\n${dim("Bind this app to a Worker by adding to your Wrangler configuration:")}`
-		);
-		logger.log(
-			JSON.stringify(
-				{ flagship: [{ binding: "FLAGS", app_id: app.id }] },
-				null,
-				2
-			)
+
+		await createdResourceConfig(
+			"flagship",
+			(bindingName) => ({
+				binding: getValidBindingName(bindingName ?? app.name, "FLAGS"),
+				app_id: app.id,
+			}),
+			config.configPath,
+			args.env,
+			args
 		);
 	},
 });

--- a/packages/wrangler/src/flagship/apps/create.ts
+++ b/packages/wrangler/src/flagship/apps/create.ts
@@ -1,0 +1,48 @@
+import { dim } from "@cloudflare/cli-shared-helpers/colors";
+import { createCommand } from "../../core/create-command";
+import { logger } from "../../logger";
+import { createApp } from "../client";
+import { renderApp } from "../render";
+
+export const flagshipAppsCreateCommand = createCommand({
+	metadata: {
+		description: "Create a Flagship app",
+		status: "open beta",
+		owner: "Product: Flagship",
+	},
+	behaviour: {
+		printBanner: (args) => !args.json,
+	},
+	args: {
+		name: {
+			type: "string",
+			demandOption: true,
+			description: "The name of the app",
+		},
+		json: {
+			type: "boolean",
+			default: false,
+			description: "Return output as JSON",
+		},
+	},
+	positionalArgs: ["name"],
+	async handler({ name, json }, { config }) {
+		const app = await createApp(config, name);
+		if (json) {
+			logger.json(app);
+			return;
+		}
+		logger.log(`✅ Created Flagship app\n`);
+		logger.log(renderApp(app));
+		logger.log(
+			`\n${dim("Bind this app to a Worker by adding to your Wrangler configuration:")}`
+		);
+		logger.log(
+			JSON.stringify(
+				{ flagship: [{ binding: "FLAGS", app_id: app.id }] },
+				null,
+				2
+			)
+		);
+	},
+});

--- a/packages/wrangler/src/flagship/apps/delete.ts
+++ b/packages/wrangler/src/flagship/apps/delete.ts
@@ -1,8 +1,8 @@
-import { UserError } from "@cloudflare/workers-utils";
 import { createCommand } from "../../core/create-command";
 import { logger } from "../../logger";
 import { runBulk } from "../bulk";
 import { deleteApp } from "../client";
+import { jsonFriendlyError } from "../shared";
 
 export const flagshipAppsDeleteCommand = createCommand({
 	metadata: {
@@ -35,9 +35,9 @@ export const flagshipAppsDeleteCommand = createCommand({
 	positionalArgs: ["app-id"],
 	async handler({ appId: appIds, force, json }, { config, confirm }) {
 		if (json && !force) {
-			throw new UserError(
+			throw jsonFriendlyError(
 				"Pass --force to skip the confirmation prompt when using --json.",
-				{ telemetryMessage: "flagship delete json requires force" }
+				"flagship delete json requires force"
 			);
 		}
 		if (!force) {

--- a/packages/wrangler/src/flagship/apps/delete.ts
+++ b/packages/wrangler/src/flagship/apps/delete.ts
@@ -1,0 +1,58 @@
+import { UserError } from "@cloudflare/workers-utils";
+import { createCommand } from "../../core/create-command";
+import { logger } from "../../logger";
+import { runBulk } from "../bulk";
+import { deleteApp } from "../client";
+
+export const flagshipAppsDeleteCommand = createCommand({
+	metadata: {
+		description: "Delete a Flagship app",
+		status: "open beta",
+		owner: "Product: Flagship",
+	},
+	behaviour: {
+		printBanner: (args) => !args.json,
+	},
+	args: {
+		"app-id": {
+			type: "string",
+			array: true,
+			demandOption: true,
+			description: "One or more app IDs to delete",
+		},
+		force: {
+			type: "boolean",
+			alias: "y",
+			default: false,
+			description: "Skip the confirmation prompt",
+		},
+		json: {
+			type: "boolean",
+			default: false,
+			description: "Return output as JSON",
+		},
+	},
+	positionalArgs: ["app-id"],
+	async handler({ appId: appIds, force, json }, { config, confirm }) {
+		if (json && !force) {
+			throw new UserError(
+				"Pass --force to skip the confirmation prompt when using --json.",
+				{ telemetryMessage: "flagship delete json requires force" }
+			);
+		}
+		if (!force) {
+			const label = appIds.length === 1 ? appIds[0] : appIds.join(", ");
+			const confirmed = await confirm(
+				`Are you sure you want to delete the Flagship app${appIds.length === 1 ? "" : "s"} '${label}'? This also deletes all of ${appIds.length === 1 ? "its" : "their"} flags.`
+			);
+			if (!confirmed) {
+				logger.log("Aborting delete.");
+				return;
+			}
+		}
+		await runBulk(appIds, (id) => deleteApp(config, id), {
+			json,
+			onSuccess: (_app, id) => logger.log(`✅ Deleted Flagship app '${id}'`),
+		});
+	},
+});

--- a/packages/wrangler/src/flagship/apps/get.ts
+++ b/packages/wrangler/src/flagship/apps/get.ts
@@ -1,0 +1,36 @@
+import { createCommand } from "../../core/create-command";
+import { logger } from "../../logger";
+import { getApp } from "../client";
+import { renderApp } from "../render";
+
+export const flagshipAppsGetCommand = createCommand({
+	metadata: {
+		description: "Get a Flagship app",
+		status: "open beta",
+		owner: "Product: Flagship",
+	},
+	behaviour: {
+		printBanner: (args) => !args.json,
+	},
+	args: {
+		"app-id": {
+			type: "string",
+			demandOption: true,
+			description: "The ID of the app",
+		},
+		json: {
+			type: "boolean",
+			default: false,
+			description: "Return output as JSON",
+		},
+	},
+	positionalArgs: ["app-id"],
+	async handler({ appId, json }, { config }) {
+		const app = await getApp(config, appId);
+		if (json) {
+			logger.json(app);
+			return;
+		}
+		logger.log(renderApp(app));
+	},
+});

--- a/packages/wrangler/src/flagship/apps/list.ts
+++ b/packages/wrangler/src/flagship/apps/list.ts
@@ -1,0 +1,43 @@
+import { dim } from "@cloudflare/cli-shared-helpers/colors";
+import { createCommand } from "../../core/create-command";
+import { logger } from "../../logger";
+import { listApps } from "../client";
+
+export const flagshipAppsListCommand = createCommand({
+	metadata: {
+		description: "List Flagship apps",
+		status: "open beta",
+		owner: "Product: Flagship",
+	},
+	behaviour: {
+		printBanner: (args) => !args.json,
+	},
+	args: {
+		json: {
+			type: "boolean",
+			default: false,
+			description: "Return output as JSON",
+		},
+	},
+	async handler({ json }, { config }) {
+		const apps = await listApps(config);
+		if (json) {
+			logger.json(apps);
+			return;
+		}
+		if (apps.length === 0) {
+			logger.log(
+				`No Flagship apps yet. Create one with ${dim("wrangler flagship apps create <name>")}.`
+			);
+			return;
+		}
+		logger.table(
+			apps.map((app) => ({
+				name: app.name,
+				id: app.id,
+				updated: app.updated_at,
+				by: app.updated_by,
+			}))
+		);
+	},
+});

--- a/packages/wrangler/src/flagship/apps/update.ts
+++ b/packages/wrangler/src/flagship/apps/update.ts
@@ -1,0 +1,42 @@
+import { createCommand } from "../../core/create-command";
+import { logger } from "../../logger";
+import { updateApp } from "../client";
+import { renderApp } from "../render";
+
+export const flagshipAppsUpdateCommand = createCommand({
+	metadata: {
+		description: "Update a Flagship app",
+		status: "open beta",
+		owner: "Product: Flagship",
+	},
+	behaviour: {
+		printBanner: (args) => !args.json,
+	},
+	args: {
+		"app-id": {
+			type: "string",
+			demandOption: true,
+			description: "The ID of the app",
+		},
+		name: {
+			type: "string",
+			demandOption: true,
+			description: "The new name of the app",
+		},
+		json: {
+			type: "boolean",
+			default: false,
+			description: "Return output as JSON",
+		},
+	},
+	positionalArgs: ["app-id"],
+	async handler({ appId, name, json }, { config }) {
+		const app = await updateApp(config, appId, name);
+		if (json) {
+			logger.json(app);
+			return;
+		}
+		logger.log(`✅ Updated Flagship app\n`);
+		logger.log(renderApp(app));
+	},
+});

--- a/packages/wrangler/src/flagship/bulk.ts
+++ b/packages/wrangler/src/flagship/bulk.ts
@@ -1,4 +1,4 @@
-import { UserError } from "@cloudflare/workers-utils";
+import { JsonFriendlyFatalError, UserError } from "@cloudflare/workers-utils";
 import { logger } from "../logger";
 
 export function splitAppIdAndKeys(targets: string[]): {
@@ -19,7 +19,7 @@ export async function runBulk<T>(
 	output: { json: boolean; onSuccess: (value: T, target: string) => void }
 ): Promise<void> {
 	const results: T[] = [];
-	const failures: string[] = [];
+	const failures: Array<{ target: string; message: string }> = [];
 	for (const target of targets) {
 		try {
 			const value = await action(target);
@@ -29,16 +29,25 @@ export async function runBulk<T>(
 			}
 		} catch (error) {
 			const message = error instanceof Error ? error.message : String(error);
-			failures.push(`  - ${target}: ${message}`);
+			failures.push({ target, message });
 		}
+	}
+	if (failures.length > 0) {
+		const details = failures
+			.map(({ target, message }) => `  - ${target}: ${message}`)
+			.join("\n");
+		const message = `Failed to process ${failures.length} of the requested items:\n${details}`;
+		if (output.json) {
+			throw new JsonFriendlyFatalError(
+				JSON.stringify({ error: message, results, failures }),
+				{ telemetryMessage: "flagship bulk operation partial failure" }
+			);
+		}
+		throw new UserError(message, {
+			telemetryMessage: "flagship bulk operation partial failure",
+		});
 	}
 	if (output.json && results.length > 0) {
 		logger.json(targets.length === 1 ? results[0] : results);
-	}
-	if (failures.length > 0) {
-		throw new UserError(
-			`Failed to process ${failures.length} of the requested items:\n${failures.join("\n")}`,
-			{ telemetryMessage: "flagship bulk operation partial failure" }
-		);
 	}
 }

--- a/packages/wrangler/src/flagship/bulk.ts
+++ b/packages/wrangler/src/flagship/bulk.ts
@@ -1,0 +1,44 @@
+import { UserError } from "@cloudflare/workers-utils";
+import { logger } from "../logger";
+
+export function splitAppIdAndKeys(targets: string[]): {
+	appId: string;
+	keys: string[];
+} {
+	if (targets.length < 2) {
+		throw new UserError("An app ID and at least one flag key are required.", {
+			telemetryMessage: "flagship flag key required",
+		});
+	}
+	return { appId: targets[0], keys: targets.slice(1) };
+}
+
+export async function runBulk<T>(
+	targets: string[],
+	action: (target: string) => Promise<T>,
+	output: { json: boolean; onSuccess: (value: T, target: string) => void }
+): Promise<void> {
+	const results: T[] = [];
+	const failures: string[] = [];
+	for (const target of targets) {
+		try {
+			const value = await action(target);
+			results.push(value);
+			if (!output.json) {
+				output.onSuccess(value, target);
+			}
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			failures.push(`  - ${target}: ${message}`);
+		}
+	}
+	if (output.json && results.length > 0) {
+		logger.json(targets.length === 1 ? results[0] : results);
+	}
+	if (failures.length > 0) {
+		throw new UserError(
+			`Failed to process ${failures.length} of the requested items:\n${failures.join("\n")}`,
+			{ telemetryMessage: "flagship bulk operation partial failure" }
+		);
+	}
+}

--- a/packages/wrangler/src/flagship/bulk.ts
+++ b/packages/wrangler/src/flagship/bulk.ts
@@ -1,18 +1,6 @@
 import { JsonFriendlyFatalError, UserError } from "@cloudflare/workers-utils";
 import { logger } from "../logger";
 
-export function splitAppIdAndKeys(targets: string[]): {
-	appId: string;
-	keys: string[];
-} {
-	if (targets.length < 2) {
-		throw new UserError("An app ID and at least one flag key are required.", {
-			telemetryMessage: "flagship flag key required",
-		});
-	}
-	return { appId: targets[0], keys: targets.slice(1) };
-}
-
 export async function runBulk<T>(
 	targets: string[],
 	action: (target: string) => Promise<T>,

--- a/packages/wrangler/src/flagship/client.ts
+++ b/packages/wrangler/src/flagship/client.ts
@@ -1,0 +1,333 @@
+import { throwFetchError } from "@cloudflare/workers-utils";
+import { fetchResult, performApiFetch } from "../cfetch";
+import { requireAuth } from "../user";
+import type { Config, FetchResult } from "@cloudflare/workers-utils";
+
+export type FlagType = "boolean" | "string" | "number" | "json";
+
+export type Operator =
+	| "equals"
+	| "not_equals"
+	| "greater_than"
+	| "less_than"
+	| "greater_than_or_equals"
+	| "less_than_or_equals"
+	| "contains"
+	| "starts_with"
+	| "ends_with"
+	| "in"
+	| "not_in";
+
+export type LogicalOperator = "AND" | "OR";
+
+export type BaseCondition = {
+	attribute: string;
+	operator: Operator;
+	value: unknown;
+};
+
+export type LogicalCondition = {
+	logical_operator: LogicalOperator;
+	clauses: Condition[];
+};
+
+export type Condition = BaseCondition | LogicalCondition;
+
+export type Rollout = {
+	percentage: number;
+	attribute?: string;
+};
+
+export type Rule = {
+	priority: number;
+	conditions: Condition[];
+	serve_variation: string;
+	rollout?: Rollout;
+};
+
+export type Flag = {
+	key: string;
+	type?: FlagType;
+	description?: string | null;
+	enabled: boolean;
+	default_variation: string;
+	variations: Record<string, unknown>;
+	rules: Rule[];
+	updated_at?: string;
+	updated_by?: string;
+};
+
+export type FlagInput = {
+	key: string;
+	description?: string | null;
+	enabled: boolean;
+	default_variation: string;
+	variations: Record<string, unknown>;
+	rules: Rule[];
+};
+
+export function toFlagInput(flag: Flag): FlagInput {
+	return {
+		key: flag.key,
+		description: flag.description,
+		enabled: flag.enabled,
+		default_variation: flag.default_variation,
+		variations: flag.variations,
+		rules: flag.rules,
+	};
+}
+
+export type App = {
+	id: string;
+	name: string;
+	created_at: string;
+	updated_at: string;
+	updated_by: string;
+};
+
+export type ChangelogEntry = {
+	flag_key: string;
+	event: "create" | "update" | "delete";
+	after: Flag;
+	diff?: Record<string, { from: unknown; to: unknown }>;
+};
+
+export type EvaluationReason =
+	| "TARGETING_MATCH"
+	| "DEFAULT"
+	| "DISABLED"
+	| "SPLIT";
+
+export type EvaluationResult = {
+	flagKey: string;
+	value?: unknown;
+	variant?: string;
+	reason?: EvaluationReason;
+};
+
+export type Page<T> = {
+	items: T[];
+	cursor: string | null;
+};
+
+const JSON_HEADERS = { "content-type": "application/json" };
+
+async function fetchPage<T>(
+	config: Config,
+	resource: string,
+	limit?: number,
+	cursor?: string
+): Promise<Page<T>> {
+	const query = new URLSearchParams();
+	if (limit !== undefined) {
+		query.set("limit", String(limit));
+	}
+	if (cursor) {
+		query.set("cursor", cursor);
+	}
+	const response = await performApiFetch(
+		config,
+		resource,
+		{ method: "GET" },
+		query
+	);
+	const body = (await response.json()) as FetchResult<T[]>;
+	if (!body.success) {
+		throwFetchError(resource, body, response.status);
+	}
+	const resultInfo = body.result_info as { cursor?: string | null } | undefined;
+	return { items: body.result ?? [], cursor: resultInfo?.cursor ?? null };
+}
+
+export async function createApp(config: Config, name: string): Promise<App> {
+	const accountId = await requireAuth(config);
+	return await fetchResult(config, `/accounts/${accountId}/flagship/apps`, {
+		method: "POST",
+		headers: JSON_HEADERS,
+		body: JSON.stringify({ name }),
+	});
+}
+
+export async function listApps(config: Config): Promise<App[]> {
+	const accountId = await requireAuth(config);
+	return await fetchResult(config, `/accounts/${accountId}/flagship/apps`, {
+		method: "GET",
+	});
+}
+
+export async function getApp(config: Config, appId: string): Promise<App> {
+	const accountId = await requireAuth(config);
+	return await fetchResult(
+		config,
+		`/accounts/${accountId}/flagship/apps/${appId}`,
+		{ method: "GET" }
+	);
+}
+
+export async function updateApp(
+	config: Config,
+	appId: string,
+	name: string
+): Promise<App> {
+	const accountId = await requireAuth(config);
+	return await fetchResult(
+		config,
+		`/accounts/${accountId}/flagship/apps/${appId}`,
+		{ method: "PUT", headers: JSON_HEADERS, body: JSON.stringify({ name }) }
+	);
+}
+
+export async function deleteApp(
+	config: Config,
+	appId: string
+): Promise<{ id: string }> {
+	const accountId = await requireAuth(config);
+	return await fetchResult(
+		config,
+		`/accounts/${accountId}/flagship/apps/${appId}`,
+		{ method: "DELETE" }
+	);
+}
+
+export async function listFlags(
+	config: Config,
+	appId: string,
+	limit?: number,
+	cursor?: string
+): Promise<Page<Flag>> {
+	const accountId = await requireAuth(config);
+	return await fetchPage<Flag>(
+		config,
+		`/accounts/${accountId}/flagship/apps/${appId}/flags`,
+		limit,
+		cursor
+	);
+}
+
+export async function listAllFlags(
+	config: Config,
+	appId: string
+): Promise<Flag[]> {
+	const items: Flag[] = [];
+	let cursor: string | undefined;
+	do {
+		const page = await listFlags(config, appId, undefined, cursor);
+		items.push(...page.items);
+		cursor = page.cursor ?? undefined;
+	} while (cursor);
+	return items;
+}
+
+export async function createFlag(
+	config: Config,
+	appId: string,
+	flag: FlagInput
+): Promise<Flag> {
+	const accountId = await requireAuth(config);
+	return await fetchResult(
+		config,
+		`/accounts/${accountId}/flagship/apps/${appId}/flags`,
+		{ method: "POST", headers: JSON_HEADERS, body: JSON.stringify(flag) }
+	);
+}
+
+export async function getFlag(
+	config: Config,
+	appId: string,
+	flagKey: string
+): Promise<Flag> {
+	const accountId = await requireAuth(config);
+	return await fetchResult(
+		config,
+		`/accounts/${accountId}/flagship/apps/${appId}/flags/${flagKey}`,
+		{ method: "GET" }
+	);
+}
+
+export async function updateFlag(
+	config: Config,
+	appId: string,
+	flagKey: string,
+	flag: FlagInput
+): Promise<Flag> {
+	const accountId = await requireAuth(config);
+	return await fetchResult(
+		config,
+		`/accounts/${accountId}/flagship/apps/${appId}/flags/${flagKey}`,
+		{ method: "PUT", headers: JSON_HEADERS, body: JSON.stringify(flag) }
+	);
+}
+
+export async function deleteFlag(
+	config: Config,
+	appId: string,
+	flagKey: string
+): Promise<{ key: string }> {
+	const accountId = await requireAuth(config);
+	return await fetchResult(
+		config,
+		`/accounts/${accountId}/flagship/apps/${appId}/flags/${flagKey}`,
+		{ method: "DELETE" }
+	);
+}
+
+export async function getFlagChangelog(
+	config: Config,
+	appId: string,
+	flagKey: string,
+	limit?: number,
+	cursor?: string
+): Promise<Page<ChangelogEntry>> {
+	const accountId = await requireAuth(config);
+	return await fetchPage<ChangelogEntry>(
+		config,
+		`/accounts/${accountId}/flagship/apps/${appId}/flags/${flagKey}/changelog`,
+		limit,
+		cursor
+	);
+}
+
+export async function getAllFlagChangelog(
+	config: Config,
+	appId: string,
+	flagKey: string
+): Promise<ChangelogEntry[]> {
+	const items: ChangelogEntry[] = [];
+	let cursor: string | undefined;
+	do {
+		const page = await getFlagChangelog(
+			config,
+			appId,
+			flagKey,
+			undefined,
+			cursor
+		);
+		items.push(...page.items);
+		cursor = page.cursor ?? undefined;
+	} while (cursor);
+	return items;
+}
+
+export async function evaluateFlag(
+	config: Config,
+	appId: string,
+	flagKey: string,
+	context: Record<string, string>
+): Promise<EvaluationResult> {
+	const accountId = await requireAuth(config);
+	const resource = `/accounts/${accountId}/flagship/apps/${appId}/evaluate`;
+	const query = new URLSearchParams({ ...context, flagKey });
+	const response = await performApiFetch(
+		config,
+		resource,
+		{ method: "GET" },
+		query
+	);
+	const body = (await response.json()) as
+		| EvaluationResult
+		| FetchResult<unknown>;
+	if ("success" in body && !body.success) {
+		throwFetchError(resource, body, response.status);
+	}
+	return body as EvaluationResult;
+}

--- a/packages/wrangler/src/flagship/client.ts
+++ b/packages/wrangler/src/flagship/client.ts
@@ -112,6 +112,10 @@ export type Page<T> = {
 
 const JSON_HEADERS = { "content-type": "application/json" };
 
+function pathSegment(value: string): string {
+	return encodeURIComponent(value);
+}
+
 async function fetchPage<T>(
 	config: Config,
 	resource: string,
@@ -150,16 +154,26 @@ export async function createApp(config: Config, name: string): Promise<App> {
 
 export async function listApps(config: Config): Promise<App[]> {
 	const accountId = await requireAuth(config);
-	return await fetchResult(config, `/accounts/${accountId}/flagship/apps`, {
-		method: "GET",
-	});
+	const items: App[] = [];
+	let cursor: string | undefined;
+	do {
+		const page = await fetchPage<App>(
+			config,
+			`/accounts/${accountId}/flagship/apps`,
+			undefined,
+			cursor
+		);
+		items.push(...page.items);
+		cursor = page.cursor ?? undefined;
+	} while (cursor);
+	return items;
 }
 
 export async function getApp(config: Config, appId: string): Promise<App> {
 	const accountId = await requireAuth(config);
 	return await fetchResult(
 		config,
-		`/accounts/${accountId}/flagship/apps/${appId}`,
+		`/accounts/${accountId}/flagship/apps/${pathSegment(appId)}`,
 		{ method: "GET" }
 	);
 }
@@ -172,7 +186,7 @@ export async function updateApp(
 	const accountId = await requireAuth(config);
 	return await fetchResult(
 		config,
-		`/accounts/${accountId}/flagship/apps/${appId}`,
+		`/accounts/${accountId}/flagship/apps/${pathSegment(appId)}`,
 		{ method: "PUT", headers: JSON_HEADERS, body: JSON.stringify({ name }) }
 	);
 }
@@ -184,7 +198,7 @@ export async function deleteApp(
 	const accountId = await requireAuth(config);
 	return await fetchResult(
 		config,
-		`/accounts/${accountId}/flagship/apps/${appId}`,
+		`/accounts/${accountId}/flagship/apps/${pathSegment(appId)}`,
 		{ method: "DELETE" }
 	);
 }
@@ -198,7 +212,7 @@ export async function listFlags(
 	const accountId = await requireAuth(config);
 	return await fetchPage<Flag>(
 		config,
-		`/accounts/${accountId}/flagship/apps/${appId}/flags`,
+		`/accounts/${accountId}/flagship/apps/${pathSegment(appId)}/flags`,
 		limit,
 		cursor
 	);
@@ -226,7 +240,7 @@ export async function createFlag(
 	const accountId = await requireAuth(config);
 	return await fetchResult(
 		config,
-		`/accounts/${accountId}/flagship/apps/${appId}/flags`,
+		`/accounts/${accountId}/flagship/apps/${pathSegment(appId)}/flags`,
 		{ method: "POST", headers: JSON_HEADERS, body: JSON.stringify(flag) }
 	);
 }
@@ -239,7 +253,7 @@ export async function getFlag(
 	const accountId = await requireAuth(config);
 	return await fetchResult(
 		config,
-		`/accounts/${accountId}/flagship/apps/${appId}/flags/${flagKey}`,
+		`/accounts/${accountId}/flagship/apps/${pathSegment(appId)}/flags/${pathSegment(flagKey)}`,
 		{ method: "GET" }
 	);
 }
@@ -253,7 +267,7 @@ export async function updateFlag(
 	const accountId = await requireAuth(config);
 	return await fetchResult(
 		config,
-		`/accounts/${accountId}/flagship/apps/${appId}/flags/${flagKey}`,
+		`/accounts/${accountId}/flagship/apps/${pathSegment(appId)}/flags/${pathSegment(flagKey)}`,
 		{ method: "PUT", headers: JSON_HEADERS, body: JSON.stringify(flag) }
 	);
 }
@@ -266,7 +280,7 @@ export async function deleteFlag(
 	const accountId = await requireAuth(config);
 	return await fetchResult(
 		config,
-		`/accounts/${accountId}/flagship/apps/${appId}/flags/${flagKey}`,
+		`/accounts/${accountId}/flagship/apps/${pathSegment(appId)}/flags/${pathSegment(flagKey)}`,
 		{ method: "DELETE" }
 	);
 }
@@ -281,7 +295,7 @@ export async function getFlagChangelog(
 	const accountId = await requireAuth(config);
 	return await fetchPage<ChangelogEntry>(
 		config,
-		`/accounts/${accountId}/flagship/apps/${appId}/flags/${flagKey}/changelog`,
+		`/accounts/${accountId}/flagship/apps/${pathSegment(appId)}/flags/${pathSegment(flagKey)}/changelog`,
 		limit,
 		cursor
 	);
@@ -315,7 +329,7 @@ export async function evaluateFlag(
 	context: Record<string, string>
 ): Promise<EvaluationResult> {
 	const accountId = await requireAuth(config);
-	const resource = `/accounts/${accountId}/flagship/apps/${appId}/evaluate`;
+	const resource = `/accounts/${accountId}/flagship/apps/${pathSegment(appId)}/evaluate`;
 	const query = new URLSearchParams({ ...context, flagKey });
 	const response = await performApiFetch(
 		config,
@@ -325,9 +339,12 @@ export async function evaluateFlag(
 	);
 	const body = (await response.json()) as
 		| EvaluationResult
-		| FetchResult<unknown>;
-	if ("success" in body && !body.success) {
-		throwFetchError(resource, body, response.status);
+		| FetchResult<EvaluationResult>;
+	if ("success" in body) {
+		if (!body.success) {
+			throwFetchError(resource, body, response.status);
+		}
+		return body.result;
 	}
 	return body as EvaluationResult;
 }

--- a/packages/wrangler/src/flagship/flags/changelog.ts
+++ b/packages/wrangler/src/flagship/flags/changelog.ts
@@ -1,0 +1,87 @@
+import { dim } from "@cloudflare/cli-shared-helpers/colors";
+import { UserError } from "@cloudflare/workers-utils";
+import { createCommand } from "../../core/create-command";
+import { logger } from "../../logger";
+import { getAllFlagChangelog, getFlagChangelog } from "../client";
+import { renderChangelogEntry } from "../render";
+import { validateLimit } from "../shared";
+import type { ChangelogEntry } from "../client";
+
+export const flagshipFlagsChangelogCommand = createCommand({
+	metadata: {
+		description: "Show the changelog for a feature flag",
+		status: "open beta",
+		owner: "Product: Flagship",
+	},
+	behaviour: {
+		printBanner: (args) => !args.json,
+	},
+	args: {
+		"app-id": {
+			type: "string",
+			demandOption: true,
+			description: "The ID of the app",
+		},
+		key: {
+			type: "string",
+			demandOption: true,
+			description: "The key of the flag",
+		},
+		limit: {
+			type: "number",
+			description: "The maximum number of entries to return (1-200)",
+		},
+		cursor: {
+			type: "string",
+			description: "The pagination cursor from a previous changelog call",
+		},
+		all: {
+			type: "boolean",
+			default: false,
+			description: "Fetch every entry, following pagination automatically",
+		},
+		json: {
+			type: "boolean",
+			default: false,
+			description: "Return output as JSON",
+		},
+	},
+	positionalArgs: ["app-id", "key"],
+	async handler(args, { config }) {
+		const { appId, key } = args;
+		if (args.all && (args.limit !== undefined || args.cursor !== undefined)) {
+			throw new UserError(
+				"Cannot use --all together with --limit or --cursor.",
+				{ telemetryMessage: "flagship changelog conflicting pagination" }
+			);
+		}
+		validateLimit(args.limit, "flagship changelog invalid limit");
+		let items: ChangelogEntry[];
+		let nextCursor: string | null = null;
+		if (args.all) {
+			items = await getAllFlagChangelog(config, appId, key);
+		} else {
+			const page = await getFlagChangelog(
+				config,
+				appId,
+				key,
+				args.limit,
+				args.cursor
+			);
+			items = page.items;
+			nextCursor = page.cursor;
+		}
+		if (args.json) {
+			logger.json({ items, cursor: nextCursor });
+			return;
+		}
+		if (items.length === 0) {
+			logger.log(`No changelog entries for flag '${key}'.`);
+			return;
+		}
+		logger.log(items.map(renderChangelogEntry).join("\n\n"));
+		if (nextCursor) {
+			logger.log(dim(`\nMore entries available. Next cursor: ${nextCursor}`));
+		}
+	},
+});

--- a/packages/wrangler/src/flagship/flags/create.ts
+++ b/packages/wrangler/src/flagship/flags/create.ts
@@ -1,0 +1,120 @@
+import { createCommand } from "../../core/create-command";
+import { logger } from "../../logger";
+import { createFlag } from "../client";
+import { renderFlag } from "../render";
+import {
+	assertConsistentVariationTypes,
+	assertVariationsExist,
+	buildCreateVariations,
+	finalizeRules,
+	parseRuleJson,
+	parseRules,
+} from "../shared";
+import type { FlagType } from "../client";
+
+export const flagshipFlagsCreateCommand = createCommand({
+	metadata: {
+		description: "Create a feature flag in a Flagship app",
+		status: "open beta",
+		owner: "Product: Flagship",
+		examples: [
+			{
+				command: "wrangler flagship flags create <APP_ID> new-checkout",
+				description: "Create a boolean flag with on/off variations",
+			},
+			{
+				command:
+					'wrangler flagship flags create <APP_ID> checkout-flow -V v1=old -V v2=new --default v1 --rule "serve=v2; when=plan equals enterprise OR plan equals team"',
+				description: "Create a string flag with an OR targeting rule",
+			},
+		],
+	},
+	behaviour: {
+		printBanner: (args) => !args.json,
+	},
+	args: {
+		"app-id": {
+			type: "string",
+			demandOption: true,
+			description: "The ID of the app",
+		},
+		key: {
+			type: "string",
+			demandOption: true,
+			description: "The key of the flag",
+		},
+		variation: {
+			type: "string",
+			array: true,
+			alias: "V",
+			description: 'A flag variation, in the form "name=value" (repeatable)',
+		},
+		"default-variation": {
+			type: "string",
+			alias: "default",
+			description:
+				"The name of the variation to serve by default (defaults to off for boolean flags, otherwise the first variation)",
+		},
+		type: {
+			type: "string",
+			choices: ["boolean", "string", "number", "json"],
+			alias: "t",
+			description: "The variation value type (inferred when omitted)",
+		},
+		description: {
+			type: "string",
+			alias: "d",
+			description: "A description of the flag",
+		},
+		disabled: {
+			type: "boolean",
+			default: false,
+			description: "Create the flag in a disabled state",
+		},
+		rule: {
+			type: "string",
+			array: true,
+			description:
+				'A targeting rule, e.g. "serve=on; when=plan equals pro AND region in [US,CA]; rollout=30%@user_id". Conditions support AND/OR; priority is optional and defaults to declaration order (repeatable)',
+		},
+		"rule-json": {
+			type: "string",
+			array: true,
+			description: "A targeting rule as a JSON object (repeatable)",
+		},
+		json: {
+			type: "boolean",
+			default: false,
+			description: "Return output as JSON",
+		},
+	},
+	positionalArgs: ["app-id", "key"],
+	async handler(args, { config }) {
+		const { appId, key } = args;
+		const { variations, defaultVariation } = buildCreateVariations(
+			args.variation,
+			args.type as FlagType
+		);
+		assertConsistentVariationTypes(variations);
+		const default_variation = args.defaultVariation ?? defaultVariation;
+		const rules = finalizeRules([
+			...parseRules(args.rule ?? []),
+			...parseRuleJson(args.ruleJson ?? []),
+		]);
+		assertVariationsExist(variations, default_variation, rules);
+		const flag = await createFlag(config, appId, {
+			key,
+			description: args.description,
+			enabled: !args.disabled,
+			default_variation,
+			variations,
+			rules,
+		});
+		if (args.json) {
+			logger.json(flag);
+			return;
+		}
+		logger.log(`✅ Created flag\n`);
+		logger.log(renderFlag(flag));
+	},
+});

--- a/packages/wrangler/src/flagship/flags/delete.ts
+++ b/packages/wrangler/src/flagship/flags/delete.ts
@@ -1,6 +1,6 @@
 import { createCommand } from "../../core/create-command";
 import { logger } from "../../logger";
-import { runBulk, splitAppIdAndKeys } from "../bulk";
+import { runBulk } from "../bulk";
 import { deleteFlag } from "../client";
 import { jsonFriendlyError } from "../shared";
 
@@ -14,11 +14,16 @@ export const flagshipFlagsDeleteCommand = createCommand({
 		printBanner: (args) => !args.json,
 	},
 	args: {
-		target: {
+		"app-id": {
+			type: "string",
+			demandOption: true,
+			description: "The ID of the app",
+		},
+		key: {
 			type: "string",
 			array: true,
 			demandOption: true,
-			description: "The app ID followed by one or more flag keys to delete",
+			description: "One or more flag keys to delete",
 		},
 		force: {
 			type: "boolean",
@@ -32,9 +37,9 @@ export const flagshipFlagsDeleteCommand = createCommand({
 			description: "Return output as JSON",
 		},
 	},
-	positionalArgs: ["target"],
+	positionalArgs: ["app-id", "key"],
 	async handler(args, { config, confirm }) {
-		const { appId, keys } = splitAppIdAndKeys(args.target);
+		const { appId, key: keys } = args;
 		if (args.json && !args.force) {
 			throw jsonFriendlyError(
 				"Pass --force to skip the confirmation prompt when using --json.",

--- a/packages/wrangler/src/flagship/flags/delete.ts
+++ b/packages/wrangler/src/flagship/flags/delete.ts
@@ -1,8 +1,8 @@
-import { UserError } from "@cloudflare/workers-utils";
 import { createCommand } from "../../core/create-command";
 import { logger } from "../../logger";
 import { runBulk, splitAppIdAndKeys } from "../bulk";
 import { deleteFlag } from "../client";
+import { jsonFriendlyError } from "../shared";
 
 export const flagshipFlagsDeleteCommand = createCommand({
 	metadata: {
@@ -36,9 +36,9 @@ export const flagshipFlagsDeleteCommand = createCommand({
 	async handler(args, { config, confirm }) {
 		const { appId, keys } = splitAppIdAndKeys(args.target);
 		if (args.json && !args.force) {
-			throw new UserError(
+			throw jsonFriendlyError(
 				"Pass --force to skip the confirmation prompt when using --json.",
-				{ telemetryMessage: "flagship delete json requires force" }
+				"flagship delete json requires force"
 			);
 		}
 		if (!args.force) {

--- a/packages/wrangler/src/flagship/flags/delete.ts
+++ b/packages/wrangler/src/flagship/flags/delete.ts
@@ -1,0 +1,59 @@
+import { UserError } from "@cloudflare/workers-utils";
+import { createCommand } from "../../core/create-command";
+import { logger } from "../../logger";
+import { runBulk, splitAppIdAndKeys } from "../bulk";
+import { deleteFlag } from "../client";
+
+export const flagshipFlagsDeleteCommand = createCommand({
+	metadata: {
+		description: "Delete a feature flag from a Flagship app",
+		status: "open beta",
+		owner: "Product: Flagship",
+	},
+	behaviour: {
+		printBanner: (args) => !args.json,
+	},
+	args: {
+		target: {
+			type: "string",
+			array: true,
+			demandOption: true,
+			description: "The app ID followed by one or more flag keys to delete",
+		},
+		force: {
+			type: "boolean",
+			alias: "y",
+			default: false,
+			description: "Skip the confirmation prompt",
+		},
+		json: {
+			type: "boolean",
+			default: false,
+			description: "Return output as JSON",
+		},
+	},
+	positionalArgs: ["target"],
+	async handler(args, { config, confirm }) {
+		const { appId, keys } = splitAppIdAndKeys(args.target);
+		if (args.json && !args.force) {
+			throw new UserError(
+				"Pass --force to skip the confirmation prompt when using --json.",
+				{ telemetryMessage: "flagship delete json requires force" }
+			);
+		}
+		if (!args.force) {
+			const label = keys.length === 1 ? keys[0] : keys.join(", ");
+			const confirmed = await confirm(
+				`Are you sure you want to delete the flag${keys.length === 1 ? "" : "s"} '${label}'?`
+			);
+			if (!confirmed) {
+				logger.log("Aborting delete.");
+				return;
+			}
+		}
+		await runBulk(keys, (key) => deleteFlag(config, appId, key), {
+			json: args.json,
+			onSuccess: (_flag, key) => logger.log(`✅ Deleted flag '${key}'`),
+		});
+	},
+});

--- a/packages/wrangler/src/flagship/flags/enable.ts
+++ b/packages/wrangler/src/flagship/flags/enable.ts
@@ -1,6 +1,6 @@
 import { createCommand } from "../../core/create-command";
 import { logger } from "../../logger";
-import { runBulk, splitAppIdAndKeys } from "../bulk";
+import { runBulk } from "../bulk";
 import { getFlag, toFlagInput, updateFlag } from "../client";
 import { renderFlag } from "../render";
 
@@ -16,11 +16,16 @@ function makeToggleCommand(enabled: boolean) {
 			printBanner: (args) => !args.json,
 		},
 		args: {
-			target: {
+			"app-id": {
+				type: "string",
+				demandOption: true,
+				description: "The ID of the app",
+			},
+			key: {
 				type: "string",
 				array: true,
 				demandOption: true,
-				description: `The app ID followed by one or more flag keys to ${verb.toLowerCase()}`,
+				description: `One or more flag keys to ${verb.toLowerCase()}`,
 			},
 			json: {
 				type: "boolean",
@@ -28,9 +33,9 @@ function makeToggleCommand(enabled: boolean) {
 				description: "Return output as JSON",
 			},
 		},
-		positionalArgs: ["target"],
+		positionalArgs: ["app-id", "key"],
 		async handler(args, { config }) {
-			const { appId, keys } = splitAppIdAndKeys(args.target);
+			const { appId, key: keys } = args;
 			await runBulk(
 				keys,
 				async (key) => {

--- a/packages/wrangler/src/flagship/flags/enable.ts
+++ b/packages/wrangler/src/flagship/flags/enable.ts
@@ -1,0 +1,56 @@
+import { createCommand } from "../../core/create-command";
+import { logger } from "../../logger";
+import { runBulk, splitAppIdAndKeys } from "../bulk";
+import { getFlag, toFlagInput, updateFlag } from "../client";
+import { renderFlag } from "../render";
+
+function makeToggleCommand(enabled: boolean) {
+	const verb = enabled ? "Enable" : "Disable";
+	return createCommand({
+		metadata: {
+			description: `${verb} a feature flag`,
+			status: "open beta",
+			owner: "Product: Flagship",
+		},
+		behaviour: {
+			printBanner: (args) => !args.json,
+		},
+		args: {
+			target: {
+				type: "string",
+				array: true,
+				demandOption: true,
+				description: `The app ID followed by one or more flag keys to ${verb.toLowerCase()}`,
+			},
+			json: {
+				type: "boolean",
+				default: false,
+				description: "Return output as JSON",
+			},
+		},
+		positionalArgs: ["target"],
+		async handler(args, { config }) {
+			const { appId, keys } = splitAppIdAndKeys(args.target);
+			await runBulk(
+				keys,
+				async (key) => {
+					const current = await getFlag(config, appId, key);
+					return updateFlag(config, appId, key, {
+						...toFlagInput(current),
+						enabled,
+					});
+				},
+				{
+					json: args.json,
+					onSuccess: (flag) => {
+						logger.log(`✅ ${verb}d flag\n`);
+						logger.log(renderFlag(flag));
+					},
+				}
+			);
+		},
+	});
+}
+
+export const flagshipFlagsEnableCommand = makeToggleCommand(true);
+export const flagshipFlagsDisableCommand = makeToggleCommand(false);

--- a/packages/wrangler/src/flagship/flags/evaluate.ts
+++ b/packages/wrangler/src/flagship/flags/evaluate.ts
@@ -1,0 +1,64 @@
+import { createCommand } from "../../core/create-command";
+import { logger } from "../../logger";
+import { evaluateFlag } from "../client";
+import { renderEvaluation } from "../render";
+import { parseContext } from "../shared";
+
+export const flagshipFlagsEvaluateCommand = createCommand({
+	metadata: {
+		description: "Evaluate a feature flag with optional context",
+		status: "open beta",
+		owner: "Product: Flagship",
+		examples: [
+			{
+				command:
+					"wrangler flagship flags evaluate <APP_ID> new-ui --context plan=enterprise --targeting-key user-42",
+				description: "Evaluate a flag against an example context",
+			},
+		],
+	},
+	behaviour: {
+		printBanner: (args) => !args.json,
+	},
+	args: {
+		"app-id": {
+			type: "string",
+			demandOption: true,
+			description: "The ID of the app",
+		},
+		key: {
+			type: "string",
+			demandOption: true,
+			description: "The key of the flag",
+		},
+		context: {
+			type: "string",
+			array: true,
+			alias: ["ctx", "C"],
+			description: 'Evaluation context, in the form "name=value" (repeatable)',
+		},
+		"targeting-key": {
+			type: "string",
+			description: "Stable bucketing key for percentage rollouts",
+		},
+		json: {
+			type: "boolean",
+			default: false,
+			description: "Return output as JSON",
+		},
+	},
+	positionalArgs: ["app-id", "key"],
+	async handler(args, { config }) {
+		const { appId, key } = args;
+		const context = parseContext(args.context);
+		if (args.targetingKey) {
+			context.targetingKey = args.targetingKey;
+		}
+		const result = await evaluateFlag(config, appId, key, context);
+		if (args.json) {
+			logger.json(result);
+			return;
+		}
+		logger.log(renderEvaluation(result));
+	},
+});

--- a/packages/wrangler/src/flagship/flags/get.ts
+++ b/packages/wrangler/src/flagship/flags/get.ts
@@ -1,0 +1,41 @@
+import { createCommand } from "../../core/create-command";
+import { logger } from "../../logger";
+import { getFlag } from "../client";
+import { renderFlag } from "../render";
+
+export const flagshipFlagsGetCommand = createCommand({
+	metadata: {
+		description: "Get a feature flag from a Flagship app",
+		status: "open beta",
+		owner: "Product: Flagship",
+	},
+	behaviour: {
+		printBanner: (args) => !args.json,
+	},
+	args: {
+		"app-id": {
+			type: "string",
+			demandOption: true,
+			description: "The ID of the app",
+		},
+		key: {
+			type: "string",
+			demandOption: true,
+			description: "The key of the flag",
+		},
+		json: {
+			type: "boolean",
+			default: false,
+			description: "Return output as JSON",
+		},
+	},
+	positionalArgs: ["app-id", "key"],
+	async handler({ appId, key, json }, { config }) {
+		const flag = await getFlag(config, appId, key);
+		if (json) {
+			logger.json(flag);
+			return;
+		}
+		logger.log(renderFlag(flag));
+	},
+});

--- a/packages/wrangler/src/flagship/flags/list.ts
+++ b/packages/wrangler/src/flagship/flags/list.ts
@@ -1,0 +1,85 @@
+import { dim } from "@cloudflare/cli-shared-helpers/colors";
+import { UserError } from "@cloudflare/workers-utils";
+import { createCommand } from "../../core/create-command";
+import { logger } from "../../logger";
+import { listAllFlags, listFlags } from "../client";
+import { statusBadge } from "../render";
+import { validateLimit } from "../shared";
+import type { Flag } from "../client";
+
+export const flagshipFlagsListCommand = createCommand({
+	metadata: {
+		description: "List feature flags in a Flagship app",
+		status: "open beta",
+		owner: "Product: Flagship",
+	},
+	behaviour: {
+		printBanner: (args) => !args.json,
+	},
+	args: {
+		"app-id": {
+			type: "string",
+			demandOption: true,
+			description: "The ID of the app",
+		},
+		limit: {
+			type: "number",
+			description: "The maximum number of flags to return (1-200)",
+		},
+		cursor: {
+			type: "string",
+			description: "The pagination cursor from a previous list call",
+		},
+		all: {
+			type: "boolean",
+			default: false,
+			description: "Fetch every flag, following pagination automatically",
+		},
+		json: {
+			type: "boolean",
+			default: false,
+			description: "Return output as JSON",
+		},
+	},
+	positionalArgs: ["app-id"],
+	async handler({ appId, limit, cursor, all, json }, { config }) {
+		if (all && (limit !== undefined || cursor !== undefined)) {
+			throw new UserError(
+				"Cannot use --all together with --limit or --cursor.",
+				{ telemetryMessage: "flagship list conflicting pagination" }
+			);
+		}
+		validateLimit(limit, "flagship list invalid limit");
+		let items: Flag[];
+		let nextCursor: string | null = null;
+		if (all) {
+			items = await listAllFlags(config, appId);
+		} else {
+			const page = await listFlags(config, appId, limit, cursor);
+			items = page.items;
+			nextCursor = page.cursor;
+		}
+		if (json) {
+			logger.json({ items, cursor: nextCursor });
+			return;
+		}
+		if (items.length === 0) {
+			logger.log(
+				`No flags in this app yet. Create one with ${dim(`wrangler flagship flags create ${appId} <key>`)}.`
+			);
+			return;
+		}
+		logger.table(
+			items.map((flag) => ({
+				key: flag.key,
+				status: statusBadge(flag.enabled),
+				type: flag.type ?? "",
+				default: flag.default_variation,
+				rules: String(flag.rules.length),
+			}))
+		);
+		if (nextCursor) {
+			logger.log(dim(`\nMore flags available. Next cursor: ${nextCursor}`));
+		}
+	},
+});

--- a/packages/wrangler/src/flagship/flags/rollout.ts
+++ b/packages/wrangler/src/flagship/flags/rollout.ts
@@ -68,7 +68,11 @@ export const flagshipFlagsRolloutCommand = createCommand({
 	positionalArgs: ["app-id", "key"],
 	async handler(args, { config, confirm }) {
 		const { appId, key } = args;
-		if (args.percentage < 0 || args.percentage > 100) {
+		if (
+			!Number.isFinite(args.percentage) ||
+			args.percentage < 0 ||
+			args.percentage > 100
+		) {
 			throw new UserError("--percentage must be between 0 and 100.", {
 				telemetryMessage: "flagship rollout invalid percentage",
 			});

--- a/packages/wrangler/src/flagship/flags/rollout.ts
+++ b/packages/wrangler/src/flagship/flags/rollout.ts
@@ -1,0 +1,125 @@
+import { UserError } from "@cloudflare/workers-utils";
+import { createCommand } from "../../core/create-command";
+import { logger } from "../../logger";
+import { getFlag, toFlagInput, updateFlag } from "../client";
+import { renderFlag } from "../render";
+import { confirmRuleReplacement } from "../shared";
+
+export const flagshipFlagsRolloutCommand = createCommand({
+	metadata: {
+		description: "Roll out one variation to a percentage of traffic",
+		status: "open beta",
+		owner: "Product: Flagship",
+		examples: [
+			{
+				command:
+					"wrangler flagship flags rollout <APP_ID> new-ui --to on --percentage 25 --by user_id",
+				description: "Serve the on variation to 25% of traffic",
+			},
+		],
+	},
+	behaviour: {
+		printBanner: (args) => !args.json,
+	},
+	args: {
+		"app-id": {
+			type: "string",
+			demandOption: true,
+			description: "The ID of the app",
+		},
+		key: {
+			type: "string",
+			demandOption: true,
+			description: "The key of the flag",
+		},
+		to: {
+			type: "string",
+			demandOption: true,
+			description: "Variation to roll out",
+		},
+		percentage: {
+			type: "number",
+			demandOption: true,
+			description:
+				"Percentage of traffic to serve the rollout variation (0-100)",
+		},
+		by: {
+			type: "string",
+			description: "Context attribute used for sticky bucketing",
+		},
+		"from-variation": {
+			type: "string",
+			alias: "from",
+			description: "Fallback variation for the remaining traffic",
+		},
+		force: {
+			type: "boolean",
+			alias: "y",
+			default: false,
+			description:
+				"Skip the confirmation prompt when this rollout replaces existing targeting rules",
+		},
+		json: {
+			type: "boolean",
+			default: false,
+			description: "Return output as JSON",
+		},
+	},
+	positionalArgs: ["app-id", "key"],
+	async handler(args, { config, confirm }) {
+		const { appId, key } = args;
+		if (args.percentage < 0 || args.percentage > 100) {
+			throw new UserError("--percentage must be between 0 and 100.", {
+				telemetryMessage: "flagship rollout invalid percentage",
+			});
+		}
+		const current = await getFlag(config, appId, key);
+		if (!(args.to in current.variations)) {
+			throw new UserError(
+				`Unknown variation "${args.to}". Available variations: ${Object.keys(current.variations).join(", ")}`,
+				{ telemetryMessage: "flagship rollout unknown variation" }
+			);
+		}
+		const clearing = args.percentage === 0;
+		const fallback = args.fromVariation ?? current.default_variation;
+		if (!clearing && !(fallback in current.variations)) {
+			throw new UserError(
+				`Unknown fallback variation "${fallback}". Available variations: ${Object.keys(current.variations).join(", ")}`,
+				{ telemetryMessage: "flagship rollout unknown fallback variation" }
+			);
+		}
+		const confirmed = await confirmRuleReplacement(current.rules, {
+			json: args.json,
+			force: args.force,
+			action: "rollout",
+			confirm,
+		});
+		if (!confirmed) {
+			logger.log("Aborting rollout.");
+			return;
+		}
+		const flag = await updateFlag(config, appId, key, {
+			...toFlagInput(current),
+			default_variation: clearing ? current.default_variation : fallback,
+			rules: clearing
+				? []
+				: [
+						{
+							priority: 1,
+							conditions: [],
+							serve_variation: args.to,
+							rollout: {
+								percentage: args.percentage,
+								attribute: args.by,
+							},
+						},
+					],
+		});
+		if (args.json) {
+			logger.json(flag);
+			return;
+		}
+		logger.log(`✅ Updated rollout for flag\n`);
+		logger.log(renderFlag(flag));
+	},
+});

--- a/packages/wrangler/src/flagship/flags/rules/delete.ts
+++ b/packages/wrangler/src/flagship/flags/rules/delete.ts
@@ -1,0 +1,60 @@
+import { UserError } from "@cloudflare/workers-utils";
+import { createCommand } from "../../../core/create-command";
+import { logger } from "../../../logger";
+import { getFlag, toFlagInput, updateFlag } from "../../client";
+import { renderFlag } from "../../render";
+import { withoutRule } from "./shared";
+
+export const flagshipFlagsRulesDeleteCommand = createCommand({
+	metadata: {
+		description: "Delete one targeting rule from a feature flag",
+		status: "open beta",
+		owner: "Product: Flagship",
+	},
+	behaviour: {
+		printBanner: (args) => !args.json,
+	},
+	args: {
+		"app-id": {
+			type: "string",
+			demandOption: true,
+			description: "The ID of the app",
+		},
+		key: {
+			type: "string",
+			demandOption: true,
+			description: "The key of the flag",
+		},
+		priority: {
+			type: "number",
+			demandOption: true,
+			description: "The priority of the rule to delete",
+		},
+		json: {
+			type: "boolean",
+			default: false,
+			description: "Return output as JSON",
+		},
+	},
+	positionalArgs: ["app-id", "key"],
+	async handler(args, { config }) {
+		if (!Number.isInteger(args.priority) || args.priority < 1) {
+			throw new UserError("Rule priority must be an integer >= 1.", {
+				telemetryMessage: "flagship rule invalid priority",
+			});
+		}
+		const { appId, key } = args;
+		const current = await getFlag(config, appId, key);
+		const rules = withoutRule(current.rules, args.priority);
+		const flag = await updateFlag(config, appId, key, {
+			...toFlagInput(current),
+			rules,
+		});
+		if (args.json) {
+			logger.json(flag);
+			return;
+		}
+		logger.log(`✅ Deleted rule ${args.priority} from flag\n`);
+		logger.log(renderFlag(flag));
+	},
+});

--- a/packages/wrangler/src/flagship/flags/rules/list.ts
+++ b/packages/wrangler/src/flagship/flags/rules/list.ts
@@ -1,0 +1,53 @@
+import { createCommand } from "../../../core/create-command";
+import { logger } from "../../../logger";
+import { getFlag } from "../../client";
+import { sortedRules, stringifyConditions, stringifyRollout } from "./shared";
+
+export const flagshipFlagsRulesListCommand = createCommand({
+	metadata: {
+		description: "List targeting rules for a feature flag",
+		status: "open beta",
+		owner: "Product: Flagship",
+	},
+	behaviour: {
+		printBanner: (args) => !args.json,
+	},
+	args: {
+		"app-id": {
+			type: "string",
+			demandOption: true,
+			description: "The ID of the app",
+		},
+		key: {
+			type: "string",
+			demandOption: true,
+			description: "The key of the flag",
+		},
+		json: {
+			type: "boolean",
+			default: false,
+			description: "Return output as JSON",
+		},
+	},
+	positionalArgs: ["app-id", "key"],
+	async handler({ appId, key, json }, { config }) {
+		const flag = await getFlag(config, appId, key);
+		const rules = sortedRules(flag.rules);
+		if (json) {
+			logger.json(rules);
+			return;
+		}
+		if (rules.length === 0) {
+			logger.log(`No targeting rules for flag '${key}'.`);
+			return;
+		}
+		logger.table(
+			rules.map((rule) => ({
+				priority: String(rule.priority),
+				serve: rule.serve_variation,
+				rollout: stringifyRollout(rule),
+				when: stringifyConditions(rule.conditions),
+			}))
+		);
+	},
+});

--- a/packages/wrangler/src/flagship/flags/rules/reorder.ts
+++ b/packages/wrangler/src/flagship/flags/rules/reorder.ts
@@ -1,0 +1,103 @@
+import { UserError } from "@cloudflare/workers-utils";
+import { createCommand } from "../../../core/create-command";
+import { logger } from "../../../logger";
+import { getFlag, toFlagInput, updateFlag } from "../../client";
+import { renderFlag } from "../../render";
+import { sortedRules } from "./shared";
+import type { Rule } from "../../client";
+
+export const flagshipFlagsRulesReorderCommand = createCommand({
+	metadata: {
+		description: "Reorder targeting rules for a feature flag",
+		status: "open beta",
+		owner: "Product: Flagship",
+		examples: [
+			{
+				command:
+					"wrangler flagship flags rules reorder <APP_ID> new-checkout --order 2,1,3",
+				description:
+					"Make existing priority 2 run first, existing priority 1 run second, and existing priority 3 run third",
+			},
+		],
+	},
+	behaviour: {
+		printBanner: (args) => !args.json,
+	},
+	args: {
+		"app-id": {
+			type: "string",
+			demandOption: true,
+			description: "The ID of the app",
+		},
+		key: {
+			type: "string",
+			demandOption: true,
+			description: "The key of the flag",
+		},
+		order: {
+			type: "string",
+			demandOption: true,
+			description:
+				"Comma-separated existing rule priorities in their new order, for example 2,1,3",
+		},
+		json: {
+			type: "boolean",
+			default: false,
+			description: "Return output as JSON",
+		},
+	},
+	positionalArgs: ["app-id", "key"],
+	async handler(args, { config }) {
+		const { appId, key } = args;
+		const current = await getFlag(config, appId, key);
+		const rules = reorderRules(current.rules, args.order);
+		const flag = await updateFlag(config, appId, key, {
+			...toFlagInput(current),
+			rules,
+		});
+		if (args.json) {
+			logger.json(flag);
+			return;
+		}
+		logger.log(`✅ Reordered rules for flag\n`);
+		logger.log(renderFlag(flag));
+	},
+});
+
+function reorderRules(rules: Rule[], rawOrder: string): Rule[] {
+	const order = rawOrder.split(",").map((part) => Number(part.trim()));
+	if (
+		order.length === 0 ||
+		order.some((priority) => !Number.isInteger(priority) || priority < 1)
+	) {
+		throw new UserError(
+			'Invalid --order. Expected comma-separated rule priorities, for example "2,1,3".',
+			{ telemetryMessage: "flagship rule reorder invalid order" }
+		);
+	}
+	const byPriority = new Map(rules.map((rule) => [rule.priority, rule]));
+	const existing = sortedRules(rules).map((rule) => rule.priority);
+	if (order.length !== rules.length || new Set(order).size !== order.length) {
+		throw new UserError(
+			`--order must contain each existing rule priority exactly once. Existing priorities: ${existing.join(", ")}.`,
+			{ telemetryMessage: "flagship rule reorder incomplete order" }
+		);
+	}
+	for (const priority of order) {
+		if (!byPriority.has(priority)) {
+			throw new UserError(
+				`No rule with priority ${priority}. Existing priorities: ${existing.join(", ")}.`,
+				{ telemetryMessage: "flagship rule reorder unknown priority" }
+			);
+		}
+	}
+	return order.map((priority, index) => {
+		const rule = byPriority.get(priority);
+		if (!rule) {
+			throw new UserError(`No rule with priority ${priority}.`, {
+				telemetryMessage: "flagship rule reorder unknown priority",
+			});
+		}
+		return { ...rule, priority: index + 1 };
+	});
+}

--- a/packages/wrangler/src/flagship/flags/rules/shared.ts
+++ b/packages/wrangler/src/flagship/flags/rules/shared.ts
@@ -1,0 +1,51 @@
+import { UserError } from "@cloudflare/workers-utils";
+import { formatValue } from "../../render";
+import type { Condition, Rule } from "../../client";
+
+export function findRule(rules: Rule[], priority: number): Rule {
+	const rule = rules.find((candidate) => candidate.priority === priority);
+	if (!rule) {
+		throw new UserError(
+			`No rule with priority ${priority}. Available priorities: ${formatPriorities(rules)}.`,
+			{ telemetryMessage: "flagship rule priority not found" }
+		);
+	}
+	return rule;
+}
+
+export function withoutRule(rules: Rule[], priority: number): Rule[] {
+	findRule(rules, priority);
+	return rules.filter((rule) => rule.priority !== priority);
+}
+
+export function sortedRules(rules: Rule[]): Rule[] {
+	return [...rules].sort((a, b) => a.priority - b.priority);
+}
+
+export function stringifyConditions(conditions: Condition[]): string {
+	if (conditions.length === 0) {
+		return "always";
+	}
+	return conditions.map(stringifyCondition).join(" AND ");
+}
+
+export function stringifyRollout(rule: Rule): string {
+	if (!rule.rollout) {
+		return "";
+	}
+	return rule.rollout.attribute
+		? `${rule.rollout.percentage}%@${rule.rollout.attribute}`
+		: `${rule.rollout.percentage}%`;
+}
+
+function stringifyCondition(condition: Condition): string {
+	if ("logical_operator" in condition) {
+		return `(${condition.clauses.map(stringifyCondition).join(` ${condition.logical_operator} `)})`;
+	}
+	return `${condition.attribute} ${condition.operator} ${formatValue(condition.value)}`;
+}
+
+function formatPriorities(rules: Rule[]): string {
+	const priorities = sortedRules(rules).map((rule) => String(rule.priority));
+	return priorities.length > 0 ? priorities.join(", ") : "(none)";
+}

--- a/packages/wrangler/src/flagship/flags/rules/shared.ts
+++ b/packages/wrangler/src/flagship/flags/rules/shared.ts
@@ -15,7 +15,9 @@ export function findRule(rules: Rule[], priority: number): Rule {
 
 export function withoutRule(rules: Rule[], priority: number): Rule[] {
 	findRule(rules, priority);
-	return rules.filter((rule) => rule.priority !== priority);
+	return sortedRules(rules)
+		.filter((rule) => rule.priority !== priority)
+		.map((rule, index) => ({ ...rule, priority: index + 1 }));
 }
 
 export function sortedRules(rules: Rule[]): Rule[] {

--- a/packages/wrangler/src/flagship/flags/rules/update.ts
+++ b/packages/wrangler/src/flagship/flags/rules/update.ts
@@ -1,0 +1,141 @@
+import { UserError } from "@cloudflare/workers-utils";
+import { createCommand } from "../../../core/create-command";
+import { logger } from "../../../logger";
+import { getFlag, toFlagInput, updateFlag } from "../../client";
+import { renderFlag } from "../../render";
+import {
+	assertVariationsExist,
+	parseConditions,
+	parseRollout,
+} from "../../shared";
+import { findRule } from "./shared";
+import type { Rule } from "../../client";
+
+export const flagshipFlagsRulesUpdateCommand = createCommand({
+	metadata: {
+		description: "Update one targeting rule for a feature flag",
+		status: "open beta",
+		owner: "Product: Flagship",
+		examples: [
+			{
+				command:
+					"wrangler flagship flags rules update <APP_ID> new-checkout --priority 1 --rollout 50%@user_id",
+				description: "Change only the rollout percentage for rule priority 1",
+			},
+		],
+	},
+	behaviour: {
+		printBanner: (args) => !args.json,
+	},
+	args: {
+		"app-id": {
+			type: "string",
+			demandOption: true,
+			description: "The ID of the app",
+		},
+		key: {
+			type: "string",
+			demandOption: true,
+			description: "The key of the flag",
+		},
+		priority: {
+			type: "number",
+			demandOption: true,
+			description: "The priority of the rule to update",
+		},
+		serve: {
+			type: "string",
+			description: "The variation to serve when this rule matches",
+		},
+		when: {
+			type: "string",
+			description:
+				"The rule conditions, using the same syntax as --rule when=...",
+		},
+		"clear-conditions": {
+			type: "boolean",
+			default: false,
+			description: "Remove conditions so the rule matches all contexts",
+		},
+		rollout: {
+			type: "string",
+			description:
+				'The rollout, in the form "percentage" or "percentage%@attribute"',
+		},
+		"clear-rollout": {
+			type: "boolean",
+			default: false,
+			description: "Remove the rollout from this rule",
+		},
+		json: {
+			type: "boolean",
+			default: false,
+			description: "Return output as JSON",
+		},
+	},
+	positionalArgs: ["app-id", "key"],
+	async handler(args, { config }) {
+		if (!Number.isInteger(args.priority) || args.priority < 1) {
+			throw new UserError("Rule priority must be an integer >= 1.", {
+				telemetryMessage: "flagship rule invalid priority",
+			});
+		}
+		if (
+			args.serve === undefined &&
+			args.when === undefined &&
+			!args.clearConditions &&
+			args.rollout === undefined &&
+			!args.clearRollout
+		) {
+			throw new UserError(
+				"Specify at least one of --serve, --when, --clear-conditions, --rollout, or --clear-rollout.",
+				{ telemetryMessage: "flagship rule update missing changes" }
+			);
+		}
+		if (args.when !== undefined && args.clearConditions) {
+			throw new UserError(
+				"Cannot use --when together with --clear-conditions.",
+				{ telemetryMessage: "flagship rule update conflicting conditions" }
+			);
+		}
+		if (args.rollout !== undefined && args.clearRollout) {
+			throw new UserError(
+				"Cannot use --rollout together with --clear-rollout.",
+				{ telemetryMessage: "flagship rule update conflicting rollout" }
+			);
+		}
+
+		const { appId, key } = args;
+		const current = await getFlag(config, appId, key);
+		findRule(current.rules, args.priority);
+		const rules: Rule[] = current.rules.map((rule) =>
+			rule.priority === args.priority
+				? {
+						...rule,
+						serve_variation: args.serve ?? rule.serve_variation,
+						conditions: args.clearConditions
+							? []
+							: args.when !== undefined
+								? parseConditions(args.when)
+								: rule.conditions,
+						rollout: args.clearRollout
+							? undefined
+							: args.rollout !== undefined
+								? parseRollout(args.rollout)
+								: rule.rollout,
+					}
+				: rule
+		);
+		assertVariationsExist(current.variations, current.default_variation, rules);
+		const flag = await updateFlag(config, appId, key, {
+			...toFlagInput(current),
+			rules,
+		});
+		if (args.json) {
+			logger.json(flag);
+			return;
+		}
+		logger.log(`✅ Updated rule ${args.priority} for flag\n`);
+		logger.log(renderFlag(flag));
+	},
+});

--- a/packages/wrangler/src/flagship/flags/set.ts
+++ b/packages/wrangler/src/flagship/flags/set.ts
@@ -1,0 +1,66 @@
+import { UserError } from "@cloudflare/workers-utils";
+import { createCommand } from "../../core/create-command";
+import { logger } from "../../logger";
+import { getFlag, toFlagInput, updateFlag } from "../client";
+import { renderFlag } from "../render";
+
+export const flagshipFlagsSetCommand = createCommand({
+	metadata: {
+		description: "Set the default variation served by a feature flag",
+		status: "open beta",
+		owner: "Product: Flagship",
+	},
+	behaviour: {
+		printBanner: (args) => !args.json,
+	},
+	args: {
+		"app-id": {
+			type: "string",
+			demandOption: true,
+			description: "The ID of the app",
+		},
+		key: {
+			type: "string",
+			demandOption: true,
+			description: "The key of the flag",
+		},
+		variation: {
+			type: "string",
+			alias: ["variant", "V"],
+			demandOption: true,
+			description: "The variation to serve by default",
+		},
+		"clear-rules": {
+			type: "boolean",
+			default: false,
+			description: "Clear targeting rules so this variation is always served",
+		},
+		json: {
+			type: "boolean",
+			default: false,
+			description: "Return output as JSON",
+		},
+	},
+	positionalArgs: ["app-id", "key"],
+	async handler(args, { config }) {
+		const { appId, key } = args;
+		const current = await getFlag(config, appId, key);
+		if (!(args.variation in current.variations)) {
+			throw new UserError(
+				`Unknown variation "${args.variation}". Available variations: ${Object.keys(current.variations).join(", ")}`,
+				{ telemetryMessage: "flagship set unknown variation" }
+			);
+		}
+		const flag = await updateFlag(config, appId, key, {
+			...toFlagInput(current),
+			default_variation: args.variation,
+			rules: args.clearRules ? [] : current.rules,
+		});
+		if (args.json) {
+			logger.json(flag);
+			return;
+		}
+		logger.log(`✅ Set default variation to "${args.variation}"\n`);
+		logger.log(renderFlag(flag));
+	},
+});

--- a/packages/wrangler/src/flagship/flags/split.ts
+++ b/packages/wrangler/src/flagship/flags/split.ts
@@ -1,0 +1,122 @@
+import { UserError } from "@cloudflare/workers-utils";
+import { createCommand } from "../../core/create-command";
+import { logger } from "../../logger";
+import { getFlag, toFlagInput, updateFlag } from "../client";
+import { renderFlag } from "../render";
+import { confirmRuleReplacement, parseWeights } from "../shared";
+import type { Rule } from "../client";
+
+export const flagshipFlagsSplitCommand = createCommand({
+	metadata: {
+		description: "Split traffic across variations by percentage",
+		status: "open beta",
+		owner: "Product: Flagship",
+		examples: [
+			{
+				command:
+					"wrangler flagship flags split <APP_ID> model --by user_id -w stable=95 -w candidate=5",
+				description: "Send 5% of traffic to the candidate variation",
+			},
+		],
+	},
+	behaviour: {
+		printBanner: (args) => !args.json,
+	},
+	args: {
+		"app-id": {
+			type: "string",
+			demandOption: true,
+			description: "The ID of the app",
+		},
+		key: {
+			type: "string",
+			demandOption: true,
+			description: "The key of the flag",
+		},
+		weight: {
+			type: "string",
+			array: true,
+			alias: "w",
+			description:
+				'A variation weight, in the form "variation=weight" (repeatable)',
+		},
+		by: {
+			type: "string",
+			description: "Context attribute used for sticky bucketing",
+		},
+		"default-variation": {
+			type: "string",
+			alias: "default",
+			description: "Fallback variation when bucketing cannot run",
+		},
+		force: {
+			type: "boolean",
+			alias: "y",
+			default: false,
+			description:
+				"Skip the confirmation prompt when this split replaces existing targeting rules",
+		},
+		json: {
+			type: "boolean",
+			default: false,
+			description: "Return output as JSON",
+		},
+	},
+	positionalArgs: ["app-id", "key"],
+	async handler(args, { config, confirm }) {
+		const { appId, key } = args;
+		const current = await getFlag(config, appId, key);
+		const weights = parseWeights(args.weight);
+		for (const variation of Object.keys(weights)) {
+			if (!(variation in current.variations)) {
+				throw new UserError(
+					`Unknown variation "${variation}". Available variations: ${Object.keys(current.variations).join(", ")}`,
+					{ telemetryMessage: "flagship split unknown variation" }
+				);
+			}
+		}
+		const total = Object.values(weights).reduce(
+			(sum, weight) => sum + weight,
+			0
+		);
+		let cumulative = 0;
+		let priority = 1;
+		const rules: Rule[] = [];
+		for (const [variation, weight] of Object.entries(weights)) {
+			if (weight === 0) {
+				continue;
+			}
+			cumulative += (weight / total) * 100;
+			rules.push({
+				priority: priority++,
+				conditions: [],
+				serve_variation: variation,
+				rollout: {
+					percentage: Math.min(100, Number(cumulative.toFixed(6))),
+					attribute: args.by,
+				},
+			});
+		}
+		const confirmed = await confirmRuleReplacement(current.rules, {
+			json: args.json,
+			force: args.force,
+			action: "split",
+			confirm,
+		});
+		if (!confirmed) {
+			logger.log("Aborting split.");
+			return;
+		}
+		const flag = await updateFlag(config, appId, key, {
+			...toFlagInput(current),
+			default_variation: args.defaultVariation ?? current.default_variation,
+			rules,
+		});
+		if (args.json) {
+			logger.json(flag);
+			return;
+		}
+		logger.log(`✅ Updated split for flag\n`);
+		logger.log(renderFlag(flag));
+	},
+});

--- a/packages/wrangler/src/flagship/flags/update.ts
+++ b/packages/wrangler/src/flagship/flags/update.ts
@@ -1,0 +1,182 @@
+import { UserError } from "@cloudflare/workers-utils";
+import { createCommand } from "../../core/create-command";
+import { logger } from "../../logger";
+import { getFlag, updateFlag } from "../client";
+import { renderFlag } from "../render";
+import {
+	assertConsistentVariationTypes,
+	assertVariationsExist,
+	finalizeRules,
+	parseRuleJson,
+	parseRules,
+	parseVariations,
+} from "../shared";
+import type { FlagType, Rule } from "../client";
+
+export const flagshipFlagsUpdateCommand = createCommand({
+	metadata: {
+		description: "Update a feature flag in a Flagship app",
+		status: "open beta",
+		owner: "Product: Flagship",
+	},
+	behaviour: {
+		printBanner: (args) => !args.json,
+	},
+	args: {
+		"app-id": {
+			type: "string",
+			demandOption: true,
+			description: "The ID of the app",
+		},
+		key: {
+			type: "string",
+			demandOption: true,
+			description: "The key of the flag",
+		},
+		enable: {
+			type: "boolean",
+			conflicts: "disable",
+			description: "Enable the flag",
+		},
+		disable: {
+			type: "boolean",
+			conflicts: "enable",
+			description: "Disable the flag",
+		},
+		description: {
+			type: "string",
+			alias: "d",
+			description: 'A new description for the flag (pass "" to clear it)',
+		},
+		"default-variation": {
+			type: "string",
+			alias: "default",
+			description: "The name of the variation to serve by default",
+		},
+		type: {
+			type: "string",
+			choices: ["boolean", "string", "number", "json"],
+			alias: "t",
+			description: "The value type used to coerce --set-variation values",
+		},
+		"set-variation": {
+			type: "string",
+			array: true,
+			description: 'Add or replace a variation, in the form "name=value"',
+		},
+		"remove-variation": {
+			type: "string",
+			array: true,
+			description: "Remove a variation by name",
+		},
+		rule: {
+			type: "string",
+			array: true,
+			description: "Replace the flag's targeting rules (repeatable)",
+		},
+		"rule-json": {
+			type: "string",
+			array: true,
+			description: "Replace the flag's targeting rules using JSON (repeatable)",
+		},
+		"add-rule": {
+			type: "string",
+			array: true,
+			description:
+				"Append a targeting rule, keeping the existing rules (repeatable)",
+		},
+		"add-rule-json": {
+			type: "string",
+			array: true,
+			description:
+				"Append a targeting rule using JSON, keeping the existing rules (repeatable)",
+		},
+		"clear-rules": {
+			type: "boolean",
+			default: false,
+			description: "Remove all targeting rules",
+		},
+		json: {
+			type: "boolean",
+			default: false,
+			description: "Return output as JSON",
+		},
+	},
+	positionalArgs: ["app-id", "key"],
+	async handler(args, { config }) {
+		const { appId, key } = args;
+		const current = await getFlag(config, appId, key);
+
+		const variations = { ...current.variations };
+		for (const [name, value] of Object.entries(
+			parseVariations(args.setVariation ?? [], args.type as FlagType)
+		)) {
+			variations[name] = value;
+		}
+		for (const name of args.removeVariation ?? []) {
+			delete variations[name];
+		}
+		assertConsistentVariationTypes(variations);
+
+		const replacementRules = [
+			...parseRules(args.rule ?? []),
+			...parseRuleJson(args.ruleJson ?? []),
+		];
+		const addedRules = [
+			...parseRules(args.addRule ?? []),
+			...parseRuleJson(args.addRuleJson ?? []),
+		];
+		if (
+			args.clearRules &&
+			(replacementRules.length > 0 || addedRules.length > 0)
+		) {
+			throw new UserError(
+				"Cannot use --clear-rules together with --rule, --rule-json, --add-rule, or --add-rule-json.",
+				{ telemetryMessage: "flagship update conflicting rule flags" }
+			);
+		}
+		if (replacementRules.length > 0 && addedRules.length > 0) {
+			throw new UserError(
+				"Cannot replace rules (--rule/--rule-json) and append rules (--add-rule/--add-rule-json) in the same command.",
+				{ telemetryMessage: "flagship update conflicting rule flags" }
+			);
+		}
+
+		let rules: Rule[] = current.rules;
+		if (args.clearRules) {
+			rules = [];
+		} else if (replacementRules.length > 0) {
+			rules = finalizeRules(replacementRules);
+		} else if (addedRules.length > 0) {
+			rules = [
+				...current.rules,
+				...finalizeRules(addedRules, { existing: current.rules }),
+			];
+		}
+
+		const default_variation =
+			args.defaultVariation ?? current.default_variation;
+		assertVariationsExist(variations, default_variation, rules);
+
+		const flag = await updateFlag(config, appId, key, {
+			key: current.key,
+			description:
+				args.description === undefined
+					? current.description
+					: args.description === ""
+						? null
+						: args.description,
+			enabled: args.enable ? true : args.disable ? false : current.enabled,
+			default_variation,
+			variations,
+			rules,
+		});
+
+		if (args.json) {
+			logger.json(flag);
+			return;
+		}
+		logger.log(`✅ Updated flag\n`);
+		logger.log(renderFlag(flag));
+	},
+});

--- a/packages/wrangler/src/flagship/flags/update.ts
+++ b/packages/wrangler/src/flagship/flags/update.ts
@@ -18,6 +18,28 @@ export const flagshipFlagsUpdateCommand = createCommand({
 		description: "Update a feature flag in a Flagship app",
 		status: "open beta",
 		owner: "Product: Flagship",
+		examples: [
+			{
+				command:
+					'wrangler flagship flags update <APP_ID> new-checkout --description "Redesigned checkout experience"',
+				description: "Update flag metadata",
+			},
+			{
+				command:
+					"wrangler flagship flags update <APP_ID> upload-limit --set-variation team=500",
+				description: "Add or replace a variation",
+			},
+			{
+				command:
+					'wrangler flagship flags update <APP_ID> premium-banner --add-rule "serve=off; when=account_age less_than 7"',
+				description: "Append a targeting rule",
+			},
+			{
+				command:
+					"wrangler flagship flags update <APP_ID> premium-banner --clear-rules",
+				description: "Remove all targeting rules",
+			},
+		],
 	},
 	behaviour: {
 		printBanner: (args) => !args.json,

--- a/packages/wrangler/src/flagship/index.ts
+++ b/packages/wrangler/src/flagship/index.ts
@@ -1,0 +1,62 @@
+import { createAlias, createNamespace } from "../core/create-command";
+
+export const flagshipNamespace = createNamespace({
+	metadata: {
+		description: "🚩 Manage Flagship apps and feature flags",
+		status: "open beta",
+		owner: "Product: Flagship",
+		category: "Compute & AI",
+	},
+});
+
+export const flagshipAppsNamespace = createNamespace({
+	metadata: {
+		description: "Manage Flagship apps",
+		status: "open beta",
+		owner: "Product: Flagship",
+	},
+});
+
+export const flagshipFlagsNamespace = createNamespace({
+	metadata: {
+		description: "Manage Flagship feature flags",
+		status: "open beta",
+		owner: "Product: Flagship",
+	},
+});
+
+export const flagshipFlagsRulesNamespace = createNamespace({
+	metadata: {
+		description: "Manage targeting rules for a Flagship feature flag",
+		status: "open beta",
+		owner: "Product: Flagship",
+	},
+});
+
+export const flagshipAppsListAlias = createAlias({
+	aliasOf: "wrangler flagship apps list",
+});
+
+export const flagshipAppsDeleteAlias = createAlias({
+	aliasOf: "wrangler flagship apps delete",
+});
+
+export const flagshipFlagsListAlias = createAlias({
+	aliasOf: "wrangler flagship flags list",
+});
+
+export const flagshipFlagsGetAlias = createAlias({
+	aliasOf: "wrangler flagship flags get",
+});
+
+export const flagshipFlagsDeleteAlias = createAlias({
+	aliasOf: "wrangler flagship flags delete",
+});
+
+export const flagshipFlagsChangelogAlias = createAlias({
+	aliasOf: "wrangler flagship flags changelog",
+});
+
+export const flagshipFlagsEvaluateAlias = createAlias({
+	aliasOf: "wrangler flagship flags evaluate",
+});

--- a/packages/wrangler/src/flagship/render.ts
+++ b/packages/wrangler/src/flagship/render.ts
@@ -1,0 +1,146 @@
+import {
+	blue,
+	bold,
+	brandColor,
+	dim,
+	gray,
+	green,
+	white,
+} from "@cloudflare/cli-shared-helpers/colors";
+import type { App, ChangelogEntry, Condition, Flag, Rule } from "./client";
+import type { EvaluationResult } from "./client";
+
+const INDENT = "  ";
+
+export function formatValue(value: unknown): string {
+	if (typeof value === "string") {
+		return `"${value}"`;
+	}
+	return JSON.stringify(value) ?? String(value);
+}
+
+export function statusBadge(enabled: boolean): string {
+	return enabled ? green("● enabled") : gray("○ disabled");
+}
+
+function sectionHeading(label: string): string {
+	return gray(label.toUpperCase());
+}
+
+export function renderApp(app: App): string {
+	return [
+		`🚩 ${bold(white(app.name))}  ${dim(app.id)}`,
+		`${INDENT}${gray("Created")}  ${app.created_at}`,
+		`${INDENT}${gray("Updated")}  ${app.updated_at} ${dim(`by ${app.updated_by}`)}`,
+	].join("\n");
+}
+
+export function renderFlag(flag: Flag): string {
+	const variations = flag.variations ?? {};
+	const rules = flag.rules ?? [];
+	const lines: string[] = [];
+
+	const type = flag.type ?? inferType(variations);
+	lines.push(
+		`🚩 ${bold(white(flag.key))}  ${dim(`[${type}]`)}  ${statusBadge(flag.enabled)}`
+	);
+	if (flag.description) {
+		lines.push(`${INDENT}${dim(flag.description)}`);
+	}
+
+	lines.push("");
+	lines.push(`${INDENT}${sectionHeading("Variations")}`);
+	const names = Object.keys(variations);
+	if (names.length === 0) {
+		lines.push(`${INDENT}${INDENT}${dim("(none)")}`);
+	} else {
+		const width = Math.max(...names.map((n) => n.length));
+		for (const name of names) {
+			const marker =
+				name === flag.default_variation ? `  ${green("default")}` : "";
+			lines.push(
+				`${INDENT}${INDENT}${white(name.padEnd(width))}  ${formatValue(variations[name])}${marker}`
+			);
+		}
+	}
+
+	lines.push("");
+	lines.push(`${INDENT}${sectionHeading("Rules")}`);
+	if (rules.length === 0) {
+		lines.push(
+			`${INDENT}${INDENT}${dim(`(none) — always serves "${flag.default_variation}"`)}`
+		);
+	} else {
+		for (const rule of [...rules].sort((a, b) => a.priority - b.priority)) {
+			lines.push(...renderRule(rule));
+		}
+	}
+
+	return lines.join("\n");
+}
+
+function renderRule(rule: Rule): string[] {
+	const when =
+		rule.conditions.length === 0
+			? dim("always")
+			: rule.conditions.map(renderCondition).join(dim(" AND "));
+	const head = `${INDENT}${INDENT}${brandColor(`${rule.priority}.`)} serve ${blue(`"${rule.serve_variation}"`)} ${dim("when")} ${when}`;
+	if (!rule.rollout) {
+		return [head];
+	}
+	const by = rule.rollout.attribute
+		? ` ${dim(`by ${rule.rollout.attribute}`)}`
+		: "";
+	return [
+		head,
+		`${INDENT}${INDENT}   ${dim(`${rule.rollout.percentage}% rollout`)}${by}`,
+	];
+}
+
+function renderCondition(condition: Condition): string {
+	if ("logical_operator" in condition) {
+		return `(${condition.clauses.map(renderCondition).join(dim(` ${condition.logical_operator} `))})`;
+	}
+	return `${condition.attribute} ${brandColor(condition.operator)} ${formatValue(condition.value)}`;
+}
+
+export function renderChangelogEntry(entry: ChangelogEntry): string {
+	const eventColor = entry.event === "delete" ? gray : brandColor;
+	const head = `${eventColor(`● ${entry.event}`)}  ${dim(entry.after.updated_at ?? "")}${
+		entry.after.updated_by ? dim(` · by ${entry.after.updated_by}`) : ""
+	}`;
+	if (entry.event !== "update" || !entry.diff) {
+		return head;
+	}
+	const changes = Object.entries(entry.diff).map(
+		([field, { from, to }]) =>
+			`${INDENT}${gray(field)} ${formatValue(from)} ${dim("→")} ${formatValue(to)}`
+	);
+	return [head, ...changes].join("\n");
+}
+
+export function renderEvaluation(result: EvaluationResult): string {
+	const reason = result.reason
+		? (result.reason === "DISABLED" ? gray : brandColor)(result.reason)
+		: dim("(unknown)");
+	return [
+		`🚩 ${bold(white(result.flagKey))}  ${brandColor("evaluated")}`,
+		`${INDENT}${gray("Value")}    ${formatValue(result.value)}`,
+		`${INDENT}${gray("Variant")}  ${result.variant ?? dim("(none)")}`,
+		`${INDENT}${gray("Reason")}   ${reason}`,
+	].join("\n");
+}
+
+function inferType(variations: Record<string, unknown>): string {
+	const first = Object.values(variations)[0];
+	if (typeof first === "boolean") {
+		return "boolean";
+	}
+	if (typeof first === "number") {
+		return "number";
+	}
+	if (typeof first === "object") {
+		return "json";
+	}
+	return "string";
+}

--- a/packages/wrangler/src/flagship/render.ts
+++ b/packages/wrangler/src/flagship/render.ts
@@ -13,10 +13,7 @@ import type { EvaluationResult } from "./client";
 const INDENT = "  ";
 
 export function formatValue(value: unknown): string {
-	if (typeof value === "string") {
-		return `"${value}"`;
-	}
-	return JSON.stringify(value) ?? String(value);
+	return JSON.stringify(value) ?? "undefined";
 }
 
 export function statusBadge(enabled: boolean): string {

--- a/packages/wrangler/src/flagship/shared.ts
+++ b/packages/wrangler/src/flagship/shared.ts
@@ -1,0 +1,805 @@
+import { UserError } from "@cloudflare/workers-utils";
+import type { Condition, FlagType, Operator, Rule } from "./client";
+
+const OPERATORS: Operator[] = [
+	"equals",
+	"not_equals",
+	"greater_than",
+	"less_than",
+	"greater_than_or_equals",
+	"less_than_or_equals",
+	"contains",
+	"starts_with",
+	"ends_with",
+	"in",
+	"not_in",
+];
+
+function invalid(message: string, telemetryMessage: string): never {
+	throw new UserError(message, { telemetryMessage });
+}
+
+export function coerceVariationValue(raw: string, type?: FlagType): unknown {
+	switch (type) {
+		case "boolean":
+			if (raw === "true") {
+				return true;
+			}
+			if (raw === "false") {
+				return false;
+			}
+			return invalid(
+				`Variation value "${raw}" is not a valid boolean (expected "true" or "false").`,
+				"flagship variation invalid boolean"
+			);
+		case "number": {
+			const n = Number(raw);
+			if (raw.trim() === "" || !Number.isFinite(n)) {
+				return invalid(
+					`Variation value "${raw}" is not a valid finite number.`,
+					"flagship variation invalid number"
+				);
+			}
+			return n;
+		}
+		case "json":
+			try {
+				return JSON.parse(raw);
+			} catch {
+				return invalid(
+					`Variation value "${raw}" is not valid JSON.`,
+					"flagship variation invalid json"
+				);
+			}
+		case "string":
+			return raw;
+		default:
+			return inferScalar(raw);
+	}
+}
+
+function inferScalar(raw: string): unknown {
+	if (raw === "true") {
+		return true;
+	}
+	if (raw === "false") {
+		return false;
+	}
+	const trimmed = raw.trim();
+	if (trimmed !== "") {
+		const n = Number(trimmed);
+		if (Number.isFinite(n) && String(n) === trimmed) {
+			return n;
+		}
+	}
+	if (trimmed.startsWith("{") || trimmed.startsWith("[")) {
+		try {
+			return JSON.parse(trimmed);
+		} catch {
+			return raw;
+		}
+	}
+	return raw;
+}
+
+export function parseVariations(
+	entries: string[],
+	type?: FlagType
+): Record<string, unknown> {
+	const variations: Record<string, unknown> = {};
+	for (const entry of entries) {
+		const eq = entry.indexOf("=");
+		if (eq === -1) {
+			invalid(
+				`Invalid --variation "${entry}". Expected format "name=value".`,
+				"flagship variation invalid format"
+			);
+		}
+		const name = entry.slice(0, eq).trim();
+		const value = entry.slice(eq + 1);
+		if (name === "") {
+			invalid(
+				`Invalid --variation "${entry}". Variation name is empty.`,
+				"flagship variation empty name"
+			);
+		}
+		if (name in variations) {
+			invalid(
+				`Duplicate variation "${name}". Each variation may only be set once.`,
+				"flagship variation duplicate name"
+			);
+		}
+		variations[name] = coerceVariationValue(value, type);
+	}
+	return variations;
+}
+
+export function buildCreateVariations(
+	entries: string[] | undefined,
+	type?: FlagType
+): { variations: Record<string, unknown>; defaultVariation: string } {
+	if (!entries || entries.length === 0) {
+		if (type === undefined || type === "boolean") {
+			return {
+				variations: { on: true, off: false },
+				defaultVariation: "off",
+			};
+		}
+		invalid(
+			`At least one --variation is required for ${type} flags.`,
+			"flagship create missing variations"
+		);
+	}
+	const variations = parseVariations(entries, type);
+	return { variations, defaultVariation: Object.keys(variations)[0] };
+}
+
+export function parseContext(
+	entries: string[] | undefined
+): Record<string, string> {
+	const context: Record<string, string> = {};
+	for (const entry of entries ?? []) {
+		const eq = entry.indexOf("=");
+		if (eq === -1) {
+			invalid(
+				`Invalid --context "${entry}". Expected format "name=value".`,
+				"flagship context invalid format"
+			);
+		}
+		const name = entry.slice(0, eq).trim();
+		if (name === "") {
+			invalid(
+				`Invalid --context "${entry}". Context name is empty.`,
+				"flagship context empty name"
+			);
+		}
+		context[name] = entry.slice(eq + 1);
+	}
+	return context;
+}
+
+export function parseWeights(
+	entries: string[] | undefined
+): Record<string, number> {
+	if (!entries || entries.length === 0) {
+		invalid(
+			"At least one --weight is required.",
+			"flagship split missing weights"
+		);
+	}
+	const weights: Record<string, number> = {};
+	for (const entry of entries) {
+		const eq = entry.indexOf("=");
+		if (eq === -1) {
+			invalid(
+				`Invalid --weight "${entry}". Expected format "variation=weight".`,
+				"flagship split invalid weight format"
+			);
+		}
+		const variation = entry.slice(0, eq).trim();
+		const weight = Number(entry.slice(eq + 1).trim());
+		if (variation === "" || !Number.isFinite(weight) || weight < 0) {
+			invalid(
+				`Invalid --weight "${entry}". Weight must be a non-negative finite number.`,
+				"flagship split invalid weight"
+			);
+		}
+		if (variation in weights) {
+			invalid(
+				`Duplicate weight for variation "${variation}". Each variation may only be weighted once.`,
+				"flagship split duplicate weight"
+			);
+		}
+		weights[variation] = weight;
+	}
+	if (Object.values(weights).every((weight) => weight === 0)) {
+		invalid(
+			"At least one --weight must be greater than 0.",
+			"flagship split zero weights"
+		);
+	}
+	return weights;
+}
+
+export type ParsedRule = Omit<Rule, "priority"> & { priority?: number };
+
+export function parseRuleJson(specs: string[]): ParsedRule[] {
+	return specs.map((spec) => {
+		let parsed: unknown;
+		try {
+			parsed = JSON.parse(spec);
+		} catch {
+			return invalid(
+				`Invalid --rule-json "${spec}". Expected a JSON object.`,
+				"flagship rule-json invalid"
+			);
+		}
+		if (
+			typeof parsed !== "object" ||
+			parsed === null ||
+			Array.isArray(parsed)
+		) {
+			return invalid(
+				`Invalid --rule-json "${spec}". Expected a JSON object describing a single rule.`,
+				"flagship rule-json invalid"
+			);
+		}
+		assertParsedRule(parsed, spec);
+		return parsed as ParsedRule;
+	});
+}
+
+export function parseRules(specs: string[]): ParsedRule[] {
+	return specs.map(parseRule);
+}
+
+export function finalizeRules(
+	rules: ParsedRule[],
+	options: { existing?: Rule[] } = {}
+): Rule[] {
+	const used = new Set<number>();
+	for (const rule of options.existing ?? []) {
+		used.add(rule.priority);
+	}
+	for (const rule of rules) {
+		if (rule.priority !== undefined) {
+			if (used.has(rule.priority)) {
+				invalid(
+					`Duplicate rule priority ${rule.priority}. Rule priorities must be unique within a flag.`,
+					"flagship rule duplicate priority"
+				);
+			}
+			used.add(rule.priority);
+		}
+	}
+	let next = 1;
+	return rules.map((rule) => {
+		if (rule.priority !== undefined) {
+			return { ...rule, priority: rule.priority };
+		}
+		while (used.has(next)) {
+			next++;
+		}
+		used.add(next);
+		return { ...rule, priority: next };
+	});
+}
+
+function variationTypeLabel(value: unknown): string {
+	if (typeof value === "boolean") {
+		return "boolean";
+	}
+	if (typeof value === "number") {
+		return "number";
+	}
+	if (typeof value === "string") {
+		return "string";
+	}
+	return "json";
+}
+
+export function assertConsistentVariationTypes(
+	variations: Record<string, unknown>
+): void {
+	const entries = Object.entries(variations);
+	if (entries.length === 0) {
+		return;
+	}
+	const [firstName, firstValue] = entries[0];
+	const expected = variationTypeLabel(firstValue);
+	for (const [name, value] of entries.slice(1)) {
+		const actual = variationTypeLabel(value);
+		if (actual !== expected) {
+			invalid(
+				`Variation "${name}" is ${actual} but variation "${firstName}" is ${expected}. All variations on a flag must use the same value type.`,
+				"flagship variation inconsistent type"
+			);
+		}
+	}
+}
+
+export function assertVariationsExist(
+	variations: Record<string, unknown>,
+	defaultVariation: string,
+	rules: Rule[]
+): void {
+	const names = Object.keys(variations);
+	const known = new Set(names);
+	const available = names.length > 0 ? names.join(", ") : "(none)";
+	if (!known.has(defaultVariation)) {
+		invalid(
+			`Default variation "${defaultVariation}" is not one of the flag's variations: ${available}.`,
+			"flagship default variation unknown"
+		);
+	}
+	for (const rule of rules) {
+		if (!known.has(rule.serve_variation)) {
+			invalid(
+				`Rule with priority ${rule.priority} serves unknown variation "${rule.serve_variation}". Available variations: ${available}.`,
+				"flagship rule serves unknown variation"
+			);
+		}
+	}
+}
+
+export function hasTargetingConditions(rules: Rule[]): boolean {
+	return rules.some((rule) => rule.conditions.length > 0);
+}
+
+export async function confirmRuleReplacement(
+	rules: Rule[],
+	options: {
+		json: boolean;
+		force: boolean;
+		action: string;
+		confirm: (message: string) => Promise<boolean>;
+	}
+): Promise<boolean> {
+	if (!hasTargetingConditions(rules)) {
+		return true;
+	}
+	if (options.json && !options.force) {
+		invalid(
+			`This flag has existing targeting rule(s) with conditions that will be replaced by this ${options.action}. Pass --force to confirm.`,
+			"flagship rule replacement requires force"
+		);
+	}
+	if (options.force) {
+		return true;
+	}
+	return await options.confirm(
+		`This flag has existing targeting rule(s) with conditions. Continuing will replace them with this ${options.action}. Continue?`
+	);
+}
+
+export function validateLimit(
+	limit: number | undefined,
+	telemetryMessage: string
+): void {
+	if (limit === undefined) {
+		return;
+	}
+	if (!Number.isInteger(limit) || limit < 1 || limit > 200) {
+		invalid(
+			`Invalid --limit "${limit}". Expected an integer between 1 and 200.`,
+			telemetryMessage
+		);
+	}
+}
+
+function assertParsedRule(
+	value: unknown,
+	spec: string
+): asserts value is ParsedRule {
+	if (!isRecord(value)) {
+		invalid(
+			`Invalid --rule-json "${spec}". Expected a JSON object describing a single rule.`,
+			"flagship rule-json invalid"
+		);
+	}
+	assertNoUnknownKeys(
+		value,
+		["priority", "conditions", "serve_variation", "rollout"],
+		spec
+	);
+	if (
+		typeof value.serve_variation !== "string" ||
+		value.serve_variation === ""
+	) {
+		invalid(
+			`Invalid --rule-json "${spec}". Expected non-empty string "serve_variation".`,
+			"flagship rule-json invalid serve"
+		);
+	}
+	if (!Array.isArray(value.conditions)) {
+		invalid(
+			`Invalid --rule-json "${spec}". Expected "conditions" to be an array.`,
+			"flagship rule-json invalid conditions"
+		);
+	}
+	if (
+		"priority" in value &&
+		(!Number.isInteger(value.priority) || Number(value.priority) < 1)
+	) {
+		invalid(
+			`Invalid --rule-json "${spec}". Expected "priority" to be an integer >= 1.`,
+			"flagship rule-json invalid priority"
+		);
+	}
+	for (const condition of value.conditions) {
+		assertJsonCondition(condition, spec);
+	}
+	if ("rollout" in value && value.rollout !== undefined) {
+		assertJsonRollout(value.rollout, spec);
+	}
+}
+
+function assertJsonCondition(value: unknown, spec: string): void {
+	if (!isRecord(value)) {
+		invalid(
+			`Invalid --rule-json "${spec}". Expected each condition to be an object.`,
+			"flagship rule-json invalid condition"
+		);
+	}
+	if ("logical_operator" in value || "clauses" in value) {
+		assertNoUnknownKeys(value, ["logical_operator", "clauses"], spec);
+		if (value.logical_operator !== "AND" && value.logical_operator !== "OR") {
+			invalid(
+				`Invalid --rule-json "${spec}". Expected logical_operator to be "AND" or "OR".`,
+				"flagship rule-json invalid logical operator"
+			);
+		}
+		if (!Array.isArray(value.clauses) || value.clauses.length === 0) {
+			invalid(
+				`Invalid --rule-json "${spec}". Expected logical condition "clauses" to be a non-empty array.`,
+				"flagship rule-json invalid clauses"
+			);
+		}
+		for (const clause of value.clauses) {
+			assertJsonCondition(clause, spec);
+		}
+		return;
+	}
+	assertNoUnknownKeys(value, ["attribute", "operator", "value"], spec);
+	if (typeof value.attribute !== "string" || value.attribute === "") {
+		invalid(
+			`Invalid --rule-json "${spec}". Expected condition "attribute" to be a non-empty string.`,
+			"flagship rule-json invalid attribute"
+		);
+	}
+	if (typeof value.operator !== "string" || !isOperator(value.operator)) {
+		invalid(
+			`Invalid --rule-json "${spec}". Expected condition "operator" to be one of: ${OPERATORS.join(", ")}.`,
+			"flagship rule-json invalid operator"
+		);
+	}
+	if (!("value" in value)) {
+		invalid(
+			`Invalid --rule-json "${spec}". Expected condition "value".`,
+			"flagship rule-json missing value"
+		);
+	}
+	if (
+		(value.operator === "in" || value.operator === "not_in") &&
+		!Array.isArray(value.value)
+	) {
+		invalid(
+			`Invalid --rule-json "${spec}". Expected condition "value" to be an array for ${value.operator}.`,
+			"flagship rule-json invalid array value"
+		);
+	}
+}
+
+function assertJsonRollout(value: unknown, spec: string): void {
+	if (!isRecord(value)) {
+		invalid(
+			`Invalid --rule-json "${spec}". Expected "rollout" to be an object.`,
+			"flagship rule-json invalid rollout"
+		);
+	}
+	assertNoUnknownKeys(value, ["percentage", "attribute"], spec);
+	if (
+		typeof value.percentage !== "number" ||
+		Number.isNaN(value.percentage) ||
+		value.percentage < 0 ||
+		value.percentage > 100
+	) {
+		invalid(
+			`Invalid --rule-json "${spec}". Expected rollout "percentage" between 0 and 100.`,
+			"flagship rule-json invalid rollout percentage"
+		);
+	}
+	if (
+		"attribute" in value &&
+		value.attribute !== undefined &&
+		typeof value.attribute !== "string"
+	) {
+		invalid(
+			`Invalid --rule-json "${spec}". Expected rollout "attribute" to be a string.`,
+			"flagship rule-json invalid rollout attribute"
+		);
+	}
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function assertNoUnknownKeys(
+	value: Record<string, unknown>,
+	allowed: string[],
+	spec: string
+): void {
+	const unknown = Object.keys(value).filter((key) => !allowed.includes(key));
+	if (unknown.length > 0) {
+		invalid(
+			`Invalid --rule-json "${spec}". Unexpected ${unknown.length === 1 ? "field" : "fields"} ${unknown
+				.map((key) => `"${key}"`)
+				.join(", ")}. Allowed: ${allowed.join(", ")}.`,
+			"flagship rule-json unknown field"
+		);
+	}
+}
+
+function isOperator(value: string): value is Operator {
+	return OPERATORS.includes(value as Operator);
+}
+
+// A string paired with a same-length "mask" in which characters inside quotes or
+// [brackets] are blanked. Splitting on the mask (";", "AND"/"OR", operators, ",")
+// therefore ignores reserved tokens inside values and lists. Slices keep both
+// strings aligned, so the mask is only ever computed once per expression.
+type Masked = { text: string; mask: string };
+
+function mask(text: string): Masked {
+	const chars = text.split("");
+	let quote: string | null = null;
+	let depth = 0;
+	for (let i = 0; i < chars.length; i++) {
+		const ch = chars[i];
+		if (quote !== null) {
+			if (ch === quote) {
+				quote = null;
+			} else {
+				chars[i] = "_";
+			}
+		} else if (ch === '"' || ch === "'") {
+			quote = ch;
+		} else if (ch === "[") {
+			depth++;
+		} else if (ch === "]") {
+			if (depth === 0) {
+				invalid(
+					`Unbalanced "]" in expression "${text}".`,
+					"flagship dsl unbalanced bracket"
+				);
+			}
+			depth--;
+		} else if (depth > 0) {
+			chars[i] = "_";
+		}
+	}
+	if (quote !== null) {
+		invalid(
+			`Unterminated ${quote === '"' ? "double" : "single"} quote in expression "${text}".`,
+			"flagship dsl unterminated quote"
+		);
+	}
+	if (depth > 0) {
+		invalid(
+			`Unterminated "[" in expression "${text}".`,
+			"flagship dsl unterminated bracket"
+		);
+	}
+	return { text, mask: chars.join("") };
+}
+
+function sliceMasked(m: Masked, start: number, end?: number): Masked {
+	return { text: m.text.slice(start, end), mask: m.mask.slice(start, end) };
+}
+
+function trimMasked(m: Masked): Masked {
+	const start = m.text.length - m.text.trimStart().length;
+	return sliceMasked(m, start, m.text.trimEnd().length);
+}
+
+function splitMasked(m: Masked, separator: string): Masked[] {
+	const parts: Masked[] = [];
+	let start = 0;
+	let index = m.mask.indexOf(separator);
+	while (index !== -1) {
+		parts.push(sliceMasked(m, start, index));
+		start = index + separator.length;
+		index = m.mask.indexOf(separator, start);
+	}
+	parts.push(sliceMasked(m, start));
+	return parts;
+}
+
+function unquote(value: string): string | undefined {
+	const quote = value[0];
+	if (
+		value.length >= 2 &&
+		(quote === '"' || quote === "'") &&
+		value[value.length - 1] === quote
+	) {
+		return value.slice(1, -1);
+	}
+	return undefined;
+}
+
+function parseRule(spec: string): ParsedRule {
+	const rule: ParsedRule = { conditions: [], serve_variation: "" };
+	let hasServe = false;
+	for (const segment of splitMasked(mask(spec), ";")) {
+		const { text, mask: segMask } = trimMasked(segment);
+		if (text === "") {
+			continue;
+		}
+		const eq = segMask.indexOf("=");
+		if (eq === -1) {
+			invalid(
+				`Invalid --rule segment "${text}". Expected "key=value".`,
+				"flagship rule segment invalid"
+			);
+		}
+		const key = text.slice(0, eq).trim();
+		const value = text.slice(eq + 1).trim();
+		switch (key) {
+			case "priority": {
+				const priority = Number(value);
+				if (!Number.isInteger(priority) || priority < 1) {
+					invalid(
+						`Invalid rule priority "${value}". Expected an integer >= 1.`,
+						"flagship rule invalid priority"
+					);
+				}
+				rule.priority = priority;
+				break;
+			}
+			case "serve":
+				if (value === "") {
+					invalid(
+						`Invalid --rule segment "${text}". "serve" must name a variation.`,
+						"flagship rule empty serve"
+					);
+				}
+				rule.serve_variation = unquote(value) ?? value;
+				hasServe = true;
+				break;
+			case "when":
+				rule.conditions = parseConditions(value);
+				break;
+			case "rollout":
+				rule.rollout = parseRollout(value);
+				break;
+			default:
+				invalid(
+					`Unknown --rule key "${key}". Expected one of: priority, serve, when, rollout.`,
+					"flagship rule unknown key"
+				);
+		}
+	}
+	if (!hasServe) {
+		invalid(
+			`Missing "serve" in --rule "${spec}".`,
+			"flagship rule missing serve"
+		);
+	}
+	return rule;
+}
+
+export function parseConditions(expr: string): Condition[] {
+	const root = trimMasked(mask(expr));
+	if (root.text === "") {
+		invalid(
+			"Condition expression is empty.",
+			"flagship condition empty expression"
+		);
+	}
+	if (
+		/^(?:AND|OR)\s/.test(root.mask) ||
+		/\s(?:AND|OR)$/.test(root.mask) ||
+		/\s(?:AND|OR)\s+(?:AND|OR)\s/.test(root.mask)
+	) {
+		invalid(
+			`Invalid condition expression "${expr}". Logical operators must appear between conditions.`,
+			"flagship condition invalid logical expression"
+		);
+	}
+	const groups = splitKeyword(root, "OR").map((group) =>
+		splitKeyword(group, "AND").map(parseCondition)
+	);
+	if (groups.length <= 1) {
+		return groups[0] ?? [];
+	}
+	const clauses: Condition[] = groups.map((conditions) =>
+		conditions.length === 1
+			? conditions[0]
+			: { logical_operator: "AND", clauses: conditions }
+	);
+	return [{ logical_operator: "OR", clauses }];
+}
+
+function splitKeyword(expr: Masked, keyword: "AND" | "OR"): Masked[] {
+	const parts = splitMasked(expr, ` ${keyword} `).map(trimMasked);
+	if (parts.some((part) => part.text === "")) {
+		invalid(
+			`Invalid condition expression "${expr.text}". Logical operators must appear between conditions.`,
+			"flagship condition invalid logical expression"
+		);
+	}
+	return parts;
+}
+
+function parseCondition(leaf: Masked): Condition {
+	const match = OPERATORS.map((operator) => ({
+		operator,
+		index: leaf.mask.indexOf(` ${operator} `),
+	}))
+		.filter(({ index }) => index !== -1)
+		.sort(
+			(a, b) => a.index - b.index || b.operator.length - a.operator.length
+		)[0];
+	if (!match) {
+		invalid(
+			`Could not find a valid operator in condition "${leaf.text}". Expected one of: ${OPERATORS.join(", ")}.`,
+			"flagship condition invalid operator"
+		);
+	}
+	const attribute = leaf.text.slice(0, match.index).trim();
+	if (attribute === "") {
+		invalid(
+			`Condition "${leaf.text}" is missing an attribute.`,
+			"flagship condition missing attribute"
+		);
+	}
+	const value = leaf.text.slice(match.index + match.operator.length + 2).trim();
+	if (value === "") {
+		invalid(
+			`Condition "${leaf.text}" is missing a value.`,
+			"flagship condition missing value"
+		);
+	}
+	return {
+		attribute,
+		operator: match.operator,
+		value: parseConditionValue(value, match.operator),
+	};
+}
+
+function parseConditionValue(raw: string, operator: Operator): unknown {
+	if (operator === "in" || operator === "not_in") {
+		return parseList(raw, operator);
+	}
+	return unquote(raw) ?? inferScalar(raw);
+}
+
+function parseList(raw: string, operator: Operator): unknown[] {
+	if (!raw.startsWith("[") || !raw.endsWith("]")) {
+		invalid(
+			`Invalid value "${raw}" for "${operator}". Expected a bracketed list, e.g. [US,CA] or ["US","CA"].`,
+			"flagship condition invalid list"
+		);
+	}
+	const inner = trimMasked(mask(raw.slice(1, -1)));
+	if (inner.text === "") {
+		return [];
+	}
+	return splitMasked(inner, ",").map((part) => {
+		const item = trimMasked(part).text;
+		if (item === "") {
+			invalid(
+				`Invalid list "${raw}" for "${operator}". List items must not be empty.`,
+				"flagship condition empty list item"
+			);
+		}
+		return unquote(item) ?? inferScalar(item);
+	});
+}
+
+export function parseRollout(value: string): {
+	percentage: number;
+	attribute?: string;
+} {
+	const at = value.indexOf("@");
+	const pctPart = at === -1 ? value : value.slice(0, at);
+	const attribute = at === -1 ? undefined : value.slice(at + 1).trim();
+	const percentage = Number(pctPart.replace(/%$/, "").trim());
+	if (!Number.isFinite(percentage) || percentage < 0 || percentage > 100) {
+		invalid(
+			`Invalid rollout "${value}". Expected a percentage between 0 and 100, optionally followed by "@attribute".`,
+			"flagship rollout invalid"
+		);
+	}
+	if (
+		attribute !== undefined &&
+		(attribute === "" || attribute.includes("@"))
+	) {
+		invalid(
+			`Invalid rollout "${value}". Expected a single non-empty attribute after "@".`,
+			"flagship rollout invalid attribute"
+		);
+	}
+	return attribute !== undefined ? { percentage, attribute } : { percentage };
+}

--- a/packages/wrangler/src/flagship/shared.ts
+++ b/packages/wrangler/src/flagship/shared.ts
@@ -1,4 +1,4 @@
-import { UserError } from "@cloudflare/workers-utils";
+import { JsonFriendlyFatalError, UserError } from "@cloudflare/workers-utils";
 import type { Condition, FlagType, Operator, Rule } from "./client";
 
 const OPERATORS: Operator[] = [
@@ -17,6 +17,15 @@ const OPERATORS: Operator[] = [
 
 function invalid(message: string, telemetryMessage: string): never {
 	throw new UserError(message, { telemetryMessage });
+}
+
+export function jsonFriendlyError(
+	message: string,
+	telemetryMessage: string
+): JsonFriendlyFatalError {
+	return new JsonFriendlyFatalError(JSON.stringify({ error: message }), {
+		telemetryMessage,
+	});
 }
 
 export function coerceVariationValue(raw: string, type?: FlagType): unknown {
@@ -339,7 +348,7 @@ export async function confirmRuleReplacement(
 		return true;
 	}
 	if (options.json && !options.force) {
-		invalid(
+		throw jsonFriendlyError(
 			`This flag has existing targeting rule(s) with conditions that will be replaced by this ${options.action}. Pass --force to confirm.`,
 			"flagship rule replacement requires force"
 		);

--- a/packages/wrangler/src/flagship/shared.ts
+++ b/packages/wrangler/src/flagship/shared.ts
@@ -794,8 +794,14 @@ export function parseRollout(value: string): {
 	const at = value.indexOf("@");
 	const pctPart = at === -1 ? value : value.slice(0, at);
 	const attribute = at === -1 ? undefined : value.slice(at + 1).trim();
-	const percentage = Number(pctPart.replace(/%$/, "").trim());
-	if (!Number.isFinite(percentage) || percentage < 0 || percentage > 100) {
+	const pctText = pctPart.replace(/%$/, "").trim();
+	const percentage = Number(pctText);
+	if (
+		pctText === "" ||
+		!Number.isFinite(percentage) ||
+		percentage < 0 ||
+		percentage > 100
+	) {
 		invalid(
 			`Invalid rollout "${value}". Expected a percentage between 0 and 100, optionally followed by "@attribute".`,
 			"flagship rollout invalid"

--- a/packages/wrangler/src/index.ts
+++ b/packages/wrangler/src/index.ts
@@ -176,6 +176,42 @@ import { emailSendingSendCommand } from "./email-routing/sending/send";
 import { emailSendingSendRawCommand } from "./email-routing/sending/send-raw";
 import { emailSendingSettingsCommand } from "./email-routing/sending/settings";
 import { emailRoutingSettingsCommand } from "./email-routing/settings";
+import { flagshipAppsCreateCommand } from "./flagship/apps/create";
+import { flagshipAppsDeleteCommand } from "./flagship/apps/delete";
+import { flagshipAppsGetCommand } from "./flagship/apps/get";
+import { flagshipAppsListCommand } from "./flagship/apps/list";
+import { flagshipAppsUpdateCommand } from "./flagship/apps/update";
+import { flagshipFlagsChangelogCommand } from "./flagship/flags/changelog";
+import { flagshipFlagsCreateCommand } from "./flagship/flags/create";
+import { flagshipFlagsDeleteCommand } from "./flagship/flags/delete";
+import {
+	flagshipFlagsDisableCommand,
+	flagshipFlagsEnableCommand,
+} from "./flagship/flags/enable";
+import { flagshipFlagsEvaluateCommand } from "./flagship/flags/evaluate";
+import { flagshipFlagsGetCommand } from "./flagship/flags/get";
+import { flagshipFlagsListCommand } from "./flagship/flags/list";
+import { flagshipFlagsRolloutCommand } from "./flagship/flags/rollout";
+import { flagshipFlagsRulesDeleteCommand } from "./flagship/flags/rules/delete";
+import { flagshipFlagsRulesListCommand } from "./flagship/flags/rules/list";
+import { flagshipFlagsRulesReorderCommand } from "./flagship/flags/rules/reorder";
+import { flagshipFlagsRulesUpdateCommand } from "./flagship/flags/rules/update";
+import { flagshipFlagsSetCommand } from "./flagship/flags/set";
+import { flagshipFlagsSplitCommand } from "./flagship/flags/split";
+import { flagshipFlagsUpdateCommand } from "./flagship/flags/update";
+import {
+	flagshipAppsDeleteAlias,
+	flagshipAppsListAlias,
+	flagshipAppsNamespace,
+	flagshipFlagsChangelogAlias,
+	flagshipFlagsDeleteAlias,
+	flagshipFlagsEvaluateAlias,
+	flagshipFlagsGetAlias,
+	flagshipFlagsListAlias,
+	flagshipFlagsNamespace,
+	flagshipFlagsRulesNamespace,
+	flagshipNamespace,
+} from "./flagship/index";
 import {
 	helloWorldGetCommand,
 	helloWorldNamespace,
@@ -1517,6 +1553,127 @@ export function createCLIParser(argv: string[]) {
 		},
 	]);
 	registry.registerNamespace("hyperdrive");
+
+	// flagship
+	registry.define([
+		{ command: "wrangler flagship", definition: flagshipNamespace },
+		{ command: "wrangler flagship apps", definition: flagshipAppsNamespace },
+		{
+			command: "wrangler flagship apps create",
+			definition: flagshipAppsCreateCommand,
+		},
+		{
+			command: "wrangler flagship apps list",
+			definition: flagshipAppsListCommand,
+		},
+		{ command: "wrangler flagship apps ls", definition: flagshipAppsListAlias },
+		{
+			command: "wrangler flagship apps get",
+			definition: flagshipAppsGetCommand,
+		},
+		{
+			command: "wrangler flagship apps update",
+			definition: flagshipAppsUpdateCommand,
+		},
+		{
+			command: "wrangler flagship apps delete",
+			definition: flagshipAppsDeleteCommand,
+		},
+		{
+			command: "wrangler flagship apps rm",
+			definition: flagshipAppsDeleteAlias,
+		},
+		{ command: "wrangler flagship flags", definition: flagshipFlagsNamespace },
+		{
+			command: "wrangler flagship flags create",
+			definition: flagshipFlagsCreateCommand,
+		},
+		{
+			command: "wrangler flagship flags list",
+			definition: flagshipFlagsListCommand,
+		},
+		{
+			command: "wrangler flagship flags ls",
+			definition: flagshipFlagsListAlias,
+		},
+		{
+			command: "wrangler flagship flags get",
+			definition: flagshipFlagsGetCommand,
+		},
+		{
+			command: "wrangler flagship flags inspect",
+			definition: flagshipFlagsGetAlias,
+		},
+		{
+			command: "wrangler flagship flags update",
+			definition: flagshipFlagsUpdateCommand,
+		},
+		{
+			command: "wrangler flagship flags set",
+			definition: flagshipFlagsSetCommand,
+		},
+		{
+			command: "wrangler flagship flags rules",
+			definition: flagshipFlagsRulesNamespace,
+		},
+		{
+			command: "wrangler flagship flags rules list",
+			definition: flagshipFlagsRulesListCommand,
+		},
+		{
+			command: "wrangler flagship flags rules update",
+			definition: flagshipFlagsRulesUpdateCommand,
+		},
+		{
+			command: "wrangler flagship flags rules delete",
+			definition: flagshipFlagsRulesDeleteCommand,
+		},
+		{
+			command: "wrangler flagship flags rules reorder",
+			definition: flagshipFlagsRulesReorderCommand,
+		},
+		{
+			command: "wrangler flagship flags split",
+			definition: flagshipFlagsSplitCommand,
+		},
+		{
+			command: "wrangler flagship flags rollout",
+			definition: flagshipFlagsRolloutCommand,
+		},
+		{
+			command: "wrangler flagship flags enable",
+			definition: flagshipFlagsEnableCommand,
+		},
+		{
+			command: "wrangler flagship flags disable",
+			definition: flagshipFlagsDisableCommand,
+		},
+		{
+			command: "wrangler flagship flags evaluate",
+			definition: flagshipFlagsEvaluateCommand,
+		},
+		{
+			command: "wrangler flagship flags eval",
+			definition: flagshipFlagsEvaluateAlias,
+		},
+		{
+			command: "wrangler flagship flags delete",
+			definition: flagshipFlagsDeleteCommand,
+		},
+		{
+			command: "wrangler flagship flags rm",
+			definition: flagshipFlagsDeleteAlias,
+		},
+		{
+			command: "wrangler flagship flags changelog",
+			definition: flagshipFlagsChangelogCommand,
+		},
+		{
+			command: "wrangler flagship flags history",
+			definition: flagshipFlagsChangelogAlias,
+		},
+	]);
+	registry.registerNamespace("flagship");
 
 	// tunnel
 	registry.define([

--- a/packages/wrangler/src/utils/add-created-resource-config.ts
+++ b/packages/wrangler/src/utils/add-created-resource-config.ts
@@ -45,7 +45,6 @@ type ValidKeys = Exclude<
 	| "secrets_store_secrets"
 	| "artifacts"
 	| "unsafe_hello_world"
-	| "flagship"
 >;
 
 export const sharedResourceCreationArgs = {


### PR DESCRIPTION
Adds `wrangler flagship` for managing Cloudflare Flagship apps and feature flags.

This includes `apps` commands for create/list/get/update/delete, and `flags` commands for create/list/get/update/set/split/rollout/enable/disable/evaluate/delete/changelog, with aliases, `--json` output, config binding fallback for app IDs, human-readable rendering, and unit test coverage.

Includes a `wrangler` minor changeset.

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [x] Cloudflare docs PR(s): https://github.com/cloudflare/cloudflare-docs/pull/31825
  - [ ] Documentation not necessary because: Flagship Wrangler command docs will be added in a separate cloudflare-docs PR after this lands.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14423" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->