### PR TITLE
WC-5290 Use PATCH APIs for 'wrangler versions secret' commands

### DIFF
--- a/.changeset/quiet-lemons-patch.md
+++ b/.changeset/quiet-lemons-patch.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Use the new PATCH APIs for versioned secret commands
+
+Wrangler now updates versioned Worker secrets by patching the latest Worker version instead of downloading the latest version contents and uploading a full replacement version. This avoids reconstructing Worker configuration in Wrangler, which should reduce bugs when Workers use less common features. For example, this avoids regressions like the previous placement preservation bug fixed in [#13843](https://github.com/cloudflare/workers-sdk/pull/13843).

--- a/packages/wrangler/src/__tests__/versions/secrets/bulk.test.ts
+++ b/packages/wrangler/src/__tests__/versions/secrets/bulk.test.ts
@@ -9,9 +9,11 @@ import { mockAccountId, mockApiToken } from "../../helpers/mock-account-id";
 import { mockConsoleMethods } from "../../helpers/mock-console";
 import { clearDialogs } from "../../helpers/mock-dialogs";
 import { runWrangler } from "../../helpers/run-wrangler";
-import { mockGetVersion, mockPostVersion, mockSetupApiCalls } from "./utils";
-import type { VersionDetails } from "../../../versions/secrets";
-import type { CfPlacement } from "@cloudflare/workers-utils";
+import {
+	expectSecretPatch,
+	mockPatchLatestVersion,
+	mockPatchLatestVersionNoVersions,
+} from "./utils";
 import type { Interface } from "node:readline";
 
 function mockReadlineInput(input: string) {
@@ -63,19 +65,12 @@ describe("versions secret bulk", () => {
 			{ encoding: "utf8" }
 		);
 
-		mockSetupApiCalls(expect);
-		mockPostVersion(expect, (metadata) => {
-			expect(metadata.bindings).toStrictEqual([
-				{ type: "inherit", name: "do-binding" },
-				{ type: "secret_text", name: "SECRET_1", text: "secret-1" },
-				{ type: "secret_text", name: "SECRET_2", text: "secret-2" },
-				{ type: "secret_text", name: "SECRET_3", text: "secret-3" },
-			]);
-			expect(metadata.keep_bindings).toStrictEqual([
-				"secret_key",
-				"secret_text",
-			]);
-			expect(metadata.keep_assets).toBeTruthy();
+		mockPatchLatestVersion(expect, (patch) => {
+			expectSecretPatch(expect, patch, {
+				SECRET_1: "secret-1",
+				SECRET_2: "secret-2",
+				SECRET_3: "secret-3",
+			});
 		});
 
 		await runWrangler(`versions secret bulk secrets.json --name script-name`);
@@ -100,8 +95,13 @@ describe("versions secret bulk", () => {
 			".env",
 			"SECRET_1=secret-1\nSECRET_2=secret-2\nSECRET_3=secret-3"
 		);
-		mockSetupApiCalls(expect);
-		mockPostVersion(expect);
+		mockPatchLatestVersion(expect, (patch) => {
+			expectSecretPatch(expect, patch, {
+				SECRET_1: "secret-1",
+				SECRET_2: "secret-2",
+				SECRET_3: "secret-3",
+			});
+		});
 		await runWrangler(`versions secret bulk .env --name script-name`);
 		expect(std.out).toMatchInlineSnapshot(
 			`
@@ -122,8 +122,9 @@ describe("versions secret bulk", () => {
 	test("no wrangler configuration warnings shown", async ({ expect }) => {
 		await writeFile("secrets.json", JSON.stringify({ SECRET_1: "secret-1" }));
 		await writeFile("wrangler.json", JSON.stringify({ invalid_field: true }));
-		mockSetupApiCalls(expect);
-		mockPostVersion(expect);
+		mockPatchLatestVersion(expect, (patch) => {
+			expectSecretPatch(expect, patch, { SECRET_1: "secret-1" });
+		});
 		await runWrangler(`versions secret bulk secrets.json --name script-name`);
 		expect(std.warn).toMatchInlineSnapshot(`""`);
 		expect(std.err).toMatchInlineSnapshot(`""`);
@@ -138,19 +139,12 @@ describe("versions secret bulk", () => {
 			})
 		);
 
-		mockSetupApiCalls(expect);
-		mockPostVersion(expect, (metadata) => {
-			expect(metadata.bindings).toStrictEqual([
-				{ type: "inherit", name: "do-binding" },
-				{ type: "secret_text", name: "SECRET_1", text: "secret-1" },
-				{ type: "secret_text", name: "SECRET_2", text: "secret-2" },
-				{ type: "secret_text", name: "SECRET_3", text: "secret-3" },
-			]);
-			expect(metadata.keep_bindings).toStrictEqual([
-				"secret_key",
-				"secret_text",
-			]);
-			expect(metadata.keep_assets).toBeTruthy();
+		mockPatchLatestVersion(expect, (patch) => {
+			expectSecretPatch(expect, patch, {
+				SECRET_1: "secret-1",
+				SECRET_2: "secret-2",
+				SECRET_3: "secret-3",
+			});
 		});
 
 		await runWrangler(`versions secret bulk --name script-name`);
@@ -175,19 +169,12 @@ describe("versions secret bulk", () => {
 			"SECRET_1=secret-1\nSECRET_2=secret-2\nSECRET_3=secret-3"
 		);
 
-		mockSetupApiCalls(expect);
-		mockPostVersion(expect, (metadata) => {
-			expect(metadata.bindings).toStrictEqual([
-				{ type: "inherit", name: "do-binding" },
-				{ type: "secret_text", name: "SECRET_1", text: "secret-1" },
-				{ type: "secret_text", name: "SECRET_2", text: "secret-2" },
-				{ type: "secret_text", name: "SECRET_3", text: "secret-3" },
-			]);
-			expect(metadata.keep_bindings).toStrictEqual([
-				"secret_key",
-				"secret_text",
-			]);
-			expect(metadata.keep_assets).toBeTruthy();
+		mockPatchLatestVersion(expect, (patch) => {
+			expectSecretPatch(expect, patch, {
+				SECRET_1: "secret-1",
+				SECRET_2: "secret-2",
+				SECRET_3: "secret-3",
+			});
 		});
 
 		await runWrangler(`versions secret bulk --name script-name`);
@@ -219,21 +206,6 @@ describe("versions secret bulk", () => {
 
 	test("should error on invalid json stdin", async ({ expect }) => {
 		mockReadlineInput("hello world");
-
-		mockSetupApiCalls(expect);
-		mockPostVersion(expect, (metadata) => {
-			expect(metadata.bindings).toStrictEqual([
-				{ type: "inherit", name: "do-binding" },
-				{ type: "secret_text", name: "SECRET_1", text: "secret-1" },
-				{ type: "secret_text", name: "SECRET_2", text: "secret-2" },
-				{ type: "secret_text", name: "SECRET_3", text: "secret-3" },
-			]);
-			expect(metadata.keep_bindings).toStrictEqual([
-				"secret_key",
-				"secret_text",
-			]);
-			expect(metadata.keep_assets).toBeTruthy();
-		});
 
 		await runWrangler(`versions secret bulk --name script-name`);
 		expect(std.out).toMatchInlineSnapshot(
@@ -267,103 +239,20 @@ describe("versions secret bulk", () => {
 		);
 	});
 
-	test("unsafe metadata is provided", async ({ expect }) => {
-		writeWranglerConfig({
-			name: "script-name",
-			unsafe: { metadata: { build_options: { stable_id: "foo/bar" } } },
-		});
-
-		await writeFile(
-			"secrets.json",
-			JSON.stringify({
-				SECRET_1: "secret-1",
-				SECRET_2: "secret-2",
-				SECRET_3: "secret-3",
-			}),
-			{ encoding: "utf8" }
-		);
-
-		mockSetupApiCalls(expect);
-		mockPostVersion(expect, (metadata) => {
-			expect(metadata.bindings).toStrictEqual([
-				{ type: "inherit", name: "do-binding" },
-				{ type: "secret_text", name: "SECRET_1", text: "secret-1" },
-				{ type: "secret_text", name: "SECRET_2", text: "secret-2" },
-				{ type: "secret_text", name: "SECRET_3", text: "secret-3" },
-			]);
-			expect(metadata.keep_bindings).toStrictEqual([
-				"secret_key",
-				"secret_text",
-			]);
-			expect(metadata.keep_assets).toBeTruthy();
-			expect(metadata["build_options"]).toStrictEqual({ stable_id: "foo/bar" });
-		});
-
-		await runWrangler(`versions secret bulk secrets.json --name script-name`);
-		expect(std.out).toMatchInlineSnapshot(
-			`
-			"
-			 ⛅️ wrangler x.x.x
-			──────────────────
-			🌀 Creating the secrets for the Worker "script-name"
-			✨ Successfully created secret for key: SECRET_1
-			✨ Successfully created secret for key: SECRET_2
-			✨ Successfully created secret for key: SECRET_3
-			✨ Success! Created version id with 3 secrets.
-			➡️  To deploy this version to production traffic use the command "wrangler versions deploy"."
-		`
-		);
-		expect(std.err).toMatchInlineSnapshot(`""`);
-	});
-
-	test("unsafe metadata not included if not in wrangler.toml", async ({
+	test("shows a nice error message when the Worker has no versions", async ({
 		expect,
 	}) => {
-		writeWranglerConfig({
-			name: "script-name",
+		await writeFile("secrets.json", JSON.stringify({ SECRET_1: "secret-1" }), {
+			encoding: "utf8",
 		});
 
-		await writeFile(
-			"secrets.json",
-			JSON.stringify({
-				SECRET_1: "secret-1",
-				SECRET_2: "secret-2",
-				SECRET_3: "secret-3",
-			}),
-			{ encoding: "utf8" }
-		);
+		mockPatchLatestVersionNoVersions(expect);
 
-		mockSetupApiCalls(expect);
-		mockPostVersion(expect, (metadata) => {
-			expect(metadata.bindings).toStrictEqual([
-				{ type: "inherit", name: "do-binding" },
-				{ type: "secret_text", name: "SECRET_1", text: "secret-1" },
-				{ type: "secret_text", name: "SECRET_2", text: "secret-2" },
-				{ type: "secret_text", name: "SECRET_3", text: "secret-3" },
-			]);
-			expect(metadata.keep_bindings).toStrictEqual([
-				"secret_key",
-				"secret_text",
-			]);
-			expect(metadata.keep_assets).toBeTruthy();
-			expect(metadata["build_options"]).toBeUndefined();
-		});
-
-		await runWrangler(`versions secret bulk secrets.json --name script-name`);
-		expect(std.out).toMatchInlineSnapshot(
-			`
-			"
-			 ⛅️ wrangler x.x.x
-			──────────────────
-			🌀 Creating the secrets for the Worker "script-name"
-			✨ Successfully created secret for key: SECRET_1
-			✨ Successfully created secret for key: SECRET_2
-			✨ Successfully created secret for key: SECRET_3
-			✨ Success! Created version id with 3 secrets.
-			➡️  To deploy this version to production traffic use the command "wrangler versions deploy"."
-		`
+		await expect(
+			runWrangler(`versions secret bulk secrets.json --name script-name`)
+		).rejects.toThrowErrorMatchingInlineSnapshot(
+			`[Error: There are currently no uploaded versions of this Worker. Please upload a version before modifying a secret.]`
 		);
-		expect(std.err).toMatchInlineSnapshot(`""`);
 	});
 
 	describe("multi-env warning", () => {
@@ -377,8 +266,9 @@ describe("versions secret bulk", () => {
 			);
 
 			writeWranglerConfig({ env: { test: {} } });
-			mockSetupApiCalls(expect);
-			mockPostVersion(expect);
+			mockPatchLatestVersion(expect, (patch) => {
+				expectSecretPatch(expect, patch, { SECRET_1: "secret-1" });
+			});
 
 			await runWrangler(`versions secret bulk --name script-name`);
 			expect(std.warn).toMatchInlineSnapshot(`
@@ -403,8 +293,9 @@ describe("versions secret bulk", () => {
 			);
 
 			writeWranglerConfig({ env: { test: {} } });
-			mockSetupApiCalls(expect);
-			mockPostVersion(expect);
+			mockPatchLatestVersion(expect, (patch) => {
+				expectSecretPatch(expect, patch, { SECRET_1: "secret-1" });
+			});
 
 			await runWrangler(`versions secret bulk --name script-name --env test`);
 			expect(std.warn).toMatchInlineSnapshot(`""`);
@@ -420,8 +311,9 @@ describe("versions secret bulk", () => {
 			);
 
 			writeWranglerConfig();
-			mockSetupApiCalls(expect);
-			mockPostVersion(expect);
+			mockPatchLatestVersion(expect, (patch) => {
+				expectSecretPatch(expect, patch, { SECRET_1: "secret-1" });
+			});
 
 			await runWrangler(`versions secret bulk --name script-name`);
 			expect(std.warn).toMatchInlineSnapshot(`""`);
@@ -438,8 +330,9 @@ describe("versions secret bulk", () => {
 			);
 
 			writeWranglerConfig({ env: { test: {} } });
-			mockSetupApiCalls(expect);
-			mockPostVersion(expect);
+			mockPatchLatestVersion(expect, (patch) => {
+				expectSecretPatch(expect, patch, { SECRET_1: "secret-1" });
+			});
 
 			await runWrangler(`versions secret bulk --name script-name`);
 			expect(std.warn).toMatchInlineSnapshot(`""`);
@@ -455,97 +348,12 @@ describe("versions secret bulk", () => {
 			);
 
 			writeWranglerConfig({ env: { test: {} } });
-			mockSetupApiCalls(expect);
-			mockPostVersion(expect);
+			mockPatchLatestVersion(expect, (patch) => {
+				expectSecretPatch(expect, patch, { SECRET_1: "secret-1" });
+			});
 
 			await runWrangler(`versions secret bulk --name script-name --env=""`);
 			expect(std.warn).toMatchInlineSnapshot(`""`);
-		});
-	});
-
-	describe("placement", () => {
-		function buildVersionInfo(placement: CfPlacement): VersionDetails {
-			return {
-				id: "ce15c78b-cc43-4f60-b5a9-15ce4f298c2a",
-				metadata: {} as VersionDetails["metadata"],
-				number: 2,
-				resources: {
-					bindings: [],
-					script: {
-						etag: "etag",
-						handlers: ["fetch"],
-						last_deployed_from: "api",
-						placement,
-					},
-					script_runtime: {
-						usage_model: "standard",
-						limits: {},
-					},
-				},
-			};
-		}
-
-		async function runBulk() {
-			await writeFile(
-				"secrets.json",
-				JSON.stringify({ SECRET_1: "secret-1" }),
-				{ encoding: "utf8" }
-			);
-			await runWrangler(`versions secret bulk secrets.json --name script-name`);
-		}
-
-		test("preserves smart placement on the new version", async ({ expect }) => {
-			const placement: CfPlacement = { mode: "smart" };
-			mockSetupApiCalls(expect);
-			mockGetVersion(expect, buildVersionInfo(placement));
-			mockPostVersion(expect, (metadata) => {
-				expect(metadata.placement).toStrictEqual(placement);
-			});
-			await runBulk();
-			expect(std.err).toMatchInlineSnapshot(`""`);
-		});
-
-		test("preserves targeted placement with service targets on the new version", async ({
-			expect,
-		}) => {
-			const placement = {
-				mode: "targeted",
-				target: [{ hostname: "example.com", id: 410, type: "http" }],
-			} as unknown as CfPlacement;
-			mockSetupApiCalls(expect);
-			mockGetVersion(expect, buildVersionInfo(placement));
-			mockPostVersion(expect, (metadata) => {
-				expect(metadata.placement).toStrictEqual(placement);
-			});
-			await runBulk();
-			expect(std.err).toMatchInlineSnapshot(`""`);
-		});
-
-		test("preserves targeted placement with region targets on the new version", async ({
-			expect,
-		}) => {
-			const placement = {
-				mode: "targeted",
-				target: [{ id: 12, region: "aws:ap-northeast-1", type: "region" }],
-			} as unknown as CfPlacement;
-			mockSetupApiCalls(expect);
-			mockGetVersion(expect, buildVersionInfo(placement));
-			mockPostVersion(expect, (metadata) => {
-				expect(metadata.placement).toStrictEqual(placement);
-			});
-			await runBulk();
-			expect(std.err).toMatchInlineSnapshot(`""`);
-		});
-
-		test("omits placement when the existing version has none", async ({
-			expect,
-		}) => {
-			mockSetupApiCalls(expect);
-			mockPostVersion(expect, (metadata) => {
-				expect(metadata.placement).toBeUndefined();
-			});
-			await runBulk();
-			expect(std.err).toMatchInlineSnapshot(`""`);
 		});
 	});
 });

--- a/packages/wrangler/src/__tests__/versions/secrets/delete.test.ts
+++ b/packages/wrangler/src/__tests__/versions/secrets/delete.test.ts
@@ -9,9 +9,11 @@ import { mockConsoleMethods } from "../../helpers/mock-console";
 import { clearDialogs, mockConfirm } from "../../helpers/mock-dialogs";
 import { useMockIsTTY } from "../../helpers/mock-istty";
 import { runWrangler } from "../../helpers/run-wrangler";
-import { mockGetVersion, mockPostVersion, mockSetupApiCalls } from "./utils";
-import type { VersionDetails } from "../../../versions/secrets";
-import type { CfPlacement } from "@cloudflare/workers-utils";
+import {
+	expectSecretPatch,
+	mockPatchLatestVersion,
+	mockPatchLatestVersionNoVersions,
+} from "./utils";
 
 describe("versions secret delete", () => {
 	const std = mockConsoleMethods();
@@ -31,17 +33,8 @@ describe("versions secret delete", () => {
 			result: true,
 		});
 
-		mockSetupApiCalls(expect);
-		mockGetVersion(expect);
-		mockPostVersion(expect, (metadata) => {
-			// We should have all secrets except the one being deleted
-			expect(metadata.bindings).toStrictEqual([
-				{ type: "inherit", name: "do-binding" },
-				{ type: "inherit", name: "ANOTHER_SECRET" },
-				{ type: "inherit", name: "YET_ANOTHER_SECRET" },
-			]);
-			// We will not be inherting secret_text as that would bring back SECRET
-			expect(metadata.keep_bindings).toStrictEqual(["secret_key"]);
+		mockPatchLatestVersion(expect, (patch) => {
+			expectSecretPatch(expect, patch, { SECRET: null });
 		});
 		await runWrangler("versions secret delete SECRET --name script-name");
 
@@ -59,16 +52,8 @@ describe("versions secret delete", () => {
 	test("can delete a secret (non-interactive)", async ({ expect }) => {
 		setIsTTY(false);
 
-		mockSetupApiCalls(expect);
-		mockGetVersion(expect);
-		mockPostVersion(expect, (metadata) => {
-			expect(metadata.bindings).toStrictEqual([
-				{ type: "inherit", name: "do-binding" },
-				{ type: "inherit", name: "ANOTHER_SECRET" },
-				{ type: "inherit", name: "YET_ANOTHER_SECRET" },
-			]);
-			// We will not be inherting secret_text as that would bring back SECRET
-			expect(metadata.keep_bindings).toStrictEqual(["secret_key"]);
+		mockPatchLatestVersion(expect, (patch) => {
+			expectSecretPatch(expect, patch, { SECRET: null });
 		});
 
 		await runWrangler("versions secret delete SECRET --name script-name");
@@ -92,16 +77,8 @@ describe("versions secret delete", () => {
 		writeWranglerConfig({ name: "script-name" });
 		setIsTTY(false);
 
-		mockSetupApiCalls(expect);
-		mockGetVersion(expect);
-		mockPostVersion(expect, (metadata) => {
-			expect(metadata.bindings).toStrictEqual([
-				{ type: "inherit", name: "do-binding" },
-				{ type: "inherit", name: "ANOTHER_SECRET" },
-				{ type: "inherit", name: "YET_ANOTHER_SECRET" },
-			]);
-			// We will not be inherting secret_text as that would bring back SECRET
-			expect(metadata.keep_bindings).toStrictEqual(["secret_key"]);
+		mockPatchLatestVersion(expect, (patch) => {
+			expectSecretPatch(expect, patch, { SECRET: null });
 		});
 
 		await runWrangler("versions secret delete SECRET");
@@ -123,14 +100,27 @@ describe("versions secret delete", () => {
 		await writeFile("wrangler.json", JSON.stringify({ invalid_field: true }));
 		setIsTTY(false);
 
-		mockSetupApiCalls(expect);
-		mockGetVersion(expect);
-		mockPostVersion(expect);
+		mockPatchLatestVersion(expect, (patch) => {
+			expectSecretPatch(expect, patch, { SECRET: null });
+		});
 
 		await runWrangler("versions secret delete SECRET --name script-name");
 
 		expect(std.warn).toMatchInlineSnapshot(`""`);
 		expect(std.err).toMatchInlineSnapshot(`""`);
+	});
+
+	test("shows a nice error message when the Worker has no versions", async ({
+		expect,
+	}) => {
+		setIsTTY(false);
+		mockPatchLatestVersionNoVersions(expect);
+
+		await expect(
+			runWrangler("versions secret delete SECRET --name script-name")
+		).rejects.toThrowErrorMatchingInlineSnapshot(
+			`[Error: There are currently no uploaded versions of this Worker. Please upload a version before modifying a secret.]`
+		);
 	});
 
 	describe("multi-env warning", () => {
@@ -142,9 +132,9 @@ describe("versions secret delete", () => {
 			writeWranglerConfig({
 				env: { test: {} },
 			});
-			mockSetupApiCalls(expect);
-			mockGetVersion(expect);
-			mockPostVersion(expect);
+			mockPatchLatestVersion(expect, (patch) => {
+				expectSecretPatch(expect, patch, { SECRET: null });
+			});
 
 			await runWrangler("versions secret delete SECRET --name script-name");
 
@@ -168,9 +158,9 @@ describe("versions secret delete", () => {
 			writeWranglerConfig({
 				env: { test: {} },
 			});
-			mockSetupApiCalls(expect);
-			mockGetVersion(expect);
-			mockPostVersion(expect);
+			mockPatchLatestVersion(expect, (patch) => {
+				expectSecretPatch(expect, patch, { SECRET: null });
+			});
 
 			await runWrangler(
 				"versions secret delete SECRET --name script-name -e test"
@@ -185,9 +175,9 @@ describe("versions secret delete", () => {
 			setIsTTY(false);
 
 			writeWranglerConfig();
-			mockSetupApiCalls(expect);
-			mockGetVersion(expect);
-			mockPostVersion(expect);
+			mockPatchLatestVersion(expect, (patch) => {
+				expectSecretPatch(expect, patch, { SECRET: null });
+			});
 
 			await runWrangler("versions secret delete SECRET --name script-name");
 
@@ -203,9 +193,9 @@ describe("versions secret delete", () => {
 			writeWranglerConfig({
 				env: { test: {} },
 			});
-			mockSetupApiCalls(expect);
-			mockGetVersion(expect);
-			mockPostVersion(expect);
+			mockPatchLatestVersion(expect, (patch) => {
+				expectSecretPatch(expect, patch, { SECRET: null });
+			});
 
 			await runWrangler("versions secret delete SECRET --name script-name");
 
@@ -220,109 +210,15 @@ describe("versions secret delete", () => {
 			writeWranglerConfig({
 				env: { test: {} },
 			});
-			mockSetupApiCalls(expect);
-			mockGetVersion(expect);
-			mockPostVersion(expect);
+			mockPatchLatestVersion(expect, (patch) => {
+				expectSecretPatch(expect, patch, { SECRET: null });
+			});
 
 			await runWrangler(
 				'versions secret delete SECRET --name script-name --env=""'
 			);
 
 			expect(std.warn).toMatchInlineSnapshot(`""`);
-		});
-	});
-
-	describe("placement", () => {
-		function buildVersionInfo(placement: CfPlacement): VersionDetails {
-			return {
-				id: "ce15c78b-cc43-4f60-b5a9-15ce4f298c2a",
-				metadata: {} as VersionDetails["metadata"],
-				number: 2,
-				resources: {
-					bindings: [
-						{ type: "secret_text", name: "SECRET", text: "Secret shhh" },
-					],
-					script: {
-						etag: "etag",
-						handlers: ["fetch"],
-						last_deployed_from: "api",
-						placement,
-					},
-					script_runtime: {
-						usage_model: "standard",
-						limits: {},
-					},
-				},
-			};
-		}
-
-		// `versions secret delete` fetches the version twice (once directly, once
-		// inside copyWorkerVersionWithNewSecrets), so register the override twice.
-		function mockGetVersionTwice(
-			expect: Parameters<typeof mockGetVersion>[0],
-			versionInfo: VersionDetails
-		) {
-			mockGetVersion(expect, versionInfo);
-			mockGetVersion(expect, versionInfo);
-		}
-
-		test("preserves smart placement on the new version", async ({ expect }) => {
-			setIsTTY(false);
-			const placement: CfPlacement = { mode: "smart" };
-			mockSetupApiCalls(expect);
-			mockGetVersionTwice(expect, buildVersionInfo(placement));
-			mockPostVersion(expect, (metadata) => {
-				expect(metadata.placement).toStrictEqual(placement);
-			});
-			await runWrangler("versions secret delete SECRET --name script-name");
-			expect(std.err).toMatchInlineSnapshot(`""`);
-		});
-
-		test("preserves targeted placement with service targets on the new version", async ({
-			expect,
-		}) => {
-			setIsTTY(false);
-			const placement = {
-				mode: "targeted",
-				target: [{ hostname: "example.com", id: 410, type: "http" }],
-			} as unknown as CfPlacement;
-			mockSetupApiCalls(expect);
-			mockGetVersionTwice(expect, buildVersionInfo(placement));
-			mockPostVersion(expect, (metadata) => {
-				expect(metadata.placement).toStrictEqual(placement);
-			});
-			await runWrangler("versions secret delete SECRET --name script-name");
-			expect(std.err).toMatchInlineSnapshot(`""`);
-		});
-
-		test("preserves targeted placement with region targets on the new version", async ({
-			expect,
-		}) => {
-			setIsTTY(false);
-			const placement = {
-				mode: "targeted",
-				target: [{ id: 12, region: "aws:ap-northeast-1", type: "region" }],
-			} as unknown as CfPlacement;
-			mockSetupApiCalls(expect);
-			mockGetVersionTwice(expect, buildVersionInfo(placement));
-			mockPostVersion(expect, (metadata) => {
-				expect(metadata.placement).toStrictEqual(placement);
-			});
-			await runWrangler("versions secret delete SECRET --name script-name");
-			expect(std.err).toMatchInlineSnapshot(`""`);
-		});
-
-		test("omits placement when the existing version has none", async ({
-			expect,
-		}) => {
-			setIsTTY(false);
-			mockSetupApiCalls(expect);
-			mockGetVersion(expect);
-			mockPostVersion(expect, (metadata) => {
-				expect(metadata.placement).toBeUndefined();
-			});
-			await runWrangler("versions secret delete SECRET --name script-name");
-			expect(std.err).toMatchInlineSnapshot(`""`);
 		});
 	});
 });

--- a/packages/wrangler/src/__tests__/versions/secrets/put.test.ts
+++ b/packages/wrangler/src/__tests__/versions/secrets/put.test.ts
@@ -193,9 +193,9 @@ describe("versions secret put", () => {
 			expect(
 				(patch.annotations as Record<string, string>)["workers/message"]
 			).toBe("Deploy a new secret");
-			expect(
-				(patch.annotations as Record<string, string>)["workers/tag"]
-			).toBe("v1");
+			expect((patch.annotations as Record<string, string>)["workers/tag"]).toBe(
+				"v1"
+			);
 		});
 		await runWrangler(
 			"versions secret put NEW_SECRET --name script-name --message 'Deploy a new secret' --tag v1"

--- a/packages/wrangler/src/__tests__/versions/secrets/put.test.ts
+++ b/packages/wrangler/src/__tests__/versions/secrets/put.test.ts
@@ -3,19 +3,18 @@ import {
 	runInTempDir,
 	writeWranglerConfig,
 } from "@cloudflare/workers-utils/test-helpers";
-import { http, HttpResponse } from "msw";
-import { FormData } from "undici";
 import { afterEach, describe, it, test, vi } from "vitest";
 import { mockAccountId, mockApiToken } from "../../helpers/mock-account-id";
 import { mockConsoleMethods } from "../../helpers/mock-console";
 import { clearDialogs, mockPrompt } from "../../helpers/mock-dialogs";
 import { useMockIsTTY } from "../../helpers/mock-istty";
 import { useMockStdin } from "../../helpers/mock-stdin";
-import { msw } from "../../helpers/msw";
 import { runWrangler } from "../../helpers/run-wrangler";
-import { mockGetVersion, mockPostVersion, mockSetupApiCalls } from "./utils";
-import type { VersionDetails } from "../../../versions/secrets";
-import type { CfPlacement } from "@cloudflare/workers-utils";
+import {
+	expectSecretPatch,
+	mockPatchLatestVersion,
+	mockPatchLatestVersionNoVersions,
+} from "./utils";
 
 describe("versions secret put", () => {
 	const std = mockConsoleMethods();
@@ -36,88 +35,8 @@ describe("versions secret put", () => {
 			result: "the-secret",
 		});
 
-		mockSetupApiCalls(expect);
-		mockPostVersion(expect, (metadata) => {
-			expect(metadata.bindings).toStrictEqual([
-				{ type: "inherit", name: "do-binding" },
-				{ type: "secret_text", name: "NEW_SECRET", text: "the-secret" },
-			]);
-			expect(metadata.keep_bindings).toStrictEqual([
-				"secret_key",
-				"secret_text",
-			]);
-			expect(metadata.keep_assets).toBeTruthy();
-		});
-		await runWrangler("versions secret put NEW_SECRET --name script-name");
-
-		expect(std.out).toMatchInlineSnapshot(`
-			"
-			 ⛅️ wrangler x.x.x
-			──────────────────
-			🌀 Creating the secret for the Worker "script-name"
-			✨ Success! Created version id with secret NEW_SECRET.
-			➡️  To deploy this version with secret NEW_SECRET to production traffic use the command "wrangler versions deploy"."
-		`);
-		expect(std.err).toMatchInlineSnapshot(`""`);
-	});
-
-	test("unsafe metadata is provided", async ({ expect }) => {
-		writeWranglerConfig({
-			name: "script-name",
-			unsafe: { metadata: { build_options: { stable_id: "foo/bar" } } },
-		});
-
-		setIsTTY(true);
-
-		mockPrompt({
-			text: "Enter a secret value:",
-			options: { isSecret: true },
-			result: "the-secret",
-		});
-
-		mockSetupApiCalls(expect);
-		mockPostVersion(expect, (metadata) => {
-			expect(metadata["build_options"]).toStrictEqual({ stable_id: "foo/bar" });
-		});
-		await runWrangler("versions secret put NEW_SECRET --name script-name");
-
-		expect(std.out).toMatchInlineSnapshot(`
-			"
-			 ⛅️ wrangler x.x.x
-			──────────────────
-			🌀 Creating the secret for the Worker "script-name"
-			✨ Success! Created version id with secret NEW_SECRET.
-			➡️  To deploy this version with secret NEW_SECRET to production traffic use the command "wrangler versions deploy"."
-		`);
-		expect(std.err).toMatchInlineSnapshot(`""`);
-	});
-
-	test("unsafe metadata not included if not in wrangler.toml", async ({
-		expect,
-	}) => {
-		writeWranglerConfig({
-			name: "script-name",
-		});
-
-		setIsTTY(true);
-
-		mockPrompt({
-			text: "Enter a secret value:",
-			options: { isSecret: true },
-			result: "the-secret",
-		});
-
-		mockSetupApiCalls(expect);
-		mockPostVersion(expect, (metadata) => {
-			expect(metadata.bindings).toStrictEqual([
-				{ type: "inherit", name: "do-binding" },
-				{ type: "secret_text", name: "NEW_SECRET", text: "the-secret" },
-			]);
-			expect(metadata.keep_bindings).toStrictEqual([
-				"secret_key",
-				"secret_text",
-			]);
-			expect(metadata["build_options"]).toBeUndefined();
+		mockPatchLatestVersion(expect, (patch) => {
+			expectSecretPatch(expect, patch, { NEW_SECRET: "the-secret" });
 		});
 		await runWrangler("versions secret put NEW_SECRET --name script-name");
 
@@ -142,27 +61,39 @@ describe("versions secret put", () => {
 			result: "the-secret",
 		});
 
-		mockSetupApiCalls(expect);
-		mockPostVersion(expect);
+		mockPatchLatestVersion(expect, (patch) => {
+			expectSecretPatch(expect, patch, { NEW_SECRET: "the-secret" });
+		});
 		await runWrangler("versions secret put NEW_SECRET --name script-name");
 		expect(std.warn).toMatchInlineSnapshot(`""`);
 		expect(std.err).toMatchInlineSnapshot(`""`);
 	});
 
+	test("shows a nice error message when the Worker has no versions", async ({
+		expect,
+	}) => {
+		setIsTTY(true);
+
+		mockPrompt({
+			text: "Enter a secret value:",
+			options: { isSecret: true },
+			result: "the-secret",
+		});
+
+		mockPatchLatestVersionNoVersions(expect);
+
+		await expect(
+			runWrangler("versions secret put NEW_SECRET --name script-name")
+		).rejects.toThrowErrorMatchingInlineSnapshot(
+			`[Error: There are currently no uploaded versions of this Worker. Please upload a version before modifying a secret.]`
+		);
+	});
+
 	describe("(non-interactive)", () => {
 		const mockStdIn = useMockStdin({ isTTY: false });
 		test("can add a new secret (non-interactive)", async ({ expect }) => {
-			mockSetupApiCalls(expect);
-			mockPostVersion(expect, (metadata) => {
-				expect(metadata.bindings).toStrictEqual([
-					{ type: "inherit", name: "do-binding" },
-					{ type: "secret_text", name: "NEW_SECRET", text: "the-secret" },
-				]);
-				expect(metadata.keep_bindings).toStrictEqual([
-					"secret_key",
-					"secret_text",
-				]);
-				expect(metadata.keep_assets).toBeTruthy();
+			mockPatchLatestVersion(expect, (patch) => {
+				expectSecretPatch(expect, patch, { NEW_SECRET: "the-secret" });
 			});
 
 			mockStdIn.send(
@@ -198,17 +129,8 @@ describe("versions secret put", () => {
 			result: "the-secret",
 		});
 
-		mockSetupApiCalls(expect);
-		mockPostVersion(expect, (metadata) => {
-			expect(metadata.bindings).toStrictEqual([
-				{ type: "inherit", name: "do-binding" },
-				{ type: "secret_text", name: "NEW_SECRET", text: "the-secret" },
-			]);
-			expect(metadata.keep_bindings).toStrictEqual([
-				"secret_key",
-				"secret_text",
-			]);
-			expect(metadata.keep_assets).toBeTruthy();
+		mockPatchLatestVersion(expect, (patch) => {
+			expectSecretPatch(expect, patch, { NEW_SECRET: "the-secret" });
 		});
 		await runWrangler("versions secret put NEW_SECRET");
 
@@ -232,21 +154,12 @@ describe("versions secret put", () => {
 			result: "the-secret",
 		});
 
-		mockSetupApiCalls(expect);
-		mockPostVersion(expect, (metadata) => {
-			expect(metadata.bindings).toStrictEqual([
-				{ type: "inherit", name: "do-binding" },
-				{ type: "secret_text", name: "NEW_SECRET", text: "the-secret" },
-			]);
-			expect(metadata.keep_bindings).toStrictEqual([
-				"secret_key",
-				"secret_text",
-			]);
-			expect(metadata.keep_assets).toBeTruthy();
+		mockPatchLatestVersion(expect, (patch) => {
+			expectSecretPatch(expect, patch, { NEW_SECRET: "the-secret" });
 
-			expect(metadata.annotations).not.toBeUndefined();
+			expect(patch.annotations).not.toBeUndefined();
 			expect(
-				(metadata.annotations as Record<string, string>)["workers/message"]
+				(patch.annotations as Record<string, string>)["workers/message"]
 			).toBe("Deploy a new secret");
 		});
 		await runWrangler(
@@ -273,24 +186,15 @@ describe("versions secret put", () => {
 			result: "the-secret",
 		});
 
-		mockSetupApiCalls(expect);
-		mockPostVersion(expect, (metadata) => {
-			expect(metadata.bindings).toStrictEqual([
-				{ type: "inherit", name: "do-binding" },
-				{ type: "secret_text", name: "NEW_SECRET", text: "the-secret" },
-			]);
-			expect(metadata.keep_bindings).toStrictEqual([
-				"secret_key",
-				"secret_text",
-			]);
-			expect(metadata.keep_assets).toBeTruthy();
+		mockPatchLatestVersion(expect, (patch) => {
+			expectSecretPatch(expect, patch, { NEW_SECRET: "the-secret" });
 
-			expect(metadata.annotations).not.toBeUndefined();
+			expect(patch.annotations).not.toBeUndefined();
 			expect(
-				(metadata.annotations as Record<string, string>)["workers/message"]
+				(patch.annotations as Record<string, string>)["workers/message"]
 			).toBe("Deploy a new secret");
 			expect(
-				(metadata.annotations as Record<string, string>)["workers/tag"]
+				(patch.annotations as Record<string, string>)["workers/tag"]
 			).toBe("v1");
 		});
 		await runWrangler(
@@ -308,161 +212,6 @@ describe("versions secret put", () => {
 		expect(std.err).toMatchInlineSnapshot(`""`);
 	});
 
-	test("all non-secret bindings are inherited", async ({ expect }) => {
-		setIsTTY(true);
-
-		mockSetupApiCalls(expect);
-
-		mockPrompt({
-			text: "Enter a secret value:",
-			options: { isSecret: true },
-			result: "the-secret",
-		});
-
-		mockPostVersion(expect, (metadata) => {
-			expect(metadata.bindings).toStrictEqual([
-				{ type: "inherit", name: "do-binding" },
-				{ type: "secret_text", name: "SECRET", text: "the-secret" },
-			]);
-			expect(metadata.keep_bindings).toStrictEqual([
-				"secret_key",
-				"secret_text",
-			]);
-			expect(metadata.annotations).not.toBeUndefined();
-		});
-		await runWrangler("versions secret put SECRET --name script-name");
-
-		expect(std.out).toMatchInlineSnapshot(`
-			"
-			 ⛅️ wrangler x.x.x
-			──────────────────
-			🌀 Creating the secret for the Worker "script-name"
-			✨ Success! Created version id with secret SECRET.
-			➡️  To deploy this version with secret SECRET to production traffic use the command "wrangler versions deploy"."
-		`);
-		expect(std.err).toMatchInlineSnapshot(`""`);
-	});
-
-	test("can update an existing secret", async ({ expect }) => {
-		setIsTTY(true);
-
-		mockPrompt({
-			text: "Enter a secret value:",
-			options: { isSecret: true },
-			result: "the-secret",
-		});
-
-		mockSetupApiCalls(expect);
-		mockPostVersion(expect, (metadata) => {
-			expect(metadata.bindings).toStrictEqual([
-				{ type: "inherit", name: "do-binding" },
-				{ type: "secret_text", name: "SECRET", text: "the-secret" },
-			]);
-			expect(metadata.keep_bindings).toStrictEqual([
-				"secret_key",
-				"secret_text",
-			]);
-			expect(metadata.keep_assets).toBeTruthy();
-
-			expect(metadata.annotations).not.toBeUndefined();
-			expect(
-				(metadata.annotations as Record<string, string>)["workers/message"]
-			).toBe("Deploy a new secret");
-		});
-		await runWrangler(
-			"versions secret put SECRET --name script-name --message 'Deploy a new secret'"
-		);
-
-		expect(std.out).toMatchInlineSnapshot(`
-			"
-			 ⛅️ wrangler x.x.x
-			──────────────────
-			🌀 Creating the secret for the Worker "script-name"
-			✨ Success! Created version id with secret SECRET.
-			➡️  To deploy this version with secret SECRET to production traffic use the command "wrangler versions deploy"."
-		`);
-		expect(std.err).toMatchInlineSnapshot(`""`);
-	});
-
-	test("can add secret on wasm worker", async ({ expect }) => {
-		setIsTTY(true);
-
-		mockSetupApiCalls(expect);
-		// Mock content call to have wasm
-		msw.use(
-			http.get(
-				`*/accounts/:accountId/workers/scripts/:scriptName/content/v2?version=ce15c78b-cc43-4f60-b5a9-15ce4f298c2a`,
-				async ({ params }) => {
-					expect(params.accountId).toEqual("some-account-id");
-					expect(params.scriptName).toEqual("script-name");
-
-					const formData = new FormData();
-					formData.set(
-						"index.js",
-						new File(["export default {}"], "index.js", {
-							type: "application/javascript+module",
-						}),
-						"index.js"
-					);
-					formData.set(
-						"module.wasm",
-						new File(
-							[Buffer.from([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])],
-							"module.wasm",
-							{
-								type: "application/wasm",
-							}
-						),
-						"module.wasm"
-					);
-					return HttpResponse.formData(formData, {
-						headers: { "cf-entrypoint": "index.js" },
-					});
-				},
-				{ once: true }
-			)
-		);
-
-		mockPrompt({
-			text: "Enter a secret value:",
-			options: { isSecret: true },
-			result: "the-secret",
-		});
-
-		mockPostVersion(expect, (metadata, formData) => {
-			expect(formData.get("module.wasm")).not.toBeNull();
-			expect((formData.get("module.wasm") as File).size).equal(10);
-
-			expect(metadata.bindings).toStrictEqual([
-				{ type: "inherit", name: "do-binding" },
-				{ type: "secret_text", name: "SECRET", text: "the-secret" },
-			]);
-			expect(metadata.keep_bindings).toStrictEqual([
-				"secret_key",
-				"secret_text",
-			]);
-			expect(metadata.keep_assets).toBeTruthy();
-
-			expect(metadata.annotations).not.toBeUndefined();
-			expect(
-				(metadata.annotations as Record<string, string>)["workers/message"]
-			).toBe("Deploy a new secret");
-		});
-		await runWrangler(
-			"versions secret put SECRET --name script-name --message 'Deploy a new secret'"
-		);
-
-		expect(std.out).toMatchInlineSnapshot(`
-			"
-			 ⛅️ wrangler x.x.x
-			──────────────────
-			🌀 Creating the secret for the Worker "script-name"
-			✨ Success! Created version id with secret SECRET.
-			➡️  To deploy this version with secret SECRET to production traffic use the command "wrangler versions deploy"."
-		`);
-		expect(std.err).toMatchInlineSnapshot(`""`);
-	});
-
 	describe("multi-env warning", () => {
 		const mockStdIn = useMockStdin({ isTTY: false });
 
@@ -473,8 +222,9 @@ describe("versions secret put", () => {
 				name: "script-name",
 				env: { test: {} },
 			});
-			mockSetupApiCalls(expect);
-			mockPostVersion(expect);
+			mockPatchLatestVersion(expect, (patch) => {
+				expectSecretPatch(expect, patch, { NEW_SECRET: "the-secret" });
+			});
 
 			mockStdIn.send(
 				`the`,
@@ -503,8 +253,9 @@ describe("versions secret put", () => {
 				name: "script-name",
 				env: { test: {} },
 			});
-			mockSetupApiCalls(expect);
-			mockPostVersion(expect);
+			mockPatchLatestVersion(expect, (patch) => {
+				expectSecretPatch(expect, patch, { NEW_SECRET: "the-secret" });
+			});
 
 			mockStdIn.send(
 				`the`,
@@ -523,8 +274,9 @@ describe("versions secret put", () => {
 			writeWranglerConfig({
 				name: "script-name",
 			});
-			mockSetupApiCalls(expect);
-			mockPostVersion(expect);
+			mockPatchLatestVersion(expect, (patch) => {
+				expectSecretPatch(expect, patch, { NEW_SECRET: "the-secret" });
+			});
 
 			mockStdIn.send(
 				`the`,
@@ -545,8 +297,9 @@ describe("versions secret put", () => {
 				name: "script-name",
 				env: { test: {} },
 			});
-			mockSetupApiCalls(expect);
-			mockPostVersion(expect);
+			mockPatchLatestVersion(expect, (patch) => {
+				expectSecretPatch(expect, patch, { NEW_SECRET: "the-secret" });
+			});
 
 			mockStdIn.send(
 				`the`,
@@ -566,8 +319,9 @@ describe("versions secret put", () => {
 				name: "script-name",
 				env: { test: {} },
 			});
-			mockSetupApiCalls(expect);
-			mockPostVersion(expect);
+			mockPatchLatestVersion(expect, (patch) => {
+				expectSecretPatch(expect, patch, { NEW_SECRET: "the-secret" });
+			});
 
 			mockStdIn.send(
 				`the`,
@@ -578,119 +332,6 @@ describe("versions secret put", () => {
 			await runWrangler('versions secret put NEW_SECRET --env=""');
 
 			expect(std.warn).toMatchInlineSnapshot(`""`);
-		});
-	});
-
-	describe("placement", () => {
-		function buildVersionInfo(placement: CfPlacement): VersionDetails {
-			return {
-				id: "ce15c78b-cc43-4f60-b5a9-15ce4f298c2a",
-				metadata: {} as VersionDetails["metadata"],
-				number: 2,
-				resources: {
-					bindings: [],
-					script: {
-						etag: "etag",
-						handlers: ["fetch"],
-						last_deployed_from: "api",
-						placement,
-					},
-					script_runtime: {
-						usage_model: "standard",
-						limits: {},
-					},
-				},
-			};
-		}
-
-		test("preserves smart placement on the new version", async ({ expect }) => {
-			setIsTTY(true);
-
-			mockPrompt({
-				text: "Enter a secret value:",
-				options: { isSecret: true },
-				result: "the-secret",
-			});
-
-			const placement: CfPlacement = { mode: "smart" };
-			mockSetupApiCalls(expect);
-			mockGetVersion(expect, buildVersionInfo(placement));
-			mockPostVersion(expect, (metadata) => {
-				expect(metadata.placement).toStrictEqual(placement);
-			});
-			await runWrangler("versions secret put NEW_SECRET --name script-name");
-
-			expect(std.err).toMatchInlineSnapshot(`""`);
-		});
-
-		test("preserves targeted placement with service targets on the new version", async ({
-			expect,
-		}) => {
-			setIsTTY(true);
-
-			mockPrompt({
-				text: "Enter a secret value:",
-				options: { isSecret: true },
-				result: "the-secret",
-			});
-
-			const placement = {
-				mode: "targeted",
-				target: [{ hostname: "example.com", id: 410, type: "http" }],
-			} as unknown as CfPlacement;
-			mockSetupApiCalls(expect);
-			mockGetVersion(expect, buildVersionInfo(placement));
-			mockPostVersion(expect, (metadata) => {
-				expect(metadata.placement).toStrictEqual(placement);
-			});
-			await runWrangler("versions secret put NEW_SECRET --name script-name");
-
-			expect(std.err).toMatchInlineSnapshot(`""`);
-		});
-
-		test("preserves targeted placement with region targets on the new version", async ({
-			expect,
-		}) => {
-			setIsTTY(true);
-
-			mockPrompt({
-				text: "Enter a secret value:",
-				options: { isSecret: true },
-				result: "the-secret",
-			});
-
-			const placement = {
-				mode: "targeted",
-				target: [{ id: 12, region: "aws:ap-northeast-1", type: "region" }],
-			} as unknown as CfPlacement;
-			mockSetupApiCalls(expect);
-			mockGetVersion(expect, buildVersionInfo(placement));
-			mockPostVersion(expect, (metadata) => {
-				expect(metadata.placement).toStrictEqual(placement);
-			});
-			await runWrangler("versions secret put NEW_SECRET --name script-name");
-
-			expect(std.err).toMatchInlineSnapshot(`""`);
-		});
-
-		test("omits placement when the existing version has none", async ({
-			expect,
-		}) => {
-			setIsTTY(true);
-
-			mockPrompt({
-				text: "Enter a secret value:",
-				options: { isSecret: true },
-				result: "the-secret",
-			});
-
-			mockSetupApiCalls(expect);
-			mockPostVersion(expect, (metadata) => {
-				expect(metadata.placement).toBeUndefined();
-			});
-			await runWrangler("versions secret put NEW_SECRET --name script-name");
-
-			expect(std.err).toMatchInlineSnapshot(`""`);
 		});
 	});
 });

--- a/packages/wrangler/src/__tests__/versions/secrets/utils.ts
+++ b/packages/wrangler/src/__tests__/versions/secrets/utils.ts
@@ -1,162 +1,56 @@
 import { http, HttpResponse } from "msw";
-import { FormData } from "undici";
 import { createFetchResult, msw } from "../../helpers/msw";
-import type { VersionDetails, WorkerVersion } from "../../../versions/secrets";
-import type { WorkerMetadata } from "@cloudflare/workers-utils";
 import type { ExpectStatic } from "vitest";
 
-function mockGetVersions(expect: ExpectStatic) {
-	msw.use(
-		http.get(
-			`*/accounts/:accountId/workers/scripts/:scriptName/versions`,
-			async ({ params }) => {
-				expect(params.accountId).toEqual("some-account-id");
-				expect(params.scriptName).toMatch(/script-name(-test)?/);
+type PatchLatestVersionEnvBinding = { type: "secret_text"; text: string };
 
-				return HttpResponse.json(
-					createFetchResult({
-						items: [
-							{
-								id: "ce15c78b-cc43-4f60-b5a9-15ce4f298c2a",
-								number: 2,
-							},
-							{
-								id: "ec5ea4f9-fe32-4301-bd73-6a86006ae8d4",
-								number: 1,
-							},
-						] as WorkerVersion[],
-					})
-				);
-			},
-			{ once: true }
-		)
-	);
+export interface PatchLatestVersionPatch {
+	annotations?: Record<string, string | undefined>;
+	env?: Record<string, PatchLatestVersionEnvBinding | null>;
+
+	// These fields should be inherited by PATCH/latest rather than resent.
+	build_options?: never;
+	keep_assets?: never;
+	keep_bindings?: never;
+	placement?: never;
 }
 
-export function mockGetVersion(
+export function expectSecretPatch(
 	expect: ExpectStatic,
-	versionInfo?: VersionDetails
+	patch: PatchLatestVersionPatch,
+	secrets: Record<string, string | null>
+) {
+	expect(patch).toMatchObject({
+		env: Object.fromEntries(
+			Object.entries(secrets).map(([name, value]) => [
+				name,
+				value === null ? null : { type: "secret_text", text: value },
+			])
+		),
+	});
+	expect(patch.keep_bindings).toBeUndefined();
+	expect(patch.keep_assets).toBeUndefined();
+	expect(patch.placement).toBeUndefined();
+	expect(patch).not.toHaveProperty("build_options");
+}
+
+export function mockPatchLatestVersion(
+	expect: ExpectStatic,
+	validate?: (patch: PatchLatestVersionPatch) => void
 ) {
 	msw.use(
-		http.get(
-			`*/accounts/:accountId/workers/scripts/:scriptName/versions/ce15c78b-cc43-4f60-b5a9-15ce4f298c2a`,
-			async ({ params }) => {
-				expect(params.accountId).toEqual("some-account-id");
-				expect(params.scriptName).toMatch(/script-name(-test)?/);
-
-				return HttpResponse.json(
-					createFetchResult(
-						versionInfo ?? {
-							id: "ce15c78b-cc43-4f60-b5a9-15ce4f298c2a",
-							metadata: {},
-							number: 2,
-							resources: {
-								bindings: [
-									{ type: "secret_text", name: "SECRET", text: "Secret shhh" },
-									{
-										type: "secret_text",
-										name: "ANOTHER_SECRET",
-										text: "Another secret shhhh",
-									},
-									{
-										type: "secret_text",
-										name: "YET_ANOTHER_SECRET",
-										text: "Yet another secret shhhhh",
-									},
-									{
-										name: "do-binding",
-										type: "durable_object_namespace",
-										namespace_id: "some-namespace-id",
-									},
-								],
-								script: {
-									etag: "etag",
-									handlers: ["fetch"],
-									last_deployed_from: "api",
-								},
-								script_runtime: {
-									usage_model: "standard",
-									limits: {},
-								},
-							},
-						}
-					)
-				);
-			},
-			{ once: true }
-		)
-	);
-}
-
-function mockGetVersionContent(expect: ExpectStatic) {
-	msw.use(
-		http.get(
-			`*/accounts/:accountId/workers/scripts/:scriptName/content/v2`,
-			async ({ params, request }) => {
-				const url = new URL(request.url);
-				expect(url.searchParams.get("version")).toEqual(
-					"ce15c78b-cc43-4f60-b5a9-15ce4f298c2a"
-				);
-				expect(params.accountId).toEqual("some-account-id");
-				expect(params.scriptName).toMatch(/script-name(-test)?/);
-
-				const formData = new FormData();
-				formData.set(
-					"index.js",
-					new File(["export default {}"], "index.js", {
-						type: "application/javascript+module",
-					}),
-					"index.js"
-				);
-
-				return HttpResponse.formData(formData, {
-					headers: { "cf-entrypoint": "index.js" },
-				});
-			},
-			{ once: true }
-		)
-	);
-}
-
-function mockGetWorkerSettings(expect: ExpectStatic) {
-	msw.use(
-		http.get(
-			`*/accounts/:accountId/workers/scripts/:scriptName/script-settings`,
-			async ({ params }) => {
-				expect(params.accountId).toEqual("some-account-id");
-				expect(params.scriptName).toMatch(/script-name(-test)?/);
-
-				return HttpResponse.json(
-					createFetchResult({
-						logpush: false,
-						tail_consumers: null,
-					})
-				);
-			},
-			{ once: true }
-		)
-	);
-}
-
-export function mockPostVersion(
-	expect: ExpectStatic,
-	validate?: (metadata: WorkerMetadata, formData: FormData) => void
-) {
-	msw.use(
-		http.post(
-			`*/accounts/:accountId/workers/scripts/:scriptName/versions`,
+		http.patch(
+			`*/accounts/:accountId/workers/workers/:scriptName/versions/latest`,
 			async ({ request, params }) => {
 				expect(params.accountId).toEqual("some-account-id");
 				expect(params.scriptName).toMatch(/script-name(-test)?/);
-
-				// eslint-disable-next-line @typescript-eslint/no-deprecated -- formData() is the standard Web API; only deprecated on undici's server-side types
-				const formData = await request.formData();
-				const metadata = JSON.parse(
-					formData.get("metadata") as string
-				) as WorkerMetadata;
+				expect(request.headers.get("content-type")).toEqual(
+					"application/merge-patch+json"
+				);
+				const patch = (await request.json()) as PatchLatestVersionPatch;
 
 				if (validate) {
-					validate(metadata, formData);
+					validate(patch);
 				}
 
 				return HttpResponse.json(
@@ -172,9 +66,29 @@ export function mockPostVersion(
 	);
 }
 
-export function mockSetupApiCalls(expect: ExpectStatic) {
-	mockGetVersions(expect);
-	mockGetVersion(expect);
-	mockGetVersionContent(expect);
-	mockGetWorkerSettings(expect);
+export function mockPatchLatestVersionNoVersions(expect: ExpectStatic) {
+	msw.use(
+		http.patch(
+			`*/accounts/:accountId/workers/workers/:scriptName/versions/latest`,
+			({ request, params }) => {
+				expect(params.accountId).toEqual("some-account-id");
+				expect(params.scriptName).toMatch(/script-name(-test)?/);
+				expect(request.headers.get("content-type")).toEqual(
+					"application/merge-patch+json"
+				);
+
+				return HttpResponse.json(
+					createFetchResult(null, false, [
+						{
+							code: 10222,
+							message:
+								"This Worker has no versions, which means this Worker has no content or versioned settings.",
+						},
+					]),
+					{ status: 404 }
+				);
+			},
+			{ once: true }
+		)
+	);
 }

--- a/packages/wrangler/src/versions/secrets/bulk.ts
+++ b/packages/wrangler/src/versions/secrets/bulk.ts
@@ -1,13 +1,11 @@
 import { configFileName, UserError } from "@cloudflare/workers-utils";
-import { fetchResult } from "../../cfetch";
 import { createCommand } from "../../core/create-command";
 import { logger } from "../../logger";
 import * as metrics from "../../metrics";
 import { parseBulkInputToObject } from "../../secret";
 import { requireAuth } from "../../user";
 import { getLegacyScriptName } from "../../utils/getLegacyScriptName";
-import { copyWorkerVersionWithNewSecrets } from "./index";
-import type { WorkerVersion } from "./index";
+import { patchLatestWorkerVersionWithSecrets } from "./index";
 
 export const versionsSecretBulkCommand = createCommand({
 	metadata: {
@@ -64,42 +62,24 @@ export const versionsSecretBulkCommand = createCommand({
 			return logger.error(`No content found in file or piped input.`);
 		}
 
-		const { content, secretSource, secretFormat } = result;
+		const { content: secrets, secretSource, secretFormat } = result;
 
-		const secrets = Object.entries(content).map(([key, value]) => ({
-			name: key,
-			value,
-		}));
+		const secretEntries = Object.entries(secrets);
 
-		// Grab the latest version
-		const versions = (
-			await fetchResult<{ items: WorkerVersion[] }>(
-				config,
-				`/accounts/${accountId}/workers/scripts/${scriptName}/versions`
-			)
-		).items;
-		if (versions.length === 0) {
-			throw new UserError(
-				"There are currently no uploaded versions of this Worker - please upload a version before uploading a secret.",
-				{ telemetryMessage: "versions secrets bulk no uploaded versions" }
-			);
-		}
-		const latestVersion = versions[0];
-
-		const newVersion = await copyWorkerVersionWithNewSecrets({
+		const newVersion = await patchLatestWorkerVersionWithSecrets({
 			config,
 			accountId,
 			scriptName,
-			versionId: latestVersion.id,
 			secrets,
-			versionMessage: args.message ?? `Bulk updated ${secrets.length} secrets`,
+			versionMessage:
+				args.message ?? `Bulk updated ${secretEntries.length} secrets`,
 			versionTag: args.tag,
 			sendMetrics: config.send_metrics,
-			unsafeMetadata: config.unsafe.metadata,
+			noVersionsTelemetryMessage: "versions secrets bulk no uploaded versions",
 		});
 
-		for (const secret of secrets) {
-			logger.log(`✨ Successfully created secret for key: ${secret.name}`);
+		for (const [name] of secretEntries) {
+			logger.log(`✨ Successfully created secret for key: ${name}`);
 		}
 
 		metrics.sendMetricsEvent(
@@ -116,7 +96,7 @@ export const versionsSecretBulkCommand = createCommand({
 		);
 
 		logger.log(
-			`✨ Success! Created version ${newVersion.id} with ${secrets.length} secrets.` +
+			`✨ Success! Created version ${newVersion.id} with ${secretEntries.length} secrets.` +
 				`\n➡️  To deploy this version to production traffic use the command "wrangler versions deploy".`
 		);
 	},

--- a/packages/wrangler/src/versions/secrets/delete.ts
+++ b/packages/wrangler/src/versions/secrets/delete.ts
@@ -1,12 +1,10 @@
 import { configFileName, UserError } from "@cloudflare/workers-utils";
-import { fetchResult } from "../../cfetch";
 import { createCommand } from "../../core/create-command";
 import { confirm } from "../../dialogs";
 import { logger } from "../../logger";
 import { requireAuth } from "../../user";
 import { getLegacyScriptName } from "../../utils/getLegacyScriptName";
-import { copyWorkerVersionWithNewSecrets } from "./index";
-import type { VersionDetails, WorkerVersion } from "./index";
+import { patchLatestWorkerVersionWithSecrets } from "./index";
 
 export const versionsSecretDeleteCommand = createCommand({
 	metadata: {
@@ -63,57 +61,27 @@ export const versionsSecretDeleteCommand = createCommand({
 
 		if (
 			await confirm(
-				`Are you sure you want to permanently delete the secret ${args.key} on the Worker ${scriptName}?`
+				`Are you sure you want to permanently delete the secret ${
+					args.key
+				} on the Worker ${scriptName}${args.env ? ` (${args.env})` : ""}?`
 			)
 		) {
 			logger.log(
-				`🌀 Deleting the secret ${args.key} on the Worker ${scriptName}`
+				`🌀 Deleting the secret ${args.key} on the Worker ${scriptName}${
+					args.env ? ` (${args.env})` : ""
+				}`
 			);
 
-			// Grab the latest version
-			const versions = (
-				await fetchResult<{ items: WorkerVersion[] }>(
-					config,
-					`/accounts/${accountId}/workers/scripts/${scriptName}/versions`
-				)
-			).items;
-			if (versions.length === 0) {
-				throw new UserError(
-					"There are currently no uploaded versions of this Worker - please upload a version before uploading a secret.",
-					{
-						telemetryMessage: "versions secrets delete no uploaded versions",
-					}
-				);
-			}
-			const latestVersion = versions[0];
-
-			const versionInfo = await fetchResult<VersionDetails>(
-				config,
-				`/accounts/${accountId}/workers/scripts/${scriptName}/versions/${latestVersion.id}`
-			);
-
-			// Go through all
-			const newSecrets = versionInfo.resources.bindings
-				.filter(
-					(binding) =>
-						binding.type === "secret_text" && binding.name !== args.key
-				)
-				.map((binding) => ({
-					name: binding.name,
-					value: "",
-					inherit: true,
-				}));
-
-			const newVersion = await copyWorkerVersionWithNewSecrets({
+			const newVersion = await patchLatestWorkerVersionWithSecrets({
 				config,
 				accountId,
 				scriptName,
-				versionId: latestVersion.id,
-				secrets: newSecrets,
+				secrets: { [args.key]: null },
 				versionMessage: args.message ?? `Deleted secret "${args.key}"`,
 				versionTag: args.tag,
 				sendMetrics: config.send_metrics,
-				overrideAllSecrets: true,
+				noVersionsTelemetryMessage:
+					"versions secrets delete no uploaded versions",
 			});
 
 			logger.log(

--- a/packages/wrangler/src/versions/secrets/index.ts
+++ b/packages/wrangler/src/versions/secrets/index.ts
@@ -1,26 +1,13 @@
-import { FatalError, UserError } from "@cloudflare/workers-utils";
+import { APIError, UserError } from "@cloudflare/workers-utils";
 import { fetchResult } from "../../cfetch";
-import { performApiFetch } from "../../cfetch/internal";
 import { createNamespace } from "../../core/create-command";
-import {
-	createWorkerUploadForm,
-	fromMimeType,
-} from "../../deployment-bundle/create-worker-upload-form";
 import { getMetricsUsageHeaders } from "../../metrics";
-import type { StartDevWorkerOptions } from "../../api";
 import type {
-	CfModule,
 	CfPlacement,
-	CfTailConsumer,
 	CfUserLimits,
-	CfWorkerInit,
-	WorkerMetadata as CfWorkerMetadata,
-	CfWorkerSourceMap,
 	Config,
-	Observability,
 	WorkerMetadataBinding,
 } from "@cloudflare/workers-utils";
-import type { SpecIterableIterator } from "undici";
 
 export const versionsSecretNamespace = createNamespace({
 	metadata: {
@@ -75,259 +62,67 @@ export interface VersionDetails {
 	cache_options?: { enabled: boolean };
 }
 
-interface ScriptSettings {
-	logpush: boolean;
-	tail_consumers: CfTailConsumer[] | null;
-	observability: Observability;
-}
+const NO_VERSIONS_ERR_CODE = 10222;
+const NO_VERSIONS_MESSAGE =
+	"There are currently no uploaded versions of this Worker. Please upload a version before modifying a secret.";
 
-type CfUnsafeMetadata = Record<string, unknown>;
-
-interface CopyLatestWorkerVersionArgs {
+interface PatchLatestWorkerVersionWithSecretsArgs {
 	config: Config;
 	accountId: string;
 	scriptName: string;
-	versionId: string;
-	secrets: { name: string; value: string; inherit?: boolean }[];
+	secrets: Record<string, string | null>;
 	versionMessage?: string;
 	versionTag?: string;
 	sendMetrics?: boolean;
-	overrideAllSecrets?: boolean; // Used for delete - this will make sure we do not inherit any
-	unsafeMetadata?: CfUnsafeMetadata | undefined;
+	noVersionsTelemetryMessage: string;
 }
 
-// TODO: This is a naive implementation, replace later
-export async function copyWorkerVersionWithNewSecrets({
+export async function patchLatestWorkerVersionWithSecrets({
 	config,
 	accountId,
 	scriptName,
-	versionId,
 	secrets,
 	versionMessage,
 	versionTag,
 	sendMetrics,
-	unsafeMetadata,
-	overrideAllSecrets,
-}: CopyLatestWorkerVersionArgs) {
-	// Grab the specific version info
-	const versionInfo = await fetchResult<VersionDetails>(
-		config,
-		`/accounts/${accountId}/workers/scripts/${scriptName}/versions/${versionId}`
-	);
-
-	// Naive implementation ahead, don't worry too much about it -- we will replace it
-	const { mainModule, modules, sourceMaps } = await parseModules(
-		config,
-		accountId,
-		scriptName,
-		versionId
-	);
-
-	// Grab the script settings
-	const scriptSettings = await fetchResult<ScriptSettings>(
-		config,
-		`/accounts/${accountId}/workers/scripts/${scriptName}/script-settings`
-	);
-
-	const bindings: StartDevWorkerOptions["bindings"] = Object.fromEntries(
-		versionInfo.resources.bindings
-			// Filter out secrets because they're handled separately
-			.filter((binding) => binding.type !== "secret_text")
-			.map((binding) => {
-				return [
-					binding.name,
-					{
-						// Inherit all of the existing bindings. This will be sent to the API as "type": "inherit"
-						// We inherit rather than just sending the actual bindings to reduce the risk of
-						// something going wrong in the round trip from the API to Wrangler and back
-						type: "inherit",
+	noVersionsTelemetryMessage,
+}: PatchLatestWorkerVersionWithSecretsArgs) {
+	try {
+		return await fetchResult<{ id: string | null }>(
+			config,
+			`/accounts/${accountId}/workers/workers/${scriptName}/versions/latest`,
+			{
+				method: "PATCH",
+				body: JSON.stringify({
+					env: Object.fromEntries(
+						Object.entries(secrets).map(([name, value]) => [
+							name,
+							value === null
+								? null
+								: {
+										type: "secret_text",
+										text: value,
+									},
+						])
+					),
+					annotations: {
+						"workers/message": versionMessage,
+						"workers/tag": versionTag,
 					},
-				];
-			})
-	);
-
-	// Add the new secrets
-	for (const secret of secrets) {
-		if (secret.inherit) {
-			bindings[secret.name] = {
-				type: "inherit",
-			};
-		} else {
-			bindings[secret.name] = {
-				type: "secret_text",
-				value: secret.value,
-			};
-		}
-	}
-
-	// We don't ever want to remove secret_key
-	const keepBindings: CfWorkerMetadata["keep_bindings"] = ["secret_key"];
-	// If we aren't overriding all secrets then inherit them
-	if (!overrideAllSecrets) {
-		keepBindings.push("secret_text");
-	}
-
-	const worker: Omit<CfWorkerInit, "bindings"> = {
-		name: scriptName,
-		main: mainModule,
-		modules,
-		containers: config.containers,
-		sourceMaps: sourceMaps,
-		migrations: undefined,
-		exports: undefined,
-		compatibility_date: versionInfo.resources.script_runtime.compatibility_date,
-		compatibility_flags:
-			versionInfo.resources.script_runtime.compatibility_flags,
-		keepVars: false, // we're re-uploading everything
-		keepSecrets: false, // handled in keepBindings
-		keepBindings,
-		logpush: scriptSettings.logpush,
-		placement:
-			versionInfo.resources.script.placement ??
-			(versionInfo.resources.script.placement_mode === "smart"
-				? { mode: "smart" }
-				: undefined),
-		tail_consumers: scriptSettings.tail_consumers ?? undefined,
-		limits: versionInfo.resources.script_runtime.limits,
-		annotations: {
-			"workers/message": versionMessage,
-			"workers/tag": versionTag,
-		},
-		keep_assets: true,
-		assets: undefined,
-		observability: scriptSettings.observability,
-		cache: versionInfo.cache_options,
-	};
-
-	const body = createWorkerUploadForm(worker, bindings, {
-		unsafe: { metadata: unsafeMetadata },
-	});
-	const result = await fetchResult<{
-		available_on_subdomain: boolean;
-		id: string | null;
-		etag: string | null;
-		deployment_id: string | null;
-	}>(
-		config,
-		`/accounts/${accountId}/workers/scripts/${scriptName}/versions`,
-		{
-			method: "POST",
-			body,
-			headers: await getMetricsUsageHeaders(sendMetrics),
-		},
-		new URLSearchParams({
-			include_subdomain_availability: "true",
-			// pass excludeScript so the whole body of the
-			// script doesn't get included in the response
-			excludeScript: "true",
-		})
-	);
-
-	return result;
-}
-
-async function parseModules(
-	config: Config,
-	accountId: string,
-	scriptName: string,
-	versionId: string
-): Promise<{
-	mainModule: CfModule;
-	modules: CfModule[];
-	sourceMaps: CfWorkerSourceMap[];
-}> {
-	// Pull the Worker content - https://developers.cloudflare.com/api/operations/worker-script-get-content
-	const contentRes = await performApiFetch(
-		config,
-		`/accounts/${accountId}/workers/scripts/${scriptName}/content/v2?version=${versionId}`
-	);
-	if (
-		contentRes.headers.get("content-type")?.startsWith("multipart/form-data")
-	) {
-		// eslint-disable-next-line @typescript-eslint/no-deprecated -- formData() is the standard Web API; only deprecated on undici's server-side types
-		const formData = await contentRes.formData();
-
-		// Workers Sites is not supported
-		if (formData.get("__STATIC_CONTENT_MANIFEST") !== null) {
-			throw new UserError(
-				"Workers Sites does not support updating secrets through `wrangler versions secret put`. You must use `wrangler secret put` instead.",
-				{ telemetryMessage: "versions secrets sites unsupported" }
-			);
-		}
-
-		// Load the main module and any additionals
-		const entrypoint = contentRes.headers.get("cf-entrypoint");
-		if (entrypoint === null) {
-			throw new FatalError("Got modules without cf-entrypoint header", {
-				telemetryMessage: "versions secrets modules missing entrypoint header",
+				}),
+				headers: {
+					...(await getMetricsUsageHeaders(sendMetrics)),
+					"Content-Type": "application/merge-patch+json",
+				},
+			}
+		);
+	} catch (e) {
+		if (e instanceof APIError && e.code === NO_VERSIONS_ERR_CODE) {
+			throw new UserError(NO_VERSIONS_MESSAGE, {
+				telemetryMessage: noVersionsTelemetryMessage,
 			});
 		}
 
-		const entrypointPart = formData.get(entrypoint) as File | null;
-		if (entrypointPart === null) {
-			throw new FatalError("Could not find entrypoint in form-data", {
-				telemetryMessage: "versions secrets modules missing entrypoint part",
-			});
-		}
-
-		const mainModule: CfModule = {
-			name: entrypointPart.name,
-			filePath: "",
-			content: Buffer.from<ArrayBuffer>(await entrypointPart.arrayBuffer()),
-			type: fromMimeType(entrypointPart.type),
-		};
-
-		// Load all modules that are not the entrypoint or sourcemaps
-		const modules = await Promise.all(
-			Array.from(formData.entries() as SpecIterableIterator<[string, File]>)
-				.filter(
-					([name, file]) =>
-						name !== entrypoint && file.type !== "application/source-map"
-				)
-				.map(
-					async ([name, file]) =>
-						({
-							name,
-							filePath: "",
-							content: Buffer.from(await file.arrayBuffer()),
-							type: fromMimeType(file.type),
-						}) as CfModule
-				)
-		);
-
-		// Load sourcemaps
-		const sourceMaps = await Promise.all(
-			Array.from(formData.entries() as SpecIterableIterator<[string, File]>)
-				.filter(([_, file]) => file.type === "application/source-map")
-				.map(
-					async ([name, file]) =>
-						({
-							name,
-							content: await file.text(),
-						}) as CfWorkerSourceMap
-				)
-		);
-
-		return { mainModule, modules, sourceMaps };
-	} else {
-		const contentType = contentRes.headers.get("content-type");
-		if (contentType === null) {
-			throw new FatalError(
-				"No content-type header was provided for non-module Worker content",
-				{ telemetryMessage: "versions secrets content missing content type" }
-			);
-		}
-
-		// good old Service Worker with no additional modules
-		const content = await contentRes.text();
-
-		const mainModule: CfModule = {
-			name: "index.js",
-			filePath: "",
-			content,
-			type: fromMimeType(contentType),
-		};
-
-		return { mainModule, modules: [], sourceMaps: [] };
+		throw e;
 	}
 }

--- a/packages/wrangler/src/versions/secrets/put.ts
+++ b/packages/wrangler/src/versions/secrets/put.ts
@@ -1,5 +1,4 @@
 import { configFileName, UserError } from "@cloudflare/workers-utils";
-import { fetchResult } from "../../cfetch";
 import { createCommand } from "../../core/create-command";
 import { prompt } from "../../dialogs";
 import { logger } from "../../logger";
@@ -7,8 +6,7 @@ import * as metrics from "../../metrics";
 import { requireAuth } from "../../user";
 import { getLegacyScriptName } from "../../utils/getLegacyScriptName";
 import { readFromStdin, trimTrailingWhitespace } from "../../utils/std";
-import { copyWorkerVersionWithNewSecrets } from "./index";
-import type { WorkerVersion } from "./index";
+import { patchLatestWorkerVersionWithSecrets } from "./index";
 
 export const versionsSecretPutCommand = createCommand({
 	metadata: {
@@ -74,31 +72,15 @@ export const versionsSecretPutCommand = createCommand({
 			`🌀 Creating the secret for the Worker "${scriptName}" ${args.env ? `(${args.env})` : ""}`
 		);
 
-		// Grab the latest version
-		const versions = (
-			await fetchResult<{ items: WorkerVersion[] }>(
-				config,
-				`/accounts/${accountId}/workers/scripts/${scriptName}/versions`
-			)
-		).items;
-		if (versions.length === 0) {
-			throw new UserError(
-				"There are currently no uploaded versions of this Worker. Please upload a version before uploading a secret.",
-				{ telemetryMessage: "versions secrets put no uploaded versions" }
-			);
-		}
-		const latestVersion = versions[0];
-
-		const newVersion = await copyWorkerVersionWithNewSecrets({
+		const newVersion = await patchLatestWorkerVersionWithSecrets({
 			config,
 			accountId,
 			scriptName,
-			versionId: latestVersion.id,
-			secrets: [{ name: args.key, value: secretValue }],
+			secrets: { [args.key]: secretValue },
 			versionMessage: args.message ?? `Updated secret "${args.key}"`,
 			versionTag: args.tag,
 			sendMetrics: config.send_metrics,
-			unsafeMetadata: config.unsafe.metadata,
+			noVersionsTelemetryMessage: "versions secrets put no uploaded versions",
 		});
 
 		metrics.sendMetricsEvent(


### PR DESCRIPTION
Fixes WC-5290.

Use PATCH APIs for `wrangler versions secret` commands. These APIs do server-side persistence of everything else so remove the need for Wrangler to try and reconstruct a version from a previous one, and so should reduce the number of bugs like https://github.com/cloudflare/workers-sdk/pull/13843.

Reviewable, but ask Greg before merging. We're landing one or two more internal things first and then we'll be ready to go.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: refactor

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14448" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->