### PR TITLE
[wrangler] Add --source-jurisdiction to ai-search create

### DIFF
--- a/.changeset/ai-search-source-jurisdiction.md
+++ b/.changeset/ai-search-source-jurisdiction.md
@@ -8,4 +8,4 @@ R2 buckets can live in a specific jurisdiction (for example `eu` or `fedramp`). 
 
 `wrangler ai-search create my-instance --type r2 --source my-bucket --source-jurisdiction eu`
 
-When run interactively, the R2 source flow also prompts for a jurisdiction and lists (and can create) buckets within it. The value is forwarded to the API as `source_params.r2_jurisdiction`; pass `default` for no specific jurisdiction. This AI Search command is in open beta.
+When run interactively, the R2 source flow also prompts for a jurisdiction and lists (and can create) buckets within it. The value is a free-form string forwarded to the API as `source_params.r2_jurisdiction` (server-side validated); omit the flag for no specific jurisdiction. This AI Search command is in open beta.

--- a/.changeset/ai-search-source-jurisdiction.md
+++ b/.changeset/ai-search-source-jurisdiction.md
@@ -1,0 +1,11 @@
+---
+"wrangler": minor
+---
+
+Add `--source-jurisdiction` to `wrangler ai-search create` for R2-backed instances
+
+R2 buckets can live in a specific jurisdiction (for example `eu` or `fedramp`). You can now point an AI Search instance at a bucket in one of those jurisdictions:
+
+`wrangler ai-search create my-instance --type r2 --source my-bucket --source-jurisdiction eu`
+
+When run interactively, the R2 source flow also prompts for a jurisdiction and lists (and can create) buckets within it. The value is forwarded to the API as `source_params.r2_jurisdiction`; pass `default` for no specific jurisdiction. This AI Search command is in open beta.

--- a/packages/wrangler/src/__tests__/ai-search.test.ts
+++ b/packages/wrangler/src/__tests__/ai-search.test.ts
@@ -598,6 +598,184 @@ describe("ai-search commands", () => {
 			});
 		});
 
