### PR TITLE
Improve `wrangler versions deploy` error messages for non-interactive usage

### DIFF
--- a/.changeset/improve-versions-deploy-error-messages.md
+++ b/.changeset/improve-versions-deploy-error-messages.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Improve `wrangler versions deploy` error messages for non-interactive usage
+
+Error messages in `wrangler versions deploy` are now clearer and more actionable, especially for non-interactive and agent-driven usage. Each error now explains what went wrong, what was expected, and how to fix it (e.g. suggesting the correct flag or command syntax).

--- a/packages/wrangler/src/__tests__/versions/versions.deploy.test.ts
+++ b/packages/wrangler/src/__tests__/versions/versions.deploy.test.ts
@@ -281,7 +281,7 @@ describe("versions deploy", () => {
 			);
 
 			await expect(result).rejects.toMatchInlineSnapshot(
-				`[Error: You need to provide a name of your worker. Either pass it as a cli arg with \`--name <name>\` or in your config file as \`name = "<name>"\`]`
+				`[Error: You need to provide a name for your Worker. Either pass it as a CLI arg with \`--name <name>\` or set the \`name\` field in your Wrangler configuration file (e.g. wrangler.json).]`
 			);
 		});
 	});
@@ -293,7 +293,7 @@ describe("versions deploy", () => {
 			const result = runWrangler("versions deploy --yes");
 
 			await expect(result).rejects.toMatchInlineSnapshot(
-				`[Error: You must select at least 1 version to deploy.]`
+				`[Error: You must select at least 1 version to deploy. Provide a version using positional args (e.g. \`wrangler versions deploy <version-id>\`), --version-id, or --version-tag.]`
 			);
 
 			expect(normalizeOutput(cliStd.out)).toMatchInlineSnapshot(`
@@ -685,7 +685,7 @@ describe("versions deploy", () => {
 				);
 
 				await expect(result).rejects.toMatchInlineSnapshot(
-					`[Error: You must select at most 2 versions to deploy.]`
+					`[Error: Too many versions selected. You can deploy at most 2 version(s) at a time. Please remove some versions and try again.]`
 				);
 
 				expect(normalizeOutput(cliStd.out)).toMatchInlineSnapshot(`
@@ -1139,7 +1139,7 @@ describe("versions deploy", () => {
 			);
 
 			await expect(result).rejects.toMatchInlineSnapshot(
-				`[Error: Percentage value (101%) must be between 0 and 100.]`
+				`[Error: The --percentage value 101% is out of range. Percentages must be between 0 and 100.]`
 			);
 
 			expect(normalizeOutput(cliStd.out)).toMatchInlineSnapshot(`""`);
@@ -1151,7 +1151,7 @@ describe("versions deploy", () => {
 			);
 
 			await expect(result).rejects.toMatchInlineSnapshot(
-				`[Error: Percentage value (-1%) must be between 0 and 100.]`
+				`[Error: The --percentage value -1% is out of range. Percentages must be between 0 and 100.]`
 			);
 
 			expect(normalizeOutput(cliStd.out)).toMatchInlineSnapshot(`""`);
@@ -1163,7 +1163,7 @@ describe("versions deploy", () => {
 			);
 
 			await expect(result).rejects.toMatchInlineSnapshot(
-				`[Error: Percentage value (101%) must be between 0 and 100.]`
+				`[Error: The --percentage value 101% is out of range. Percentages must be between 0 and 100.]`
 			);
 
 			expect(normalizeOutput(cliStd.out)).toMatchInlineSnapshot(`""`);
@@ -1175,7 +1175,7 @@ describe("versions deploy", () => {
 			);
 
 			await expect(result).rejects.toMatchInlineSnapshot(
-				`[Error: Percentage value (-1%) must be between 0 and 100.]`
+				`[Error: The --percentage value -1% is out of range. Percentages must be between 0 and 100.]`
 			);
 
 			expect(normalizeOutput(cliStd.out)).toMatchInlineSnapshot(`""`);
@@ -1532,7 +1532,7 @@ describe("units", () => {
 			expect(() =>
 				parseTagSpecs({ versionTag: ["abc1234@101%"] })
 			).toThrowError(
-				`Percentage value (101%) parsed from --version-tag arg "abc1234@101%" must be between 0 and 100.`
+				`Percentage value 101% (from --version-tag arg "abc1234@101%") is out of range. Percentages must be between 0 and 100.`
 			);
 		});
 
@@ -1683,21 +1683,21 @@ describe("units", () => {
 			expect(() =>
 				validateTrafficSubtotal(101, { min: 0, max: 100 })
 			).toThrowErrorMatchingInlineSnapshot(
-				`[Error: Sum of specified percentages (101%) must be at most 100%]`
+				`[Error: The specified traffic percentages add up to 101%, which exceeds the maximum of 100%. Reduce one or more percentages so they sum to at most 100%.]`
 			);
 		});
 		test("errors if subtotal below min", ({ expect }) => {
 			expect(() =>
 				validateTrafficSubtotal(-1, { min: 0, max: 100 })
 			).toThrowErrorMatchingInlineSnapshot(
-				`[Error: Sum of specified percentages (-1%) must be at least 0%]`
+				`[Error: The specified traffic percentages add up to -1%, which is below the minimum of 0%. Increase one or more percentages so they sum to at least 0%.]`
 			);
 		});
 		test("different error message if min === max", ({ expect }) => {
 			expect(() =>
 				validateTrafficSubtotal(101, { min: 100, max: 100 })
 			).toThrowErrorMatchingInlineSnapshot(
-				`[Error: Sum of specified percentages (101%) must be 100%]`
+				`[Error: The specified traffic percentages add up to 101%, but must total exactly 100%. Adjust the --percentage values or version-spec percentages so they sum to 100%.]`
 			);
 		});
 		test("no error if subtotal above max but not above max + EPSILON", ({
@@ -1708,7 +1708,7 @@ describe("units", () => {
 			expect(() =>
 				validateTrafficSubtotal(100.01)
 			).toThrowErrorMatchingInlineSnapshot(
-				`[Error: Sum of specified percentages (100.01%) must be 100%]`
+				`[Error: The specified traffic percentages add up to 100.01%, but must total exactly 100%. Adjust the --percentage values or version-spec percentages so they sum to 100%.]`
 			);
 		});
 		test("no error if subtotal below min but not below min - EPSILON", ({
@@ -1719,7 +1719,7 @@ describe("units", () => {
 			expect(() =>
 				validateTrafficSubtotal(99.99)
 			).toThrowErrorMatchingInlineSnapshot(
-				`[Error: Sum of specified percentages (99.99%) must be 100%]`
+				`[Error: The specified traffic percentages add up to 99.99%, but must total exactly 100%. Adjust the --percentage values or version-spec percentages so they sum to 100%.]`
 			);
 		});
 	});

--- a/packages/wrangler/src/versions/deploy.ts
+++ b/packages/wrangler/src/versions/deploy.ts
@@ -114,7 +114,7 @@ export const versionsDeployCommand = createCommand({
 
 		if (workerName === undefined) {
 			throw new UserError(
-				'You need to provide a name of your worker. Either pass it as a cli arg with `--name <name>` or in your config file as `name = "<name>"`',
+				"You need to provide a name for your Worker. Either pass it as a CLI arg with `--name <name>` or set the `name` field in your Wrangler configuration file (e.g. wrangler.json).",
 				{ telemetryMessage: "versions deploy missing worker name" }
 			);
 		}
@@ -160,15 +160,18 @@ export const versionsDeployCommand = createCommand({
 
 		// validate we have at least 1 version
 		if (confirmedVersionsToDeploy.length === 0) {
-			throw new UserError("You must select at least 1 version to deploy.", {
-				telemetryMessage: "versions deploy missing selected versions",
-			});
+			throw new UserError(
+				"You must select at least 1 version to deploy. Provide a version using positional args (e.g. `wrangler versions deploy <version-id>`), --version-id, or --version-tag.",
+				{
+					telemetryMessage: "versions deploy missing selected versions",
+				}
+			);
 		}
 
 		// validate we have at most experimentalMaxVersions (default: 2)
 		if (confirmedVersionsToDeploy.length > args.maxVersions) {
 			throw new UserError(
-				`You must select at most ${args.maxVersions} versions to deploy.`,
+				`Too many versions selected. You can deploy at most ${args.maxVersions} version(s) at a time. Please remove some versions and try again.`,
 				{ telemetryMessage: "versions deploy too many selected versions" }
 			);
 		}
@@ -356,7 +359,7 @@ ${ZERO_WIDTH_SPACE}       Message:  ${
 		acceptDefault,
 		validate(versionIds) {
 			if (versionIds === undefined) {
-				return `You must select at least 1 version to deploy.`;
+				return "You must select at least 1 version to deploy. Provide a version using positional args (e.g. `wrangler versions deploy <version-id>`), --version-id, or --version-tag.";
 			}
 		},
 		renderers: {
@@ -596,14 +599,14 @@ function parseOptionalPercentage(
 
 	if (isNaN(percentage)) {
 		throw new UserError(
-			`Could not parse percentage value from ${specLabel} "${spec}"`,
+			`Could not parse percentage value from ${specLabel} "${spec}". Expected format: <version-id>@<percentage> (e.g. \`<version-id>@50%\`).`,
 			{ telemetryMessage: "versions deploy percentage parse failed" }
 		);
 	}
 
 	if (percentage < 0 || percentage > 100) {
 		throw new UserError(
-			`Percentage value (${percentage}%) parsed from ${specLabel} "${spec}" must be between 0 and 100.`,
+			`Percentage value ${percentage}% (from ${specLabel} "${spec}") is out of range. Percentages must be between 0 and 100.`,
 			{
 				telemetryMessage: "versions deploy positional percentage out of range",
 			}
@@ -644,9 +647,12 @@ export function parseVersionSpecs(
 		/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
 	for (const versionId of args.versionId ?? []) {
 		if (!UUID_REGEX.test(versionId)) {
-			throw new UserError(`Version ID must be a valid UUID (${versionId}).`, {
-				telemetryMessage: "versions deploy invalid version id",
-			});
+			throw new UserError(
+				`"${versionId}" is not a valid Version ID. Version IDs must be UUIDs (e.g. \`12345678-1234-1234-1234-123456789abc\`). Run \`wrangler versions list\` to see available versions.`,
+				{
+					telemetryMessage: "versions deploy invalid version id",
+				}
+			);
 		}
 
 		versionIds.push(versionId);
@@ -655,7 +661,7 @@ export function parseVersionSpecs(
 	for (const percentage of args.percentage ?? []) {
 		if (percentage < 0 || percentage > 100) {
 			throw new UserError(
-				`Percentage value (${percentage}%) must be between 0 and 100.`,
+				`The --percentage value ${percentage}% is out of range. Percentages must be between 0 and 100.`,
 				{ telemetryMessage: "versions deploy percentage out of range" }
 			);
 		}
@@ -874,13 +880,13 @@ export function validateTrafficSubtotal(
 
 	if (max === min && (isAbove || isBelow)) {
 		throw new UserError(
-			`Sum of specified percentages (${subtotal}%) must be ${max}%`,
+			`The specified traffic percentages add up to ${subtotal}%, but must total exactly ${max}%. Adjust the --percentage values or version-spec percentages so they sum to ${max}%.`,
 			{ telemetryMessage: "versions deploy traffic subtotal mismatch" }
 		);
 	}
 	if (isAbove) {
 		throw new UserError(
-			`Sum of specified percentages (${subtotal}%) must be at most ${max}%`,
+			`The specified traffic percentages add up to ${subtotal}%, which exceeds the maximum of ${max}%. Reduce one or more percentages so they sum to at most ${max}%.`,
 			{
 				telemetryMessage: "versions deploy traffic subtotal above maximum",
 			}
@@ -888,7 +894,7 @@ export function validateTrafficSubtotal(
 	}
 	if (isBelow) {
 		throw new UserError(
-			`Sum of specified percentages (${subtotal}%) must be at least ${min}%`,
+			`The specified traffic percentages add up to ${subtotal}%, which is below the minimum of ${min}%. Increase one or more percentages so they sum to at least ${min}%.`,
 			{
 				telemetryMessage: "versions deploy traffic subtotal below minimum",
 			}


### PR DESCRIPTION
Just slightly improve error messages for `wrangler versions deploy`

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: just improving some error messages

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14429" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->