### PR TITLE
Slightly improve KV error messages to be clearer and more actionable

### DIFF
--- a/.changeset/improve-kv-error-messages.md
+++ b/.changeset/improve-kv-error-messages.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Improve KV error messages to be clearer and more actionable
+
+Error messages for KV namespace and key operations now consistently explain what went wrong, which flags or config fields to use, and what commands to run as alternatives. This covers namespace selection errors (delete, rename), binding resolution errors, config file issues, and preview namespace ambiguity.

--- a/packages/wrangler/src/__tests__/kv/key.test.ts
+++ b/packages/wrangler/src/__tests__/kv/key.test.ts
@@ -693,7 +693,7 @@ describe("kv", () => {
 				await expect(
 					runWrangler("kv key put --remote key value --binding otherBinding")
 				).rejects.toThrowErrorMatchingInlineSnapshot(
-					`[Error: A namespace with binding name "otherBinding" was not found in the configured "kv_namespaces".]`
+					`[Error: No KV namespace with binding "otherBinding" was found in the "kv_namespaces" section of your wrangler config. Check the binding name is correct, or use \`--namespace-id\` instead.]`
 				);
 
 				expect(std.out).toMatchInlineSnapshot(`
@@ -705,7 +705,7 @@ describe("kv", () => {
 					"
 				`);
 				expect(std.err).toMatchInlineSnapshot(`
-					"[31mX [41;31m[[41;97mERROR[41;31m][0m [1mA namespace with binding name "otherBinding" was not found in the configured "kv_namespaces".[0m
+					"[31mX [41;31m[[41;97mERROR[41;31m][0m [1mNo KV namespace with binding "otherBinding" was found in the "kv_namespaces" section of your wrangler config. Check the binding name is correct, or use \`--namespace-id\` instead.[0m
 
 					"
 				`);
@@ -724,7 +724,7 @@ describe("kv", () => {
 						"kv key put --remote my-key my-value --binding someBinding"
 					)
 				).rejects.toThrowErrorMatchingInlineSnapshot(
-					`[Error: someBinding has both a namespace ID and a preview ID. Specify "--preview" or "--preview false" to avoid writing data to the wrong namespace.]`
+					`[Error: The binding "someBinding" has both an "id" and a "preview_id" configured. Pass \`--preview\` to target the preview namespace, or \`--preview false\` to target the production namespace.]`
 				);
 				expect(std.out).toMatchInlineSnapshot(`
 					"
@@ -735,7 +735,7 @@ describe("kv", () => {
 					"
 				`);
 				expect(std.err).toMatchInlineSnapshot(`
-					"[31mX [41;31m[[41;97mERROR[41;31m][0m [1msomeBinding has both a namespace ID and a preview ID. Specify "--preview" or "--preview false" to avoid writing data to the wrong namespace.[0m
+					"[31mX [41;31m[[41;97mERROR[41;31m][0m [1mThe binding "someBinding" has both an "id" and a "preview_id" configured. Pass \`--preview\` to target the preview namespace, or \`--preview false\` to target the production namespace.[0m
 
 					"
 				`);
@@ -915,10 +915,10 @@ describe("kv", () => {
 				await expect(
 					runWrangler("kv key list --remote --binding otherBinding")
 				).rejects.toThrowErrorMatchingInlineSnapshot(
-					`[Error: A namespace with binding name "otherBinding" was not found in the configured "kv_namespaces".]`
+					`[Error: No KV namespace with binding "otherBinding" was found in the "kv_namespaces" section of your wrangler config. Check the binding name is correct, or use \`--namespace-id\` instead.]`
 				);
 				expect(std.err).toMatchInlineSnapshot(`
-					"[31mX [41;31m[[41;97mERROR[41;31m][0m [1mA namespace with binding name "otherBinding" was not found in the configured "kv_namespaces".[0m
+					"[31mX [41;31m[[41;97mERROR[41;31m][0m [1mNo KV namespace with binding "otherBinding" was found in the "kv_namespaces" section of your wrangler config. Check the binding name is correct, or use \`--namespace-id\` instead.[0m
 
 					"
 				`);
@@ -1219,11 +1219,11 @@ describe("kv", () => {
 				await expect(
 					runWrangler("kv key get --remote key --binding otherBinding")
 				).rejects.toThrowErrorMatchingInlineSnapshot(
-					`[Error: A namespace with binding name "otherBinding" was not found in the configured "kv_namespaces".]`
+					`[Error: No KV namespace with binding "otherBinding" was found in the "kv_namespaces" section of your wrangler config. Check the binding name is correct, or use \`--namespace-id\` instead.]`
 				);
 				expect(std.out).toMatchInlineSnapshot(`""`);
 				expect(std.err).toMatchInlineSnapshot(`
-					"[31mX [41;31m[[41;97mERROR[41;31m][0m [1mA namespace with binding name "otherBinding" was not found in the configured "kv_namespaces".[0m
+					"[31mX [41;31m[[41;97mERROR[41;31m][0m [1mNo KV namespace with binding "otherBinding" was found in the "kv_namespaces" section of your wrangler config. Check the binding name is correct, or use \`--namespace-id\` instead.[0m
 
 					"
 				`);
@@ -1412,11 +1412,11 @@ describe("kv", () => {
 				await expect(
 					runWrangler(`kv key delete --remote --binding otherBinding someKey`)
 				).rejects.toThrowErrorMatchingInlineSnapshot(
-					`[Error: A namespace with binding name "otherBinding" was not found in the configured "kv_namespaces".]`
+					`[Error: No KV namespace with binding "otherBinding" was found in the "kv_namespaces" section of your wrangler config. Check the binding name is correct, or use \`--namespace-id\` instead.]`
 				);
 
 				expect(std.err).toMatchInlineSnapshot(`
-					"[31mX [41;31m[[41;97mERROR[41;31m][0m [1mA namespace with binding name "otherBinding" was not found in the configured "kv_namespaces".[0m
+					"[31mX [41;31m[[41;97mERROR[41;31m][0m [1mNo KV namespace with binding "otherBinding" was found in the "kv_namespaces" section of your wrangler config. Check the binding name is correct, or use \`--namespace-id\` instead.[0m
 
 					"
 				`);

--- a/packages/wrangler/src/__tests__/kv/namespace.test.ts
+++ b/packages/wrangler/src/__tests__/kv/namespace.test.ts
@@ -414,12 +414,13 @@ describe("kv", () => {
 				await expect(runWrangler("kv namespace delete --binding otherBinding"))
 					.rejects.toThrowErrorMatchingInlineSnapshot(`
 					[Error: Not able to delete namespace.
-					A namespace with binding name "otherBinding" was not found in the configured "kv_namespaces".]
+					No KV namespace with binding "otherBinding" was found in the "kv_namespaces" section of your wrangler config. Check the binding name is correct, or use \`--namespace-id\` instead.]
 				`);
 				expect(std.err).toMatchInlineSnapshot(`
 					"[31mX [41;31m[[41;97mERROR[41;31m][0m [1mNot able to delete namespace.[0m
 
-					  A namespace with binding name "otherBinding" was not found in the configured "kv_namespaces".
+					  No KV namespace with binding "otherBinding" was found in the "kv_namespaces" section of your
+					  wrangler config. Check the binding name is correct, or use \`--namespace-id\` instead.
 
 					"
 				`);
@@ -526,7 +527,7 @@ describe("kv", () => {
 				).rejects.toThrowErrorMatchingInlineSnapshot(
 					`
 					[Error: Not able to delete namespace.
-					No namespace found with the name "nonexistent-namespace". Use --namespace-id or --binding instead, or check available namespaces with "wrangler kv namespace list".]
+					No KV namespace named "nonexistent-namespace" was found in your account. Use \`--namespace-id\` or \`--binding\` instead, or run \`wrangler kv namespace list\` to see all available namespaces.]
 				`
 				);
 			});
@@ -537,7 +538,7 @@ describe("kv", () => {
 				await expect(
 					runWrangler("kv namespace delete my-namespace --namespace-id some-id")
 				).rejects.toThrowErrorMatchingInlineSnapshot(
-					`[Error: Cannot specify multiple of: namespace name (as positional argument), --binding, or --namespace-id. Use only one.]`
+					`[Error: Only one namespace selector is allowed. Provide exactly one of: a positional namespace name, \`--binding\`, or \`--namespace-id\`.]`
 				);
 			});
 
@@ -548,7 +549,7 @@ describe("kv", () => {
 				await expect(
 					runWrangler("kv namespace delete my-namespace --binding someBinding")
 				).rejects.toThrowErrorMatchingInlineSnapshot(
-					`[Error: Cannot specify multiple of: namespace name (as positional argument), --binding, or --namespace-id. Use only one.]`
+					`[Error: Only one namespace selector is allowed. Provide exactly one of: a positional namespace name, \`--binding\`, or \`--namespace-id\`.]`
 				);
 			});
 
@@ -572,7 +573,7 @@ describe("kv", () => {
 				await expect(
 					runWrangler("kv namespace delete")
 				).rejects.toThrowErrorMatchingInlineSnapshot(
-					`[Error: Must specify one of: namespace name (as positional argument), --binding, or --namespace-id]`
+					`[Error: No KV namespace specified. Provide a namespace name as a positional argument, or use \`--binding\` or \`--namespace-id\`.]`
 				);
 			});
 		});
@@ -671,7 +672,7 @@ describe("kv", () => {
 				await expect(
 					runWrangler("kv namespace rename --new-name new-name")
 				).rejects.toThrowErrorMatchingInlineSnapshot(
-					`[Error: Either old-name (as first argument) or --namespace-id must be specified]`
+					`[Error: No KV namespace specified. Provide the current namespace name as a positional argument, or use \`--namespace-id\` to identify the namespace to rename.]`
 				);
 			});
 
@@ -744,7 +745,7 @@ describe("kv", () => {
 						"kv namespace rename nonexistent-name --new-name new-name"
 					)
 				).rejects.toThrowErrorMatchingInlineSnapshot(
-					`[Error: No namespace found with the name "nonexistent-name". Use --namespace-id instead or check available namespaces with "wrangler kv namespace list".]`
+					`[Error: No KV namespace named "nonexistent-name" was found in your account. Use \`--namespace-id\` to identify the namespace by ID, or run \`wrangler kv namespace list\` to see all available namespaces.]`
 				);
 			});
 

--- a/packages/wrangler/src/kv/helpers.ts
+++ b/packages/wrangler/src/kv/helpers.ts
@@ -425,7 +425,7 @@ async function getIdFromSettings(
 	);
 	if (!existingKV || !("namespace_id" in existingKV)) {
 		throw new UserError(
-			`No KV namespace ID found for binding "${binding}" in the deployed Worker settings for "${config.name}". Add an "id" to the "${binding}" entry in your config's "kv_namespaces" array, or use \`--namespace-id\` instead.`,
+			`No KV namespace ID found for binding "${binding}" in the deployed Worker settings for "${config.name}". Deploy the Worker so the binding is provisioned, or use \`--namespace-id\` instead.`,
 			{
 				telemetryMessage:
 					"kv namespace id missing from deployed worker binding",

--- a/packages/wrangler/src/kv/helpers.ts
+++ b/packages/wrangler/src/kv/helpers.ts
@@ -412,9 +412,12 @@ async function getIdFromSettings(
 	}
 	const accountId = await requireAuth(config);
 	if (!config.name) {
-		throw new UserError("No Worker name found in config", {
-			telemetryMessage: "kv binding resolution missing worker name",
-		});
+		throw new UserError(
+			'Cannot resolve KV binding: no Worker name is configured. Add a "name" field to your wrangler config file, or use `--namespace-id` instead.',
+			{
+				telemetryMessage: "kv binding resolution missing worker name",
+			}
+		);
 	}
 	const settings = await getSettings(config, accountId, config.name);
 	const existingKV = settings?.bindings.find(
@@ -422,7 +425,7 @@ async function getIdFromSettings(
 	);
 	if (!existingKV || !("namespace_id" in existingKV)) {
 		throw new UserError(
-			`No namespace ID found for binding "${binding}". Add one to your wrangler config file or pass it via \`--namespace-id\`.`,
+			`No KV namespace ID found for binding "${binding}" in the deployed Worker settings for "${config.name}". Add an "id" to the "${binding}" entry in your config's "kv_namespaces" array, or use \`--namespace-id\` instead.`,
 			{
 				telemetryMessage:
 					"kv namespace id missing from deployed worker binding",
@@ -457,8 +460,7 @@ export async function getKVNamespaceId(
 
 		if (!found) {
 			throw new UserError(
-				`No namespace found with the name "${namespace}". ` +
-					`Use --namespace-id or --binding instead, or check available namespaces with "wrangler kv namespace list".`,
+				`No KV namespace named "${namespace}" was found in your account. Use \`--namespace-id\` or \`--binding\` instead, or run \`wrangler kv namespace list\` to see all available namespaces.`,
 				{ telemetryMessage: "kv namespace name not found" }
 			);
 		}
@@ -472,16 +474,18 @@ export async function getKVNamespaceId(
 
 	// `--binding` is only valid if there's a wrangler configuration.
 	if (binding && !config) {
-		throw new UserError("--binding specified, but no config file was found.", {
-			telemetryMessage: "kv namespace resolution binding requires config",
-		});
+		throw new UserError(
+			'Cannot resolve `--binding` without a wrangler config file. Create a wrangler.json with a "kv_namespaces" section, or use `--namespace-id` instead.',
+			{
+				telemetryMessage: "kv namespace resolution binding requires config",
+			}
+		);
 	}
 
 	// there's no config. abort here
 	if (!config) {
 		throw new UserError(
-			"Failed to find a config file.\n" +
-				"Either use --namespace-id to upload directly or create a configuration file with a binding.",
+			'No wrangler config file found. Use `--namespace-id` to specify the KV namespace directly, or create a wrangler.json with a "kv_namespaces" section.',
 			{ telemetryMessage: "kv namespace resolution missing config file" }
 		);
 	}
@@ -489,7 +493,7 @@ export async function getKVNamespaceId(
 	// there's no KV namespaces
 	if (!config.kv_namespaces || config.kv_namespaces.length === 0) {
 		throw new UserError(
-			"No KV Namespaces configured! Either use --namespace-id to upload directly or add a KV namespace to your wrangler config file.",
+			'No KV namespaces are configured in your wrangler config file. Use `--namespace-id` to specify the namespace directly, or add a "kv_namespaces" entry to your config.',
 			{ telemetryMessage: "kv namespaces not configured" }
 		);
 	}
@@ -501,7 +505,7 @@ export async function getKVNamespaceId(
 	// we couldn't find a namespace with that binding
 	if (!configNamespace) {
 		throw new UserError(
-			`A namespace with binding name "${binding}" was not found in the configured "kv_namespaces".`,
+			`No KV namespace with binding "${binding}" was found in the "kv_namespaces" section of your wrangler config. Check the binding name is correct, or use \`--namespace-id\` instead.`,
 			{ telemetryMessage: "kv namespace binding not found in config" }
 		);
 	}
@@ -519,7 +523,7 @@ export async function getKVNamespaceId(
 		return { namespaceId: nsId, displayName: formatDisplayName(nsId) };
 	} else if (preview) {
 		throw new UserError(
-			`No preview ID found for ${binding}. Add one to your wrangler config file to use a separate namespace for previewing your worker.`,
+			`No preview namespace ID is configured for binding "${binding}". Add a "preview_id" to the "${binding}" entry in your config's "kv_namespaces" section, or use \`--namespace-id\` to specify a preview namespace directly.`,
 			{ telemetryMessage: "kv namespace preview id missing" }
 		);
 	}
@@ -540,7 +544,7 @@ export async function getKVNamespaceId(
 			return { namespaceId: nsId, displayName: formatDisplayName(nsId) };
 		}
 		throw new UserError(
-			`No namespace ID found for ${binding}. Add one to your wrangler config file or pass it via \`--namespace-id\`.`,
+			`No namespace ID is configured for binding "${binding}". Add an "id" to the "${binding}" entry in your config's "kv_namespaces" section, or use \`--namespace-id\` instead.`,
 			{ telemetryMessage: "kv namespace id missing" }
 		);
 	}
@@ -563,7 +567,7 @@ export async function getKVNamespaceId(
 		return { namespaceId: nsId, displayName: formatDisplayName(nsId) };
 	} else {
 		throw new UserError(
-			`${binding} has both a namespace ID and a preview ID. Specify "--preview" or "--preview false" to avoid writing data to the wrong namespace.`,
+			`The binding "${binding}" has both an "id" and a "preview_id" configured. Pass \`--preview\` to target the preview namespace, or \`--preview false\` to target the production namespace.`,
 			{ telemetryMessage: "kv namespace requires preview selection" }
 		);
 	}

--- a/packages/wrangler/src/kv/index.ts
+++ b/packages/wrangler/src/kv/index.ts
@@ -240,14 +240,14 @@ export const kvNamespaceDeleteCommand = createCommand({
 
 		if (providedOptions.length === 0) {
 			throw new CommandLineArgsError(
-				"Must specify one of: namespace name (as positional argument), --binding, or --namespace-id",
+				"No KV namespace specified. Provide a namespace name as a positional argument, or use `--binding` or `--namespace-id`.",
 				{ telemetryMessage: "kv namespace delete missing namespace selector" }
 			);
 		}
 
 		if (providedOptions.length > 1) {
 			throw new CommandLineArgsError(
-				"Cannot specify multiple of: namespace name (as positional argument), --binding, or --namespace-id. Use only one.",
+				"Only one namespace selector is allowed. Provide exactly one of: a positional namespace name, `--binding`, or `--namespace-id`.",
 				{
 					telemetryMessage:
 						"kv namespace delete conflicting namespace selectors",
@@ -343,7 +343,7 @@ export const kvNamespaceRenameCommand = createCommand({
 		// Check if both name and namespace-id are provided
 		if (args.oldName && args.namespaceId) {
 			throw new CommandLineArgsError(
-				"Cannot specify both old-name and --namespace-id. Use either old-name (as first argument) or --namespace-id flag, not both.",
+				"Cannot specify both a positional namespace name and `--namespace-id`. Use one or the other to identify the namespace to rename.",
 				{
 					telemetryMessage:
 						"kv namespace rename conflicting namespace selectors",
@@ -354,7 +354,7 @@ export const kvNamespaceRenameCommand = createCommand({
 		// Require either old-name or namespace-id
 		if (!args.namespaceId && !args.oldName) {
 			throw new CommandLineArgsError(
-				"Either old-name (as first argument) or --namespace-id must be specified",
+				"No KV namespace specified. Provide the current namespace name as a positional argument, or use `--namespace-id` to identify the namespace to rename.",
 				{ telemetryMessage: "kv namespace rename missing namespace selector" }
 			);
 		}
@@ -362,7 +362,7 @@ export const kvNamespaceRenameCommand = createCommand({
 		// Validate new-name length (API limit is 512 characters)
 		if (args.newName && args.newName.length > 512) {
 			throw new CommandLineArgsError(
-				`new-name must be 512 characters or less (current: ${args.newName.length})`,
+				`The new namespace name exceeds the 512-character limit (got ${args.newName.length} characters). Provide a shorter name with \`--new-name\`.`,
 				{ telemetryMessage: "kv namespace rename new name too long" }
 			);
 		}
@@ -382,8 +382,7 @@ export const kvNamespaceRenameCommand = createCommand({
 
 			if (!namespace) {
 				throw new UserError(
-					`No namespace found with the name "${args.oldName}". ` +
-						`Use --namespace-id instead or check available namespaces with "wrangler kv namespace list".`,
+					`No KV namespace named "${args.oldName}" was found in your account. Use \`--namespace-id\` to identify the namespace by ID, or run \`wrangler kv namespace list\` to see all available namespaces.`,
 					{ telemetryMessage: "kv namespace rename namespace not found" }
 				);
 			}


### PR DESCRIPTION
Error messages for KV namespace and key operations now consistently explain what went wrong, which flags or config fields to use, and what commands to run as alternatives. This covers namespace selection errors (delete, rename), binding resolution errors, config file issues, and preview namespace ambiguity.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: just slightly improving error messages

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14436" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->