+		it("should send source_params.r2_jurisdiction for an R2 source", async ({
+			expect,
+		}) => {
+			let capturedBody: Record<string, unknown> | undefined;
+			mockListTokens([MOCK_TOKEN]);
+			mockConfirm({
+				text: "Configure custom metadata fields? (optional)",
+				result: false,
+			});
+			msw.use(
+				http.post(
+					"*/accounts/:accountId/ai-search/namespaces/:namespace/instances",
+					async ({ request }) => {
+						capturedBody = (await request.json()) as Record<string, unknown>;
+						return HttpResponse.json(createFetchResult(MOCK_INSTANCE, true));
+					},
+					{ once: true }
+				)
+			);
+			await runWrangler(
+				"ai-search create my-instance --namespace default --type r2 --source my-bucket --source-jurisdiction eu"
+			);
+			expect(capturedBody).toMatchObject({
+				source: "my-bucket",
+				type: "r2",
+				source_params: { r2_jurisdiction: "eu" },
+			});
+		});
+
+		it("should omit r2_jurisdiction when --source-jurisdiction is 'default'", async ({
+			expect,
+		}) => {
+			let capturedBody: Record<string, unknown> | undefined;
+			mockListTokens([MOCK_TOKEN]);
+			mockConfirm({
+				text: "Configure custom metadata fields? (optional)",
+				result: false,
+			});
+			msw.use(
+				http.post(
+					"*/accounts/:accountId/ai-search/namespaces/:namespace/instances",
+					async ({ request }) => {
+						capturedBody = (await request.json()) as Record<string, unknown>;
+						return HttpResponse.json(createFetchResult(MOCK_INSTANCE, true));
+					},
+					{ once: true }
+				)
+			);
+			await runWrangler(
+				"ai-search create my-instance --namespace default --type r2 --source my-bucket --source-jurisdiction default"
+			);
+			// "default" is treated as no jurisdiction, so source_params is not sent.
+			expect(capturedBody?.source_params).toBeUndefined();
+		});
+
+		it("should reject an invalid --source-jurisdiction value", async ({
+			expect,
+		}) => {
+			await expect(
+				runWrangler(
+					"ai-search create my-instance --namespace default --type r2 --source my-bucket --source-jurisdiction mars"
+				)
+			).rejects.toThrowError(/Choices: "default", "eu", "fedramp"/);
+		});
+
+		it("should error when --source-jurisdiction is used with --type builtin", async ({
+			expect,
+		}) => {
+			mockListTokens([MOCK_TOKEN]);
+			await expect(
+				runWrangler(
+					"ai-search create my-instance --namespace default --type builtin --source-jurisdiction eu"
+				)
+			).rejects.toThrowError(
+				/--source-jurisdiction is only supported with --type r2/
+			);
+		});
+
+		it("should error when --source-jurisdiction is used with --type web-crawler", async ({
+			expect,
+		}) => {
+			mockListTokens([MOCK_TOKEN]);
+			await expect(
+				runWrangler(
+					"ai-search create my-instance --namespace default --type web-crawler --source https://example.com --source-jurisdiction eu"
+				)
+			).rejects.toThrowError(
+				/--source-jurisdiction is only supported with --type r2/
+			);
+		});
+
+		it("should list buckets in the chosen jurisdiction and forward r2_jurisdiction (interactive)", async ({
+			expect,
+		}) => {
+			let listJurisdiction: string | null = null;
+			let capturedBody: Record<string, unknown> | undefined;
+			mockListTokens([MOCK_TOKEN]);
+			mockSelect({ text: "Select the source type:", result: "r2" });
+			mockSelect({ text: "Select an R2 jurisdiction:", result: "eu" });
+			msw.use(
+				http.get(
+					"*/accounts/:accountId/r2/buckets",
+					({ request }) => {
+						listJurisdiction = request.headers.get("cf-r2-jurisdiction");
+						return HttpResponse.json(
+							createFetchResult({
+								buckets: [{ name: "eu-bucket", creation_date: "01-01-2001" }],
+							})
+						);
+					},
+					{ once: true }
+				)
+			);
+			mockSelect({ text: "Select an R2 bucket:", result: "eu-bucket" });
+			mockConfirm({
+				text: "Configure custom metadata fields? (optional)",
+				result: false,
+			});
+			msw.use(
+				http.post(
+					"*/accounts/:accountId/ai-search/namespaces/:namespace/instances",
+					async ({ request }) => {
+						capturedBody = (await request.json()) as Record<string, unknown>;
+						return HttpResponse.json(
+							createFetchResult({ ...MOCK_INSTANCE, source: "eu-bucket" }, true)
+						);
+					},
+					{ once: true }
+				)
+			);
+			await runWrangler("ai-search create my-instance --namespace default");
+			expect(listJurisdiction).toBe("eu");
+			expect(capturedBody).toMatchObject({
+				source: "eu-bucket",
+				type: "r2",
+				source_params: { r2_jurisdiction: "eu" },
+			});
+		});
+
+		it("should create a new bucket in the chosen jurisdiction (interactive)", async ({
+			expect,
+		}) => {
+			let createJurisdiction: string | null = null;
+			mockListTokens([MOCK_TOKEN]);
+			mockSelect({ text: "Select the source type:", result: "r2" });
+			mockSelect({ text: "Select an R2 jurisdiction:", result: "eu" });
+			msw.use(
+				http.get(
+					"*/accounts/:accountId/r2/buckets",
+					() => HttpResponse.json(createFetchResult({ buckets: [] })),
+					{ once: true }
+				)
+			);
+			mockSelect({ text: "Select an R2 bucket:", result: "__create_new__" });
+			mockPrompt({
+				text: "Enter a name for the new R2 bucket:",
+				result: "eu-bucket",
+			});
+			msw.use(
+				http.post(
+					"*/accounts/:accountId/r2/buckets",
+					({ request }) => {
+						createJurisdiction = request.headers.get("cf-r2-jurisdiction");
+						return HttpResponse.json(createFetchResult({}));
+					},
+					{ once: true }
+				)
+			);
+			mockConfirm({
+				text: "Configure custom metadata fields? (optional)",
+				result: false,
+			});
+			mockCreateInstance({ ...MOCK_INSTANCE, source: "eu-bucket" });
+			await runWrangler("ai-search create my-instance --namespace default");
+			expect(createJurisdiction).toBe("eu");
+			expect(std.out).toContain('Creating R2 bucket "eu-bucket"...');
+		});
+
 		it("should error in non-interactive mode when no tokens exist", async ({
 			expect,
 		}) => {
@@ -660,7 +838,12 @@ describe("ai-search commands", () => {
 				text: "Select the source type:",
 				result: "r2",
 			});
-			// 2. Select an existing R2 bucket from the list
+			// 2. Select the R2 jurisdiction (default = no jurisdiction)
+			mockSelect({
+				text: "Select an R2 jurisdiction:",
+				result: "default",
+			});
+			// 3. Select an existing R2 bucket from the list
 			msw.use(
 				http.get(
 					"*/accounts/:accountId/r2/buckets",
@@ -694,6 +877,10 @@ describe("ai-search commands", () => {
 		}) => {
 			mockListTokens([MOCK_TOKEN]);
 			mockSelect({ text: "Select the source type:", result: "r2" });
+			mockSelect({
+				text: "Select an R2 jurisdiction:",
+				result: "default",
+			});
 			msw.use(
 				http.get(
 					"*/accounts/:accountId/r2/buckets",

--- a/packages/wrangler/src/__tests__/ai-search.test.ts
+++ b/packages/wrangler/src/__tests__/ai-search.test.ts
@@ -627,7 +627,7 @@ describe("ai-search commands", () => {
 			});
 		});
 
-		it("should omit r2_jurisdiction when --source-jurisdiction is 'default'", async ({
+		it("should omit r2_jurisdiction when --source-jurisdiction is not provided", async ({
 			expect,
 		}) => {
 			let capturedBody: Record<string, unknown> | undefined;
@@ -647,20 +647,36 @@ describe("ai-search commands", () => {
 				)
 			);
 			await runWrangler(
-				"ai-search create my-instance --namespace default --type r2 --source my-bucket --source-jurisdiction default"
+				"ai-search create my-instance --namespace default --type r2 --source my-bucket"
 			);
-			// "default" is treated as no jurisdiction, so source_params is not sent.
 			expect(capturedBody?.source_params).toBeUndefined();
 		});
 
-		it("should reject an invalid --source-jurisdiction value", async ({
+		it("should forward an arbitrary --source-jurisdiction value (server-side validated)", async ({
 			expect,
 		}) => {
-			await expect(
-				runWrangler(
-					"ai-search create my-instance --namespace default --type r2 --source my-bucket --source-jurisdiction mars"
+			let capturedBody: Record<string, unknown> | undefined;
+			mockListTokens([MOCK_TOKEN]);
+			mockConfirm({
+				text: "Configure custom metadata fields? (optional)",
+				result: false,
+			});
+			msw.use(
+				http.post(
+					"*/accounts/:accountId/ai-search/namespaces/:namespace/instances",
+					async ({ request }) => {
+						capturedBody = (await request.json()) as Record<string, unknown>;
+						return HttpResponse.json(createFetchResult(MOCK_INSTANCE, true));
+					},
+					{ once: true }
 				)
-			).rejects.toThrowError(/Choices: "default", "eu", "fedramp"/);
+			);
+			await runWrangler(
+				"ai-search create my-instance --namespace default --type r2 --source my-bucket --source-jurisdiction apac"
+			);
+			expect(capturedBody).toMatchObject({
+				source_params: { r2_jurisdiction: "apac" },
+			});
 		});
 
 		it("should error when --source-jurisdiction is used with --type builtin", async ({
@@ -696,7 +712,10 @@ describe("ai-search commands", () => {
 			let capturedBody: Record<string, unknown> | undefined;
 			mockListTokens([MOCK_TOKEN]);
 			mockSelect({ text: "Select the source type:", result: "r2" });
-			mockSelect({ text: "Select an R2 jurisdiction:", result: "eu" });
+			mockPrompt({
+				text: "R2 jurisdiction (optional, e.g. eu, fedramp; leave blank for none):",
+				result: "eu",
+			});
 			msw.use(
 				http.get(
 					"*/accounts/:accountId/r2/buckets",
@@ -743,7 +762,10 @@ describe("ai-search commands", () => {
 			let createJurisdiction: string | null = null;
 			mockListTokens([MOCK_TOKEN]);
 			mockSelect({ text: "Select the source type:", result: "r2" });
-			mockSelect({ text: "Select an R2 jurisdiction:", result: "eu" });
+			mockPrompt({
+				text: "R2 jurisdiction (optional, e.g. eu, fedramp; leave blank for none):",
+				result: "eu",
+			});
 			msw.use(
 				http.get(
 					"*/accounts/:accountId/r2/buckets",
@@ -838,10 +860,10 @@ describe("ai-search commands", () => {
 				text: "Select the source type:",
 				result: "r2",
 			});
-			// 2. Select the R2 jurisdiction (default = no jurisdiction)
-			mockSelect({
-				text: "Select an R2 jurisdiction:",
-				result: "default",
+			// 2. Enter the R2 jurisdiction (blank = no jurisdiction)
+			mockPrompt({
+				text: "R2 jurisdiction (optional, e.g. eu, fedramp; leave blank for none):",
+				result: "",
 			});
 			// 3. Select an existing R2 bucket from the list
 			msw.use(
@@ -877,9 +899,9 @@ describe("ai-search commands", () => {
 		}) => {
 			mockListTokens([MOCK_TOKEN]);
 			mockSelect({ text: "Select the source type:", result: "r2" });
-			mockSelect({
-				text: "Select an R2 jurisdiction:",
-				result: "default",
+			mockPrompt({
+				text: "R2 jurisdiction (optional, e.g. eu, fedramp; leave blank for none):",
+				result: "",
 			});
 			msw.use(
 				http.get(

--- a/packages/wrangler/src/ai-search/create.ts
+++ b/packages/wrangler/src/ai-search/create.ts
@@ -22,6 +22,20 @@ import type {
 const CREATE_NEW_BUCKET = "__create_new__";
 const CREATE_NEW_NAMESPACE = "__create_new__";
 
+// R2 jurisdictions selectable for an R2 source bucket. "default" means no
+// specific jurisdiction (standard) and is omitted from the request payload.
+const SOURCE_JURISDICTION_CHOICES = ["default", "eu", "fedramp"] as const;
+type SourceJurisdiction = (typeof SOURCE_JURISDICTION_CHOICES)[number];
+
+// Maps the user-facing jurisdiction choice to the value sent to R2 / the API.
+// "default" (and undefined) become undefined, i.e. no `cf-r2-jurisdiction`
+// header and no `r2_jurisdiction` in the request body.
+function normalizeJurisdiction(
+	jurisdiction: SourceJurisdiction | undefined
+): string | undefined {
+	return jurisdiction && jurisdiction !== "default" ? jurisdiction : undefined;
+}
+
 const CUSTOM_METADATA_DATA_TYPES = [
 	"text",
 	"number",
@@ -229,6 +243,13 @@ export const aiSearchCreateCommand = createCommand({
 			type: "string",
 			choices: ["builtin", "r2", "web-crawler"],
 			description: "The source type for the instance.",
+		},
+		"source-jurisdiction": {
+			type: "string",
+			choices: [...SOURCE_JURISDICTION_CHOICES],
+			description:
+				"The R2 jurisdiction of the source bucket (R2 sources only). " +
+				'Use "default" for no specific jurisdiction.',
 		},
 		"embedding-model": {
 			type: "string",
@@ -465,10 +486,25 @@ export const aiSearchCreateCommand = createCommand({
 			}
 		}
 
+		// --source-jurisdiction only applies to R2 source buckets.
+		if (instanceType !== "r2" && args.sourceJurisdiction !== undefined) {
+			throw new UserError(
+				`--source-jurisdiction is only supported with --type r2 (got --type ${instanceType}).`,
+				{
+					telemetryMessage:
+						"ai search create source-jurisdiction unsupported type",
+				}
+			);
+		}
+
 		// 2. Source selection — depends on the type
 		let instanceSource = args.source;
 		// Track whether the user went through the web/sitemap interactive flow
 		let webParseType: string | undefined;
+		// R2 jurisdiction of the source bucket. May be supplied via flag or
+		// chosen interactively; "default" is normalized away before use.
+		let sourceJurisdiction: SourceJurisdiction | undefined =
+			args.sourceJurisdiction as SourceJurisdiction | undefined;
 
 		if (instanceType === "r2" && !instanceSource) {
 			if (isNonInteractiveOrCI()) {
@@ -478,8 +514,24 @@ export const aiSearchCreateCommand = createCommand({
 					{ telemetryMessage: "ai search create missing r2 source" }
 				);
 			}
+			// 2.0 R2 jurisdiction: pick where the source bucket lives so we list
+			// (and optionally create) buckets in the matching jurisdiction.
+			if (sourceJurisdiction === undefined) {
+				sourceJurisdiction = await select("Select an R2 jurisdiction:", {
+					choices: SOURCE_JURISDICTION_CHOICES.map((j) => ({
+						title: j,
+						value: j,
+					})),
+					defaultOption: 0,
+				});
+			}
+			const effectiveJurisdiction = normalizeJurisdiction(sourceJurisdiction);
 			// 2.1 R2: list buckets and let user pick, with "Create new" option
-			const buckets = await listR2Buckets(config, accountId);
+			const buckets = await listR2Buckets(
+				config,
+				accountId,
+				effectiveJurisdiction
+			);
 			const bucketChoices = [
 				...buckets.map((b) => ({
 					title: b.name,
@@ -506,7 +558,13 @@ export const aiSearchCreateCommand = createCommand({
 					}
 				);
 				logger.log(`Creating R2 bucket "${newBucketName}"...`);
-				await createR2Bucket(config, accountId, newBucketName);
+				await createR2Bucket(
+					config,
+					accountId,
+					newBucketName,
+					undefined,
+					effectiveJurisdiction
+				);
 				logger.log(`Successfully created R2 bucket "${newBucketName}".`);
 				instanceSource = newBucketName;
 			} else {
@@ -686,6 +744,10 @@ export const aiSearchCreateCommand = createCommand({
 		if (args.excludeItems) {
 			sourceParams.exclude_items = args.excludeItems;
 		}
+		const sourceJurisdictionValue = normalizeJurisdiction(sourceJurisdiction);
+		if (instanceType === "r2" && sourceJurisdictionValue) {
+			sourceParams.r2_jurisdiction = sourceJurisdictionValue;
+		}
 		if (webParseType) {
 			sourceParams.web_crawler = {
 				parse_type: webParseType,
@@ -710,12 +772,20 @@ export const aiSearchCreateCommand = createCommand({
 		if (args.json) {
 			logger.log(JSON.stringify(instance, null, 2));
 		} else {
+			const jurisdiction =
+				instance.source_params?.r2_jurisdiction ?? sourceJurisdictionValue;
+			const sourceDisplay =
+				instance.source != null
+					? jurisdiction
+						? `${instance.source} (${jurisdiction})`
+						: instance.source
+					: "-";
 			let summary =
 				`Successfully created AI Search instance "${instance.id}"\n` +
 				`  Name:       ${instance.id}\n` +
 				`  Namespace:  ${instance.namespace ?? instanceNamespace}\n` +
 				`  Type:       ${instance.type ?? "builtin"}\n` +
-				`  Source:     ${instance.source ?? "-"}\n` +
+				`  Source:     ${sourceDisplay}\n` +
 				`  Model:      ${instance.ai_search_model ?? "default"}\n` +
 				`  Embedding:  ${instance.embedding_model ?? "default"}`;
 			if (instance.custom_metadata && instance.custom_metadata.length > 0) {

--- a/packages/wrangler/src/ai-search/create.ts
+++ b/packages/wrangler/src/ai-search/create.ts
@@ -22,20 +22,6 @@ import type {
 const CREATE_NEW_BUCKET = "__create_new__";
 const CREATE_NEW_NAMESPACE = "__create_new__";
 
-// R2 jurisdictions selectable for an R2 source bucket. "default" means no
-// specific jurisdiction (standard) and is omitted from the request payload.
-const SOURCE_JURISDICTION_CHOICES = ["default", "eu", "fedramp"] as const;
-type SourceJurisdiction = (typeof SOURCE_JURISDICTION_CHOICES)[number];
-
-// Maps the user-facing jurisdiction choice to the value sent to R2 / the API.
-// "default" (and undefined) become undefined, i.e. no `cf-r2-jurisdiction`
-// header and no `r2_jurisdiction` in the request body.
-function normalizeJurisdiction(
-	jurisdiction: SourceJurisdiction | undefined
-): string | undefined {
-	return jurisdiction && jurisdiction !== "default" ? jurisdiction : undefined;
-}
-
 const CUSTOM_METADATA_DATA_TYPES = [
 	"text",
 	"number",
@@ -246,10 +232,10 @@ export const aiSearchCreateCommand = createCommand({
 		},
 		"source-jurisdiction": {
 			type: "string",
-			choices: [...SOURCE_JURISDICTION_CHOICES],
+			requiresArg: true,
 			description:
-				"The R2 jurisdiction of the source bucket (R2 sources only). " +
-				'Use "default" for no specific jurisdiction.',
+				"The R2 jurisdiction of the source bucket (e.g. eu, fedramp). " +
+				"Only valid with --type r2; omit for no specific jurisdiction.",
 		},
 		"embedding-model": {
 			type: "string",
@@ -502,9 +488,9 @@ export const aiSearchCreateCommand = createCommand({
 		// Track whether the user went through the web/sitemap interactive flow
 		let webParseType: string | undefined;
 		// R2 jurisdiction of the source bucket. May be supplied via flag or
-		// chosen interactively; "default" is normalized away before use.
-		let sourceJurisdiction: SourceJurisdiction | undefined =
-			args.sourceJurisdiction as SourceJurisdiction | undefined;
+		// entered interactively; passed through to the API as-is (server-side
+		// validated) so future jurisdictions work without a Wrangler upgrade.
+		let sourceJurisdiction = args.sourceJurisdiction;
 
 		if (instanceType === "r2" && !instanceSource) {
 			if (isNonInteractiveOrCI()) {
@@ -514,18 +500,14 @@ export const aiSearchCreateCommand = createCommand({
 					{ telemetryMessage: "ai search create missing r2 source" }
 				);
 			}
-			// 2.0 R2 jurisdiction: pick where the source bucket lives so we list
+			// 2.0 R2 jurisdiction: ask where the source bucket lives so we list
 			// (and optionally create) buckets in the matching jurisdiction.
 			if (sourceJurisdiction === undefined) {
-				sourceJurisdiction = await select("Select an R2 jurisdiction:", {
-					choices: SOURCE_JURISDICTION_CHOICES.map((j) => ({
-						title: j,
-						value: j,
-					})),
-					defaultOption: 0,
-				});
+				sourceJurisdiction = await prompt(
+					"R2 jurisdiction (optional, e.g. eu, fedramp; leave blank for none):"
+				);
 			}
-			const effectiveJurisdiction = normalizeJurisdiction(sourceJurisdiction);
+			const effectiveJurisdiction = sourceJurisdiction?.trim() || undefined;
 			// 2.1 R2: list buckets and let user pick, with "Create new" option
 			const buckets = await listR2Buckets(
 				config,
@@ -744,7 +726,7 @@ export const aiSearchCreateCommand = createCommand({
 		if (args.excludeItems) {
 			sourceParams.exclude_items = args.excludeItems;
 		}
-		const sourceJurisdictionValue = normalizeJurisdiction(sourceJurisdiction);
+		const sourceJurisdictionValue = sourceJurisdiction?.trim() || undefined;
 		if (instanceType === "r2" && sourceJurisdictionValue) {
 			sourceParams.r2_jurisdiction = sourceJurisdictionValue;
 		}


### PR DESCRIPTION
Fixes [RAG-1369](https://jira.cfdata.org/browse/RAG-1369).

Adds a `--source-jurisdiction` flag to `wrangler ai-search create` so an AI Search instance can use an R2 source bucket that lives in a specific jurisdiction (e.g. `eu` or `fedramp`).

- New flag `--source-jurisdiction` with choices `default` / `eu` / `fedramp` (`default` means no specific jurisdiction).
- Only valid for `--type r2`; passing it with `--type builtin` or `--type web-crawler` errors.
- Forwarded to the API as `source_params.r2_jurisdiction` (the field already existed on the type, so no client/type changes were needed).
- The interactive R2 flow now prompts `Select an R2 jurisdiction:` and then lists (and can create) buckets within the chosen jurisdiction.

Example:

`wrangler ai-search create my-instance --type r2 --source my-bucket --source-jurisdiction eu`

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: the `wrangler ai-search` commands are in open beta and not yet part of the published public Wrangler command docs; this flag will be documented alongside that command set.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14426" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->