### PR TITLE
Replace all the occurrences of the deprecated `toThrowError` API with the appropriate `toThrow` one

### DIFF
--- a/fixtures/additional-modules/test/index.test.ts
+++ b/fixtures/additional-modules/test/index.test.ts
@@ -87,7 +87,7 @@ describe("find_additional_modules dev", () => {
 		await fs.rm(path.join(srcDir, "lang", "en.js"));
 
 		await vi.waitFor(async () => {
-			await expect(get(worker, "/lang/en")).rejects.toThrowError(
+			await expect(get(worker, "/lang/en")).rejects.toThrow(
 				'No such module "lang/en.js".'
 			);
 		});

--- a/fixtures/get-platform-proxy/tests/get-platform-proxy.caches.test.ts
+++ b/fixtures/get-platform-proxy/tests/get-platform-proxy.caches.test.ts
@@ -39,31 +39,31 @@ describe("getPlatformProxy - caches", () => {
 
 			expect(() => {
 				caches.has("my-cache");
-			}).toThrowError(
+			}).toThrow(
 				"Failed to execute 'has' on 'CacheStorage': the method is not implemented."
 			);
 
 			expect(() => {
 				caches.delete("my-cache");
-			}).toThrowError(
+			}).toThrow(
 				"Failed to execute 'delete' on 'CacheStorage': the method is not implemented."
 			);
 
 			expect(() => {
 				caches.keys();
-			}).toThrowError(
+			}).toThrow(
 				"Failed to execute 'keys' on 'CacheStorage': the method is not implemented."
 			);
 
 			expect(() => {
 				caches.match(new URL("https://localhost"));
-			}).toThrowError(
+			}).toThrow(
 				"Failed to execute 'match' on 'CacheStorage': the method is not implemented."
 			);
 
 			expect(() => {
 				caches.nonExistentMethod();
-			}).toThrowError("caches.nonExistentMethod is not a function");
+			}).toThrow("caches.nonExistentMethod is not a function");
 		} finally {
 			await dispose();
 		}

--- a/fixtures/get-platform-proxy/tests/get-platform-proxy.cf.test.ts
+++ b/fixtures/get-platform-proxy/tests/get-platform-proxy.cf.test.ts
@@ -22,14 +22,14 @@ describe("getPlatformProxy - cf", () => {
 
 			expect(() => {
 				cf.city = "test city";
-			}).toThrowError(
+			}).toThrow(
 				"Cannot assign to read only property 'city' of object '#<Object>'"
 			);
 			expect(cf.city).not.toBe("test city");
 
 			expect(() => {
 				cf.newField = "test new field";
-			}).toThrowError("Cannot add property newField, object is not extensible");
+			}).toThrow("Cannot add property newField, object is not extensible");
 			expect("newField" in cf).toBe(false);
 
 			expect(cf.botManagement).toMatchObject({

--- a/fixtures/get-platform-proxy/tests/get-platform-proxy.ctx.test.ts
+++ b/fixtures/get-platform-proxy/tests/get-platform-proxy.ctx.test.ts
@@ -67,11 +67,11 @@ describe("getPlatformProxy - ctx", () => {
 			try {
 				expect(() => {
 					waitUntil(new Promise(() => {}));
-				}).toThrowError("Illegal invocation");
+				}).toThrow("Illegal invocation");
 
 				expect(() => {
 					passThroughOnException();
-				}).toThrowError("Illegal invocation");
+				}).toThrow("Illegal invocation");
 			} finally {
 				await dispose();
 			}
@@ -87,11 +87,11 @@ describe("getPlatformProxy - ctx", () => {
 			try {
 				expect(() => {
 					waitUntil(new Promise(() => {}));
-				}).toThrowError("Illegal invocation");
+				}).toThrow("Illegal invocation");
 
 				expect(() => {
 					passThroughOnException();
-				}).toThrowError("Illegal invocation");
+				}).toThrow("Illegal invocation");
 			} finally {
 				await dispose();
 			}
@@ -107,15 +107,15 @@ describe("getPlatformProxy - ctx", () => {
 			try {
 				expect(() => {
 					waitUntil(new Promise(() => {}));
-				}).not.toThrowError("Illegal invocation");
+				}).not.toThrow("Illegal invocation");
 
 				expect(() => {
 					passThroughOnException.apply(ctx, []);
-				}).not.toThrowError("Illegal invocation");
+				}).not.toThrow("Illegal invocation");
 
 				expect(() => {
 					passThroughOnException.call(ctx);
-				}).not.toThrowError("Illegal invocation");
+				}).not.toThrow("Illegal invocation");
 			} finally {
 				await dispose();
 			}
@@ -131,15 +131,15 @@ describe("getPlatformProxy - ctx", () => {
 			try {
 				expect(() => {
 					waitUntil(new Promise(() => {}));
-				}).toThrowError("Illegal invocation");
+				}).toThrow("Illegal invocation");
 
 				expect(() => {
 					passThroughOnException.apply(5, []);
-				}).toThrowError("Illegal invocation");
+				}).toThrow("Illegal invocation");
 
 				expect(() => {
 					passThroughOnException.call(new Boolean());
-				}).toThrowError("Illegal invocation");
+				}).toThrow("Illegal invocation");
 			} finally {
 				await dispose();
 			}

--- a/fixtures/pages-workerjs-app/tests/index.test.ts
+++ b/fixtures/pages-workerjs-app/tests/index.test.ts
@@ -15,7 +15,7 @@ describe("Pages _worker.js", () => {
 				cwd: path.resolve(__dirname, ".."),
 				stdio: "ignore",
 			})
-		).toThrowError();
+		).toThrow();
 	});
 
 	it("should throw an error when the _worker.js file imports something and --no-bundle is true", ({
@@ -26,7 +26,7 @@ describe("Pages _worker.js", () => {
 				cwd: path.resolve(__dirname, ".."),
 				stdio: "ignore",
 			})
-		).toThrowError();
+		).toThrow();
 	});
 
 	it("should not throw an error when the _worker.js file imports something if --no-bundle is false", async ({

--- a/packages/autoconfig/tests/details/framework-detection/multiple-frameworks-detected.test.ts
+++ b/packages/autoconfig/tests/details/framework-detection/multiple-frameworks-detected.test.ts
@@ -136,9 +136,7 @@ describe("detectFramework() / multiple frameworks detected", () => {
 				"package-lock.json": JSON.stringify({ lockfileVersion: 3 }),
 			});
 
-			await expect(
-				detectFramework(process.cwd(), ciContext)
-			).rejects.toThrowError(
+			await expect(detectFramework(process.cwd(), ciContext)).rejects.toThrow(
 				/Cloudflare's tooling was unable to automatically configure your project, since multiple frameworks were found/
 			);
 		});

--- a/packages/autoconfig/tests/details/get-details-for-auto-config.test.ts
+++ b/packages/autoconfig/tests/details/get-details-for-auto-config.test.ts
@@ -475,7 +475,7 @@ describe("autoconfig details - getDetailsForAutoConfig()", () => {
 
 				await expect(
 					details.getDetailsForAutoConfig({ context: ciContext })
-				).rejects.toThrowError(
+				).rejects.toThrow(
 					/Cloudflare's tooling was unable to automatically configure your project, since multiple frameworks were found/
 				);
 			});

--- a/packages/autoconfig/tests/vite-config.test.ts
+++ b/packages/autoconfig/tests/vite-config.test.ts
@@ -260,7 +260,7 @@ export default defineConfig({
 `
 			);
 
-			expect(() => transformViteConfig(".")).toThrowError(
+			expect(() => transformViteConfig(".")).toThrow(
 				/Cannot modify Vite config: could not find a valid plugins array/
 			);
 		});
@@ -279,7 +279,7 @@ export default defineConfig(() => ({
 `
 			);
 
-			expect(() => transformViteConfig(".")).toThrowError(
+			expect(() => transformViteConfig(".")).toThrow(
 				/Cannot modify Vite config: could not find a valid plugins array/
 			);
 		});

--- a/packages/containers-shared/tests/images.test.ts
+++ b/packages/containers-shared/tests/images.test.ts
@@ -116,7 +116,7 @@ describe("getAndValidateRegistryType - GAR", () => {
 	];
 	for (const domain of invalidGarDomains) {
 		it(`rejects ${domain}`, ({ expect }) => {
-			expect(() => getAndValidateRegistryType(domain)).toThrowError(
+			expect(() => getAndValidateRegistryType(domain)).toThrow(
 				`${domain} is not a supported image registry`
 			);
 		});

--- a/packages/create-cloudflare/src/helpers/__tests__/retry.test.ts
+++ b/packages/create-cloudflare/src/helpers/__tests__/retry.test.ts
@@ -44,7 +44,7 @@ describe("retry", () => {
 			await retry({ times: 3 }, async () => {
 				throw Error("testing");
 			});
-		}).rejects.toThrowError("testing");
+		}).rejects.toThrow("testing");
 	});
 
 	test("exit condition encountered", async ({ expect }) => {
@@ -65,6 +65,6 @@ describe("retry", () => {
 					throw Error("special condition");
 				}
 			);
-		}).rejects.toThrowError("special condition");
+		}).rejects.toThrow("special condition");
 	});
 });

