### PR TITLE
Replace the use of some vitest deprecated utilities with their current counterpart

### DIFF
--- a/fixtures/vitest-pool-workers-examples/pipelines/test/pipeline-send-unit.test.ts
+++ b/fixtures/vitest-pool-workers-examples/pipelines/test/pipeline-send-unit.test.ts
@@ -39,7 +39,7 @@ it("produces message to pipeline", async ({ expect }) => {
 
 	// Check `PIPELINE.send()` was called
 	expect(mockPipeline.send).toBeCalledTimes(1);
-	expect(mockPipeline.send).toBeCalledWith([
+	expect(mockPipeline.send).toHaveBeenCalledWith([
 		{ method: "POST", url: "https://example.com/ingest" },
 	]);
 });

--- a/fixtures/vitest-pool-workers-examples/pipelines/test/pipeline-send-unit.test.ts
+++ b/fixtures/vitest-pool-workers-examples/pipelines/test/pipeline-send-unit.test.ts
@@ -38,7 +38,7 @@ it("produces message to pipeline", async ({ expect }) => {
 	expect(await response.text()).toBe("Accepted");
 
 	// Check `PIPELINE.send()` was called
-	expect(mockPipeline.send).toBeCalledTimes(1);
+	expect(mockPipeline.send).toHaveBeenCalledTimes(1);
 	expect(mockPipeline.send).toHaveBeenCalledWith([
 		{ method: "POST", url: "https://example.com/ingest" },
 	]);

--- a/fixtures/vitest-pool-workers-examples/queues/test/queue-producer-unit.test.ts
+++ b/fixtures/vitest-pool-workers-examples/queues/test/queue-producer-unit.test.ts
@@ -43,7 +43,7 @@ it("produces queue message with mocked send", async ({ expect }) => {
 
 	// Check `QUEUE_PRODUCER.send()` was called
 	expect(sendSpy).toBeCalledTimes(1);
-	expect(sendSpy).toBeCalledWith({ key: "/key", value: "value" });
+	expect(sendSpy).toHaveBeenCalledWith({ key: "/key", value: "value" });
 });
 
 it("produces queue message with mocked consumer", async ({ expect }) => {

--- a/fixtures/vitest-pool-workers-examples/queues/test/queue-producer-unit.test.ts
+++ b/fixtures/vitest-pool-workers-examples/queues/test/queue-producer-unit.test.ts
@@ -42,7 +42,7 @@ it("produces queue message with mocked send", async ({ expect }) => {
 	expect(await response.text()).toBe("Accepted");
 
 	// Check `QUEUE_PRODUCER.send()` was called
-	expect(sendSpy).toBeCalledTimes(1);
+	expect(sendSpy).toHaveBeenCalledTimes(1);
 	expect(sendSpy).toHaveBeenCalledWith({ key: "/key", value: "value" });
 });
 
@@ -69,7 +69,7 @@ it("produces queue message with mocked consumer", async ({ expect }) => {
 
 	// Wait for consumer to be called
 	await vi.waitUntil(() => consumerSpy.mock.calls.length > 0);
-	expect(consumerSpy).toBeCalledTimes(1);
+	expect(consumerSpy).toHaveBeenCalledTimes(1);
 	const batch = consumerSpy.mock.lastCall?.[0];
 	assert(batch);
 	expect(batch.messages[0].body).toStrictEqual({

--- a/fixtures/workers-shared-asset-config/html-handling.test.ts
+++ b/fixtures/workers-shared-asset-config/html-handling.test.ts
@@ -92,7 +92,7 @@ describe.each(testSuites)("$title", ({ title, suite }) => {
 					// can't check intermediate 307 directly:
 					expect(response.redirected).toBe(requestPath !== finalPath);
 				} else {
-					expect(getAssetWithMetadataFromKV).not.toBeCalled();
+					expect(getAssetWithMetadataFromKV).not.toHaveBeenCalled();
 					expect(response.status).toBe(404);
 				}
 			}

--- a/fixtures/workers-shared-asset-config/html-handling.test.ts
+++ b/fixtures/workers-shared-asset-config/html-handling.test.ts
@@ -82,7 +82,7 @@ describe.each(testSuites)("$title", ({ title, suite }) => {
 				const request = new IncomingRequest(BASE_URL + requestPath);
 				let response = await SELF.fetch(request);
 				if (matchedFile && finalPath) {
-					expect(getAssetWithMetadataFromKV).toBeCalledTimes(1);
+					expect(getAssetWithMetadataFromKV).toHaveBeenCalledTimes(1);
 					expect(getAssetWithMetadataFromKV).toHaveBeenCalledWith(
 						undefined,
 						matchedFile

--- a/fixtures/workers-shared-asset-config/html-handling.test.ts
+++ b/fixtures/workers-shared-asset-config/html-handling.test.ts
@@ -83,7 +83,7 @@ describe.each(testSuites)("$title", ({ title, suite }) => {
 				let response = await SELF.fetch(request);
 				if (matchedFile && finalPath) {
 					expect(getAssetWithMetadataFromKV).toBeCalledTimes(1);
-					expect(getAssetWithMetadataFromKV).toBeCalledWith(
+					expect(getAssetWithMetadataFromKV).toHaveBeenCalledWith(
 						undefined,
 						matchedFile
 					);

--- a/fixtures/workers-shared-asset-config/loopback.test.ts
+++ b/fixtures/workers-shared-asset-config/loopback.test.ts
@@ -58,6 +58,9 @@ describe("[Asset Worker] loopback", () => {
 		expect(outerExists).not.toBeCalled();
 		expect(innerExists).toBeCalledTimes(1);
 		expect(getAssetWithMetadataFromKV).toBeCalledTimes(1);
-		expect(getAssetWithMetadataFromKV).toBeCalledWith(undefined, "/file.bin");
+		expect(getAssetWithMetadataFromKV).toHaveBeenCalledWith(
+			undefined,
+			"/file.bin"
+		);
 	});
 });

--- a/fixtures/workers-shared-asset-config/loopback.test.ts
+++ b/fixtures/workers-shared-asset-config/loopback.test.ts
@@ -55,7 +55,7 @@ describe("[Asset Worker] loopback", () => {
 		const response = await SELF.fetch(request);
 
 		expect(response.status).toBe(200);
-		expect(outerExists).not.toBeCalled();
+		expect(outerExists).not.toHaveBeenCalled();
 		expect(innerExists).toHaveBeenCalledTimes(1);
 		expect(getAssetWithMetadataFromKV).toHaveBeenCalledTimes(1);
 		expect(getAssetWithMetadataFromKV).toHaveBeenCalledWith(

--- a/fixtures/workers-shared-asset-config/loopback.test.ts
+++ b/fixtures/workers-shared-asset-config/loopback.test.ts
@@ -56,8 +56,8 @@ describe("[Asset Worker] loopback", () => {
 
 		expect(response.status).toBe(200);
 		expect(outerExists).not.toBeCalled();
-		expect(innerExists).toBeCalledTimes(1);
-		expect(getAssetWithMetadataFromKV).toBeCalledTimes(1);
+		expect(innerExists).toHaveBeenCalledTimes(1);
+		expect(getAssetWithMetadataFromKV).toHaveBeenCalledTimes(1);
 		expect(getAssetWithMetadataFromKV).toHaveBeenCalledWith(
 			undefined,
 			"/file.bin"

--- a/packages/create-cloudflare/src/__tests__/metrics.test.ts
+++ b/packages/create-cloudflare/src/__tests__/metrics.test.ts
@@ -58,7 +58,7 @@ describe("createReporter", () => {
 			promise: () => deferred.promise,
 		});
 
-		expect(sendEvent).toBeCalledWith(
+		expect(sendEvent).toHaveBeenCalledWith(
 			{
 				event: "c3 session started",
 				deviceId,
@@ -85,7 +85,7 @@ describe("createReporter", () => {
 
 		await expect(operation).resolves.toBe("test result");
 
-		expect(sendEvent).toBeCalledWith(
+		expect(sendEvent).toHaveBeenCalledWith(
 			{
 				event: "c3 session completed",
 				deviceId,
@@ -125,7 +125,7 @@ describe("createReporter", () => {
 			promise: () => deferred.promise,
 		});
 
-		expect(sendEvent).toBeCalledWith(
+		expect(sendEvent).toHaveBeenCalledWith(
 			{
 				event: "c3 session started",
 				deviceId,
@@ -152,7 +152,7 @@ describe("createReporter", () => {
 
 		await expect(operation).resolves.toBe("test result");
 
-		expect(sendEvent).toBeCalledWith(
+		expect(sendEvent).toHaveBeenCalledWith(
 			{
 				event: "c3 session completed",
 				deviceId,
@@ -274,7 +274,7 @@ describe("createReporter", () => {
 			promise: () => deferred.promise,
 		});
 
-		expect(sendEvent).toBeCalledWith(
+		expect(sendEvent).toHaveBeenCalledWith(
 			{
 				event: "c3 session started",
 				deviceId,
@@ -300,7 +300,7 @@ describe("createReporter", () => {
 
 		await expect(operation).rejects.toThrow(CancelError);
 
-		expect(sendEvent).toBeCalledWith(
+		expect(sendEvent).toHaveBeenCalledWith(
 			{
 				event: "c3 session cancelled",
 				deviceId,
@@ -336,7 +336,7 @@ describe("createReporter", () => {
 			promise: () => deferred.promise,
 		});
 
-		expect(sendEvent).toBeCalledWith(
+		expect(sendEvent).toHaveBeenCalledWith(
 			{
 				event: "c3 session started",
 				deviceId,
@@ -362,7 +362,7 @@ describe("createReporter", () => {
 
 		await expect(process).rejects.toThrow(Error);
 
-		expect(sendEvent).toBeCalledWith(
+		expect(sendEvent).toHaveBeenCalledWith(
 			{
 				event: "c3 session errored",
 				deviceId,
@@ -406,7 +406,7 @@ describe("createReporter", () => {
 			promise: () => deferred.promise,
 		});
 
-		expect(sendEvent).toBeCalledWith(
+		expect(sendEvent).toHaveBeenCalledWith(
 			{
 				event: "c3 session started",
 				deviceId,
@@ -432,7 +432,7 @@ describe("createReporter", () => {
 
 		await expect(run).rejects.toThrow(CancelError);
 
-		expect(sendEvent).toBeCalledWith(
+		expect(sendEvent).toHaveBeenCalledWith(
 			{
 				event: "c3 session cancelled",
 				deviceId,
@@ -471,7 +471,7 @@ describe("createReporter", () => {
 			promise: () => deferred.promise,
 		});
 
-		expect(sendEvent).toBeCalledWith(
+		expect(sendEvent).toHaveBeenCalledWith(
 			{
 				event: "c3 session started",
 				deviceId,
@@ -497,7 +497,7 @@ describe("createReporter", () => {
 
 		await expect(run).rejects.toThrow(CancelError);
 
-		expect(sendEvent).toBeCalledWith(
+		expect(sendEvent).toHaveBeenCalledWith(
 			{
 				event: "c3 session cancelled",
 				deviceId,
@@ -583,7 +583,7 @@ describe("runTelemetryCommand", () => {
 
 		runTelemetryCommand("enable");
 
-		expect(writeMetricsConfig).toBeCalledWith({
+		expect(writeMetricsConfig).toHaveBeenCalledWith({
 			c3permission: {
 				enabled: true,
 				date: new Date(),
@@ -630,7 +630,7 @@ describe("runTelemetryCommand", () => {
 
 		runTelemetryCommand("disable");
 
-		expect(writeMetricsConfig).toBeCalledWith({
+		expect(writeMetricsConfig).toHaveBeenCalledWith({
 			c3permission: {
 				enabled: false,
 				date: new Date(),

--- a/packages/create-cloudflare/src/__tests__/metrics.test.ts
+++ b/packages/create-cloudflare/src/__tests__/metrics.test.ts
@@ -77,7 +77,7 @@ describe("createReporter", () => {
 			},
 			false
 		);
-		expect(sendEvent).toBeCalledTimes(1);
+		expect(sendEvent).toHaveBeenCalledTimes(1);
 
 		deferred.resolve("test result");
 
@@ -105,7 +105,7 @@ describe("createReporter", () => {
 			},
 			false
 		);
-		expect(sendEvent).toBeCalledTimes(2);
+		expect(sendEvent).toHaveBeenCalledTimes(2);
 	});
 
 	test("sends event with logs enabled if CREATE_CLOUDFLARE_TELEMETRY_DEBUG is set to `1`", async ({
@@ -144,7 +144,7 @@ describe("createReporter", () => {
 			},
 			true
 		);
-		expect(sendEvent).toBeCalledTimes(1);
+		expect(sendEvent).toHaveBeenCalledTimes(1);
 
 		deferred.resolve("test result");
 
@@ -172,7 +172,7 @@ describe("createReporter", () => {
 			},
 			true
 		);
-		expect(sendEvent).toBeCalledTimes(2);
+		expect(sendEvent).toHaveBeenCalledTimes(2);
 	});
 
 	test("sends no event if no sparrow source key", async ({ expect }) => {
@@ -192,12 +192,12 @@ describe("createReporter", () => {
 
 		expect(reporter.isEnabled).toBe(false);
 
-		expect(sendEvent).toBeCalledTimes(0);
+		expect(sendEvent).toHaveBeenCalledTimes(0);
 
 		deferred.resolve("test result");
 
 		await expect(operation).resolves.toBe("test result");
-		expect(sendEvent).toBeCalledTimes(0);
+		expect(sendEvent).toHaveBeenCalledTimes(0);
 	});
 
 	test("sends no event if the c3 permission is disabled", async ({
@@ -224,12 +224,12 @@ describe("createReporter", () => {
 
 		expect(reporter.isEnabled).toBe(false);
 
-		expect(sendEvent).toBeCalledTimes(0);
+		expect(sendEvent).toHaveBeenCalledTimes(0);
 
 		deferred.resolve("test result");
 
 		await expect(operation).resolves.toBe("test result");
-		expect(sendEvent).toBeCalledTimes(0);
+		expect(sendEvent).toHaveBeenCalledTimes(0);
 	});
 
 	test("sends no event if the CREATE_CLOUDFLARE_TELEMETRY_DISABLED env is set to '1'", async ({
@@ -251,12 +251,12 @@ describe("createReporter", () => {
 
 		expect(reporter.isEnabled).toBe(false);
 
-		expect(sendEvent).toBeCalledTimes(0);
+		expect(sendEvent).toHaveBeenCalledTimes(0);
 
 		deferred.resolve("test result");
 
 		await expect(operation).resolves.toBe("test result");
-		expect(sendEvent).toBeCalledTimes(0);
+		expect(sendEvent).toHaveBeenCalledTimes(0);
 	});
 
 	test("sends started and cancelled event to sparrow if the promise reject with a CancelError", async ({
@@ -293,7 +293,7 @@ describe("createReporter", () => {
 			},
 			false
 		);
-		expect(sendEvent).toBeCalledTimes(1);
+		expect(sendEvent).toHaveBeenCalledTimes(1);
 
 		deferred.reject(new CancelError("test cancel"));
 		vi.advanceTimersByTime(1234);
@@ -320,7 +320,7 @@ describe("createReporter", () => {
 			},
 			false
 		);
-		expect(sendEvent).toBeCalledTimes(2);
+		expect(sendEvent).toHaveBeenCalledTimes(2);
 	});
 
 	test("sends started and errored event to sparrow if the promise reject with a non CancelError", async ({
@@ -355,7 +355,7 @@ describe("createReporter", () => {
 			},
 			false
 		);
-		expect(sendEvent).toBeCalledTimes(1);
+		expect(sendEvent).toHaveBeenCalledTimes(1);
 
 		deferred.reject(new Error("test error"));
 		vi.advanceTimersByTime(1234);
@@ -387,7 +387,7 @@ describe("createReporter", () => {
 			},
 			false
 		);
-		expect(sendEvent).toBeCalledTimes(2);
+		expect(sendEvent).toHaveBeenCalledTimes(2);
 	});
 
 	test("sends cancelled event if a SIGINT signal is received", async ({
@@ -425,7 +425,7 @@ describe("createReporter", () => {
 			},
 			false
 		);
-		expect(sendEvent).toBeCalledTimes(1);
+		expect(sendEvent).toHaveBeenCalledTimes(1);
 
 		process.emit("SIGINT", "SIGINT");
 		vi.advanceTimersByTime(1234);
@@ -453,7 +453,7 @@ describe("createReporter", () => {
 			},
 			false
 		);
-		expect(sendEvent).toBeCalledTimes(2);
+		expect(sendEvent).toHaveBeenCalledTimes(2);
 	});
 
 	test("sends cancelled event if a SIGTERM signal is received", async ({
@@ -490,7 +490,7 @@ describe("createReporter", () => {
 			},
 			false
 		);
-		expect(sendEvent).toBeCalledTimes(1);
+		expect(sendEvent).toHaveBeenCalledTimes(1);
 
 		process.emit("SIGTERM", "SIGTERM");
 		vi.advanceTimersByTime(1234);
@@ -518,7 +518,7 @@ describe("createReporter", () => {
 			},
 			false
 		);
-		expect(sendEvent).toBeCalledTimes(2);
+		expect(sendEvent).toHaveBeenCalledTimes(2);
 	});
 });
 

--- a/packages/create-cloudflare/src/__tests__/metrics.test.ts
+++ b/packages/create-cloudflare/src/__tests__/metrics.test.ts
@@ -609,7 +609,7 @@ describe("runTelemetryCommand", () => {
 
 		runTelemetryCommand("enable");
 
-		expect(writeMetricsConfig).not.toBeCalled();
+		expect(writeMetricsConfig).not.toHaveBeenCalled();
 		expect(normalizeOutput(std.out)).toMatchInlineSnapshot(`
 			"Status: Enabled
 
@@ -656,7 +656,7 @@ describe("runTelemetryCommand", () => {
 
 		runTelemetryCommand("disable");
 
-		expect(writeMetricsConfig).not.toBeCalled();
+		expect(writeMetricsConfig).not.toHaveBeenCalled();
 		expect(normalizeOutput(std.out)).toMatchInlineSnapshot(`
 			"Status: Disabled
 

--- a/packages/wrangler/src/__tests__/r2/pipe.test.ts
+++ b/packages/wrangler/src/__tests__/r2/pipe.test.ts
@@ -19,7 +19,7 @@ describe("pipe test", () => {
 		);
 		await runWrangler("r2 object get bucket-object-test/wormhole.txt");
 
-		expect(stdSpy).not.toBeCalled();
+		expect(stdSpy).not.toHaveBeenCalled();
 		expect(consoleSpy.out).toMatchInlineSnapshot(`
 			"
 			 ⛅️ wrangler x.x.x


### PR DESCRIPTION
I noticed a few vitest deprecated utilities that we're using, and I'm replacing them with their current (non-deprecated) counterparts here.

Specifically:

- ~~`toBeCalledWith`~~ → `toHaveBeenCalledWith`
- ~~`toBeCalledTimes`~~ → `toHaveBeenCalledTimes`
- ~~`toBeCalled`~~ → `toHaveBeenCalled`

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: no functional change at all

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
