### PR TITLE
[wrangler] Abort custom builds on dev teardown

### DIFF
--- a/.changeset/tame-custom-build-aborts.md
+++ b/.changeset/tame-custom-build-aborts.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Abort in-flight custom builds when `wrangler dev` exits or restarts a build
+
+Previously, `wrangler dev` marked in-flight custom builds as stale but did not pass the abort signal to the spawned build command. This meant Ctrl-C could appear to hang while Wrangler waited for a custom build command to finish naturally. Custom build commands are now cancelled when the dev session tears down or a newer watched build supersedes them.

--- a/packages/wrangler/src/__tests__/api/startDevWorker/BundleController.test.ts
+++ b/packages/wrangler/src/__tests__/api/startDevWorker/BundleController.test.ts
@@ -1,3 +1,4 @@
+import { existsSync } from "node:fs";
 import path from "node:path";
 import {
 	normalizeString,
@@ -256,6 +257,63 @@ describe("BundleController", { retry: 5, timeout: 10_000 }, () => {
 				},
 				{ timeout: 5_000, interval: 500 }
 			);
+		});
+
+		test("teardown aborts an in-flight watched custom build", async ({
+			expect,
+		}) => {
+			await seed({
+				"build.js": dedent /* javascript */ `
+					const fs = require("node:fs");
+					fs.writeFileSync("out.ts", "export default { fetch() { return new Response('done') } };");
+					console.log("custom build started");
+					process.on("SIGTERM", () => {
+						fs.writeFileSync("aborted.txt", "yes");
+						process.exit(0);
+					});
+					setTimeout(() => {
+						fs.writeFileSync("completed.txt", "yes");
+						process.exit(0);
+					}, 10_000);
+					setInterval(() => {}, 1000);
+				`,
+				"custom_build_dir/index.ts": dedent /* javascript */ `
+					export default {
+						fetch() {
+							return new Response("initial")
+						}
+					}
+				`,
+			});
+			const config = configDefaults({
+				entrypoint: path.resolve("out.ts"),
+				projectRoot: path.resolve("."),
+				build: {
+					custom: {
+						command: "node build.js",
+						watch: "custom_build_dir",
+					},
+					moduleRoot: path.resolve("."),
+				},
+			});
+
+			controller.onConfigUpdate({ type: "configUpdate", config });
+			await vi.waitFor(() => {
+				const buildStartedEvents = bus.events.filter(
+					(event) => event.type === "bundleStart"
+				);
+				expect(buildStartedEvents).toHaveLength(1);
+			});
+
+			await controller.teardown();
+			expect(existsSync("aborted.txt")).toBe(true);
+			expect(existsSync("completed.txt")).toBe(false);
+			expect(
+				bus.events.some(
+					(event) =>
+						event.type === "error" && event.source === "BundlerController"
+				)
+			).toBe(false);
 		});
 	});
 

--- a/packages/wrangler/src/__tests__/api/startDevWorker/BundleController.test.ts
+++ b/packages/wrangler/src/__tests__/api/startDevWorker/BundleController.test.ts
@@ -306,7 +306,14 @@ describe("BundleController", { retry: 5, timeout: 10_000 }, () => {
 			});
 
 			await controller.teardown();
