### PR TITLE
fix(wrangler): replace existing resource bindings during creation

### DIFF
--- a/.changeset/tidy-kv-placeholder.md
+++ b/.changeset/tidy-kv-placeholder.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Replace existing bindings when adding newly created resources to Wrangler configuration
+
+When config updates are authorized interactively or through `--update-config` or `--binding`, Wrangler now replaces an existing resource binding with the selected name instead of adding a duplicate entry. This allows template bindings with placeholder resource IDs to be updated in both interactive and non-interactive workflows.

--- a/packages/wrangler/src/__tests__/update-config-file.test.ts
+++ b/packages/wrangler/src/__tests__/update-config-file.test.ts
@@ -142,6 +142,96 @@ describe("createdResourceConfig()", () => {
 		);
 	});
 
+	it("interactive: replaces an existing binding with the same name", async ({
+		expect,
+	}) => {
+		writeWranglerConfig(
+			{
+				name: "worker",
+				kv_namespaces: [
+					{ binding: "OTHER_KV", id: "other-id" },
+					{
+						binding: "KV",
+						id: "<your-kv-namespace-id>",
+						preview_id: "preview-id",
+						remote: true,
+					},
+				],
+			},
+			"wrangler.json"
+		);
+
+		setIsTTY(true);
+		mockConfirm({
+			text: "Would you like Wrangler to add it on your behalf?",
+			result: true,
+		});
+		mockPrompt({
+			text: "What binding name would you like to use?",
+			result: "KV",
+		});
+		mockConfirm({
+			text: "For local dev, do you want to connect to the remote resource instead of a local resource?",
+			result: false,
+		});
+
+		await createdResourceConfig(
+			"kv_namespaces",
+			(name) => ({ binding: name ?? "KV", id: "random-id" }),
+			"wrangler.json",
+			undefined
+		);
+
+		expect(await readFile("wrangler.json", "utf8")).toMatchInlineSnapshot(`
+			"{
+				"compatibility_date": "2022-01-12",
+				"name": "worker",
+				"kv_namespaces": [
+					{
+						"binding": "OTHER_KV",
+						"id": "other-id"
+					},
+					{
+						"binding": "KV",
+						"id": "random-id",
+						"preview_id": "preview-id"
+					}
+				]
+			}"
+		`);
+	});
+
+	it("non interactive: replaces an existing binding with the same name", async ({
+		expect,
+	}) => {
+		writeWranglerConfig(
+			{
+				name: "worker",
+				kv_namespaces: [
+					{
+						binding: "KV",
+						id: "<your-kv-namespace-id>",
+						remote: true,
+					},
+				],
+			},
+			"wrangler.json"
+		);
+
+		await createdResourceConfig(
+			"kv_namespaces",
+			(name) => ({ binding: name ?? "KV", id: "random-id" }),
+			"wrangler.json",
+			undefined,
+			{ binding: "KV", updateConfig: true }
+		);
+
+		expect(await readFile("wrangler.json", "utf8")).toContain(
+			'"id": "random-id"'
+		);
+		expect(await readFile("wrangler.json", "utf8")).not.toContain('"remote"');
+	});
+
 	it("interactive: file update in env after answering yes", async ({
 		expect,
 	}) => {

--- a/packages/wrangler/src/utils/add-created-resource-config.ts
+++ b/packages/wrangler/src/utils/add-created-resource-config.ts
@@ -1,5 +1,6 @@
 import {
 	configFormat,
+	experimental_readRawConfig,
 	experimental_patchConfig,
 	formatConfigSnippet,
 	friendlyBindingNames,
@@ -129,16 +130,39 @@ export async function createdResourceConfig<K extends ValidKeys>(
 							{ defaultValue: false }
 						));
 
-			const configFilePatch = {
-				[resource]: [
-					{ ...snippet(bindingName), ...(useRemote ? { remote: true } : {}) },
-				],
+			const { rawConfig } = experimental_readRawConfig({ config: configPath });
+			const environment = env ? rawConfig.env?.[env] : rawConfig;
+
+			const binding = {
+				...snippet(bindingName),
+				remote: useRemote ? true : undefined,
 			};
 
+			const existingBindings = environment?.[resource];
+			const matchingBindingIndex = existingBindings?.findIndex(
+				(existingBinding) => existingBinding.binding === binding.binding
+			);
+
+			const shouldReplaceExistingBinding =
+				existingBindings !== undefined &&
+				matchingBindingIndex !== undefined &&
+				matchingBindingIndex !== -1;
+
+			let bindings: Partial<NonNullable<RawConfig[K]>[number]>[] = [binding];
+			if (shouldReplaceExistingBinding) {
+				bindings = existingBindings.map((existingBinding, index) => {
+					if (index !== matchingBindingIndex) {
+						return existingBinding;
+					}
+					return { ...existingBinding, ...binding };
+				});
+			}
+
+			const configFilePatch = { [resource]: bindings };
 			experimental_patchConfig(
 				configPath,
 				env ? { env: { [env]: configFilePatch } } : configFilePatch,
-				true
+				!shouldReplaceExistingBinding
 			);
 		}
 	}


### PR DESCRIPTION
When Wrangler creates a resource and config updates have been authorized, replace an existing binding with the selected name instead of appending a duplicate entry.

Authorization follows the existing command behavior:

- Interactive users answer yes to `Would you like Wrangler to add it on your behalf?`.
- Non-interactive users provide `--update-config` or `--binding`.

No additional replacement flag or confirmation is required. This allows project templates containing placeholder resource IDs to work in both interactive and automated workflows. Unrelated fields on the existing binding are preserved while the newly created resource details and selected local/remote setting are applied.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: This corrects Wrangler's existing config-update behavior without changing the public CLI or configuration schema.

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
