### PR TITLE
[wrangler] Bump am-i-vibing from 0.4.0 to 0.5.0

### DIFF
--- a/.changeset/bump-am-i-vibing-0-5-0.md
+++ b/.changeset/bump-am-i-vibing-0-5-0.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Bump `am-i-vibing` from 0.4.0 to 0.5.0
+
+This updates the agentic environment detection library to the latest version, which adds detection for the Pi coding agent (`earendil-works/pi`).

--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -125,7 +125,7 @@
 		"@types/yargs": "^17.0.22",
 		"@vitest/ui": "catalog:default",
 		"@webcontainer/env": "^1.1.0",
-		"am-i-vibing": "^0.4.0",
+		"am-i-vibing": "^0.5.0",
 		"capnweb": "catalog:default",
 		"chalk": "catalog:default",
 		"chokidar": "^4.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4362,8 +4362,8 @@ importers:
         specifier: ^1.1.0
         version: 1.1.0
       am-i-vibing:
-        specifier: ^0.4.0
-        version: 0.4.0
+        specifier: ^0.5.0
+        version: 0.5.0
       capnweb:
         specifier: catalog:default
         version: 0.5.0
@@ -9667,8 +9667,8 @@ packages:
   ajv@8.17.1:
     resolution: {integrity: sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==}
 
-  am-i-vibing@0.4.0:
-    resolution: {integrity: sha512-MxT4XZL7pzLHpuvhDKdMaQHMGGkJDLluKBLsbstn+8wv9sWcFT6h+0ve9qkml95amVTZtZV83gQe2hY+ojgHLg==}
+  am-i-vibing@0.5.0:
+    resolution: {integrity: sha512-KLcsDhqf1XRrJmJr+9I/C0EX2K+sGrAGZFgkmd84c8TJO9zJBu+/kFInjazu1KfJWFhWDKdRWkpBzEs7s35DVA==}
     hasBin: true
 
   ansi-colors@4.1.3:
@@ -20843,7 +20843,7 @@ snapshots:
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
-  am-i-vibing@0.4.0:
+  am-i-vibing@0.5.0:
     dependencies:
       process-ancestry: 0.1.0
 


### PR DESCRIPTION
Bumps `am-i-vibing` from 0.4.0 to 0.5.0 for improved agentic environment detection coverage.

0.5.0 adds detection for the Pi coding agent (`earendil-works/pi`) via the `PI_CODING_AGENT` environment variable. The library's `detectAgenticEnvironment` API is unchanged, so no call-site changes are required.

---

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: dependency version bump only, no API changes. The existing `metrics.test.ts` and `agents-skills-install.test.ts` suites (which consume `am-i-vibing`) pass.
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: internal dependency bump with no user-facing behaviour change.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14424" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->