### PR TITLE
Support workflow terminate rollback

### DIFF
--- a/.changeset/workflows-terminate-rollback.md
+++ b/.changeset/workflows-terminate-rollback.md
@@ -1,0 +1,11 @@
+---
+"@cloudflare/workflows-shared": minor
+"wrangler": minor
+"miniflare": minor
+---
+
+Add rollback support when terminating Workflow instances
+
+`WorkflowInstance.terminate({ rollback: true })` now runs registered rollback handlers before marking a local Workflow instance as terminated. Wrangler also supports this via `wrangler workflows instances terminate --rollback`, including local mode.
+
+The rollback option is only sent for terminate operations and is rejected by the Local Explorer API for pause, resume, and restart actions.

--- a/packages/miniflare/scripts/openapi-filter-config.ts
+++ b/packages/miniflare/scripts/openapi-filter-config.ts
@@ -1169,6 +1169,11 @@ const config = {
 												},
 											},
 										},
+										rollback: {
+											type: "boolean",
+											description:
+												"Run rollback before terminating. Only valid when action is terminate.",
+										},
 									},
 								},
 							},

--- a/packages/miniflare/scripts/openapi-filter-config.ts
+++ b/packages/miniflare/scripts/openapi-filter-config.ts
@@ -1172,7 +1172,7 @@ const config = {
 										rollback: {
 											type: "boolean",
 											description:
-												"Run rollback before terminating. Only valid when action is terminate.",
+												"The option to trigger rollbacks when terminating the workflow instance.",
 										},
 									},
 								},

--- a/packages/miniflare/src/workers/local-explorer/generated/types.gen.ts
+++ b/packages/miniflare/src/workers/local-explorer/generated/types.gen.ts
@@ -1748,7 +1748,7 @@ export type WorkflowsChangeInstanceStatusData = {
 			type?: "do" | "sleep" | "waitForEvent";
 		};
 		/**
-		 * Run rollback before terminating. Only valid when action is terminate.
+		 * The option to trigger rollbacks when terminating the workflow instance.
 		 */
 		rollback?: boolean;
 	};

--- a/packages/miniflare/src/workers/local-explorer/generated/types.gen.ts
+++ b/packages/miniflare/src/workers/local-explorer/generated/types.gen.ts
@@ -1747,6 +1747,10 @@ export type WorkflowsChangeInstanceStatusData = {
 			 */
 			type?: "do" | "sleep" | "waitForEvent";
 		};
+		/**
+		 * Run rollback before terminating. Only valid when action is terminate.
+		 */
+		rollback?: boolean;
 	};
 	path: {
 		workflow_name: WorkflowsWorkflowName;

--- a/packages/miniflare/src/workers/local-explorer/generated/zod.gen.ts
+++ b/packages/miniflare/src/workers/local-explorer/generated/zod.gen.ts
@@ -1090,6 +1090,7 @@ export const zWorkflowsChangeInstanceStatusData = z.object({
 				type: z.enum(["do", "sleep", "waitForEvent"]).optional(),
 			})
 			.optional(),
+		rollback: z.boolean().optional(),
 	}),
 	path: z.object({
 		workflow_name: zWorkflowsWorkflowName,

--- a/packages/miniflare/src/workers/local-explorer/openapi.local.json
+++ b/packages/miniflare/src/workers/local-explorer/openapi.local.json
@@ -1810,6 +1810,10 @@
 												"description": "The step type. Defaults to do."
 											}
 										}
+									},
+									"rollback": {
+										"type": "boolean",
+										"description": "Run rollback before terminating. Only valid when action is terminate."
 									}
 								}
 							}

--- a/packages/miniflare/src/workers/local-explorer/openapi.local.json
+++ b/packages/miniflare/src/workers/local-explorer/openapi.local.json
@@ -1813,7 +1813,7 @@
 									},
 									"rollback": {
 										"type": "boolean",
-										"description": "Run rollback before terminating. Only valid when action is terminate."
+										"description": "The option to trigger rollbacks when terminating the workflow instance."
 									}
 								}
 							}

--- a/packages/miniflare/src/workers/local-explorer/resources/workflows.ts
+++ b/packages/miniflare/src/workers/local-explorer/resources/workflows.ts
@@ -920,6 +920,7 @@ export async function changeWorkflowInstanceStatus(
 				break;
 			}
 			case "terminate":
+				// TODO(vaish): remove cast once @cloudflare/workers-types ships terminate options
 				await (handle as unknown as WorkflowHandle).terminate(
 					body.rollback === true ? { rollback: true } : undefined
 				);

--- a/packages/miniflare/src/workers/local-explorer/resources/workflows.ts
+++ b/packages/miniflare/src/workers/local-explorer/resources/workflows.ts
@@ -11,7 +11,10 @@ import type {
 	WorkflowsWorkflow,
 } from "../generated";
 import type { zWorkflowsListInstancesData } from "../generated/zod.gen";
-import type { RestartFromStep } from "@cloudflare/workflows-shared/src/binding";
+import type {
+	RestartFromStep,
+	WorkflowInstanceTerminateOptions,
+} from "@cloudflare/workflows-shared/src/binding";
 import type { z } from "zod";
 
 // ============================================================================
@@ -35,7 +38,7 @@ interface WorkflowHandle {
 	pause(): Promise<void>;
 	resume(): Promise<void>;
 	restart(options?: { from?: RestartFromStep }): Promise<void>;
-	terminate(): Promise<void>;
+	terminate(options?: WorkflowInstanceTerminateOptions): Promise<void>;
 	sendEvent(args: { payload: unknown; type: string }): Promise<void>;
 	status(): Promise<{ status: string; output?: unknown; error?: unknown }>;
 }
@@ -886,6 +889,14 @@ export async function changeWorkflowInstanceStatus(
 			);
 		}
 
+		if (body.rollback !== undefined && action !== "terminate") {
+			return errorResponse(
+				400,
+				10001,
+				"'rollback' is only valid when terminating."
+			);
+		}
+
 		const handle = await workflow.get(instanceId);
 
 		switch (action) {
@@ -909,7 +920,9 @@ export async function changeWorkflowInstanceStatus(
 				break;
 			}
 			case "terminate":
-				await handle.terminate();
+				await (handle as unknown as WorkflowHandle).terminate(
+					body.rollback === true ? { rollback: true } : undefined
+				);
 				break;
 		}
 

--- a/packages/miniflare/src/workers/workflows/wrapped-binding.worker.ts
+++ b/packages/miniflare/src/workers/workflows/wrapped-binding.worker.ts
@@ -1,6 +1,8 @@
 import type {
 	WorkflowBinding,
+	WorkflowHandle,
 	WorkflowInstanceRestartOptions,
+	WorkflowInstanceTerminateOptions,
 } from "@cloudflare/workflows-shared/src/binding";
 import type { WorkflowIntrospectionOperation } from "@cloudflare/workflows-shared/src/types";
 
@@ -104,9 +106,12 @@ class InstanceImpl implements WorkflowInstance {
 		await instance.resume();
 	}
 