--- a/packages/kv-asset-handler/test/getAssetFromKV.test.ts
+++ b/packages/kv-asset-handler/test/getAssetFromKV.test.ts
@@ -66,7 +66,7 @@ test("getAssetFromKV if no asset manifest /client -> client fails", async ({
 	const event = getEvent(new Request(`https://foo.com/client`));
 	await expect(() =>
 		getAssetFromKV(event, { ASSET_MANIFEST: {} })
-	).rejects.toThrowError(expect.objectContaining({ status: 404 }));
+	).rejects.toThrow(expect.objectContaining({ status: 404 }));
 });
 
 test("getAssetFromKV if sub/ -> sub/index.html served", async ({ expect }) => {

--- a/packages/vite-plugin-cloudflare/src/__tests__/dev-vars.spec.ts
+++ b/packages/vite-plugin-cloudflare/src/__tests__/dev-vars.spec.ts
@@ -75,7 +75,7 @@ describe("quoteForDotenv", () => {
 
 	test("throws when a value cannot be losslessly serialized", ({ expect }) => {
 		// Contains all three quote characters — no safe encoding under dotenv.
-		expect(() => quoteForDotenv("'`\"")).toThrowError(
+		expect(() => quoteForDotenv("'`\"")).toThrow(
 			/Unable to serialize value to \.dev\.vars/
 		);
 	});

--- a/packages/vite-plugin-cloudflare/src/__tests__/get-worker-config.spec.ts
+++ b/packages/vite-plugin-cloudflare/src/__tests__/get-worker-config.spec.ts
@@ -177,7 +177,7 @@ describe("resolveWorkerType", () => {
 		);
 		expect(() =>
 			resolveWorkerType(config, raw, nonApplicable, { configPath })
-		).toThrowError(
+		).toThrow(
 			/The provided Wrangler config main field \(.*?index\.ts\) doesn't point to an existing file/
 		);
 	});

--- a/packages/vitest-pool-workers/test/compatibility-flag-assertions.test.ts
+++ b/packages/vitest-pool-workers/test/compatibility-flag-assertions.test.ts
@@ -145,7 +145,7 @@ describe("FlagAssertions", () => {
 					enableFlag: "enable-flag",
 					defaultOnDate: "invalid-date",
 				});
-			}).toThrowError('Invalid date format: "invalid-date"');
+			}).toThrow('Invalid date format: "invalid-date"');
 		});
 
 		it("throws error when compatibilityDate is invalid", ({ expect }) => {
@@ -161,7 +161,7 @@ describe("FlagAssertions", () => {
 					enableFlag: "enable-flag",
 					defaultOnDate: "2023-01-01",
 				});
-			}).toThrowError('Invalid date format: "invalid-date"');
+			}).toThrow('Invalid date format: "invalid-date"');
 		});
 	});
 

--- a/packages/workers-shared/asset-worker/tests/kv.test.ts
+++ b/packages/workers-shared/asset-worker/tests/kv.test.ts
@@ -50,7 +50,7 @@ describe("[Asset Worker] Fetching assets from KV", () => {
 
 			await expect(() =>
 				getAssetWithMetadataFromKV(mockKVNamespace, "abcd")
-			).rejects.toThrowError("KV GET abcd failed.");
+			).rejects.toThrow("KV GET abcd failed.");
 		});
 
 		it("should retry once by default if something went wrong while fetching the asset", async ({
@@ -60,7 +60,7 @@ describe("[Asset Worker] Fetching assets from KV", () => {
 
 			await expect(() =>
 				getAssetWithMetadataFromKV(mockKVNamespace, "abcd")
-			).rejects.toThrowError("KV GET abcd failed.");
+			).rejects.toThrow("KV GET abcd failed.");
 			expect(spy).toHaveBeenCalledTimes(2);
 		});
 
@@ -69,7 +69,7 @@ describe("[Asset Worker] Fetching assets from KV", () => {
 
 			await expect(() =>
 				getAssetWithMetadataFromKV(mockKVNamespace, "abcd", undefined, 2)
-			).rejects.toThrowError("KV GET abcd failed.");
+			).rejects.toThrow("KV GET abcd failed.");
 			expect(spy).toHaveBeenCalledTimes(3);
 		});
 
@@ -80,7 +80,7 @@ describe("[Asset Worker] Fetching assets from KV", () => {
 
 			await expect(() =>
 				getAssetWithMetadataFromKV(mockKVNamespace, "abcd")
-			).rejects.toThrowError("KV GET abcd failed: Oeps! Something went wrong");
+			).rejects.toThrow("KV GET abcd failed: Oeps! Something went wrong");
 			expect(spy).toHaveBeenCalledTimes(2);
 		});
 

--- a/packages/workers-shared/router-worker/tests/index.test.ts
+++ b/packages/workers-shared/router-worker/tests/index.test.ts
@@ -54,7 +54,7 @@ describe("inner entrypoint unit tests", () => {
 
 		await expect(
 			async () => await fetchFromInnerEntrypoint(request, env, ctx)
-		).rejects.toThrowError(
+		).rejects.toThrow(
 			"Fetch for user worker without having a user worker binding"
 		);
 	});

