### PR TITLE
[Wrangler] Improve deploy warn for workflows with repeated names

### DIFF
--- a/.changeset/explain-workflow-name-conflict.md
+++ b/.changeset/explain-workflow-name-conflict.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Improve the deploy warning shown when a Workflow name already belongs to another Worker
+
+The warning still notes that deploying reassigns the workflow to the current Worker, and now also explains why this happens (workflow names must be unique per account) and how to resolve it (rename the workflow in the Wrangler config).

--- a/packages/deploy-helpers/src/deploy/helpers/check-workflow-conflicts.ts
+++ b/packages/deploy-helpers/src/deploy/helpers/check-workflow-conflicts.ts
@@ -85,7 +85,7 @@ export async function checkWorkflowConflicts(
 
 	const message =
 		`The following workflow(s) already exist and belong to different workers:\n${conflictList}\n\n` +
-		`Deploying will reassign these workflows to "${scriptName}".`;
+		`Deploying will reassign these workflows to "${scriptName}". Workflow names must be unique per account. If this reassignment is unintended, rename the workflow(s) in the Wrangler config.`;
 
 	return { hasConflicts: true, conflicts, message };
 }

--- a/packages/wrangler/src/__tests__/deploy/check-workflow-conflicts.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/check-workflow-conflicts.test.ts
@@ -277,7 +277,7 @@ describe("checkWorkflowConflicts", () => {
 		expect(message).toBe(
 			`The following workflow(s) already exist and belong to different workers:\n` +
 				`  - "my-workflow" (currently belongs to "other-worker")\n\n` +
-				`Deploying will reassign these workflows to "my-worker".`
+				`Deploying will reassign these workflows to "my-worker". Workflow names must be unique per account. If this reassignment is unintended, rename the workflow(s) in the Wrangler config.`
 		);
 	});
 });

--- a/packages/wrangler/src/__tests__/deploy/workflows.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/workflows.test.ts
@@ -987,6 +987,12 @@ describe("deploy", () => {
 				expect(std.warn).toContain(
 					'Deploying will reassign these workflows to "test-name".'
 				);
+				expect(std.warn).toContain(
+					"Workflow names must be unique per account."
+				);
+				expect(std.warn).toContain(
+					"If this reassignment is unintended, rename the workflow(s) in the Wrangler config."
+				);
 			});
 
 			it("should abort deploy when user declines the workflow conflict confirmation", async ({


### PR DESCRIPTION
Fixes WOR-1361.

Improves the warning message when deploying a Workflow with a name belonging to an already deployed Workflow. 

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: just improves a warn message

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14435" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->