-	public async terminate(): Promise<void> {
+	public async terminate(
+		options?: WorkflowInstanceTerminateOptions
+	): Promise<void> {
 		using instance = await this.getInstance();
-		await instance.terminate();
+		// TODO(vaish): remove cast once @cloudflare/workers-types ships terminate options
+		await (instance as WorkflowHandle).terminate(options);
 	}
 
 	public async restart(

--- a/packages/miniflare/src/workers/workflows/wrapped-binding.worker.ts
+++ b/packages/miniflare/src/workers/workflows/wrapped-binding.worker.ts
@@ -93,7 +93,8 @@ class InstanceImpl implements WorkflowInstance {
 	) {}
 
 	private async getInstance(): Promise<WorkflowInstance & Disposable> {
-		return (await this.binding.get(this.id)) as WorkflowInstance & Disposable;
+		return (await this.binding.get(this.id)) as unknown as WorkflowInstance &
+			Disposable;
 	}
 
 	public async pause(): Promise<void> {
@@ -111,7 +112,7 @@ class InstanceImpl implements WorkflowInstance {
 	): Promise<void> {
 		using instance = await this.getInstance();
 		// TODO(vaish): remove cast once @cloudflare/workers-types ships terminate options
-		await (instance as WorkflowHandle).terminate(options);
+		await (instance as unknown as WorkflowHandle).terminate(options);
 	}
 
 	public async restart(

--- a/packages/miniflare/src/workers/workflows/wrapped-binding.worker.ts
+++ b/packages/miniflare/src/workers/workflows/wrapped-binding.worker.ts
@@ -1,6 +1,5 @@
 import type {
 	WorkflowBinding,
-	WorkflowHandle,
 	WorkflowInstanceRestartOptions,
 	WorkflowInstanceTerminateOptions,
 } from "@cloudflare/workflows-shared/src/binding";
@@ -93,8 +92,7 @@ class InstanceImpl implements WorkflowInstance {
 	) {}
 
 	private async getInstance(): Promise<WorkflowInstance & Disposable> {
-		return (await this.binding.get(this.id)) as unknown as WorkflowInstance &
-			Disposable;
+		return (await this.binding.get(this.id)) as WorkflowInstance & Disposable;
 	}
 
 	public async pause(): Promise<void> {
@@ -112,7 +110,11 @@ class InstanceImpl implements WorkflowInstance {
 	): Promise<void> {
 		using instance = await this.getInstance();
 		// TODO(vaish): remove cast once @cloudflare/workers-types ships terminate options
-		await (instance as unknown as WorkflowHandle).terminate(options);
+		await (
+			instance.terminate as (
+				options?: WorkflowInstanceTerminateOptions
+			) => Promise<void>
+		)(options);
 	}
 
 	public async restart(

--- a/packages/workflows-shared/src/binding.ts
+++ b/packages/workflows-shared/src/binding.ts
@@ -205,7 +205,7 @@ export class WorkflowBinding extends WorkerEntrypoint<Env> {
 		};
 	}
 
-	public async get(id: string): Promise<WorkflowHandle> {
+	public async get(id: string): Promise<WorkflowInstance> {
 		const stubId = this.env.ENGINE.idFromName(id);
 		const stub = this.env.ENGINE.get(stubId);
 

--- a/packages/workflows-shared/src/binding.ts
+++ b/packages/workflows-shared/src/binding.ts
@@ -124,6 +124,13 @@ export interface RestartFromStep {
 	type?: "do" | "sleep" | "waitForEvent";
 }
 
+export interface WorkflowInstanceTerminateOptions {
+	/**
+	 * If true, run registered rollback handlers before terminating the instance.
+	 */
+	rollback?: boolean;
+}
+
 export interface WorkflowInstanceRestartOptions {
 	from?: RestartFromStep;
 }
@@ -198,7 +205,7 @@ export class WorkflowBinding extends WorkerEntrypoint<Env> {
 		};
 	}
 
-	public async get(id: string): Promise<WorkflowInstance> {
+	public async get(id: string): Promise<WorkflowHandle> {
 		const stubId = this.env.ENGINE.idFromName(id);
 		const stub = this.env.ENGINE.get(stubId);
 
@@ -357,9 +364,11 @@ export class WorkflowHandle extends RpcTarget implements WorkflowInstance {
 		await this.stub.changeInstanceStatus("resume");
 	}
 
-	public async terminate(): Promise<void> {
+	public async terminate(
+		options?: WorkflowInstanceTerminateOptions
+	): Promise<void> {
 		try {
-			await this.stub.changeInstanceStatus("terminate");
+			await this.stub.changeInstanceStatus("terminate", undefined, options);
 		} catch (e) {
 			// terminate causes instance abortion
 			if (!isUserTriggeredTerminate(e)) {

--- a/packages/workflows-shared/src/context.ts
+++ b/packages/workflows-shared/src/context.ts
@@ -17,7 +17,6 @@ import {
 import { calcRetryDuration } from "./lib/retries";
 import {
 	parseRollbackOptions,
-	registerRollbackFn,
 	ROLLBACK_CACHE_KEY_PREFIX,
 } from "./lib/rollback";
 import {
@@ -247,7 +246,7 @@ export class Context extends RpcTarget {
 		const { cacheKey, rollbackFn, stepContext, output, rollbackConfig } =
 			options;
 		if (rollbackFn && this.#rollbackStep === undefined) {
-			registerRollbackFn(this.#engine.rollbackRegistry, {
+			this.#engine.registerRollbackFn({
 				cacheKey,
 				fn: rollbackFn,
 				stepContext,
@@ -297,6 +296,12 @@ export class Context extends RpcTarget {
 		const { rollback: rollbackFn, rollbackConfig } = rollbackOptions ?? {};
 
 		const isRollback = this.#rollbackStep !== undefined;
+		if (this.#engine.rollbackPhase === "rollback" && !isRollback) {
+			throw new WorkflowFatalError(
+				"Cannot execute steps during rollback phase"
+			);
+		}
+
 		const events = isRollback
 			? {
 					start: InstanceEvent.ROLLBACK_STEP_START,
@@ -937,7 +942,7 @@ export class Context extends RpcTarget {
 						events.failure,
 						cacheKey,
 						stepNameWithCounter,
-						{}
+						!isRollback && rollbackFn ? { hasRollback: true } : {}
 					);
 					this.#registerRollback({
 						cacheKey,
@@ -1039,7 +1044,7 @@ export class Context extends RpcTarget {
 						events.failure,
 						cacheKey,
 						stepNameWithCounter,
-						{}
+						!isRollback && rollbackFn ? { hasRollback: true } : {}
 					);
 					this.#registerRollback({
 						cacheKey,
@@ -1059,6 +1064,7 @@ export class Context extends RpcTarget {
 				...(lastStreamMeta && {
 					streamOutput: { cacheKey, meta: lastStreamMeta },
 				}),
+				...(!isRollback && rollbackFn ? { hasRollback: true } : {}),
 			});
 			this.#registerRollback({
 				cacheKey,
@@ -1073,13 +1079,21 @@ export class Context extends RpcTarget {
 
 		const result = await doWrapper(closure);
 
-		// Check if a pause was requested while this step was running
-		await this.#checkForPendingPause();
+		// Check if a pause was requested while this step was running.
+		// Rollback steps may run while the instance is paused; don't let stale pause
+		// state abort rollback cleanup after the rollback step itself succeeds.
+		if (!isRollback) {
+			await this.#checkForPendingPause();
+		}
 
 		return result;
 	}
 
 	async sleep(name: string, duration: WorkflowSleepDuration): Promise<void> {
+		if (this.#engine.rollbackPhase === "replay") {
+			return;
+		}
+
 		if (typeof duration == "string") {
 			duration = ms(duration);
 		}
@@ -1201,6 +1215,10 @@ export class Context extends RpcTarget {
 	}
 
 	async sleepUntil(name: string, timestamp: Date | number): Promise<void> {
+		if (this.#engine.rollbackPhase === "replay") {
+			return;
+		}
+
 		if (timestamp instanceof Date) {
 			timestamp = timestamp.valueOf();
 		}
@@ -1223,6 +1241,12 @@ export class Context extends RpcTarget {
 			timeout?: string | number;
 		}
 	): Promise<WorkflowStepEvent<T>> {
+		if (this.#engine.rollbackPhase === "rollback") {
+			throw new WorkflowFatalError(
+				"Cannot execute steps during rollback phase"
+			);
+		}
+
 		if (!options.timeout) {
 			options.timeout = "24 hours";
 		}
@@ -1241,6 +1265,10 @@ export class Context extends RpcTarget {
 		) as Error & UserErrorField;
 
 		const maybeResult = await this.#state.storage.get<Event>(waitForEventKey);
+
+		if (this.#engine.rollbackPhase === "replay") {
+			return maybeResult as WorkflowStepEvent<T>;
+		}
 
 		if (maybeResult) {
 			const shouldWriteLog =

--- a/packages/workflows-shared/src/context.ts
+++ b/packages/workflows-shared/src/context.ts
@@ -459,6 +459,17 @@ export class Context extends RpcTarget {
 		) as Error | undefined;
 
 		if (maybeError) {
+			const cachedState = maybeMap.get(stepStateKey) as StepState | undefined;
+			this.#registerRollback({
+				cacheKey,
+				rollbackFn,
+				stepContext: {
+					step: { name, count },
+					attempt: cachedState?.attemptedCount ?? 1,
+					config: cachedConfig ?? config,
+				},
+				rollbackConfig,
+			});
 			maybeError.isUserError = true;
 			throw maybeError;
 		}
@@ -468,6 +479,21 @@ export class Context extends RpcTarget {
 			await this.#state.storage.put(configKey, config);
 		} else {
 			config = cachedConfig;
+		}
+
+		if (this.#engine.rollbackPhase === "replay" && !isRollback) {
+			const cachedState = maybeMap.get(stepStateKey) as StepState | undefined;
+			this.#registerRollback({
+				cacheKey,
+				rollbackFn,
+				stepContext: {
+					step: { name, count },
+					attempt: cachedState?.attemptedCount ?? 1,
+					config,
+				},
+				rollbackConfig,
+			});
+			return undefined;
 		}
 
 		const attemptLogs = this.#engine
@@ -543,6 +569,7 @@ export class Context extends RpcTarget {
 			if (stepState.attemptedCount == 0) {
 				this.#engine.writeLog(events.start, cacheKey, stepNameWithCounter, {
 					config,
+					...(!isRollback && rollbackFn ? { hasRollback: true } : {}),
 				});
 			} else {
 				// in case the engine dies while retrying and wakes up before the retry period
@@ -628,6 +655,12 @@ export class Context extends RpcTarget {
 					}
 				);
 				stepState.attemptedCount++;
+				this.#registerRollback({
+					cacheKey,
+					rollbackFn,
+					stepContext: forwardStepContext(),
+					rollbackConfig,
+				});
 				await this.#state.storage.put(stepStateKey, stepState);
 				const priorityQueueHash = `${cacheKey}-${stepState.attemptedCount}`;
 

--- a/packages/workflows-shared/src/engine.ts
+++ b/packages/workflows-shared/src/engine.ts
@@ -270,7 +270,6 @@ export class Engine extends DurableObject<Env> {
 		for (const row of rows) {
 			if (row.event === InstanceEvent.STEP_START) {
 				stepStartGroupKeysDesc.push(row.groupKey);
-				continue;
 			}
 
 			if (
@@ -286,6 +285,7 @@ export class Engine extends DurableObject<Env> {
 			}
 
 			if (
+				row.event !== InstanceEvent.STEP_START &&
 				row.event !== InstanceEvent.STEP_SUCCESS &&
 				row.event !== InstanceEvent.STEP_FAILURE
 			) {

--- a/packages/workflows-shared/src/engine.ts
+++ b/packages/workflows-shared/src/engine.ts
@@ -120,6 +120,8 @@ export const DEFAULT_STEP_LIMIT = 10_000;
 
 const PAUSE_DATETIME = "PAUSE_DATETIME";
 
+export type RollbackPhase = "replay" | "rollback";
+
 /**
  * JSON.stringify replacer that converts TypedArrays and ArrayBuffers to a
  * human-readable description. Without this, JSON.stringify(Uint8Array) encodes
@@ -157,7 +159,7 @@ export class Engine extends DurableObject<Env> {
 	stepLimit: number;
 	engineAbortController: AbortController = new AbortController();
 	pauseController: AbortController = new AbortController();
-	rollbackPhase: "replay" | "rollback" | undefined = undefined;
+	rollbackPhase: RollbackPhase | undefined = undefined;
 	rollbackEligibleCacheKeys: Set<string> | undefined = undefined;
 
 	waiters: Map<
@@ -254,42 +256,38 @@ export class Engine extends DurableObject<Env> {
 	private getEligibleRollbackSteps(limit?: number): string[] {
 		const rollbackTerminalGroups = new Set<string>();
 		const rollbackEligibleGroups = new Set<string>();
-		const startedRows = [
-			...this.ctx.storage.sql.exec<{ groupKey: string }>(
-				"SELECT groupKey FROM states WHERE event = ? AND groupKey IS NOT NULL ORDER BY id DESC",
-				InstanceEvent.STEP_START
-			),
-		];
-		const completedRows = [
+		const stepStartGroupKeysDesc: string[] = [];
+		const rows = [
 			...this.ctx.storage.sql.exec<{
 				event: InstanceEvent;
-				groupKey: string | null;
+				groupKey: string;
 				metadata: string;
 			}>(
-				"SELECT event, groupKey, metadata FROM states WHERE groupKey IS NOT NULL"
+				"SELECT event, groupKey, metadata FROM states WHERE groupKey IS NOT NULL ORDER BY id DESC"
 			),
 		];
 
-		for (const row of completedRows) {
+		for (const row of rows) {
+			if (row.event === InstanceEvent.STEP_START) {
+				stepStartGroupKeysDesc.push(row.groupKey);
+				continue;
+			}
+
 			if (
-				row.groupKey !== null &&
-				(row.event === InstanceEvent.ROLLBACK_STEP_SUCCESS ||
-					row.event === InstanceEvent.ROLLBACK_STEP_FAILURE)
+				row.event === InstanceEvent.ROLLBACK_STEP_SUCCESS ||
+				row.event === InstanceEvent.ROLLBACK_STEP_FAILURE
 			) {
 				rollbackTerminalGroups.add(
 					row.groupKey.startsWith(ROLLBACK_CACHE_KEY_PREFIX)
 						? row.groupKey.slice(ROLLBACK_CACHE_KEY_PREFIX.length)
 						: row.groupKey
 				);
+				continue;
 			}
-		}
 
-		for (const row of completedRows) {
 			if (
-				row.groupKey === null ||
-				rollbackTerminalGroups.has(row.groupKey) ||
-				(row.event !== InstanceEvent.STEP_SUCCESS &&
-					row.event !== InstanceEvent.STEP_FAILURE)
+				row.event !== InstanceEvent.STEP_SUCCESS &&
+				row.event !== InstanceEvent.STEP_FAILURE
 			) {
 				continue;
 			}
@@ -307,8 +305,11 @@ export class Engine extends DurableObject<Env> {
 		}
 
 		const eligible: string[] = [];
-		for (const { groupKey } of startedRows) {
-			if (rollbackEligibleGroups.has(groupKey)) {
+		for (const groupKey of stepStartGroupKeysDesc) {
+			if (
+				rollbackEligibleGroups.has(groupKey) &&
+				!rollbackTerminalGroups.has(groupKey)
+			) {
 				eligible.push(groupKey);
 				if (limit !== undefined && eligible.length >= limit) {
 					break;
@@ -332,7 +333,7 @@ export class Engine extends DurableObject<Env> {
 		registerRollbackFn(this.rollbackRegistry, registration);
 	}
 
-	setRollbackPhase(phase: "replay" | "rollback" | undefined): void {
+	setRollbackPhase(phase: RollbackPhase | undefined): void {
 		this.rollbackPhase = phase;
 	}
 

--- a/packages/workflows-shared/src/engine.ts
+++ b/packages/workflows-shared/src/engine.ts
@@ -29,7 +29,13 @@ import {
 	storeRestartFromStep,
 	wipeRestartState,
 } from "./lib/restart";
-import { clearRollbackRegistry, executeRollbacks } from "./lib/rollback";
+import {
+	clearRollbackRegistry,
+	disposeRollbackStub,
+	executeRollbacks,
+	registerRollbackFn,
+	ROLLBACK_CACHE_KEY_PREFIX,
+} from "./lib/rollback";
 import {
 	createReplayReadableStream,
 	getInvalidStoredStreamOutputError,
@@ -44,7 +50,10 @@ import type {
 } from "./binding";
 import type { Event } from "./context";
 import type { InstanceMetadata, RawInstanceLog } from "./instance";
-import type { RollbackRegistryEntry } from "./lib/rollback";
+import type {
+	RollbackRegistration,
+	RollbackRegistryEntry,
+} from "./lib/rollback";
 import type { StreamOutputMeta } from "./lib/streams";
 import type {
 	WorkflowEntrypoint,
@@ -148,6 +157,8 @@ export class Engine extends DurableObject<Env> {
 	stepLimit: number;
 	engineAbortController: AbortController = new AbortController();
 	pauseController: AbortController = new AbortController();
+	rollbackPhase: "replay" | "rollback" | undefined = undefined;
+	rollbackEligibleCacheKeys: Set<string> | undefined = undefined;
 
 	waiters: Map<
 		string,
@@ -238,6 +249,91 @@ export class Engine extends DurableObject<Env> {
 			),
 		];
 		return rows.map(({ groupKey }) => groupKey);
+	}
+
+	private getEligibleRollbackSteps(limit?: number): string[] {
+		const rollbackTerminalGroups = new Set<string>();
+		const rollbackEligibleGroups = new Set<string>();
+		const startedRows = [
+			...this.ctx.storage.sql.exec<{ groupKey: string }>(
+				"SELECT groupKey FROM states WHERE event = ? AND groupKey IS NOT NULL ORDER BY id DESC",
+				InstanceEvent.STEP_START
+			),
+		];
+		const completedRows = [
+			...this.ctx.storage.sql.exec<{
+				event: InstanceEvent;
+				groupKey: string | null;
+				metadata: string;
+			}>(
+				"SELECT event, groupKey, metadata FROM states WHERE groupKey IS NOT NULL"
+			),
+		];
+
+		for (const row of completedRows) {
+			if (
+				row.groupKey !== null &&
+				(row.event === InstanceEvent.ROLLBACK_STEP_SUCCESS ||
+					row.event === InstanceEvent.ROLLBACK_STEP_FAILURE)
+			) {
+				rollbackTerminalGroups.add(
+					row.groupKey.startsWith(ROLLBACK_CACHE_KEY_PREFIX)
+						? row.groupKey.slice(ROLLBACK_CACHE_KEY_PREFIX.length)
+						: row.groupKey
+				);
+			}
+		}
+
+		for (const row of completedRows) {
+			if (
+				row.groupKey === null ||
+				rollbackTerminalGroups.has(row.groupKey) ||
+				(row.event !== InstanceEvent.STEP_SUCCESS &&
+					row.event !== InstanceEvent.STEP_FAILURE)
+			) {
+				continue;
+			}
+
+			try {
+				if (
+					(JSON.parse(row.metadata) as { hasRollback?: boolean })
+						.hasRollback === true
+				) {
+					rollbackEligibleGroups.add(row.groupKey);
+				}
+			} catch {
+				// Ignore malformed metadata in local persisted logs.
+			}
+		}
+
+		const eligible: string[] = [];
+		for (const { groupKey } of startedRows) {
+			if (rollbackEligibleGroups.has(groupKey)) {
+				eligible.push(groupKey);
+				if (limit !== undefined && eligible.length >= limit) {
+					break;
+				}
+			}
+		}
+
+		return eligible;
+	}
+
+	registerRollbackFn(registration: RollbackRegistration): void {
+		if (
+			this.rollbackPhase === "replay" &&
+			this.rollbackEligibleCacheKeys !== undefined &&
+			!this.rollbackEligibleCacheKeys.has(registration.cacheKey)
+		) {
+			disposeRollbackStub(registration.fn);
+			return;
+		}
+
+		registerRollbackFn(this.rollbackRegistry, registration);
+	}
+
+	setRollbackPhase(phase: "replay" | "rollback" | undefined): void {
+		this.rollbackPhase = phase;
 	}
 
 	// Lives here for access to the protected DurableObject `ctx`.
@@ -868,6 +964,35 @@ export class Engine extends DurableObject<Env> {
 		}
 	}
 
+	private async replayRollbackRegistry(
+		metadata: InstanceMetadata
+	): Promise<void> {
+		if (this.rollbackRegistry.size > 0) {
+			return;
+		}
+
+		const eligible = this.getEligibleRollbackSteps();
+		if (eligible.length === 0) {
+			return;
+		}
+
+		this.rollbackEligibleCacheKeys = new Set(eligible);
+		const stubStep = this.createRollbackContext();
+		this.setRollbackPhase("replay");
+		try {
+			await this.env.USER_WORKFLOW.run(
+				metadata.event,
+				stubStep as unknown as WorkflowStep
+			);
+		} catch {
+			// Match the production engine: replay may stop on normal workflow control
+			// flow; rollback execution uses whatever handlers replay registered.
+		} finally {
+			this.setRollbackPhase(undefined);
+			this.rollbackEligibleCacheKeys = undefined;
+		}
+	}
+
 	async userTriggeredTerminate(options?: WorkflowInstanceTerminateOptions) {
 		const metadata =
 			await this.ctx.storage.get<InstanceMetadata>(INSTANCE_METADATA);
@@ -879,13 +1004,18 @@ export class Engine extends DurableObject<Env> {
 			);
 		}
 
-		if (options?.rollback === true && this.rollbackRegistry.size > 0) {
+		if (options?.rollback === true) {
+			await this.replayRollbackRegistry(metadata);
+
 			const error = new Error("Instance terminated during rollback");
 			error.name = "Terminated";
+			this.setRollbackPhase("rollback");
 			try {
 				await executeRollbacks(this, error);
 			} catch (rollbackErr) {
 				console.error("Rollback execution failed:", rollbackErr);
+			} finally {
+				this.setRollbackPhase(undefined);
 			}
 		}
 

--- a/packages/workflows-shared/src/engine.ts
+++ b/packages/workflows-shared/src/engine.ts
@@ -985,9 +985,10 @@ export class Engine extends DurableObject<Env> {
 				metadata.event,
 				stubStep as unknown as WorkflowStep
 			);
-		} catch {
+		} catch (replayErr) {
 			// Match the production engine: replay may stop on normal workflow control
 			// flow; rollback execution uses whatever handlers replay registered.
+			console.debug("Rollback replay stopped:", replayErr);
 		} finally {
 			this.setRollbackPhase(undefined);
 			this.rollbackEligibleCacheKeys = undefined;

--- a/packages/workflows-shared/src/engine.ts
+++ b/packages/workflows-shared/src/engine.ts
@@ -243,33 +243,27 @@ export class Engine extends DurableObject<Env> {
 		}
 	}
 
-	readStepStartGroupKeysDesc(): string[] {
-		const rows = [
-			...this.ctx.storage.sql.exec<{ groupKey: string }>(
-				"SELECT groupKey FROM states WHERE event = ? AND groupKey IS NOT NULL ORDER BY id DESC",
-				InstanceEvent.STEP_START
-			),
-		];
-		return rows.map(({ groupKey }) => groupKey);
-	}
-
-	private getEligibleRollbackSteps(limit?: number): string[] {
+	readEligibleRollbackStepsDesc(
+		limit?: number
+	): Array<{ cacheKey: string; target: string }> {
 		const rollbackTerminalGroups = new Set<string>();
 		const rollbackEligibleGroups = new Set<string>();
-		const stepStartGroupKeysDesc: string[] = [];
+		const stepStartsDesc: Array<{ groupKey: string; target: string | null }> =
+			[];
 		const rows = [
 			...this.ctx.storage.sql.exec<{
 				event: InstanceEvent;
 				groupKey: string;
+				target: string | null;
 				metadata: string;
 			}>(
-				"SELECT event, groupKey, metadata FROM states WHERE groupKey IS NOT NULL ORDER BY id DESC"
+				"SELECT event, groupKey, target, metadata FROM states WHERE groupKey IS NOT NULL ORDER BY id DESC"
 			),
 		];
 
 		for (const row of rows) {
 			if (row.event === InstanceEvent.STEP_START) {
-				stepStartGroupKeysDesc.push(row.groupKey);
+				stepStartsDesc.push({ groupKey: row.groupKey, target: row.target });
 			}
 
 			if (
@@ -304,13 +298,13 @@ export class Engine extends DurableObject<Env> {
 			}
 		}
 
-		const eligible: string[] = [];
-		for (const groupKey of stepStartGroupKeysDesc) {
+		const eligible: Array<{ cacheKey: string; target: string }> = [];
+		for (const { groupKey, target } of stepStartsDesc) {
 			if (
 				rollbackEligibleGroups.has(groupKey) &&
 				!rollbackTerminalGroups.has(groupKey)
 			) {
-				eligible.push(groupKey);
+				eligible.push({ cacheKey: groupKey, target: target ?? groupKey });
 				if (limit !== undefined && eligible.length >= limit) {
 					break;
 				}
@@ -318,6 +312,12 @@ export class Engine extends DurableObject<Env> {
 		}
 
 		return eligible;
+	}
+
+	private getEligibleRollbackSteps(limit?: number): string[] {
+		return this.readEligibleRollbackStepsDesc(limit).map(
+			({ cacheKey }) => cacheKey
+		);
 	}
 
 	registerRollbackFn(registration: RollbackRegistration): void {

--- a/packages/workflows-shared/src/engine.ts
+++ b/packages/workflows-shared/src/engine.ts
@@ -38,7 +38,10 @@ import {
 } from "./lib/streams";
 import { TimePriorityQueue } from "./lib/timePriorityQueue";
 import { MODIFIER_KEYS, WorkflowInstanceModifier } from "./modifier";
-import type { RestartFromStep } from "./binding";
+import type {
+	RestartFromStep,
+	WorkflowInstanceTerminateOptions,
+} from "./binding";
 import type { Event } from "./context";
 import type { InstanceMetadata, RawInstanceLog } from "./instance";
 import type { RollbackRegistryEntry } from "./lib/rollback";
@@ -804,8 +807,9 @@ export class Engine extends DurableObject<Env> {
 
 	async changeInstanceStatus(
 		newStatus: "resume" | "pause" | "terminate" | "restart",
-		from?: RestartFromStep
-	) {
+		from?: RestartFromStep,
+		terminateOptions?: WorkflowInstanceTerminateOptions
+	): Promise<void> {
 		const metadata =
 			await this.ctx.storage.get<InstanceMetadata>(INSTANCE_METADATA);
 
@@ -849,7 +853,7 @@ export class Engine extends DurableObject<Env> {
 						"instance.cannot_terminate"
 					);
 				}
-				await this.userTriggeredTerminate();
+				await this.userTriggeredTerminate(terminateOptions);
 				break;
 			}
 			case "restart":
@@ -864,7 +868,7 @@ export class Engine extends DurableObject<Env> {
 		}
 	}
 
-	async userTriggeredTerminate() {
+	async userTriggeredTerminate(options?: WorkflowInstanceTerminateOptions) {
 		const metadata =
 			await this.ctx.storage.get<InstanceMetadata>(INSTANCE_METADATA);
 
@@ -873,6 +877,16 @@ export class Engine extends DurableObject<Env> {
 				"Instance does not exist",
 				"instance.not_found"
 			);
+		}
+
+		if (options?.rollback === true && this.rollbackRegistry.size > 0) {
+			const error = new Error("Instance terminated during rollback");
+			error.name = "Terminated";
+			try {
+				await executeRollbacks(this, error);
+			} catch (rollbackErr) {
+				console.error("Rollback execution failed:", rollbackErr);
+			}
 		}
 
 		this.writeLog(InstanceEvent.WORKFLOW_TERMINATED, null, null, {

--- a/packages/workflows-shared/src/engine.ts
+++ b/packages/workflows-shared/src/engine.ts
@@ -1007,6 +1007,7 @@ export class Engine extends DurableObject<Env> {
 		}
 
 		if (options?.rollback === true) {
+			this.priorityQueue ??= new TimePriorityQueue(this.ctx, metadata);
 			await this.replayRollbackRegistry(metadata);
 
 			const error = new Error("Instance terminated during rollback");

--- a/packages/workflows-shared/src/lib/rollback.ts
+++ b/packages/workflows-shared/src/lib/rollback.ts
@@ -136,82 +136,67 @@ export function clearRollbackRegistry(
 	registry.clear();
 }
 
-function getRollbackRegistryEntriesInExecutionOrder(
-	engine: Engine
-): Array<[string, RollbackRegistryEntry]> {
-	const entries: Array<[string, RollbackRegistryEntry]> = [];
-	const seen = new Set<string>();
-	const stepStartGroupKeysDesc = engine.readStepStartGroupKeysDesc();
-	const rollbackRegistryEntriesDesc = [
-		...engine.rollbackRegistry.entries(),
-	].reverse();
-
-	for (const cacheKey of stepStartGroupKeysDesc) {
-		const entry = engine.rollbackRegistry.get(cacheKey);
-		if (entry === undefined || seen.has(cacheKey)) {
-			continue;
-		}
-		entries.push([cacheKey, entry]);
-		seen.add(cacheKey);
-	}
-
-	for (const [cacheKey, entry] of rollbackRegistryEntriesDesc) {
-		if (!seen.has(cacheKey)) {
-			entries.push([cacheKey, entry]);
-		}
-	}
-
-	return entries;
-}
-
 // LIFO; halts on first failure. Goes through Context.do so each rollback
 // inherits retries/timeouts/attempt-logging.
 export async function executeRollbacks(
 	engine: Engine,
 	triggerError: Error
 ): Promise<{ ranAny: boolean; allSucceeded: boolean }> {
-	if (engine.rollbackRegistry.size === 0) {
+	const eligibleSteps = engine.readEligibleRollbackStepsDesc();
+	if (eligibleSteps.length === 0) {
+		clearRollbackRegistry(engine.rollbackRegistry);
 		return { ranAny: false, allSucceeded: true };
 	}
 
-	const entries = getRollbackRegistryEntriesInExecutionOrder(engine);
-	engine.rollbackRegistry.clear();
-
 	engine.writeLog(InstanceEvent.ROLLBACK_START, null, null, {
 		triggerError: { name: triggerError.name, message: triggerError.message },
-		totalSteps: entries.length,
+		totalSteps: eligibleSteps.length,
 	});
 
 	let allSucceeded = true;
 	let completed = 0;
-	let stoppedAt = entries.length;
 
-	for (const [i, [cacheKey, entry]] of entries.entries()) {
-		const ctx = engine.createRollbackContext({ cacheKey });
-		const rollbackName = `${entry.stepContext.step.name}-${entry.stepContext.step.count}`;
-		try {
-			await ctx.do(rollbackName, entry.config ?? {}, async () => {
-				await entry.fn({
-					ctx: structuredClone(entry.stepContext),
-					error: triggerError,
-					output: entry.output,
-					stepName: rollbackName,
+	try {
+		for (const step of eligibleSteps) {
+			const entry = engine.rollbackRegistry.get(step.cacheKey);
+			if (entry === undefined) {
+				engine.writeLog(
+					InstanceEvent.ROLLBACK_STEP_FAILURE,
+					step.cacheKey,
+					step.target,
+					{
+						error: {
+							name: "RollbackMissing",
+							message: "Rollback function not available in registry",
+						},
+					}
+				);
+				allSucceeded = false;
+				break;
+			}
+
+			const ctx = engine.createRollbackContext({ cacheKey: step.cacheKey });
+			try {
+				await ctx.do(step.target, entry.config ?? {}, async () => {
+					await entry.fn({
+						ctx: structuredClone(entry.stepContext),
+						error: triggerError,
+						output: entry.output,
+						stepName: step.target,
+					});
 				});
-			});
-			completed++;
-		} catch {
-			// Context.do already wrote ROLLBACK_STEP_FAILURE; halt the chain.
-			allSucceeded = false;
-			stoppedAt = i + 1;
-			break;
-		} finally {
-			disposeRollbackStub(entry.fn);
+				completed++;
+			} catch {
+				// Context.do already wrote ROLLBACK_STEP_FAILURE; halt the chain.
+				allSucceeded = false;
+				break;
+			} finally {
+				disposeRollbackStub(entry.fn);
+				engine.rollbackRegistry.delete(step.cacheKey);
+			}
 		}
-	}
-
-	const remainingEntries = entries.slice(stoppedAt);
-	for (const [, entry] of remainingEntries) {
-		disposeRollbackStub(entry.fn);
+	} finally {
+		clearRollbackRegistry(engine.rollbackRegistry);
 	}
 
 	engine.writeLog(
@@ -220,7 +205,7 @@ export async function executeRollbacks(
 			: InstanceEvent.ROLLBACK_FAILED,
 		null,
 		null,
-		{ totalSteps: entries.length, completedSteps: completed }
+		{ totalSteps: eligibleSteps.length, completedSteps: completed }
 	);
 	return { ranAny: completed > 0, allSucceeded };
 }

--- a/packages/workflows-shared/src/lib/rollback.ts
+++ b/packages/workflows-shared/src/lib/rollback.ts
@@ -110,7 +110,12 @@ export function registerRollbackFn(
 	const { cacheKey, fn, stepContext, output, config } = registration;
 	const existing = registry.get(cacheKey);
 	if (existing) {
-		disposeRollbackStub(existing.fn);
+		registry.set(cacheKey, {
+			...existing,
+			stepContext,
+			...("output" in registration && { output }),
+		});
+		return;
 	}
 	registry.set(cacheKey, {
 		fn: dupRollbackStub(fn),

--- a/packages/workflows-shared/src/lib/rollback.ts
+++ b/packages/workflows-shared/src/lib/rollback.ts
@@ -110,6 +110,8 @@ export function registerRollbackFn(
 	const { cacheKey, fn, stepContext, output, config } = registration;
 	const existing = registry.get(cacheKey);
 	if (existing) {
+		// Existing entry already owns the duped rollback stub. Duplicate registrations
+		// refresh context/output only; this helper has not duped the incoming fn.
 		registry.set(cacheKey, {
 			...existing,
 			stepContext,

--- a/packages/workflows-shared/tests/engine.test.ts
+++ b/packages/workflows-shared/tests/engine.test.ts
@@ -1721,6 +1721,129 @@ describe("Rollback", () => {
 		expect(countOf(logs, InstanceEvent.ROLLBACK_COMPLETE)).toBe(1);
 	});
 
+	it("replays cached steps before terminate rollback when registry is empty", async ({
+		expect,
+	}) => {
+		const instanceId = "RB-TERMINATE-REPLAY";
+		const engineStub = await runWorkflow(instanceId, async (_e, step) => {
+			await doWithRollback(
+				step,
+				"setup-resource",
+				async () => "resource-id",
+				rollbackOptions()
+			);
+			await step.sleep("wait-forever", "1 hour");
+		});
+
+		await readLogsAfter(engineStub, (currentLogs) =>
+			currentLogs.logs.some(
+				(log) =>
+					log.event === InstanceEvent.STEP_SUCCESS &&
+					log.target === "setup-resource-1"
+			)
+		);
+
+		await runInDurableObject(engineStub, async (engine) => {
+			engine.rollbackRegistry.clear();
+		});
+
+		try {
+			await runInDurableObject(engineStub, async (engine) => {
+				await engine.changeInstanceStatus("terminate", undefined, {
+					rollback: true,
+				});
+			});
+		} catch (error) {
+			if (
+				!(error instanceof Error) ||
+				!error.message.startsWith("Aborting engine:")
+			) {
+				throw error;
+			}
+		}
+
+		const logs = await readLogsAfter(
+			env.ENGINE.get(env.ENGINE.idFromName(instanceId)),
+			(currentLogs) =>
+				currentLogs.logs.some(
+					(log) => log.event === InstanceEvent.WORKFLOW_TERMINATED
+				)
+		);
+		expect(targetsOf(logs, InstanceEvent.ROLLBACK_STEP_SUCCESS)).toEqual([
+			"setup-resource-1",
+		]);
+		expect(countOf(logs, InstanceEvent.ROLLBACK_COMPLETE)).toBe(1);
+	});
+
+	it("runs terminate rollback while paused with an empty registry", async ({
+		expect,
+	}) => {
+		const instanceId = "RB-TERMINATE-PAUSED";
+		const engineId = env.ENGINE.idFromName(instanceId);
+		const engineStub = await runWorkflow(instanceId, async (_e, step) => {
+			await doWithRollback(
+				step,
+				"setup-resource",
+				async () => "resource-id",
+				rollbackOptions()
+			);
+			await step.sleep("wait-forever", "1 hour");
+		});
+
+		await readLogsAfter(engineStub, (currentLogs) =>
+			currentLogs.logs.some(
+				(log) =>
+					log.event === InstanceEvent.STEP_SUCCESS &&
+					log.target === "setup-resource-1"
+			)
+		);
+
+		try {
+			await runInDurableObject(engineStub, async (engine) => {
+				await engine.changeInstanceStatus("pause");
+			});
+		} catch (error) {
+			if (!isAbortError(error)) {
+				throw error;
+			}
+		}
+
+		await vi.waitUntil(
+			async () =>
+				runInDurableObject(
+					env.ENGINE.get(engineId),
+					async (engine) => (await engine.getStatus()) === InstanceStatus.Paused
+				),
+			{ timeout: 5000 }
+		);
+
+		await runInDurableObject(env.ENGINE.get(engineId), async (engine) => {
+			engine.rollbackRegistry.clear();
+		});
+
+		try {
+			await runInDurableObject(env.ENGINE.get(engineId), async (engine) => {
+				await engine.changeInstanceStatus("terminate", undefined, {
+					rollback: true,
+				});
+			});
+		} catch (error) {
+			if (!isAbortError(error)) {
+				throw error;
+			}
+		}
+
+		const logs = await readLogsAfter(env.ENGINE.get(engineId), (currentLogs) =>
+			currentLogs.logs.some(
+				(log) => log.event === InstanceEvent.WORKFLOW_TERMINATED
+			)
+		);
+		expect(targetsOf(logs, InstanceEvent.ROLLBACK_STEP_SUCCESS)).toEqual([
+			"setup-resource-1",
+		]);
+		expect(countOf(logs, InstanceEvent.ROLLBACK_COMPLETE)).toBe(1);
+	});
+
 	it("does not run rollback when workflow succeeds", async ({ expect }) => {
 		const stub = await runWorkflowAndAwait("RB-NOOP", async (_e, step) => {
 			await doWithRollback(step, "a", async () => "ok", rollbackOptions());

--- a/packages/workflows-shared/tests/engine.test.ts
+++ b/packages/workflows-shared/tests/engine.test.ts
@@ -1775,6 +1775,87 @@ describe("Rollback", () => {
 		expect(countOf(logs, InstanceEvent.ROLLBACK_COMPLETE)).toBe(1);
 	});
 
+	it("replays started unfinished steps before terminate rollback when registry is empty", async ({
+		expect,
+	}) => {
+		const instanceId = `RB-TERMINATE-STARTED-REPLAY-${crypto.randomUUID()}`;
+		const engineId = env.ENGINE.idFromName(instanceId);
+		const engineStub = await runWorkflow(instanceId, async (_e, step) => {
+			await doWithRollback(
+				step,
+				"started-setup",
+				async () => {
+					await scheduler.wait(30_000);
+					return "late-resource-id";
+				},
+				rollbackOptions()
+			);
+		});
+
+		await readLogsAfter(engineStub, (currentLogs) =>
+			currentLogs.logs.some(
+				(log) =>
+					log.event === InstanceEvent.ATTEMPT_START &&
+					log.target === "started-setup-1"
+			)
+		);
+
+		try {
+			await runInDurableObject(engineStub, async (engine) => {
+				await engine.abort("test restart before step completion");
+			});
+		} catch (error) {
+			if (
+				!(error instanceof Error) ||
+				error.message !== "test restart before step completion"
+			) {
+				throw error;
+			}
+		}
+
+		const restartedStub = env.ENGINE.get(engineId);
+		await runInDurableObject(restartedStub, async (engine) => {
+			engine.rollbackRegistry.clear();
+		});
+
+		try {
+			await runInDurableObject(restartedStub, async (engine) => {
+				await engine.changeInstanceStatus("terminate", undefined, {
+					rollback: true,
+				});
+			});
+		} catch (error) {
+			if (!isAbortError(error)) {
+				throw error;
+			}
+		}
+
+		let logs: EngineLogs | undefined;
+		await vi.waitUntil(
+			async () => {
+				try {
+					logs = (await env.ENGINE.get(engineId).readLogs()) as EngineLogs;
+					return logs.logs.some(
+						(log) => log.event === InstanceEvent.WORKFLOW_TERMINATED
+					);
+				} catch (error) {
+					if (isAbortError(error)) {
+						return false;
+					}
+					throw error;
+				}
+			},
+			{ timeout: 5000 }
+		);
+		if (logs === undefined) {
+			throw new Error("Expected workflow logs after terminate");
+		}
+		expect(targetsOf(logs, InstanceEvent.ROLLBACK_STEP_SUCCESS)).toEqual([
+			"started-setup-1",
+		]);
+		expect(countOf(logs, InstanceEvent.ROLLBACK_COMPLETE)).toBe(1);
+	});
+
 	it("replays cached failed steps before terminate rollback when registry is empty", async ({
 		expect,
 	}) => {

--- a/packages/workflows-shared/tests/engine.test.ts
+++ b/packages/workflows-shared/tests/engine.test.ts
@@ -1856,6 +1856,71 @@ describe("Rollback", () => {
 		expect(countOf(logs, InstanceEvent.ROLLBACK_COMPLETE)).toBe(1);
 	});
 
+	it("fails terminate rollback when replay cannot rebuild an eligible handler", async ({
+		expect,
+	}) => {
+		const instanceId = `RB-TERMINATE-MISSING-REPLAY-${crypto.randomUUID()}`;
+		const engineId = env.ENGINE.idFromName(instanceId);
+		const engineStub = await runWorkflow(instanceId, async (_e, step) => {
+			await doWithRollback(
+				step,
+				"branchy-setup",
+				async () => "resource-id",
+				rollbackOptions()
+			);
+			await step.sleep("wait-forever", "1 hour");
+		});
+
+		await readLogsAfter(engineStub, (currentLogs) =>
+			currentLogs.logs.some(
+				(log) =>
+					log.event === InstanceEvent.STEP_SUCCESS &&
+					log.target === "branchy-setup-1"
+			)
+		);
+
+		try {
+			await runInDurableObject(engineStub, async (engine) => {
+				await engine.abort("test restart before replay branch changes");
+			});
+		} catch (error) {
+			if (
+				!(error instanceof Error) ||
+				error.message !== "test restart before replay branch changes"
+			) {
+				throw error;
+			}
+		}
+
+		setTestWorkflowCallback(async () => {
+			// Simulate nondeterministic replay control flow that no longer reaches
+			// the persisted eligible step. Production treats this as rollback failure.
+		});
+
+		try {
+			await runInDurableObject(env.ENGINE.get(engineId), async (engine) => {
+				await engine.changeInstanceStatus("terminate", undefined, {
+					rollback: true,
+				});
+			});
+		} catch (error) {
+			if (!isAbortError(error)) {
+				throw error;
+			}
+		}
+
+		const logs = await readLogsAfter(env.ENGINE.get(engineId), (currentLogs) =>
+			currentLogs.logs.some(
+				(log) => log.event === InstanceEvent.WORKFLOW_TERMINATED
+			)
+		);
+		expect(targetsOf(logs, InstanceEvent.ROLLBACK_STEP_FAILURE)).toEqual([
+			"branchy-setup-1",
+		]);
+		expect(countOf(logs, InstanceEvent.ROLLBACK_FAILED)).toBe(1);
+		expect(countOf(logs, InstanceEvent.ROLLBACK_COMPLETE)).toBe(0);
+	});
+
 	it("replays cached failed steps before terminate rollback when registry is empty", async ({
 		expect,
 	}) => {

--- a/packages/workflows-shared/tests/engine.test.ts
+++ b/packages/workflows-shared/tests/engine.test.ts
@@ -1673,6 +1673,52 @@ describe("Rollback", () => {
 		expect(countOf(logs, InstanceEvent.ROLLBACK_COMPLETE)).toBe(0);
 	});
 
+	it("runs rollback when terminate requests it", async ({ expect }) => {
+		const instanceId = "RB-TERMINATE";
+		const engineStub = await runWorkflow(instanceId, async (_e, step) => {
+			await doWithRollback(
+				step,
+				"setup-resource",
+				async () => "resource-id",
+				rollbackOptions()
+			);
+			await step.sleep("wait-forever", "1 hour");
+		});
+
+		await readLogsAfter(engineStub, (logs) =>
+			logs.logs.some(
+				(log) =>
+					log.event === InstanceEvent.STEP_SUCCESS &&
+					log.target === "setup-resource-1"
+			)
+		);
+
+		try {
+			await runInDurableObject(engineStub, async (engine) => {
+				await engine.changeInstanceStatus("terminate", undefined, {
+					rollback: true,
+				});
+			});
+		} catch (error) {
+			if (
+				!(error instanceof Error) ||
+				!error.message.startsWith("Aborting engine:")
+			) {
+				throw error;
+			}
+		}
+
+		const logs = await readLogsAfter(
+			env.ENGINE.get(env.ENGINE.idFromName(instanceId)),
+			(logs) =>
+				logs.logs.some((log) => log.event === InstanceEvent.WORKFLOW_TERMINATED)
+		);
+		expect(targetsOf(logs, InstanceEvent.ROLLBACK_STEP_SUCCESS)).toEqual([
+			"setup-resource-1",
+		]);
+		expect(countOf(logs, InstanceEvent.ROLLBACK_COMPLETE)).toBe(1);
+	});
+
 	it("does not run rollback when workflow succeeds", async ({ expect }) => {
 		const stub = await runWorkflowAndAwait("RB-NOOP", async (_e, step) => {
 			await doWithRollback(step, "a", async () => "ok", rollbackOptions());

--- a/packages/workflows-shared/tests/engine.test.ts
+++ b/packages/workflows-shared/tests/engine.test.ts
@@ -1775,6 +1775,68 @@ describe("Rollback", () => {
 		expect(countOf(logs, InstanceEvent.ROLLBACK_COMPLETE)).toBe(1);
 	});
 
+	it("replays cached failed steps before terminate rollback when registry is empty", async ({
+		expect,
+	}) => {
+		const instanceId = "RB-TERMINATE-FAILED-REPLAY";
+		const engineStub = await runWorkflow(instanceId, async (_e, step) => {
+			try {
+				await doWithRollback(
+					step,
+					"failed-setup",
+					{ retries: { limit: 0, delay: 0, backoff: "constant" } },
+					async () => {
+						throw new Error("step-boom");
+					},
+					rollbackOptions()
+				);
+			} catch {
+				// Keep the workflow running so terminate rollback can replay the cached
+				// failed step and re-register its rollback handler.
+			}
+			await step.sleep("wait-forever", "1 hour");
+		});
+
+		await readLogsAfter(engineStub, (currentLogs) =>
+			currentLogs.logs.some(
+				(log) =>
+					log.event === InstanceEvent.STEP_FAILURE &&
+					log.target === "failed-setup-1"
+			)
+		);
+
+		await runInDurableObject(engineStub, async (engine) => {
+			engine.rollbackRegistry.clear();
+		});
+
+		try {
+			await runInDurableObject(engineStub, async (engine) => {
+				await engine.changeInstanceStatus("terminate", undefined, {
+					rollback: true,
+				});
+			});
+		} catch (error) {
+			if (
+				!(error instanceof Error) ||
+				!error.message.startsWith("Aborting engine:")
+			) {
+				throw error;
+			}
+		}
+
+		const logs = await readLogsAfter(
+			env.ENGINE.get(env.ENGINE.idFromName(instanceId)),
+			(currentLogs) =>
+				currentLogs.logs.some(
+					(log) => log.event === InstanceEvent.WORKFLOW_TERMINATED
+				)
+		);
+		expect(targetsOf(logs, InstanceEvent.ROLLBACK_STEP_SUCCESS)).toEqual([
+			"failed-setup-1",
+		]);
+		expect(countOf(logs, InstanceEvent.ROLLBACK_COMPLETE)).toBe(1);
+	});
+
 	it("runs terminate rollback while paused with an empty registry", async ({
 		expect,
 	}) => {

--- a/packages/workflows-shared/tests/engine.test.ts
+++ b/packages/workflows-shared/tests/engine.test.ts
@@ -1685,8 +1685,8 @@ describe("Rollback", () => {
 			await step.sleep("wait-forever", "1 hour");
 		});
 
-		await readLogsAfter(engineStub, (logs) =>
-			logs.logs.some(
+		await readLogsAfter(engineStub, (currentLogs) =>
+			currentLogs.logs.some(
 				(log) =>
 					log.event === InstanceEvent.STEP_SUCCESS &&
 					log.target === "setup-resource-1"
@@ -1710,8 +1710,10 @@ describe("Rollback", () => {
 
 		const logs = await readLogsAfter(
 			env.ENGINE.get(env.ENGINE.idFromName(instanceId)),
-			(logs) =>
-				logs.logs.some((log) => log.event === InstanceEvent.WORKFLOW_TERMINATED)
+			(currentLogs) =>
+				currentLogs.logs.some(
+					(log) => log.event === InstanceEvent.WORKFLOW_TERMINATED
+				)
 		);
 		expect(targetsOf(logs, InstanceEvent.ROLLBACK_STEP_SUCCESS)).toEqual([
 			"setup-resource-1",

--- a/packages/wrangler/src/__tests__/workflows.test.ts
+++ b/packages/wrangler/src/__tests__/workflows.test.ts
@@ -49,13 +49,17 @@ describe("wrangler workflows", () => {
 
 	const mockChangeStatusRequest = async (
 		expect: ExpectStatic,
-		expectedInstance: string
+		expectedInstance: string,
+		expectedBody?: Record<string, unknown>
 	) => {
 		msw.use(
 			http.patch(
 				`*/accounts/:accountId/workflows/some-workflow/instances/:instanceId/status`,
-				async ({ params }) => {
+				async ({ params, request }) => {
 					expect(params.instanceId).toEqual(expectedInstance);
+					if (expectedBody) {
+						expect(await request.json()).toEqual(expectedBody);
+					}
 					return HttpResponse.json({
 						success: true,
 						errors: [],
@@ -656,9 +660,27 @@ describe("wrangler workflows", () => {
 		}) => {
 			writeWranglerConfig();
 			await mockGetInstances(mockInstances);
-			await mockChangeStatusRequest(expect, "bar");
+			await mockChangeStatusRequest(expect, "bar", {
+				status: "terminate",
+			});
 
 			await runWrangler(`workflows instances terminate some-workflow bar`);
+			expect(std.info).toMatchInlineSnapshot(
+				`"🥷 The instance "bar" from some-workflow was terminated successfully"`
+			);
+		});
+
+		it("should pass rollback when requested", async ({ expect }) => {
+			writeWranglerConfig();
+			await mockGetInstances(mockInstances);
+			await mockChangeStatusRequest(expect, "bar", {
+				status: "terminate",
+				rollback: true,
+			});
+
+			await runWrangler(
+				`workflows instances terminate some-workflow bar --rollback`
+			);
 			expect(std.info).toMatchInlineSnapshot(
 				`"🥷 The instance "bar" from some-workflow was terminated successfully"`
 			);
@@ -1733,8 +1755,9 @@ describe("wrangler workflows", () => {
 						async ({ params, request }) => {
 							expect(params.workflowName).toEqual("my-workflow");
 							expect(params.instanceId).toEqual("instance-123");
-							const body = (await request.json()) as Record<string, unknown>;
-							expect(body.action).toEqual("terminate");
+							expect(await request.json()).toEqual({
+								action: "terminate",
+							});
 							return HttpResponse.json({
 								success: true,
 								errors: [],
@@ -1747,6 +1770,37 @@ describe("wrangler workflows", () => {
 
 				await runWrangler(
 					"workflows instances terminate my-workflow instance-123 --local"
+				);
+				expect(std.info).toMatchInlineSnapshot(
+					`"🥷 The instance "instance-123" from my-workflow was terminated successfully"`
+				);
+			});
+
+			it("should pass rollback in local dev session", async ({ expect }) => {
+				writeWranglerConfig();
+
+				msw.use(
+					http.patch(
+						`${LOCAL_BASE}/workflows/:workflowName/instances/:instanceId/status`,
+						async ({ params, request }) => {
+							expect(params.workflowName).toEqual("my-workflow");
+							expect(params.instanceId).toEqual("instance-123");
+							expect(await request.json()).toEqual({
+								action: "terminate",
+								rollback: true,
+							});
+							return HttpResponse.json({
+								success: true,
+								errors: [],
+								messages: [],
+								result: { success: true },
+							});
+						}
+					)
+				);
+
+				await runWrangler(
+					"workflows instances terminate my-workflow instance-123 --local --rollback"
 				);
 				expect(std.info).toMatchInlineSnapshot(
 					`"🥷 The instance "instance-123" from my-workflow was terminated successfully"`

--- a/packages/wrangler/src/workflows/commands/instances/terminate.ts
+++ b/packages/wrangler/src/workflows/commands/instances/terminate.ts
@@ -28,6 +28,11 @@ export const workflowsInstancesTerminateCommand = createCommand({
 			type: "string",
 			demandOption: true,
 		},
+		rollback: {
+			describe: "Run registered rollback handlers before terminating",
+			type: "boolean",
+			default: false,
+		},
 	},
 
 	async handler(args, { config }) {
@@ -35,11 +40,26 @@ export const workflowsInstancesTerminateCommand = createCommand({
 
 		if (args.local) {
 			id = await getLocalInstanceIdFromArgs(args.port, args);
-			await updateLocalInstanceStatus(args.port, args.name, id, "terminate");
+			await updateLocalInstanceStatus(
+				args.port,
+				args.name,
+				id,
+				"terminate",
+				undefined,
+				args.rollback
+			);
 		} else {
 			const accountId = await requireAuth(config);
 			id = await getInstanceIdFromArgs(accountId, args, config);
-			await updateInstanceStatus(config, accountId, args.name, id, "terminate");
+			await updateInstanceStatus(
+				config,
+				accountId,
+				args.name,
+				id,
+				"terminate",
+				undefined,
+				args.rollback
+			);
 		}
 
 		logger.info(

--- a/packages/wrangler/src/workflows/local.ts
+++ b/packages/wrangler/src/workflows/local.ts
@@ -143,9 +143,14 @@ export async function updateLocalInstanceStatus(
 	workflowName: string,
 	instanceId: string,
 	action: "pause" | "resume" | "restart" | "terminate",
-	from?: WorkflowInstanceRestartFrom
+	from?: WorkflowInstanceRestartFrom,
+	rollback?: boolean
 ): Promise<void> {
-	const body = from ? { action, from } : { action };
+	const body = {
+		action,
+		...(from ? { from } : {}),
+		...(action === "terminate" && rollback === true ? { rollback: true } : {}),
+	};
 
 	await fetchLocalResult<{ success: boolean }>(
 		port,

--- a/packages/wrangler/src/workflows/utils.ts
+++ b/packages/wrangler/src/workflows/utils.ts
@@ -122,9 +122,14 @@ export async function updateInstanceStatus(
 	workflowName: string,
 	instanceId: string,
 	status: "pause" | "resume" | "restart" | "terminate",
-	from?: WorkflowInstanceRestartFrom
+	from?: WorkflowInstanceRestartFrom,
+	rollback?: boolean
 ): Promise<void> {
-	const body = from ? { status, from } : { status };
+	const body = {
+		status,
+		...(from ? { from } : {}),
+		...(status === "terminate" && rollback === true ? { rollback: true } : {}),
+	};
 
 	await fetchResult(
 		config,


### PR DESCRIPTION
Adds terminate rollback support across Workflows local tooling and the remote Wrangler terminate command.

This wires `rollback: true` through the terminate path:
- `@cloudflare/workflows-shared` binding and local engine
- Miniflare wrapped Workflows binding
- Local Explorer API/OpenAPI schema
- Wrangler `workflows instances terminate --rollback`
- Wrangler `workflows instances terminate --local --rollback`
- Local rollback recovery now matches production shape: replay rebuilds rollback handlers from persisted eligible steps, started/failed cached steps are covered, and missing rebuilt handlers fail rollback loudly instead of being silently skipped.

The production Workflows API already accepts terminate rollback; this PR adds the SDK/Wrangler client surfaces and fixes local rollback recovery so rollback can run after local engine restart/eviction.

Rollback is only valid for terminate and is only serialized when explicitly set to `true`.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [x] Cloudflare docs PR(s): https://github.com/cloudflare/cloudflare-docs/pull/31769
  - [ ] Documentation not necessary because:

*A picture of a cute animal (not mandatory, but encouraged)*
wires cat
<img width="680" height="459" alt="image" src="https://github.com/user-attachments/assets/7b70121e-1cc1-40be-906c-acf1bea242b7" />

