### PR TITLE
fix(create-cloudflare): avoid Analog npm Vite overrides

### DIFF
--- a/.changeset/fix-analog-npm-overrides.md
+++ b/.changeset/fix-analog-npm-overrides.md
@@ -1,0 +1,7 @@
+---
+"create-cloudflare": patch
+---
+
+Fix npm installs for Analog projects
+
+Analog's generated Vite overrides can cause npm to fail with `Unable to resolve reference $vite` when dependency resolution changes. `create-cloudflare` now opts npm-generated Analog projects out of those overrides so project creation can complete successfully.

--- a/packages/create-cloudflare/templates/analog/c3.ts
+++ b/packages/create-cloudflare/templates/analog/c3.ts
@@ -15,6 +15,7 @@ const generate = async (ctx: C3Context) => {
 	await runFrameworkGenerator(ctx, [
 		ctx.project.name,
 		"--template=latest",
+		// Analog's npm Vite overrides can fail as deps shift; remove once fixed upstream.
 		...(npm === "npm" ? ["--skipViteOverrides"] : []),
 	]);
 	logRaw("");

--- a/packages/create-cloudflare/templates/analog/c3.ts
+++ b/packages/create-cloudflare/templates/analog/c3.ts
@@ -12,7 +12,11 @@ import type { C3Context } from "types";
 const { npm } = detectPackageManager();
 
 const generate = async (ctx: C3Context) => {
-	await runFrameworkGenerator(ctx, [ctx.project.name, "--template=latest"]);
+	await runFrameworkGenerator(ctx, [
+		ctx.project.name,
+		"--template=latest",
+		...(npm === "npm" ? ["--skipViteOverrides"] : []),
+	]);
 	logRaw("");
 };
 


### PR DESCRIPTION
Fixes n/a.

This fixes a CI error we are seeing in https://github.com/cloudflare/workers-sdk/actions/runs/28168168030/job/83430559119?pr=14401#step:11:427, which appears to be triggered by a recent angular release that Analog depends on.

This skips the vite overrides introduced in https://github.com/analogjs/analog/pull/2358

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: covered by existing test
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bugfix

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