-			expect(existsSync("aborted.txt")).toBe(true);
+			// On POSIX the build process is sent SIGTERM and can run its handler to
+			// shut down gracefully. Windows has no graceful signal for console
+			// processes, so `tree-kill` force-terminates the tree (`taskkill /F`) and
+			// the SIGTERM handler never runs. Either way the build must be aborted
+			// before it completes, which is what `completed.txt` verifies below.
+			if (process.platform !== "win32") {
+				expect(existsSync("aborted.txt")).toBe(true);
+			}
 			expect(existsSync("completed.txt")).toBe(false);
 			expect(
 				bus.events.some(

--- a/packages/wrangler/src/__tests__/custom-build.test.ts
+++ b/packages/wrangler/src/__tests__/custom-build.test.ts
@@ -1,6 +1,8 @@
+import { existsSync, writeFileSync } from "node:fs";
+import { setTimeout as sleep } from "node:timers/promises";
 import { UserError } from "@cloudflare/workers-utils";
 import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
-import { assert, describe, it } from "vitest";
+import { assert, describe, it, vi } from "vitest";
 import {
 	runCommand,
 	runCustomBuild,
@@ -29,6 +31,60 @@ describe("Custom Builds", () => {
 		}
 	});
 
+	it("runCommand aborts the custom build command", async ({ expect }) => {
+		const aborter = new AbortController();
+		const commandPromise = runCommand(
+			`node -e "console.log('started'); setInterval(() => {}, 1000)"`,
+			process.cwd(),
+			"[test]",
+			{ signal: aborter.signal }
+		);
+
+		await vi.waitFor(() => expect(std.out).toContain("started"));
+
+		aborter.abort();
+		await expect(commandPromise).rejects.toBeInstanceOf(Error);
+	});
+
+	it("runCommand aborts child processes spawned by shell commands", async ({
+		expect,
+	}) => {
+		writeFileSync(
+			"child.js",
+			`
+				const fs = require("node:fs");
+				fs.writeFileSync("child-started.txt", "yes");
+				setTimeout(() => fs.writeFileSync("child-finished.txt", "yes"), 750);
+				setInterval(() => {}, 1000);
+			`
+		);
+		writeFileSync(
+			"parent.js",
+			`
+				const childProcess = require("node:child_process");
+				childProcess.spawn(process.execPath, ["child.js"], { stdio: "inherit" });
+				console.log("parent started");
+				setInterval(() => {}, 1000);
+			`
+		);
+		const aborter = new AbortController();
+		const commandPromise = runCommand(
+			"node parent.js",
+			process.cwd(),
+			"[test]",
+			{
+				signal: aborter.signal,
+			}
+		);
+
+		await vi.waitFor(() => expect(existsSync("child-started.txt")).toBe(true));
+
+		aborter.abort();
+		await expect(commandPromise).rejects.toBeInstanceOf(Error);
+		await sleep(1_000);
+		expect(existsSync("child-finished.txt")).toBe(false);
+	});
+
 	describe("WRANGLER_COMMAND environment variable", () => {
 		it("should set WRANGLER_COMMAND=dev when wranglerCommand is dev", async ({
 			expect,
@@ -37,7 +93,7 @@ describe("Custom Builds", () => {
 				`node -e "console.log('WRANGLER_COMMAND=' + process.env.WRANGLER_COMMAND)"`,
 				process.cwd(),
 				"[test]",
-				"dev"
+				{ wranglerCommand: "dev" }
 			);
 			expect(std.out).toContain("WRANGLER_COMMAND=dev");
 		});
@@ -49,7 +105,7 @@ describe("Custom Builds", () => {
 				`node -e "console.log('WRANGLER_COMMAND=' + process.env.WRANGLER_COMMAND)"`,
 				process.cwd(),
 				"[test]",
-				"deploy"
+				{ wranglerCommand: "deploy" }
 			);
 			expect(std.out).toContain("WRANGLER_COMMAND=deploy");
 		});
@@ -61,7 +117,7 @@ describe("Custom Builds", () => {
 				`node -e "console.log('WRANGLER_COMMAND=' + process.env.WRANGLER_COMMAND)"`,
 				process.cwd(),
 				"[test]",
-				"versions upload"
+				{ wranglerCommand: "versions upload" }
 			);
 			expect(std.out).toContain("WRANGLER_COMMAND=versions upload");
 		});
@@ -73,7 +129,7 @@ describe("Custom Builds", () => {
 				`node -e "console.log('WRANGLER_COMMAND=' + process.env.WRANGLER_COMMAND)"`,
 				process.cwd(),
 				"[test]",
-				"types"
+				{ wranglerCommand: "types" }
 			);
 			expect(std.out).toContain("WRANGLER_COMMAND=types");
 		});

--- a/packages/wrangler/src/api/startDevWorker/BundlerController.ts
+++ b/packages/wrangler/src/api/startDevWorker/BundlerController.ts
@@ -17,6 +17,7 @@ import { runBuild } from "../../dev/use-esbuild";
 import { logger } from "../../logger";
 import { isNavigatorDefined } from "../../navigator-user-agent";
 import { debounce } from "../../utils/debounce";
+import { isAbortError } from "../../utils/isAbortError";
 import { Controller } from "./BaseController";
 import { castErrorCause } from "./events";
 import type { BundleResult } from "../../deployment-bundle/bundle";
@@ -32,6 +33,16 @@ export class BundlerController extends Controller {
 
 	// Handle aborting in-flight custom builds as new ones come in from the filesystem watcher
 	#customBuildAborter = new AbortController();
+	#activeCustomBuilds = new Set<Promise<void>>();
+
+	#startCustomBuildRun(config: StartDevWorkerOptions, filePath: string) {
+		const buildPromise = this.#runCustomBuild(config, filePath);
+		this.#activeCustomBuilds.add(buildPromise);
+		void buildPromise
+			.finally(() => this.#activeCustomBuilds.delete(buildPromise))
+			.catch(() => {});
+		return buildPromise;
+	}
 
 	async #runCustomBuild(config: StartDevWorkerOptions, filePath: string) {
 		// If a new custom build comes in, we need to cancel in-flight builds
@@ -53,7 +64,7 @@ export class BundlerController extends Controller {
 					command: config.build?.custom?.command,
 				},
 				config.config,
-				"dev"
+				{ wranglerCommand: "dev", signal: buildAborter.signal }
 			);
 			if (buildAborter.signal.aborted) {
 				return;
@@ -173,6 +184,9 @@ export class BundlerController extends Controller {
 				entrypointSource: readFileSync(entrypointPath, "utf8"),
 			});
 		} catch (err) {
+			if (buildAborter.signal.aborted || isAbortError(err)) {
+				return;
+			}
 			this.emitErrorEvent({
 				type: "error",
 				reason: "Custom build failed",
@@ -198,7 +212,7 @@ export class BundlerController extends Controller {
 		assert(pathsToWatch, "config.build.custom.watch");
 
 		if (config.dev.watch === false) {
-			await this.#runCustomBuild(config, String(pathsToWatch));
+			await this.#startCustomBuildRun(config, String(pathsToWatch));
 			return;
 		}
 
@@ -208,12 +222,12 @@ export class BundlerController extends Controller {
 			ignoreInitial: true,
 		});
 		this.#customBuildWatcher.on("ready", () => {
-			void this.#runCustomBuild(config, String(pathsToWatch));
+			void this.#startCustomBuildRun(config, String(pathsToWatch));
 		});
 
 		this.#customBuildWatcher.on(
 			"all",
-			(_event, filePath) => void this.#runCustomBuild(config, filePath)
+			(_event, filePath) => void this.#startCustomBuildRun(config, filePath)
 		);
 	}
 
@@ -408,6 +422,9 @@ export class BundlerController extends Controller {
 		logger.debug("BundlerController teardown beginning...");
 		await super.teardown();
 		this.#customBuildAborter?.abort();
+		const activeCustomBuilds = Array.from(this.#activeCustomBuilds, (build) =>
+			build.catch(() => {})
+		);
 		// Abort any in-flight esbuild build so that a finishing build doesn't
 		// emit `bundleComplete`/`bundleStart` into a torn-down event bus.
 		// `Controller.#tearingDown` already suppresses error events, but not
@@ -420,6 +437,7 @@ export class BundlerController extends Controller {
 			// ...middleware-loader.entry.ts" during teardown.
 			this.#bundlerCleanup?.(),
 			this.#customBuildWatcher?.close(),
+			...activeCustomBuilds,
 			this.#assetsWatcher?.close(),
 		]);
 		// Defence-in-depth: `bundle.ts`'s `stop()` normally removes the tmp

--- a/packages/wrangler/src/deployment-bundle/entry.ts
+++ b/packages/wrangler/src/deployment-bundle/entry.ts
@@ -101,7 +101,7 @@ export async function getEntry(
 		paths.relativePath,
 		config.build,
 		config.configPath,
-		command
+		{ wranglerCommand: command }
 	);
 
 	const projectRoot = paths.projectRoot ?? process.cwd();

--- a/packages/wrangler/src/deployment-bundle/run-custom-build.ts
+++ b/packages/wrangler/src/deployment-bundle/run-custom-build.ts
@@ -1,7 +1,6 @@
 import { existsSync, statSync } from "node:fs";
 import path from "node:path";
 import { Writable } from "node:stream";
-import { setTimeout as sleep } from "node:timers/promises";
 import { configFileName, UserError } from "@cloudflare/workers-utils";
 import chalk from "chalk";
 import { execaCommand } from "execa";
@@ -19,7 +18,6 @@ type RunCommandOptions = {
 };
 
 const FORCE_KILL_AFTER_MS = 5_000;
-const PROCESS_EXIT_POLL_INTERVAL_MS = 50;
 
 export async function runCommand(
 	command: string,
@@ -38,7 +36,6 @@ export async function runCommand(
 		const res = execaCommand(command, {
 			shell: true,
 			cwd,
-			detached: runOptions?.signal ? process.platform !== "win32" : false,
 			env: {
 				...process.env,
 				...(runOptions?.wranglerCommand
@@ -144,16 +141,48 @@ function assertEntryPointExists(
 	}
 }
 
+/**
+ * Terminate a spawned custom build command (and any processes it spawned) when
+ * the given `signal` aborts.
+ *
+ * `tree-kill` sends the signal to the process and all of its descendants on both
+ * POSIX and Windows. This matters because custom build commands are run through
+ * a shell and typically spawn their own child processes (e.g. `npm run build`).
+ * Killing the whole tree both terminates those children and closes the stdio
+ * pipes they inherited — without the latter, the `execa` promise would hang
+ * waiting for the pipes to reach EOF.
+ */
 function terminateProcessOnAbort(
 	signal: AbortSignal | undefined,
 	subprocess: ExecaChildProcess
 ) {
 	let processExitPromise: Promise<void> | undefined;
+	let forceKillTimer: NodeJS.Timeout | undefined;
 	const terminate = () => {
 		signal?.removeEventListener("abort", terminate);
-		if (subprocess.pid !== undefined) {
-			processExitPromise ??= terminateProcessTree(subprocess.pid);
+		const pid = subprocess.pid;
+		if (pid === undefined) {
+			return;
 		}
+		processExitPromise ??= new Promise<void>((resolve) => {
+			treeKill(pid, "SIGTERM", (error) => {
+				if (error) {
+					logger.debug("Failed to kill custom build process tree", error);
+				}
+				resolve();
+			});
+		});
+		// If the process tree ignores SIGTERM (and keeps stdio pipes open, which
+		// would otherwise hang the `execa` promise), escalate to SIGKILL after a
+		// grace period. The timer is cleared in `cleanup()` once the command has
+		// settled, so SIGKILL is only sent to a process tree that refused to exit.
+		forceKillTimer ??= setTimeout(() => {
+			treeKill(pid, "SIGKILL", (error) => {
+				if (error) {
+					logger.debug("Failed to force kill custom build process tree", error);
+				}
+			});
+		}, FORCE_KILL_AFTER_MS);
 	};
 	if (signal?.aborted) {
 		terminate();
@@ -164,70 +193,15 @@ function terminateProcessOnAbort(
 	return {
 		cleanup() {
 			signal?.removeEventListener("abort", terminate);
+			if (forceKillTimer !== undefined) {
+				clearTimeout(forceKillTimer);
+				forceKillTimer = undefined;
+			}
 		},
 		waitForExit() {
 			return processExitPromise ?? Promise.resolve();
 		},
 	};
-}
-
-async function terminateProcessTree(pid: number) {
-	if (process.platform === "win32") {
-		await new Promise<void>((resolve) => {
-			treeKill(pid, (error) => {
-				if (error) {
-					logger.debug("Failed to kill custom build process tree", error);
-				}
-				resolve();
-			});
-		});
-		return;
-	}
-
-	killProcessGroup(pid, "SIGTERM");
-	if (await waitForProcessGroupToExit(pid, FORCE_KILL_AFTER_MS)) {
-		return;
-	}
-	killProcessGroup(pid, "SIGKILL");
-	await waitForProcessGroupToExit(pid, 1_000);
-}
-
-function killProcessGroup(pid: number, signal: NodeJS.Signals) {
-	try {
-		process.kill(-pid, signal);
-	} catch (error) {
-		if (!isMissingProcessError(error)) {
-			logger.debug("Failed to kill custom build process group", error);
-		}
-	}
-}
-
-async function waitForProcessGroupToExit(pid: number, timeoutMs: number) {
-	const deadline = Date.now() + timeoutMs;
-	while (Date.now() < deadline) {
-		if (!processGroupExists(pid)) {
-			return true;
-		}
-		await sleep(PROCESS_EXIT_POLL_INTERVAL_MS);
-	}
-	return !processGroupExists(pid);
-}
-
-function processGroupExists(pid: number) {
-	try {
-		process.kill(-pid, 0);
-		return true;
-	} catch (error) {
-		if (isMissingProcessError(error)) {
-			return false;
-		}
-		logger.debug("Failed to check custom build process group", error);
-		return false;
-	}
-}
-
-function isMissingProcessError(error: unknown): error is NodeJS.ErrnoException {
-	return error instanceof Error && "code" in error && error.code === "ESRCH";
 }
 
 /**

--- a/packages/wrangler/src/deployment-bundle/run-custom-build.ts
+++ b/packages/wrangler/src/deployment-bundle/run-custom-build.ts
@@ -23,13 +23,8 @@ export async function runCommand(
 	command: string,
 	cwd: string | undefined,
 	prefix = "[custom build]",
-	options?: WranglerCommand | RunCommandOptions,
-	signal?: AbortSignal
+	runOptions?: RunCommandOptions
 ) {
-	const runOptions =
-		typeof options === "string"
-			? { wranglerCommand: options, signal }
-			: options;
 	logger.log(chalk.blue(prefix), "Running:", command);
 	let abortHandler: ReturnType<typeof terminateProcessOnAbort> | undefined;
 	try {
@@ -98,13 +93,8 @@ export async function runCustomBuild(
 	expectedEntryRelative: string,
 	build: Pick<Config["build"], "command" | "cwd">,
 	configPath: string | undefined,
-	options?: WranglerCommand | RunCommandOptions,
-	signal?: AbortSignal
+	runOptions?: RunCommandOptions
 ) {
-	const runOptions =
-		typeof options === "string"
-			? { wranglerCommand: options, signal }
-			: options;
 	if (build.command) {
 		await runCommand(build.command, build.cwd, "[custom build]", runOptions);
 

--- a/packages/wrangler/src/deployment-bundle/run-custom-build.ts
+++ b/packages/wrangler/src/deployment-bundle/run-custom-build.ts
@@ -1,31 +1,52 @@
 import { existsSync, statSync } from "node:fs";
 import path from "node:path";
 import { Writable } from "node:stream";
+import { setTimeout as sleep } from "node:timers/promises";
 import { configFileName, UserError } from "@cloudflare/workers-utils";
 import chalk from "chalk";
 import { execaCommand } from "execa";
+import treeKill from "tree-kill";
 import dedent from "ts-dedent";
 import { logger } from "../logger";
 import type { Config } from "@cloudflare/workers-utils";
+import type { ExecaChildProcess } from "execa";
 
 export type WranglerCommand = "dev" | "deploy" | "versions upload" | "types";
+
+type RunCommandOptions = {
+	wranglerCommand?: WranglerCommand;
+	signal?: AbortSignal;
+};
+
+const FORCE_KILL_AFTER_MS = 5_000;
+const PROCESS_EXIT_POLL_INTERVAL_MS = 50;
 
 export async function runCommand(
 	command: string,
 	cwd: string | undefined,
 	prefix = "[custom build]",
-	wranglerCommand?: WranglerCommand
+	options?: WranglerCommand | RunCommandOptions,
+	signal?: AbortSignal
 ) {
+	const runOptions =
+		typeof options === "string"
+			? { wranglerCommand: options, signal }
+			: options;
 	logger.log(chalk.blue(prefix), "Running:", command);
+	let abortHandler: ReturnType<typeof terminateProcessOnAbort> | undefined;
 	try {
 		const res = execaCommand(command, {
 			shell: true,
 			cwd,
+			detached: runOptions?.signal ? process.platform !== "win32" : false,
 			env: {
 				...process.env,
-				...(wranglerCommand ? { WRANGLER_COMMAND: wranglerCommand } : {}),
+				...(runOptions?.wranglerCommand
+					? { WRANGLER_COMMAND: runOptions.wranglerCommand }
+					: {}),
 			},
 		});
+		abortHandler = terminateProcessOnAbort(runOptions?.signal, res);
 		res.stdout?.pipe(
 			new Writable({
 				write(chunk: Buffer, _, callback) {
@@ -49,7 +70,14 @@ export async function runCommand(
 			})
 		);
 		await res;
+		if (runOptions?.signal?.aborted) {
+			await abortHandler?.waitForExit();
+		}
 	} catch (e) {
+		if (runOptions?.signal?.aborted) {
+			await abortHandler?.waitForExit();
+			throw e;
+		}
 		logger.error(e);
 		throw new UserError(
 			`Running custom build \`${command}\` failed. There are likely more logs from your build command above.`,
@@ -58,6 +86,8 @@ export async function runCommand(
 				cause: e,
 			}
 		);
+	} finally {
+		abortHandler?.cleanup();
 	}
 }
 /**
@@ -71,15 +101,15 @@ export async function runCustomBuild(
 	expectedEntryRelative: string,
 	build: Pick<Config["build"], "command" | "cwd">,
 	configPath: string | undefined,
-	wranglerCommand?: WranglerCommand
+	options?: WranglerCommand | RunCommandOptions,
+	signal?: AbortSignal
 ) {
+	const runOptions =
+		typeof options === "string"
+			? { wranglerCommand: options, signal }
+			: options;
 	if (build.command) {
-		await runCommand(
-			build.command,
-			build.cwd,
-			"[custom build]",
-			wranglerCommand
-		);
+		await runCommand(build.command, build.cwd, "[custom build]", runOptions);
 
 		assertEntryPointExists(
 			expectedEntryAbsolute,
@@ -112,6 +142,92 @@ function assertEntryPointExists(
 			{ telemetryMessage: "missing entrypoint after custom build" }
 		);
 	}
+}
+
+function terminateProcessOnAbort(
+	signal: AbortSignal | undefined,
+	subprocess: ExecaChildProcess
+) {
+	let processExitPromise: Promise<void> | undefined;
+	const terminate = () => {
+		signal?.removeEventListener("abort", terminate);
+		if (subprocess.pid !== undefined) {
+			processExitPromise ??= terminateProcessTree(subprocess.pid);
+		}
+	};
+	if (signal?.aborted) {
+		terminate();
+	} else {
+		signal?.addEventListener("abort", terminate);
+	}
+
+	return {
+		cleanup() {
+			signal?.removeEventListener("abort", terminate);
+		},
+		waitForExit() {
+			return processExitPromise ?? Promise.resolve();
+		},
+	};
+}
+
+async function terminateProcessTree(pid: number) {
+	if (process.platform === "win32") {
+		await new Promise<void>((resolve) => {
+			treeKill(pid, (error) => {
+				if (error) {
+					logger.debug("Failed to kill custom build process tree", error);
+				}
+				resolve();
+			});
+		});
+		return;
+	}
+
+	killProcessGroup(pid, "SIGTERM");
+	if (await waitForProcessGroupToExit(pid, FORCE_KILL_AFTER_MS)) {
+		return;
+	}
+	killProcessGroup(pid, "SIGKILL");
+	await waitForProcessGroupToExit(pid, 1_000);
+}
+
+function killProcessGroup(pid: number, signal: NodeJS.Signals) {
+	try {
+		process.kill(-pid, signal);
+	} catch (error) {
+		if (!isMissingProcessError(error)) {
+			logger.debug("Failed to kill custom build process group", error);
+		}
+	}
+}
+
+async function waitForProcessGroupToExit(pid: number, timeoutMs: number) {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		if (!processGroupExists(pid)) {
+			return true;
+		}
+		await sleep(PROCESS_EXIT_POLL_INTERVAL_MS);
+	}
+	return !processGroupExists(pid);
+}
+
+function processGroupExists(pid: number) {
+	try {
+		process.kill(-pid, 0);
+		return true;
+	} catch (error) {
+		if (isMissingProcessError(error)) {
+			return false;
+		}
+		logger.debug("Failed to check custom build process group", error);
+		return false;
+	}
+}
+
+function isMissingProcessError(error: unknown): error is NodeJS.ErrnoException {
+	return error instanceof Error && "code" in error && error.code === "ESRCH";
 }
 
 /**


### PR DESCRIPTION
Fixes internal report of Ctrl-C not stopping `wrangler dev` when a watched custom build is still running.

Thread the existing build abort signal into watched custom builds and make Wrangler own custom-build cancellation instead of relying on execa's shell-only abort behavior. On POSIX, dev custom builds with an abort signal run in their own process group so teardown can terminate the shell and child build tools together, with a SIGKILL fallback if SIGTERM does not drain. On Windows, Wrangler uses the existing `tree-kill` dependency to terminate the process tree. Abort/cancel errors from this path are treated as normal teardown rather than surfaced as build failures.

The dev BundlerController now also tracks active custom build promises and waits for them during teardown, so Ctrl-C does not complete while an aborted custom build is still settling.

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: This fixes teardown behavior for existing dev custom builds without changing the documented CLI surface.

Tested with:

- `pnpm -w test:ci -F wrangler -- custom-build.test.ts BundleController.test.ts`
- `pnpm --filter wrangler check:type`