--- a/packages/workers-utils/tests/prometheus-metrics.test.ts
+++ b/packages/workers-utils/tests/prometheus-metrics.test.ts
@@ -69,9 +69,7 @@ describe("MetricsRegistry", () => {
 		it("throws on negative values", ({ expect }) => {
 			const registry = new MetricsRegistry();
 			const counter = registry.createCounter("test_total", "A test counter");
-			expect(() => counter.add(-1)).toThrowError(
-				"Counter value cannot decrease"
-			);
+			expect(() => counter.add(-1)).toThrow("Counter value cannot decrease");
 		});
 
 		it("can be combined with inc", ({ expect }) => {

--- a/packages/wrangler/e2e/dev.test.ts
+++ b/packages/wrangler/e2e/dev.test.ts
@@ -1448,7 +1448,7 @@ describe("custom builds", () => {
 		// regression: https://github.com/cloudflare/workers-sdk/issues/6876
 		await expect(
 			worker.readUntil(/\[custom build\] Running/, 5_000)
-		).rejects.toThrowError();
+		).rejects.toThrow();
 
 		// now check assets are still fetchable, even after updates
 
@@ -2085,7 +2085,7 @@ describe("watch mode", () => {
 				await worker.waitForReload();
 
 				// The three changes should be debounced, so only one reload should occur
-				await expect(worker.waitForReload(5_000)).rejects.toThrowError();
+				await expect(worker.waitForReload(5_000)).rejects.toThrow();
 
 				// now check assets are still fetchable
 				await expect(fetchText(url)).resolves.toBe("Hello from Assets");

--- a/packages/wrangler/e2e/startWorker.test.ts
+++ b/packages/wrangler/e2e/startWorker.test.ts
@@ -327,9 +327,9 @@ describe("DevEnv", { sequential: true }, () => {
 			undiciRes = await undici.fetch(`http://127.0.0.1:${newPort}`);
 			await expect(undiciRes.text()).resolves.toBe("body:1");
 
-			await expect(
-				undici.fetch(`http://127.0.0.1:${oldPort}`)
-			).rejects.toThrowError("fetch failed");
+			await expect(undici.fetch(`http://127.0.0.1:${oldPort}`)).rejects.toThrow(
+				"fetch failed"
+			);
 		});
 
 		it("liveReload", async ({ expect }) => {
@@ -456,7 +456,7 @@ describe("DevEnv", { sequential: true }, () => {
 			});
 			onTestFinished(worker?.dispose);
 
-			await expect(worker.fetch("http://dummy")).rejects.toThrowError("Boom!");
+			await expect(worker.fetch("http://dummy")).rejects.toThrow("Boom!");
 
 			await helper.seed({
 				"src/index.ts": dedent`
@@ -469,9 +469,7 @@ describe("DevEnv", { sequential: true }, () => {
 			});
 
 			await waitFor(async () => {
-				await expect(worker.fetch("http://dummy")).rejects.toThrowError(
-					"Boom 2!"
-				);
+				await expect(worker.fetch("http://dummy")).rejects.toThrow("Boom 2!");
 			});
 
 			// test eyeball requests receive the pretty error page

--- a/packages/wrangler/src/__tests__/ai-search.test.ts
+++ b/packages/wrangler/src/__tests__/ai-search.test.ts
@@ -807,7 +807,7 @@ describe("ai-search commands", () => {
 				runWrangler(
 					"ai-search create my-instance --namespace default --type r2 --source my-bucket"
 				)
-			).rejects.toThrowError(/No AI Search API token found/);
+			).rejects.toThrow(/No AI Search API token found/);
 		});
 
 		it("should abort when user declines to create a token", async ({
@@ -822,7 +822,7 @@ describe("ai-search commands", () => {
 				runWrangler(
 					"ai-search create my-instance --namespace default --type r2 --source my-bucket"
 				)
-			).rejects.toThrowError(/AI Search instance creation cancelled/);
+			).rejects.toThrow(/AI Search instance creation cancelled/);
 		});
 
 		it("should proceed after user creates a token on retry", async ({
@@ -1031,7 +1031,7 @@ describe("ai-search commands", () => {
 				runWrangler(
 					"ai-search create my-instance --namespace default --source my-bucket"
 				)
-			).rejects.toThrowError(/Missing required flag.*--type/);
+			).rejects.toThrow(/Missing required flag.*--type/);
 		});
 
 		it("should error in non-interactive mode when --source is missing for r2", async ({
@@ -1043,7 +1043,7 @@ describe("ai-search commands", () => {
 				runWrangler(
 					"ai-search create my-instance --namespace default --type r2"
 				)
-			).rejects.toThrowError(/Missing required flag.*--source/);
+			).rejects.toThrow(/Missing required flag.*--source/);
 		});
 
 		it("should error in non-interactive mode when --source is missing for web-crawler", async ({
@@ -1055,7 +1055,7 @@ describe("ai-search commands", () => {
 				runWrangler(
 					"ai-search create my-instance --namespace default --type web-crawler"
 				)
-			).rejects.toThrowError(/Missing required flag.*--source/);
+			).rejects.toThrow(/Missing required flag.*--source/);
 		});
 
 		it("should create a builtin instance and omit type/source from the request body", async ({
@@ -1110,7 +1110,7 @@ describe("ai-search commands", () => {
 				runWrangler(
 					"ai-search create my-instance --namespace default --type builtin --source my-bucket"
 				)
-			).rejects.toThrowError(/not supported with --type builtin.*--source/);
+			).rejects.toThrow(/not supported with --type builtin.*--source/);
 		});
 
 		it("should error when source_params flags are passed with --type builtin", async ({
@@ -1121,7 +1121,7 @@ describe("ai-search commands", () => {
 				runWrangler(
 					'ai-search create my-instance --namespace default --type builtin --prefix docs/ --include-items "*.md" --exclude-items "*.tmp"'
 				)
-			).rejects.toThrowError(
+			).rejects.toThrow(
 				/not supported with --type builtin.*--prefix.*--include-items.*--exclude-items/
 			);
 		});
@@ -1226,7 +1226,7 @@ describe("ai-search commands", () => {
 				runWrangler(
 					"ai-search create my-instance --namespace default --type r2 --source my-bucket --custom-metadata title:bogus"
 				)
-			).rejects.toThrowError(
+			).rejects.toThrow(
 				/data_type must be one of text, number, boolean, datetime/
 			);
 		});
@@ -1239,7 +1239,7 @@ describe("ai-search commands", () => {
 				runWrangler(
 					"ai-search create my-instance --namespace default --type r2 --source my-bucket --custom-metadata title"
 				)
-			).rejects.toThrowError(/Expected format: field_name:data_type/);
+			).rejects.toThrow(/Expected format: field_name:data_type/);
 		});
 
 		it("should reject --custom-metadata with a reserved field name", async ({
@@ -1250,7 +1250,7 @@ describe("ai-search commands", () => {
 				runWrangler(
 					"ai-search create my-instance --namespace default --type r2 --source my-bucket --custom-metadata timestamp:number"
 				)
-			).rejects.toThrowError(/reserved field name/);
+			).rejects.toThrow(/reserved field name/);
 		});
 
 		it("should interactively configure custom_metadata when the flag is omitted", async ({
@@ -1391,7 +1391,7 @@ describe("ai-search commands", () => {
 				runWrangler(
 					"ai-search create my-instance --namespace default --type r2 --source my-bucket --custom-metadata-schema schema.json"
 				)
-			).rejects.toThrowError(
+			).rejects.toThrow(
 				/Expected an array of \{ field_name, data_type \} objects/
 			);
 		});
@@ -1438,7 +1438,7 @@ describe("ai-search commands", () => {
 				runWrangler(
 					"ai-search create my-instance --namespace default --type r2 --source my-bucket --custom-metadata-schema schema.json"
 				)
-			).rejects.toThrowError();
+			).rejects.toThrow();
 		});
 
 		it("should reject --custom-metadata-schema with an unsupported shape", async ({
@@ -1453,7 +1453,7 @@ describe("ai-search commands", () => {
 				runWrangler(
 					"ai-search create my-instance --namespace default --type r2 --source my-bucket --custom-metadata-schema schema.json"
 				)
-			).rejects.toThrowError(
+			).rejects.toThrow(
 				/Expected an array of \{ field_name, data_type \} objects/
 			);
 		});
@@ -1470,7 +1470,7 @@ describe("ai-search commands", () => {
 				runWrangler(
 					"ai-search create my-instance --namespace default --type r2 --source my-bucket --custom-metadata-schema schema.json"
 				)
-			).rejects.toThrowError(
+			).rejects.toThrow(
 				/"data_type" must be one of text, number, boolean, datetime/
 			);
 		});
@@ -1487,7 +1487,7 @@ describe("ai-search commands", () => {
 				runWrangler(
 					"ai-search create my-instance --namespace default --type r2 --source my-bucket --custom-metadata-schema schema.json"
 				)
-			).rejects.toThrowError(/reserved field name/);
+			).rejects.toThrow(/reserved field name/);
 		});
 
 		it("should reject combining --custom-metadata and --custom-metadata-schema", async ({
@@ -1502,7 +1502,7 @@ describe("ai-search commands", () => {
 				runWrangler(
 					"ai-search create my-instance --namespace default --type r2 --source my-bucket --custom-metadata title:text --custom-metadata-schema schema.json"
 				)
-			).rejects.toThrowError(
+			).rejects.toThrow(
 				/custom-metadata and custom-metadata-schema are mutually exclusive/
 			);
 		});

--- a/packages/wrangler/src/__tests__/artifacts.test.ts
+++ b/packages/wrangler/src/__tests__/artifacts.test.ts
@@ -133,7 +133,7 @@ describe("artifacts", () => {
 		});
 
 		it("should require --namespace for repo commands", async ({ expect }) => {
-			await expect(runWrangler("artifacts repos list")).rejects.toThrowError(
+			await expect(runWrangler("artifacts repos list")).rejects.toThrow(
 				/Missing required argument: namespace/
 			);
 		});
@@ -381,7 +381,7 @@ describe("artifacts", () => {
 				runWrangler(
 					"artifacts repos issue-token starter-repo --namespace default --ttl 0"
 				)
-			).rejects.toThrowError(/--ttl must be greater than 0/);
+			).rejects.toThrow(/--ttl must be greater than 0/);
 		});
 
 		it("should issue a repo token with JSON output", async ({ expect }) => {

--- a/packages/wrangler/src/__tests__/autoconfig/run.test.ts
+++ b/packages/wrangler/src/__tests__/autoconfig/run.test.ts
@@ -94,7 +94,7 @@ vi.mock("../deploy/deploy", async (importOriginal) => ({
 
 async function runDeploy(expect: ExpectStatic, withArgs: string = "") {
 	// Expect "Bailing early in tests" to be thrown
-	await expect(runWrangler(`deploy ${withArgs}`)).rejects.toThrowError();
+	await expect(runWrangler(`deploy ${withArgs}`)).rejects.toThrow();
 }
 
 // We don't care about module/service worker detection in the autoconfig tests,

--- a/packages/wrangler/src/__tests__/browser-run.test.ts
+++ b/packages/wrangler/src/__tests__/browser-run.test.ts
@@ -236,9 +236,9 @@ describe("wrangler browser", () => {
 		it("should throw error when no targets found", async () => {
 			mockGetSessionTargets("invalid-session", []);
 
-			await expect(
-				runWrangler("browser view invalid-session")
-			).rejects.toThrowError('No targets found for session "invalid-session"');
+			await expect(runWrangler("browser view invalid-session")).rejects.toThrow(
+				'No targets found for session "invalid-session"'
+			);
 		});
 
 		it("should prefer page targets over other types", async () => {
@@ -522,7 +522,7 @@ describe("wrangler browser", () => {
 
 				await expect(
 					runWrangler("browser view session-nomatch --target bing")
-				).rejects.toThrowError(
+				).rejects.toThrow(
 					'No target found matching "bing". Available targets:'
 				);
 			});
@@ -552,7 +552,7 @@ describe("wrangler browser", () => {
 
 				await expect(
 					runWrangler("browser view session-ambig --target google")
-				).rejects.toThrowError(
+				).rejects.toThrow(
 					'Multiple targets match "google". Please be more specific:'
 				);
 			});
@@ -562,7 +562,7 @@ describe("wrangler browser", () => {
 			it("should error when no sessions exist", async () => {
 				mockListSessions([]);
 
-				await expect(runWrangler("browser view")).rejects.toThrowError(
+				await expect(runWrangler("browser view")).rejects.toThrow(
 					"No active Browser Run sessions found. Use `wrangler browser create` to create one."
 				);
 			});
@@ -891,7 +891,7 @@ describe("wrangler browser", () => {
 			};
 			mockAcquireSession(response);
 
-			await expect(runWrangler("browser create")).rejects.toThrowError(
+			await expect(runWrangler("browser create")).rejects.toThrow(
 				"Session created (empty-session) but no targets found"
 			);
 		});
@@ -1003,9 +1003,9 @@ describe("wrangler browser", () => {
 				)
 			);
 
-			await expect(
-				runWrangler("browser close nonexistent")
-			).rejects.toThrowError("Browser Run API error: Session not found");
+			await expect(runWrangler("browser close nonexistent")).rejects.toThrow(
+				"Browser Run API error: Session not found"
+			);
 		});
 	});
 });

--- a/packages/wrangler/src/__tests__/containers/instances.test.ts
+++ b/packages/wrangler/src/__tests__/containers/instances.test.ts
@@ -201,7 +201,7 @@ describe("containers instances", () => {
 		setWranglerConfig({});
 		await expect(
 			runWrangler(`containers instances ${APP_ID} --per-page 0`)
-		).rejects.toThrowError(/--per-page must be at least 1/);
+		).rejects.toThrow(/--per-page must be at least 1/);
 	});
 
 	it("should reject --per-page with negative value", async ({ expect }) => {
@@ -209,7 +209,7 @@ describe("containers instances", () => {
 		setWranglerConfig({});
 		await expect(
 			runWrangler(`containers instances ${APP_ID} --per-page -1`)
-		).rejects.toThrowError(/--per-page must be at least 1/);
+		).rejects.toThrow(/--per-page must be at least 1/);
 	});
 
 	it("should error on invalid ID format", async ({ expect }) => {

--- a/packages/wrangler/src/__tests__/containers/list.test.ts
+++ b/packages/wrangler/src/__tests__/containers/list.test.ts
@@ -66,17 +66,17 @@ describe("containers list", () => {
 	it("should reject --per-page 0", async ({ expect }) => {
 		setIsTTY(false);
 		setWranglerConfig({});
-		await expect(
-			runWrangler("containers list --per-page 0")
-		).rejects.toThrowError(/--per-page must be at least 1/);
+		await expect(runWrangler("containers list --per-page 0")).rejects.toThrow(
+			/--per-page must be at least 1/
+		);
 	});
 
 	it("should reject --per-page with negative value", async ({ expect }) => {
 		setIsTTY(false);
 		setWranglerConfig({});
-		await expect(
-			runWrangler("containers list --per-page -1")
-		).rejects.toThrowError(/--per-page must be at least 1/);
+		await expect(runWrangler("containers list --per-page -1")).rejects.toThrow(
+			/--per-page must be at least 1/
+		);
 	});
 
 	it("should show the correct authentication error", async ({ expect }) => {
@@ -113,7 +113,7 @@ describe("containers list", () => {
 				{ once: true }
 			)
 		);
-		await expect(runWrangler("containers list")).rejects.toThrowError(
+		await expect(runWrangler("containers list")).rejects.toThrow(
 			/There has been an error listing containers/
 		);
 	});
@@ -138,7 +138,7 @@ describe("containers list", () => {
 				{ once: true }
 			)
 		);
-		await expect(runWrangler("containers list")).rejects.toThrowError(
+		await expect(runWrangler("containers list")).rejects.toThrow(
 			/unknown error listing containers/
 		);
 	});
@@ -463,7 +463,7 @@ describe("containers list", () => {
 					{ once: true }
 				)
 			);
-			await expect(runWrangler("containers list --json")).rejects.toThrowError(
+			await expect(runWrangler("containers list --json")).rejects.toThrow(
 				/unknown error listing containers/
 			);
 		});
@@ -491,7 +491,7 @@ describe("containers list", () => {
 					{ once: true }
 				)
 			);
-			await expect(runWrangler("containers list --json")).rejects.toThrowError(
+			await expect(runWrangler("containers list --json")).rejects.toThrow(
 				/There has been an error listing containers/
 			);
 		});

--- a/packages/wrangler/src/__tests__/create-worker-upload-form/bindings.test.ts
+++ b/packages/wrangler/src/__tests__/create-worker-upload-form/bindings.test.ts
@@ -57,9 +57,9 @@ describe("createWorkerUploadForm — bindings", () => {
 			const bindings: StartDevWorkerInput["bindings"] = {
 				MY_KV: { type: "kv_namespace" } as never,
 			};
-			expect(() =>
-				createWorkerUploadForm(createEsmWorker(), bindings)
-			).toThrowError('MY_KV bindings must have an "id" field');
+			expect(() => createWorkerUploadForm(createEsmWorker(), bindings)).toThrow(
+				'MY_KV bindings must have an "id" field'
+			);
 		});
 
 		it("should convert KV namespace to inherit binding during dry run when ID is missing", ({
@@ -115,9 +115,9 @@ describe("createWorkerUploadForm — bindings", () => {
 			const bindings: StartDevWorkerInput["bindings"] = {
 				MY_BUCKET: { type: "r2_bucket" } as never,
 			};
-			expect(() =>
-				createWorkerUploadForm(createEsmWorker(), bindings)
-			).toThrowError('MY_BUCKET bindings must have a "bucket_name" field');
+			expect(() => createWorkerUploadForm(createEsmWorker(), bindings)).toThrow(
+				'MY_BUCKET bindings must have a "bucket_name" field'
+			);
 		});
 
 		it("should convert R2 bucket to inherit binding during dry run when bucket_name is missing", ({
@@ -155,9 +155,9 @@ describe("createWorkerUploadForm — bindings", () => {
 			const bindings: StartDevWorkerInput["bindings"] = {
 				MY_DB: { type: "d1" } as never,
 			};
-			expect(() =>
-				createWorkerUploadForm(createEsmWorker(), bindings)
-			).toThrowError('MY_DB bindings must have a "database_id" field');
+			expect(() => createWorkerUploadForm(createEsmWorker(), bindings)).toThrow(
+				'MY_DB bindings must have a "database_id" field'
+			);
 		});
 
 		it("should convert D1 to inherit binding during dry run when database_id is missing", ({
@@ -356,9 +356,9 @@ describe("createWorkerUploadForm — bindings", () => {
 			const bindings: StartDevWorkerInput["bindings"] = {
 				AI_SEARCH: { type: "ai_search_namespace" } as never,
 			};
-			expect(() =>
-				createWorkerUploadForm(createEsmWorker(), bindings)
-			).toThrowError('AI_SEARCH bindings must have a "namespace" field');
+			expect(() => createWorkerUploadForm(createEsmWorker(), bindings)).toThrow(
+				'AI_SEARCH bindings must have a "namespace" field'
+			);
 		});
 
 		it("should convert ai_search_namespace to inherit binding during dry run when namespace is missing", ({
@@ -399,9 +399,9 @@ describe("createWorkerUploadForm — bindings", () => {
 			const bindings: StartDevWorkerInput["bindings"] = {
 				MEMORY: { type: "agent_memory" } as never,
 			};
-			expect(() =>
-				createWorkerUploadForm(createEsmWorker(), bindings)
-			).toThrowError('MEMORY bindings must have a "namespace" field');
+			expect(() => createWorkerUploadForm(createEsmWorker(), bindings)).toThrow(
+				'MEMORY bindings must have a "namespace" field'
+			);
 		});
 
 		it("should convert agent_memory to inherit binding during dry run when namespace is missing", ({

--- a/packages/wrangler/src/__tests__/create-worker-upload-form/metadata.test.ts
+++ b/packages/wrangler/src/__tests__/create-worker-upload-form/metadata.test.ts
@@ -100,9 +100,7 @@ describe("createWorkerUploadForm — basic structure", () => {
 				}),
 				{}
 			)
-		).toThrowError(
-			"More than one module can only be specified when type = 'esm'"
-		);
+		).toThrow("More than one module can only be specified when type = 'esm'");
 	});
 });
 

--- a/packages/wrangler/src/__tests__/create-worker-upload-form/mime-types.test.ts
+++ b/packages/wrangler/src/__tests__/create-worker-upload-form/mime-types.test.ts
@@ -35,7 +35,7 @@ describe("fromMimeType", () => {
 	);
 
 	it("should throw for unsupported mime types", ({ expect }) => {
-		expect(() => fromMimeType("image/png")).toThrowError(
+		expect(() => fromMimeType("image/png")).toThrow(
 			"Unsupported mime type: image/png"
 		);
 	});

--- a/packages/wrangler/src/__tests__/d1/create.test.ts
+++ b/packages/wrangler/src/__tests__/d1/create.test.ts
@@ -19,13 +19,13 @@ describe("create", () => {
 	const { setIsTTY } = useMockIsTTY();
 
 	it("should throw if local flag is provided", async ({ expect }) => {
-		await expect(runWrangler("d1 create test --local")).rejects.toThrowError(
+		await expect(runWrangler("d1 create test --local")).rejects.toThrow(
 			`Unknown argument: local`
 		);
 	});
 
 	it("should throw if remote flag is provided", async ({ expect }) => {
-		await expect(runWrangler("d1 create test --remote")).rejects.toThrowError(
+		await expect(runWrangler("d1 create test --remote")).rejects.toThrow(
 			`Unknown argument: remote`
 		);
 	});

--- a/packages/wrangler/src/__tests__/d1/execute.test.ts
+++ b/packages/wrangler/src/__tests__/d1/execute.test.ts
@@ -32,7 +32,7 @@ describe("execute", () => {
 
 		await expect(
 			runWrangler("d1 execute db --command 'select 1;' --remote")
-		).rejects.toThrowError(
+		).rejects.toThrow(
 			`In a non-interactive environment, it's necessary to set a CLOUDFLARE_API_TOKEN environment variable for wrangler to work. Please go to https://developers.cloudflare.com/fundamentals/api/get-started/create-token/ for instructions on how to create an api token, and assign its value to CLOUDFLARE_API_TOKEN.
 
 To continue without logging in, rerun this command with \`--temporary\`. Wrangler will use a temporary account and print a claim URL.`
@@ -47,7 +47,7 @@ To continue without logging in, rerun this command with \`--temporary\`. Wrangle
 			],
 		});
 
-		await expect(runWrangler("d1 execute db")).rejects.toThrowError(
+		await expect(runWrangler("d1 execute db")).rejects.toThrow(
 			`Missing required option --command or --file. Provide a SQL command inline with --command="<SQL>", or a path to a SQL file with --file=<path>.`
 		);
 	});
@@ -82,9 +82,7 @@ To continue without logging in, rerun this command with \`--temporary\`. Wrangle
 
 		await expect(
 			runWrangler(`d1 execute db --command "select;" --local --remote`)
-		).rejects.toThrowError(
-			`Error: can't use --local and --remote at the same time`
-		);
+		).rejects.toThrow(`Error: can't use --local and --remote at the same time`);
 	});
 
 	it("should reject the use of --preview with --local", async ({ expect }) => {
@@ -97,7 +95,7 @@ To continue without logging in, rerun this command with \`--temporary\`. Wrangle
 
 		await expect(
 			runWrangler(`d1 execute db --command "select;" --local --preview`)
-		).rejects.toThrowError(
+		).rejects.toThrow(
 			`Cannot use --preview without --remote. The --preview flag targets a preview D1 database, which requires the --remote flag. Remove --preview or add --remote.`
 		);
 	});
@@ -114,7 +112,7 @@ To continue without logging in, rerun this command with \`--temporary\`. Wrangle
 
 		await expect(
 			runWrangler(`d1 execute db --command "select;" --local --preview --json`)
-		).rejects.toThrowError(
+		).rejects.toThrow(
 			JSON.stringify(
 				{
 					error: {
@@ -139,7 +137,7 @@ To continue without logging in, rerun this command with \`--temporary\`. Wrangle
 
 		await expect(
 			runWrangler(`d1 execute db --file db.sqlite3 --local --json`)
-		).rejects.toThrowError(
+		).rejects.toThrow(
 			JSON.stringify(
 				{
 					error: {

--- a/packages/wrangler/src/__tests__/d1/export.test.ts
+++ b/packages/wrangler/src/__tests__/d1/export.test.ts
@@ -22,7 +22,7 @@ describe("export", () => {
 	const { setIsTTY } = useMockIsTTY();
 
 	it("should throw if output is missing", async ({ expect }) => {
-		await expect(runWrangler("d1 export db")).rejects.toThrowError(
+		await expect(runWrangler("d1 export db")).rejects.toThrow(
 			`Missing required argument: output`
 		);
 	});
@@ -30,9 +30,7 @@ describe("export", () => {
 	it("should throw if output is a directory", async ({ expect }) => {
 		fs.mkdirSync("test-dir");
 
-		await expect(
-			runWrangler("d1 export db --output test-dir")
-		).rejects.toThrowError(
+		await expect(runWrangler("d1 export db --output test-dir")).rejects.toThrow(
 			`Please specify a file path for --output, not a directory.`
 		);
 	});
@@ -40,7 +38,7 @@ describe("export", () => {
 	it("should throw if local and remote are both set", async ({ expect }) => {
 		await expect(
 			runWrangler("d1 export db --local --remote --output test-local.sql")
-		).rejects.toThrowError("Arguments local and remote are mutually exclusive");
+		).rejects.toThrow("Arguments local and remote are mutually exclusive");
 	});
 
 	it("should handle local", async ({ expect }) => {
@@ -249,7 +247,7 @@ describe("export", () => {
 
 		await expect(
 			runWrangler("d1 export db --remote --output test-remote.sql")
-		).rejects.toThrowError(
+		).rejects.toThrow(
 			/There was an error while downloading from the presigned URL with status code: 403/
 		);
 	});

--- a/packages/wrangler/src/__tests__/d1/insights.test.ts
+++ b/packages/wrangler/src/__tests__/d1/insights.test.ts
@@ -25,14 +25,14 @@ describe("getDurationDates()", () => {
 	it("should throw an error if duration is greater than 31 days (in days)", ({
 		expect,
 	}) => {
-		expect(() => getDurationDates("32d")).toThrowError(
+		expect(() => getDurationDates("32d")).toThrow(
 			`Invalid --time-period value "32d": 32 days exceeds the maximum of 31 days. Provide a value of 31d or less.`
 		);
 	});
 	it("should throw an error if duration is greater than 31 days (in minutes)", ({
 		expect,
 	}) => {
-		expect(() => getDurationDates("44641m")).toThrowError(
+		expect(() => getDurationDates("44641m")).toThrow(
 			`Invalid --time-period value "44641m": 44641 minutes exceeds the maximum of 44640 minutes (31 days). Provide a value of 44640m or less.`
 		);
 	});
@@ -40,13 +40,13 @@ describe("getDurationDates()", () => {
 	it("should throw an error if duration is greater than 31 days (in hours)", ({
 		expect,
 	}) => {
-		expect(() => getDurationDates("745h")).toThrowError(
+		expect(() => getDurationDates("745h")).toThrow(
 			`Invalid --time-period value "745h": 745 hours exceeds the maximum of 744 hours (31 days). Provide a value of 744h or less.`
 		);
 	});
 
 	it("should throw an error if duration unit is invalid", ({ expect }) => {
-		expect(() => getDurationDates("1y")).toThrowError(
+		expect(() => getDurationDates("1y")).toThrow(
 			`Invalid --time-period unit "y" in "1y". Supported units: d (days), h (hours), m (minutes). Example: --time-period=7d.`
 		);
 	});

--- a/packages/wrangler/src/__tests__/d1/migrate.test.ts
+++ b/packages/wrangler/src/__tests__/d1/migrate.test.ts
@@ -33,14 +33,14 @@ describe("migrate", () => {
 
 			await expect(
 				runWrangler("d1 migrations create test some-message --local DATABASE")
-			).rejects.toThrowError(`Unknown argument: local`);
+			).rejects.toThrow(`Unknown argument: local`);
 		});
 
 		it("should error when no config file is present", async ({ expect }) => {
 			setIsTTY(false);
 			await expect(
 				runWrangler("d1 migrations create DATABASE test-migration")
-			).rejects.toThrowError(
+			).rejects.toThrow(
 				"No configuration file found. Create a wrangler.jsonc file to define your D1 database."
 			);
 		});
@@ -137,9 +137,9 @@ describe("migrate", () => {
 			// runs first we never reach the prompt, and the dir is still
 			// absent after the throw.
 
-			await expect(
-				runWrangler("d1 migrations create db test")
-			).rejects.toThrowError(/does not match the configured/);
+			await expect(runWrangler("d1 migrations create db test")).rejects.toThrow(
+				/does not match the configured/
+			);
 
 			expect(fs.existsSync("./migrations")).toBe(false);
 		});
@@ -241,9 +241,9 @@ describe("migrate", () => {
 				],
 			});
 			// If we get to the point where we are checking for migrations then we have not been asked to log in.
-			await expect(
-				runWrangler("d1 migrations apply DATABASE")
-			).rejects.toThrowError(`No migrations present at <cwd>/migrations.`);
+			await expect(runWrangler("d1 migrations apply DATABASE")).rejects.toThrow(
+				`No migrations present at <cwd>/migrations.`
+			);
 		});
 
 		it("should try to read D1 config from wrangler.toml", async ({
@@ -253,7 +253,7 @@ describe("migrate", () => {
 			writeWranglerConfig();
 			await expect(
 				runWrangler("d1 migrations apply DATABASE --remote")
-			).rejects.toThrowError(
+			).rejects.toThrow(
 				"Couldn't find a D1 DB with the name or binding 'DATABASE' in your wrangler.toml file."
 			);
 		});
@@ -264,16 +264,14 @@ describe("migrate", () => {
 			setIsTTY(false);
 			writeWranglerConfig();
 			// If we get to the point where we are checking for migrations then we have not checked wrangler.toml.
-			await expect(
-				runWrangler("d1 migrations apply DATABASE")
-			).rejects.toThrowError(`No migrations present at <cwd>/migrations.`);
+			await expect(runWrangler("d1 migrations apply DATABASE")).rejects.toThrow(
+				`No migrations present at <cwd>/migrations.`
+			);
 		});
 
 		it("should error when no config file is present", async ({ expect }) => {
 			setIsTTY(false);
-			await expect(
-				runWrangler("d1 migrations apply DATABASE")
-			).rejects.toThrowError(
+			await expect(runWrangler("d1 migrations apply DATABASE")).rejects.toThrow(
 				"No configuration file found. Create a wrangler.jsonc file to define your D1 database."
 			);
 		});
@@ -291,7 +289,7 @@ describe("migrate", () => {
 
 			await expect(
 				runWrangler("d1 migrations apply --local db --preview")
-			).rejects.toThrowError(
+			).rejects.toThrow(
 				`Cannot use --preview without --remote. The --preview flag targets a preview D1 database, which requires the --remote flag. Remove --preview or add --remote.`
 			);
 		});
@@ -331,7 +329,7 @@ Your database may not be available to serve requests during the migration, conti
 			});
 			await expect(
 				runWrangler("d1 migrations apply db --remote")
-			).rejects.toThrowError(
+			).rejects.toThrow(
 				`More than one account available but unable to select one in non-interactive mode.`
 			);
 		});
@@ -441,7 +439,7 @@ Your database may not be available to serve requests during the migration, conti
 
 			await expect(
 				runWrangler("d1 migrations apply db --local")
-			).rejects.toThrowError(
+			).rejects.toThrow(
 				`Migration "0001_test.sql" was not applied — execution was cancelled.`
 			);
 		});
@@ -537,14 +535,12 @@ Your database may not be available to serve requests during the migration, conti
 			// If we get to the point where we are checking for migrations then we have not been asked to log in.
 			await expect(
 				runWrangler("d1 migrations list --local DATABASE")
-			).rejects.toThrowError(`No migrations present at <cwd>/migrations.`);
+			).rejects.toThrow(`No migrations present at <cwd>/migrations.`);
 		});
 
 		it("should error when no config file is present", async ({ expect }) => {
 			setIsTTY(false);
-			await expect(
-				runWrangler("d1 migrations list DATABASE")
-			).rejects.toThrowError(
+			await expect(runWrangler("d1 migrations list DATABASE")).rejects.toThrow(
 				"No configuration file found. Create a wrangler.jsonc file to define your D1 database."
 			);
 		});
@@ -565,7 +561,7 @@ Your database may not be available to serve requests during the migration, conti
 			});
 			await expect(
 				runWrangler("d1 migrations list --local DATABASE")
-			).rejects.toThrowError(
+			).rejects.toThrow(
 				`No migrations present at <cwd>/my-migrations-go-here.`
 			);
 		});
@@ -584,7 +580,7 @@ Your database may not be available to serve requests during the migration, conti
 			);
 			await expect(
 				runWrangler("d1 migrations list --local DATABASE")
-			).rejects.toThrowError(`No migrations present at <cwd>/migrations.`);
+			).rejects.toThrow(`No migrations present at <cwd>/migrations.`);
 			expect(mockStd.warn).toContain(
 				"Set `migrations_dir` in your wrangler.jsonc file to choose a different path."
 			);
@@ -613,7 +609,7 @@ Your database may not be available to serve requests during the migration, conti
 			);
 			await expect(
 				runWrangler("d1 migrations list --local DATABASE")
-			).rejects.toThrowError(`No migrations present at <cwd>/migrations.`);
+			).rejects.toThrow(`No migrations present at <cwd>/migrations.`);
 			expect(mockStd.warn).toContain("No migrations folder found.");
 			expect(mockStd.warn).not.toContain("Set `migrations_dir`");
 		});
@@ -626,7 +622,7 @@ Your database may not be available to serve requests during the migration, conti
 			writeWranglerConfig();
 			await expect(
 				runWrangler("d1 migrations list DATABASE --remote")
-			).rejects.toThrowError(
+			).rejects.toThrow(
 				"Couldn't find a D1 DB with the name or binding 'DATABASE' in your wrangler.toml file."
 			);
 		});
@@ -638,7 +634,7 @@ Your database may not be available to serve requests during the migration, conti
 
 			await expect(
 				runWrangler("d1 migrations list DATABASE --remote")
-			).rejects.toThrowError(
+			).rejects.toThrow(
 				"In a non-interactive environment, it's necessary to set a CLOUDFLARE_API_TOKEN environment variable for wrangler to work"
 			);
 		});
@@ -649,9 +645,9 @@ Your database may not be available to serve requests during the migration, conti
 			setIsTTY(false);
 			writeWranglerConfig();
 			// If we get to the point where we are checking for migrations then we have not checked wrangler.toml.
-			await expect(
-				runWrangler("d1 migrations list DATABASE")
-			).rejects.toThrowError(`No migrations present at <cwd>/migrations.`);
+			await expect(runWrangler("d1 migrations list DATABASE")).rejects.toThrow(
+				`No migrations present at <cwd>/migrations.`
+			);
 		});
 
 		it("`list` only shows migrations matching migrations_pattern (nested layout)", async ({

--- a/packages/wrangler/src/__tests__/d1/timeTravel.test.ts
+++ b/packages/wrangler/src/__tests__/d1/timeTravel.test.ts
@@ -34,7 +34,7 @@ describe("time-travel", () => {
 				runWrangler(
 					"d1 time-travel restore db --timestamp=1234 --bookmark=5678"
 				)
-			).rejects.toThrowError(
+			).rejects.toThrow(
 				`Cannot use --timestamp and --bookmark together. Provide only one: --timestamp to restore to a point in time, or --bookmark to restore to a specific bookmark.`
 			);
 		});
@@ -77,7 +77,7 @@ describe("time-travel", () => {
 					"1701",
 					"d5b1d127-xxxx-xxxx-xxxx-cbc69f0a9e06"
 				)
-			).rejects.toThrowError(
+			).rejects.toThrow(
 				"Time travel is not available for alpha D1 databases. You will need to migrate to a new database for access to this feature."
 			);
 		});

--- a/packages/wrangler/src/__tests__/deploy/build.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/build.test.ts
@@ -1077,7 +1077,7 @@ export default { fetch() { return new Response(foo); } }`
 				main: "index.js",
 			});
 
-			await expect(runWrangler("deploy")).rejects.toThrowError();
+			await expect(runWrangler("deploy")).rejects.toThrow();
 			expect(std).toMatchInlineSnapshot(`
 				{
 				  "debug": "",

--- a/packages/wrangler/src/__tests__/deploy/config-args-merging.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/config-args-merging.test.ts
@@ -354,7 +354,7 @@ describe.each([
 				writeWorkerSource();
 				const today = getTodaysCompatDate();
 				await expect(runWrangler("deploy ./index.js")).rejects
-					.toThrowError(`A compatibility_date is required when uploading a Worker. Add the following to your wrangler.toml file:
+					.toThrow(`A compatibility_date is required when uploading a Worker. Add the following to your wrangler.toml file:
     \`\`\`
     compatibility_date = "${today}"
 
@@ -449,7 +449,7 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 				// On main, versions upload calls requireAuth() before validating compat date,
 				// so we need the service metadata mock to avoid an unrelated API error
 				mockGetScript();
-				await expect(runWrangler("versions upload")).rejects.toThrowError(
+				await expect(runWrangler("versions upload")).rejects.toThrow(
 					/A compatibility_date is required/
 				);
 			});

--- a/packages/wrangler/src/__tests__/deploy/core.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/core.test.ts
@@ -599,7 +599,7 @@ describe("deploy", () => {
 			pages_build_output_dir: "public",
 			name: "test-name",
 		});
-		await expect(runWrangler("deploy")).rejects.toThrowError();
+		await expect(runWrangler("deploy")).rejects.toThrow();
 		expect(std.warn).toContain(
 			"It seems that you have run `wrangler deploy` on a Pages project, `wrangler pages deploy` should be used instead."
 		);
@@ -883,9 +883,7 @@ describe("deploy", () => {
 				})
 			);
 
-			await expect(
-				runWrangler("deploy index.js --temporary")
-			).rejects.toThrowError(
+			await expect(runWrangler("deploy index.js --temporary")).rejects.toThrow(
 				/You must accept Cloudflare's Terms of Service .* to use --temporary\./
 			);
 
@@ -999,9 +997,7 @@ describe("deploy", () => {
 				})
 			);
 
-			await expect(
-				runWrangler("deploy index.js --temporary")
-			).rejects.toThrowError(
+			await expect(runWrangler("deploy index.js --temporary")).rejects.toThrow(
 				/You're already authenticated with Cloudflare, so `--temporary` can't be used\./
 			);
 
@@ -1145,7 +1141,7 @@ describe("deploy", () => {
 
 				await expect(
 					runWrangler("deploy index.js --temporary")
-				).rejects.toThrowError(
+				).rejects.toThrow(
 					/You're already authenticated with Cloudflare, so `--temporary` can't be used\./
 				);
 
@@ -1538,7 +1534,7 @@ describe("deploy", () => {
 					])
 				);
 
-				await expect(runWrangler("deploy index.js")).rejects.toThrowError();
+				await expect(runWrangler("deploy index.js")).rejects.toThrow();
 
 				expect(std.err).toContain(
 					"In a non-interactive environment, it's necessary to set a CLOUDFLARE_API_TOKEN environment variable"
@@ -1621,7 +1617,7 @@ describe("deploy", () => {
 				mockOAuthServerCallback();
 				msw.use(...getMswSuccessMembershipHandlers([]));
 
-				await expect(runWrangler("deploy index.js")).rejects.toThrowError();
+				await expect(runWrangler("deploy index.js")).rejects.toThrow();
 
 				expect(std.err).toMatchInlineSnapshot(`
 					"[31mX [41;31m[[41;97mERROR[41;31m][0m [1mFailed to automatically retrieve account IDs for the logged in user.[0m

--- a/packages/wrangler/src/__tests__/deploy/queues.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/queues.test.ts
@@ -452,7 +452,7 @@ describe("deploy", () => {
 				},
 			});
 			await fs.promises.writeFile("index.js", `export default {};`);
-			await expect(runWrangler("deploy index.js")).rejects.toThrowError(
+			await expect(runWrangler("deploy index.js")).rejects.toThrow(
 				/Only "worker" consumers can be configured in your Wrangler configuration/
 			);
 		});

--- a/packages/wrangler/src/__tests__/deploy/secrets.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/secrets.test.ts
@@ -265,7 +265,7 @@ SECRET3=value3`
 		it("should fail when secrets file does not exist", async ({ expect }) => {
 			await expect(
 				runWrangler("deploy --secrets-file non-existent-file.json")
-			).rejects.toThrowError();
+			).rejects.toThrow();
 		});
 
 		it("should fail when secrets file contains invalid JSON", async ({
@@ -276,7 +276,7 @@ SECRET3=value3`
 
 			await expect(
 				runWrangler(`deploy --secrets-file ${secretsFile}`)
-			).rejects.toThrowError();
+			).rejects.toThrow();
 		});
 	});
 

--- a/packages/wrangler/src/__tests__/index.test.ts
+++ b/packages/wrangler/src/__tests__/index.test.ts
@@ -124,7 +124,7 @@ describe("wrangler", () => {
 
 	describe("--temporary", () => {
 		it("is rejected on commands that don't opt in", async ({ expect }) => {
-			await expect(runWrangler("whoami --temporary")).rejects.toThrowError(
+			await expect(runWrangler("whoami --temporary")).rejects.toThrow(
 				/Unknown argument: temporary/
 			);
 		});

--- a/packages/wrangler/src/__tests__/init.test.ts
+++ b/packages/wrangler/src/__tests__/init.test.ts
@@ -943,7 +943,7 @@ describe("init", () => {
 				runWrangler(
 					"init isolinear-optical-chip --from-dash i-dont-exist --no-delegate-c3"
 				)
-			).rejects.toThrowError();
+			).rejects.toThrow();
 
 			expect(std.err).toMatchInlineSnapshot(`
 					"[31mX [41;31m[[41;97mERROR[41;31m][0m [1mwrangler couldn't find a Worker with that name in your account.[0m
@@ -1267,7 +1267,7 @@ describe("init", () => {
 
 			await expect(
 				runWrangler("init --from-dash isolinear-optical-chip --no-delegate-c3")
-			).rejects.toThrowError();
+			).rejects.toThrow();
 
 			expect(std.err).toMatchInlineSnapshot(`
 				"[31mX [41;31m[[41;97mERROR[41;31m][0m [1mError Occurred: Unable to fetch bindings, routes, or services metadata from the dashboard. Please try again later.[0m

--- a/packages/wrangler/src/__tests__/pages/functions-build.test.ts
+++ b/packages/wrangler/src/__tests__/pages/functions-build.test.ts
@@ -26,7 +26,7 @@ describe("pages functions build", () => {
 	it("should throw an error if no worker script and no Functions directory was found", async ({
 		expect,
 	}) => {
-		await expect(runWrangler("pages functions build")).rejects.toThrowError();
+		await expect(runWrangler("pages functions build")).rejects.toThrow();
 		expect(std.err).toContain("Could not find anything to build.");
 	});
 

--- a/packages/wrangler/src/__tests__/pages/pages.test.ts
+++ b/packages/wrangler/src/__tests__/pages/pages.test.ts
@@ -292,7 +292,7 @@ describe("pages", () => {
 		});
 
 		it("should display for pages:functions:build", async ({ expect }) => {
-			await expect(runWrangler("pages functions build")).rejects.toThrowError();
+			await expect(runWrangler("pages functions build")).rejects.toThrow();
 
 			expect(std.out).toMatchInlineSnapshot(`
 				"
@@ -309,7 +309,7 @@ describe("pages", () => {
 				runWrangler(
 					'pages functions optimize-routes --routes-path="/build/_routes.json" --output-routes-path="/build/_optimized-routes.json"'
 				)
-			).rejects.toThrowError();
+			).rejects.toThrow();
 
 			expect(std.out).toMatchInlineSnapshot(`
 				"

--- a/packages/wrangler/src/__tests__/pages/project-validate.test.ts
+++ b/packages/wrangler/src/__tests__/pages/project-validate.test.ts
@@ -81,7 +81,7 @@ describe("pages project validate", () => {
 		// Should fail when passing a custom fileCountLimit of 5
 		await expect(() =>
 			validate({ directory: ".", fileCountLimit: 5 })
-		).rejects.toThrowError(
+		).rejects.toThrow(
 			"Error: Pages only supports up to 5 files in a deployment for your current plan. Ensure you have specified your build output directory correctly."
 		);
 	});

--- a/packages/wrangler/src/__tests__/print-bindings.test.ts
+++ b/packages/wrangler/src/__tests__/print-bindings.test.ts
@@ -167,7 +167,7 @@ describe("warnOrError", () => {
 		it("throws when `remote: true` is set on a local-only binding", ({
 			expect,
 		}) => {
-			expect(() => warnOrError("ratelimit", true)).toThrowError(
+			expect(() => warnOrError("ratelimit", true)).toThrow(
 				"Rate Limit bindings do not support accessing remote resources."
 			);
 		});
@@ -185,7 +185,7 @@ describe("warnOrError", () => {
 		it("throws when `remote: false` is set on a remote-only binding", ({
 			expect,
 		}) => {
-			expect(() => warnOrError("vectorize", false)).toThrowError(
+			expect(() => warnOrError("vectorize", false)).toThrow(
 				"Vectorize Index bindings do not support local development. You can set `remote: true` for the binding definition in your configuration file to access a remote version of the resource."
 			);
 		});
@@ -211,7 +211,7 @@ describe("warnOrError", () => {
 		it("throws when `remote: false` is set on an always-remote binding", ({
 			expect,
 		}) => {
-			expect(() => warnOrError("ai", false)).toThrowError(
+			expect(() => warnOrError("ai", false)).toThrow(
 				"AI bindings do not support local development. You can set `remote: true` for the binding definition in your configuration file to access a remote version of the resource."
 			);
 		});

--- a/packages/wrangler/src/__tests__/queues/queues-subscription.test.ts
+++ b/packages/wrangler/src/__tests__/queues/queues-subscription.test.ts
@@ -847,7 +847,7 @@ describe("queues subscription", () => {
 				runWrangler(
 					`queues subscription update test-queue --id ${subscriptionId}`
 				)
-			).rejects.toThrowError(
+			).rejects.toThrow(
 				"No fields specified for update. Provide at least one of --name, --events, or --enabled to update the subscription."
 			);
 		});

--- a/packages/wrangler/src/__tests__/queues/queues.test.ts
+++ b/packages/wrangler/src/__tests__/queues/queues.test.ts
@@ -1054,7 +1054,7 @@ describe("wrangler", () => {
 
 					await expect(
 						runWrangler(`queues consumer add ${queueName} testScript`)
-					).rejects.toThrowError();
+					).rejects.toThrow();
 					expect(std.out).toMatchInlineSnapshot(`
 				"Adding consumer to queue testQueue.
 				Queues is not currently enabled on this account. Go to https://dash.cloudflare.com/some-account-id/workers/queues to enable it.

--- a/packages/wrangler/src/__tests__/r2/bucket.test.ts
+++ b/packages/wrangler/src/__tests__/r2/bucket.test.ts
@@ -3214,7 +3214,7 @@ describe("r2", () => {
 						runWrangler(
 							`r2 bucket cors set my-bucket --file ${filePath} --force`
 						)
-					).rejects.toThrowError(
+					).rejects.toThrow(
 						/Wrangler detected an AWS S3 CORS configuration format/
 					);
 				});
@@ -3236,7 +3236,7 @@ describe("r2", () => {
 						runWrangler(
 							`r2 bucket cors set my-bucket --file ${filePath} --force`
 						)
-					).rejects.toThrowError(/Wrangler detected AWS S3 style keys/);
+					).rejects.toThrow(/Wrangler detected AWS S3 style keys/);
 				});
 
 				it("should set CORS configuration from a JSON file", async () => {

--- a/packages/wrangler/src/__tests__/tunnel/tunnel.test.ts
+++ b/packages/wrangler/src/__tests__/tunnel/tunnel.test.ts
@@ -205,7 +205,7 @@ describe("tunnel commands", () => {
 
 			await expect(
 				runWrangler("tunnel info f70ff985-a4ef-4643-bbbc-4a0ed4fc0000")
-			).rejects.toThrowError(UserError);
+			).rejects.toThrow(UserError);
 
 			expect(std.err).toContain("ERROR");
 		});
@@ -305,7 +305,7 @@ describe("tunnel commands", () => {
 		});
 
 		it("should require tunnel or token", async ({ expect }) => {
-			await expect(runWrangler("tunnel run")).rejects.toThrowError(UserError);
+			await expect(runWrangler("tunnel run")).rejects.toThrow(UserError);
 		});
 	});
 });

--- a/packages/wrangler/src/__tests__/type-generation.test.ts
+++ b/packages/wrangler/src/__tests__/type-generation.test.ts
@@ -211,7 +211,7 @@ describe("validateEnvInterfaceNames", () => {
 	});
 
 	it("should throw for reserved name Env", ({ expect }) => {
-		expect(() => validateEnvInterfaceNames(["env"])).toThrowError(
+		expect(() => validateEnvInterfaceNames(["env"])).toThrow(
 			/Environment name "env" converts to reserved interface name "Env"/
 		);
 	});
@@ -222,7 +222,7 @@ describe("validateEnvInterfaceNames", () => {
 		// Both staging-env and staging_env convert to StagingEnv
 		expect(() =>
 			validateEnvInterfaceNames(["staging-env", "staging_env"])
-		).toThrowError(
+		).toThrow(
 			/Environment names "staging-env" and "staging_env" both convert to interface name "StagingEnv"/
 		);
 	});
@@ -230,9 +230,7 @@ describe("validateEnvInterfaceNames", () => {
 	it("should throw when names with different separators collide", ({
 		expect,
 	}) => {
-		expect(() =>
-			validateEnvInterfaceNames(["my-prod", "my_prod"])
-		).toThrowError(
+		expect(() => validateEnvInterfaceNames(["my-prod", "my_prod"])).toThrow(
 			/Environment names "my-prod" and "my_prod" both convert to interface name "MyProdEnv"/
 		);
 	});
@@ -251,7 +249,7 @@ describe("throwMissingBindingError", () => {
 				fieldName: "binding",
 				index: 0,
 			})
-		).toThrowError(
+		).toThrow(
 			'Processing wrangler.json configuration:\n  - "kv_namespaces[0]" bindings should have a string "binding" field but got {"id":"1234"}.'
 		);
 	});
@@ -268,7 +266,7 @@ describe("throwMissingBindingError", () => {
 				fieldName: "binding",
 				index: 2,
 			})
-		).toThrowError(
+		).toThrow(
 			'Processing wrangler.json configuration:\n  - "env.production" environment configuration\n    - "env.production.d1_databases[2]" bindings should have a string "binding" field but got {"database_id":"abc123"}.'
 		);
 	});
@@ -282,7 +280,7 @@ describe("throwMissingBindingError", () => {
 				envName: TOP_LEVEL_ENV_NAME,
 				fieldName: "binding",
 			})
-		).toThrowError(
+		).toThrow(
 			'Processing wrangler.json configuration:\n  - "ai" bindings should have a string "binding" field but got {}.'
 		);
 	});
@@ -297,7 +295,7 @@ describe("throwMissingBindingError", () => {
 				fieldName: "binding",
 				index: 0,
 			})
-		).toThrowError(
+		).toThrow(
 			'Processing Wrangler configuration configuration:\n  - "kv_namespaces[0]" bindings should have a string "binding" field but got {}.'
 		);
 	});
@@ -312,7 +310,7 @@ describe("throwMissingBindingError", () => {
 				fieldName: "name",
 				index: 1,
 			})
-		).toThrowError(
+		).toThrow(
 			'Processing wrangler.json configuration:\n  - "env.staging" environment configuration\n    - "env.staging.unsafe[1]" bindings should have a string "name" field but got {"type":"ratelimit"}.'
 		);
 	});
@@ -2652,7 +2650,7 @@ describe("generate types - CLI", () => {
 
 			await expect(
 				runWrangler("types --include-runtime=false")
-			).rejects.toThrowError(
+			).rejects.toThrow(
 				/Processing wrangler\.jsonc configuration:\n\s+- "env\.staging" environment configuration\n\s+- "env\.staging\.kv_namespaces\[0\]" bindings should have a string "binding" field but got \{\}/
 			);
 		});
@@ -2674,7 +2672,7 @@ describe("generate types - CLI", () => {
 
 			await expect(
 				runWrangler("types --include-runtime=false")
-			).rejects.toThrowError(
+			).rejects.toThrow(
 				/Processing wrangler\.jsonc configuration:\n\s+- "r2_buckets\[0\]" bindings should have a string "binding" field/
 			);
 		});
@@ -3232,7 +3230,7 @@ describe("generate types - CLI", () => {
 
 			await expect(
 				runWrangler("types --include-runtime=false")
-			).rejects.toThrowError(
+			).rejects.toThrow(
 				/Environment names "my-env" and "my_env" both convert to interface name "MyEnv"/
 			);
 		});
@@ -3290,7 +3288,7 @@ describe("generate types - CLI", () => {
 					"utf-8"
 				);
 
-				await expect(runWrangler("types --env-interface")).rejects.toThrowError(
+				await expect(runWrangler("types --env-interface")).rejects.toThrow(
 					`Not enough arguments following: env-interface`
 				);
 			});
@@ -3318,7 +3316,7 @@ describe("generate types - CLI", () => {
 				for (const interfaceName of invalidInterfaceNames) {
 					await expect(
 						runWrangler(`types --env-interface '${interfaceName}'`)
-					).rejects.toThrowError(
+					).rejects.toThrow(
 						/The provided env-interface value .*? does not satisfy the validation regex/
 					);
 				}
@@ -3344,7 +3342,7 @@ describe("generate types - CLI", () => {
 
 				await expect(
 					runWrangler("types --env-interface CloudflareEnv")
-				).rejects.toThrowError(
+				).rejects.toThrow(
 					"An env-interface value has been provided but the worker uses the incompatible Service Worker syntax"
 				);
 			});
@@ -3408,7 +3406,7 @@ describe("generate types - CLI", () => {
 				];
 
 				for (const path of invalidPaths) {
-					await expect(runWrangler(`types ${path}`)).rejects.toThrowError(
+					await expect(runWrangler(`types ${path}`)).rejects.toThrow(
 						/The provided output path '.*?' does not point to a declaration file/
 					);
 				}
@@ -3427,7 +3425,7 @@ describe("generate types - CLI", () => {
 
 				await expect(
 					runWrangler("types --include-env=false --include-runtime=false")
-				).rejects.toThrowError(
+				).rejects.toThrow(
 					"At least one of --include-env or --include-runtime must be enabled."
 				);
 			});

--- a/packages/wrangler/src/__tests__/update-config-file.test.ts
+++ b/packages/wrangler/src/__tests__/update-config-file.test.ts
@@ -301,9 +301,7 @@ describe("createdResourceConfig()", () => {
 			  ]
 			}"
 		`);
-		await expect(readFile("wrangler.json", "utf8")).rejects.toThrowError(
-			"ENOENT"
-		);
+		await expect(readFile("wrangler.json", "utf8")).rejects.toThrow("ENOENT");
 	});
 
 	it("logs correct binding type", async ({ expect }) => {

--- a/packages/wrangler/src/__tests__/versions/secrets.test.ts
+++ b/packages/wrangler/src/__tests__/versions/secrets.test.ts
@@ -236,7 +236,7 @@ SECRET3=value3`
 				runWrangler(
 					`versions upload --name ${workerName} --secrets-file non-existent-file.json`
 				)
-			).rejects.toThrowError();
+			).rejects.toThrow();
 		});
 
 		it("should fail when secrets file is neither valid JSON nor .env format", async ({
@@ -249,7 +249,7 @@ SECRET3=value3`
 				runWrangler(
 					`versions upload --name ${workerName} --secrets-file ${secretsFile}`
 				)
-			).rejects.toThrowError();
+			).rejects.toThrow();
 		});
 	});
 

--- a/packages/wrangler/src/__tests__/versions/versions.deploy.test.ts
+++ b/packages/wrangler/src/__tests__/versions/versions.deploy.test.ts
@@ -1523,15 +1523,13 @@ describe("units", () => {
 		});
 
 		test("throws on empty tag", ({ expect }) => {
-			expect(() => parseTagSpecs({ versionTag: ["@100%"] })).toThrowError(
+			expect(() => parseTagSpecs({ versionTag: ["@100%"] })).toThrow(
 				`Could not parse a tag from --version-tag arg "@100%".`
 			);
 		});
 
 		test("throws on out-of-range percentage", ({ expect }) => {
-			expect(() =>
-				parseTagSpecs({ versionTag: ["abc1234@101%"] })
-			).toThrowError(
+			expect(() => parseTagSpecs({ versionTag: ["abc1234@101%"] })).toThrow(
 				`Percentage value 101% (from --version-tag arg "abc1234@101%") is out of range. Percentages must be between 0 and 100.`
 			);
 		});

--- a/packages/wrangler/src/__tests__/whoami.test.ts
+++ b/packages/wrangler/src/__tests__/whoami.test.ts
@@ -595,9 +595,7 @@ describe("whoami", () => {
 				)
 			)
 		);
-		await expect(
-			runWrangler(`whoami --account "account-2"`)
-		).rejects.toThrowError(
+		await expect(runWrangler(`whoami --account "account-2"`)).rejects.toThrow(
 			/A request to the Cloudflare API \(\/memberships\) failed/
 		);
 	});


### PR DESCRIPTION
Vitest's `toThrowError` is deprecated and simply `toThrow` should be used instead

<img width="808" height="527" alt="Screenshot of vscode showing deprecation warning" src="https://github.com/user-attachments/assets/d4d6e928-1bb4-400a-8c0a-011e722d7eac" />

This PR simply makes this change across the whole monorepo

___

[vitest `toThrow` docs](https://vitest.dev/api/expect.html#tothrow) (mentioning the deprecated alias)

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: minor code refactoring

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14442" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->