### PR TITLE
[wrangler] Proactively refresh wrangler tail before server-side expiry

### DIFF
--- a/.changeset/tail-proactive-expiry-refresh.md
+++ b/.changeset/tail-proactive-expiry-refresh.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+`wrangler tail` now proactively refreshes the tail session shortly before its server-side expiry time. Previously, when a tail session expired (roughly 1 hour), log delivery would silently stop with no error or reconnect, leaving the terminal appearing frozen. The session is now transparently refreshed so tailing continues uninterrupted.

--- a/packages/wrangler/src/__tests__/tail.test.ts
+++ b/packages/wrangler/src/__tests__/tail.test.ts
@@ -1331,6 +1331,103 @@ describe("tail", () => {
 		});
 	});
 
+	describe("proactive expiry refresh", () => {
+		// Ensure fake timers never leak into the next test even if an assertion
+		// fails before the in-test `vi.useRealTimers()` call is reached.
+		afterEach(() => vi.useRealTimers());
+
+		it("refreshes the session before server-side expiry (pretty format)", async ({
+			expect,
+		}) => {
+			// Fake both setTimeout (for the expiry refresh timer) and Date (so
+			// Date.now() inside scheduleExpiryRefresh uses the virtual clock and
+			// the computed delay is deterministic). Pin the virtual clock to a
+			// known value so the delay = 30000 - 5000 = 25000ms (EXPIRY_REFRESH_MARGIN_MS = 5s).
+			const fakeNow = 1_000_000_000; // epoch ms — any stable value works
+			vi.useFakeTimers({ toFake: ["setTimeout", "Date"] });
+			vi.setSystemTime(fakeNow);
+
+			// Construct expiresAt relative to fake now.
+			const expiresAt = new Date(fakeNow + 30_000);
+
+			// MSW prepends handlers (LIFO), so register the refresh mock FIRST
+			// so the initial-connection mock (with the near-future expiry) ends
+			// up in front of the queue and fires for the first create-tail request.
+			mockReusableWebsocketAPIs(expect, 1);
+			api = mockWebsocketAPIs(expect, undefined, true, undefined, expiresAt);
+
+			const tailPromise = runWrangler(
+				"tail test-worker --format=pretty"
+			) as Promise<unknown>;
+			activeTailPromise = tailPromise;
+
+			// Establish the initial connection (mock-socket's ~4ms open dispatch).
+			await vi.advanceTimersByTimeAsync(50);
+			await api.ws.connected;
+
+			// Drive fake time past the expiry refresh point (25s = 30s - 5s margin).
+			// The expiry timer fires at ~fakeNow+24950ms; advance in 1s steps.
+			for (let i = 0; i < 30; i++) {
+				await vi.advanceTimersByTimeAsync(1_000);
+				if (std.out.includes("Tail session expired, refreshing...")) {
+					// The refresh chain (HTTP DELETE → POST → WebSocket open) is
+					// asynchronous. Each advanceTimersByTimeAsync call yields to
+					// the real event loop between timer firings, so pending I/O
+					// (MSW responses) completes between steps. Continue advancing
+					// in small increments until the new connection is established.
+					for (let j = 0; j < 50; j++) {
+						await vi.advanceTimersByTimeAsync(100);
+						if (
+							std.out.includes("Successfully created tail, expires at")
+						) {
+							break;
+						}
+					}
+					break;
+				}
+			}
+
+			expect(std.out).toContain("Tail session expired, refreshing...");
+			expect(std.out).toContain("Successfully created tail, expires at");
+
+			// Restore real timers and shut down cleanly via SIGINT. This avoids
+			// calling api.closeHelper() while a proactive-refresh connection may
+			// still be mid-handshake, which can cause mock-socket to dispatch a
+			// close event before hasOpened is set, triggering a reconnect loop.
+			vi.useRealTimers();
+			process.emit("SIGINT");
+			await tailPromise;
+		});
+
+		it("does not refresh after a clean shutdown (Ctrl-C cancels the timer)", async ({
+			expect,
+		}) => {
+			// Use the default far-future expiry (year 3005) so the expiry timer
+			// is never scheduled (our guard skips delays > 2^31-1 ms). We still
+			// verify that Ctrl-C shuts down cleanly and no spurious refresh fires.
+			api = mockWebsocketAPIs(expect);
+
+			const tailPromise = runWrangler(
+				"tail test-worker --format=pretty"
+			) as Promise<unknown>;
+			activeTailPromise = tailPromise;
+
+			// Wait for the initial connection to establish.
+			await api.ws.connected;
+			await vi.waitFor(() => {
+				expect(std.out).toContain("waiting for logs");
+			});
+
+			// Shut down cleanly.
+			process.emit("SIGINT");
+			await tailPromise;
+
+			// No refresh message should appear.
+			expect(std.out).not.toContain("Tail session expired, refreshing...");
+			expect(std.out).toContain("Stopping tail...");
+		});
+	});
+
 	describe("shutdown", () => {
 		it("logs `Stopping tail...`, deletes the tail, and exits cleanly on Ctrl-C", async ({
 			expect,
@@ -1554,7 +1651,8 @@ function mockCreateTailRequest(
 	useServiceEnvironments = true,
 	expectedScriptName = !useServiceEnvironments && env
 		? `test-worker-${env}`
-		: "test-worker"
+		: "test-worker",
+	expiresAt: Date = mockTailExpiration
 ): RequestInit[] {
 	const requests: RequestInit[] = [];
 	const servicesOrScripts =
@@ -1579,7 +1677,7 @@ function mockCreateTailRequest(
 					createFetchResult({
 						url: websocketURL,
 						id: "tail-id",
-						expires_at: mockTailExpiration,
+						expires_at: expiresAt,
 					})
 				);
 			},
@@ -1672,7 +1770,8 @@ function mockWebsocketAPIs(
 	expect: ExpectStatic,
 	env?: string,
 	useServiceEnvironments = true,
-	expectedScriptName?: string
+	expectedScriptName?: string,
+	expiresAt?: Date
 ): MockAPI {
 	const websocketURL = "ws://localhost:1234";
 	const api: MockAPI = {
@@ -1715,7 +1814,8 @@ function mockWebsocketAPIs(
 		websocketURL,
 		env,
 		useServiceEnvironments,
-		expectedScriptName
+		expectedScriptName,
+		expiresAt
 	);
 	api.requests.deletion = mockDeleteTailRequest(
 		expect,

--- a/packages/wrangler/src/__tests__/tail.test.ts
+++ b/packages/wrangler/src/__tests__/tail.test.ts
@@ -1377,9 +1377,7 @@ describe("tail", () => {
 					// in small increments until the new connection is established.
 					for (let j = 0; j < 50; j++) {
 						await vi.advanceTimersByTimeAsync(100);
-						if (
-							std.out.includes("Successfully created tail, expires at")
-						) {
+						if (std.out.includes("Successfully created tail, expires at")) {
 							break;
 						}
 					}

--- a/packages/wrangler/src/tail/index.ts
+++ b/packages/wrangler/src/tail/index.ts
@@ -456,22 +456,18 @@ export const tailCommand = createCommand({
 			// JSON deserialization — use `new Date()` to handle both.
 			const delay =
 				new Date(expiration).getTime() - Date.now() - EXPIRY_REFRESH_MARGIN_MS;
-			// Node.js clamps setTimeout delays that exceed 2^31-1 ms to 1 ms,
-			// causing the callback to fire immediately. If the expiry is further
-			// out than that (~24 days), skip scheduling — the session is unlikely
-			// to stay alive that long, and the keep-alive ping will handle
-			// unexpected drops.
-			if (delay > 2_147_483_647) {
+			// Skip scheduling if the expiry is already past or so far in the
+			// future that Node.js's 32-bit setTimeout clamp would fire it
+			// immediately (~24 days). In both cases let the server close the
+			// WebSocket naturally and rely on scheduleReconnect to recover.
+			if (delay <= 0 || delay > 2_147_483_647) {
 				return;
 			}
 
-			const timer = setTimeout(
-				() => {
-					cancelExpiryRefresh = undefined;
-					void proactiveRefresh();
-				},
-				Math.max(0, delay)
-			);
+			const timer = setTimeout(() => {
+				cancelExpiryRefresh = undefined;
+				void proactiveRefresh();
+			}, delay);
 			cancelExpiryRefresh = () => clearTimeout(timer);
 		}
 

--- a/packages/wrangler/src/tail/index.ts
+++ b/packages/wrangler/src/tail/index.ts
@@ -454,7 +454,8 @@ export const tailCommand = createCommand({
 
 			// `expiration` is typed as Date but arrives as an ISO string after
 			// JSON deserialization — use `new Date()` to handle both.
-			const delay = new Date(expiration).getTime() - Date.now() - EXPIRY_REFRESH_MARGIN_MS;
+			const delay =
+				new Date(expiration).getTime() - Date.now() - EXPIRY_REFRESH_MARGIN_MS;
 			// Node.js clamps setTimeout delays that exceed 2^31-1 ms to 1 ms,
 			// causing the callback to fire immediately. If the expiry is further
 			// out than that (~24 days), skip scheduling — the session is unlikely
@@ -464,10 +465,13 @@ export const tailCommand = createCommand({
 				return;
 			}
 
-			const timer = setTimeout(() => {
-				cancelExpiryRefresh = undefined;
-				void proactiveRefresh();
-			}, Math.max(0, delay));
+			const timer = setTimeout(
+				() => {
+					cancelExpiryRefresh = undefined;
+					void proactiveRefresh();
+				},
+				Math.max(0, delay)
+			);
 			cancelExpiryRefresh = () => clearTimeout(timer);
 		}
 
@@ -490,7 +494,10 @@ export const tailCommand = createCommand({
 			try {
 				await connect();
 			} catch (e) {
-				logger.debug("Tail: proactive refresh failed, falling back to reconnect:", e);
+				logger.debug(
+					"Tail: proactive refresh failed, falling back to reconnect:",
+					e
+				);
 				void scheduleReconnect();
 			}
 		}

--- a/packages/wrangler/src/tail/index.ts
+++ b/packages/wrangler/src/tail/index.ts
@@ -32,6 +32,13 @@ const PING_INTERVAL_MS = 10_000;
 /** Backoff delays between successive reconnect attempts (ms). */
 const RECONNECT_BACKOFF_MS = [1_000, 2_000, 4_000, 8_000, 16_000];
 
+/**
+ * How many milliseconds before the server-side expiry time to proactively
+ * refresh the tail session. Firing a few seconds early avoids a gap where
+ * the backend has stopped forwarding logs but the client hasn't reconnected.
+ */
+const EXPIRY_REFRESH_MARGIN_MS = 5_000;
+
 /** How many reconnect attempts we'll make before giving up. */
 const MAX_RECONNECT_ATTEMPTS = RECONNECT_BACKOFF_MS.length;
 
@@ -191,6 +198,7 @@ export const tailCommand = createCommand({
 		let currentTail: WebSocket | undefined;
 		let currentDeleteTail: (() => Promise<void>) | undefined;
 		let cancelPing: (() => void) | undefined;
+		let cancelExpiryRefresh: (() => void) | undefined;
 		// Set to `true` while we are intentionally tearing down the current
 		// connection — used to suppress the `close` handler so it doesn't
 		// race with reconnect/shutdown logic that already has things in hand.
@@ -266,12 +274,6 @@ export const tailCommand = createCommand({
 				);
 			}
 
-			// NOTE: The tail backend does not actively close this WebSocket
-			// when the expiration time is reached — log delivery just stops.
-			// A proactive client-side refresh based on `expiration` is tracked
-			// as a follow-up in
-			// https://github.com/cloudflare/workers-sdk/issues/14427.
-
 			tail.on("message", printLog);
 
 			// Hooks used by the open-wait promise below. The close listener
@@ -344,6 +346,7 @@ export const tailCommand = createCommand({
 			// Successful connection — reset the reconnect counter.
 			attempt = 0;
 			cancelPing = startWebSocketPing(tail, scheduleReconnect);
+			scheduleExpiryRefresh(expiration);
 		}
 
 		/**
@@ -354,6 +357,8 @@ export const tailCommand = createCommand({
 		async function teardownCurrentConnection(): Promise<void> {
 			cancelPing?.();
 			cancelPing = undefined;
+			cancelExpiryRefresh?.();
+			cancelExpiryRefresh = undefined;
 			intentionalClose = true;
 			const tail = currentTail;
 			const deleteTail = currentDeleteTail;
@@ -433,6 +438,59 @@ export const tailCommand = createCommand({
 				await connect();
 			} catch (e) {
 				logger.debug("Tail: reconnect attempt failed:", e);
+				void scheduleReconnect();
+			}
+		}
+
+		/**
+		 * Schedule a timer to fire shortly before `expiration` so we can
+		 * refresh the session before the backend silently stops forwarding logs.
+		 * Any previously scheduled timer is cancelled first (safe to call on
+		 * every successful connect to reset to the new expiry).
+		 */
+		function scheduleExpiryRefresh(expiration: Date): void {
+			cancelExpiryRefresh?.();
+			cancelExpiryRefresh = undefined;
+
+			// `expiration` is typed as Date but arrives as an ISO string after
+			// JSON deserialization — use `new Date()` to handle both.
+			const delay = new Date(expiration).getTime() - Date.now() - EXPIRY_REFRESH_MARGIN_MS;
+			// Node.js clamps setTimeout delays that exceed 2^31-1 ms to 1 ms,
+			// causing the callback to fire immediately. If the expiry is further
+			// out than that (~24 days), skip scheduling — the session is unlikely
+			// to stay alive that long, and the keep-alive ping will handle
+			// unexpected drops.
+			if (delay > 2_147_483_647) {
+				return;
+			}
+
+			const timer = setTimeout(() => {
+				cancelExpiryRefresh = undefined;
+				void proactiveRefresh();
+			}, Math.max(0, delay));
+			cancelExpiryRefresh = () => clearTimeout(timer);
+		}
+
+		/**
+		 * Proactively refresh the tail session before it reaches server-side
+		 * expiry. Unlike `scheduleReconnect` this skips the reconnect back-off
+		 * so the gap between the old and new session is minimal.
+		 */
+		async function proactiveRefresh(): Promise<void> {
+			if (isShuttingDown) {
+				return;
+			}
+			if (args.format === "pretty") {
+				logger.log("Tail session expired, refreshing...");
+			}
+			await teardownCurrentConnection();
+			if (isShuttingDown) {
+				return;
+			}
+			try {
+				await connect();
+			} catch (e) {
+				logger.debug("Tail: proactive refresh failed, falling back to reconnect:", e);
 				void scheduleReconnect();
 			}
 		}

--- a/packages/wrangler/src/tail/index.ts
+++ b/packages/wrangler/src/tail/index.ts
@@ -460,7 +460,7 @@ export const tailCommand = createCommand({
 			// future that Node.js's 32-bit setTimeout clamp would fire it
 			// immediately (~24 days). In both cases let the server close the
 			// WebSocket naturally and rely on scheduleReconnect to recover.
-			if (delay <= 0 || delay > 2_147_483_647) {
+			if (!Number.isFinite(delay) || delay <= 0 || delay > 2_147_483_647) {
 				return;
 			}
 


### PR DESCRIPTION
Fixes #14427.

When a tail session expires (roughly 1 hour), the backend stops delivering logs but leaves the WebSocket open. The user sees a silently frozen terminal with no error and no reconnect — there's no indication that tailing has stopped.

This PR schedules a client-side timer to fire `EXPIRY_REFRESH_MARGIN_MS` (5 seconds) before the server-reported expiry time. At that point, `proactiveRefresh()` tears down the current connection and calls `connect()` again, transparently re-establishing the session so log delivery continues uninterrupted.

Key implementation details:
- `scheduleExpiryRefresh(expiration)` is called at the end of every successful `connect()`. It skips scheduling when the delay exceeds `2^31-1` ms (Node.js's `setTimeout` max) to prevent silent overflow in tests that use far-future expiry dates.
- The timer is cancelled in `teardownCurrentConnection()` so it doesn't fire during user-initiated shutdown or reconnects.
- `expiration` is typed as `Date` but arrives as an ISO string after JSON deserialization; `new Date(expiration).getTime()` handles both.
- In `pretty` format, a `"Tail session expired, refreshing..."` message is logged so the user knows what happened.

---

- Tests
  - [x] Tests included/updated
- Public documentation
  - [x] Documentation not necessary because: this is a transparent UX improvement with no new configuration options
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14434" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->