### PR TITLE
use `stream` instead of deprecated `pipeline` key in pipelines setup config snippet

### DIFF
--- a/.changeset/fix-pipelines-setup-stream-binding.md
+++ b/.changeset/fix-pipelines-setup-stream-binding.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+use `stream` instead of deprecated `pipeline` key in pipelines setup config snippet
+
+The `wrangler pipelines setup` and `wrangler pipelines create` commands now output the correct `stream` property name in the configuration snippet, matching the rename from `pipeline` to `stream` that was applied across the rest of the codebase.

--- a/packages/wrangler/src/__tests__/pipelines-setup.test.ts
+++ b/packages/wrangler/src/__tests__/pipelines-setup.test.ts
@@ -1402,7 +1402,7 @@ describe("wrangler pipelines setup", () => {
 				{
 				  "pipelines": [
 				    {
-				      "pipeline": "stream_123",
+				      "stream": "stream_123",
 				      "binding": "TEST_PIPELINE_STREAM"
 				    }
 				  ]

--- a/packages/wrangler/src/pipelines/cli/streams/utils.ts
+++ b/packages/wrangler/src/pipelines/cli/streams/utils.ts
@@ -218,7 +218,7 @@ export async function displayUsageExamples(
 	await createdResourceConfig(
 		"pipelines",
 		(customBindingName) => ({
-			pipeline: stream.id,
+			stream: stream.id,
 			binding: customBindingName ?? bindingName,
 		}),
 		config.configPath,


### PR DESCRIPTION
The `wrangler pipelines setup` and `wrangler pipelines create` commands now output the correct `stream` property name in the configuration snippet, matching the rename from `pipeline` to `stream` that was applied across the rest of the codebase.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: not publicly documented

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14430" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->