### PR TITLE
fix(wrangler): encode asset upload manifest paths

### DIFF
--- a/.changeset/bright-hounds-smile.md
+++ b/.changeset/bright-hounds-smile.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Fix Workers Assets deploys failing for filenames that require URI encoding
+
+Wrangler now URI-encodes asset manifest paths before starting an assets upload session. This prevents the Cloudflare API from rejecting deployments containing filenames with spaces, non-ASCII characters, or reserved URL characters.

--- a/.changeset/bright-hounds-smile.md
+++ b/.changeset/bright-hounds-smile.md
@@ -2,6 +2,6 @@
 "wrangler": patch
 ---
 
-Fix Workers Assets deploys failing for filenames that require URI encoding
+Improve Workers Assets manifest validation diagnostics
 
-Wrangler now URI-encodes asset manifest paths before starting an assets upload session. This prevents the Cloudflare API from rejecting deployments containing filenames with spaces, non-ASCII characters, or reserved URL characters.
+When the Cloudflare API rejects an assets upload session because a manifest path must be URI encoded, Wrangler now logs candidate asset paths containing URI-sensitive characters. This helps identify the file that triggered the API error without changing the manifest paths sent to the API.

--- a/.changeset/bright-hounds-smile.md
+++ b/.changeset/bright-hounds-smile.md
@@ -4,4 +4,4 @@
 
 Improve Workers Assets manifest validation diagnostics
 
-When the Cloudflare API rejects an assets upload session because a manifest path must be URI encoded, Wrangler now logs candidate asset paths containing URI-sensitive characters. This helps identify the file that triggered the API error without changing the manifest paths sent to the API.
+When the Cloudflare API rejects an assets upload session because a manifest path must be URI encoded, Wrangler now logs asset paths that fail URI decoding. This helps identify filenames with malformed percent escapes without changing the manifest paths sent to the API.

--- a/packages/deploy-helpers/src/deploy/helpers/assets.ts
+++ b/packages/deploy-helpers/src/deploy/helpers/assets.ts
@@ -54,6 +54,7 @@ const MAX_UPLOAD_ATTEMPTS = 5;
 const MAX_UPLOAD_GATEWAY_ERRORS = 5;
 
 const MAX_DIFF_LINES = 100;
+const MAX_MANIFEST_PATH_CANDIDATES = 20;
 
 export const syncAssets = async (
 	complianceConfig: ComplianceConfig,
@@ -67,15 +68,6 @@ export const syncAssets = async (
 	// 1. generate asset manifest
 	logger.info("🌀 Building list of assets...");
 	const manifest = await buildAssetManifest(assetDirectory);
-	const uploadSessionManifest: AssetManifest = {};
-	for (const [assetPath, assetMetadata] of Object.entries(manifest)) {
-		uploadSessionManifest[
-			assetPath
-				.split("/")
-				.map((segment) => encodeURIComponent(segment))
-				.join("/")
-		] = assetMetadata;
-	}
 
 	const url = dispatchNamespace
 		? `/accounts/${accountId}/workers/dispatch/namespaces/${dispatchNamespace}/scripts/${scriptName}/assets-upload-session`
@@ -83,12 +75,21 @@ export const syncAssets = async (
 
 	// 2. fetch buckets w/ hashes
 	logger.info("🌀 Starting asset upload...");
-	const initializeAssetsResponse =
-		await fetchResult<InitializeAssetsResponse | null>(complianceConfig, url, {
-			headers: { "Content-Type": "application/json" },
-			method: "POST",
-			body: JSON.stringify({ manifest: uploadSessionManifest }),
-		});
+	let initializeAssetsResponse: InitializeAssetsResponse | null;
+	try {
+		initializeAssetsResponse = await fetchResult<InitializeAssetsResponse | null>(
+			complianceConfig,
+			url,
+			{
+				headers: { "Content-Type": "application/json" },
+				method: "POST",
+				body: JSON.stringify({ manifest: manifest }),
+			}
+		);
+	} catch (e) {
+		logPotentialUriEncodingPaths(e, manifest);
+		throw e;
+	}
 
 	// In the past we've seen the endpoint return that incorrectly doesn't contain
 	// a null response (see: https://github.com/cloudflare/workers-sdk/issues/9465).
@@ -338,6 +339,42 @@ export const buildAssetManifest = async (dir: string) => {
 	);
 	return manifest;
 };
+
+function logPotentialUriEncodingPaths(e: unknown, manifest: AssetManifest) {
+	if (
+		!(e instanceof APIError) ||
+		e.code !== 10304 ||
+		!e.notes.some((note) => note.text.includes("Manifest path must be URI encoded"))
+	) {
+		return;
+	}
+
+	const candidatePaths = Object.keys(manifest).filter((assetPath) =>
+		assetPath
+			.split("/")
+			.some((segment) => encodeURIComponent(segment) !== segment)
+	);
+	if (candidatePaths.length === 0) {
+		logger.warn(
+			"The Assets API rejected the upload manifest because one or more paths must be URI encoded, but Wrangler could not identify any asset paths with URI-sensitive characters."
+		);
+		return;
+	}
+
+	const displayedPaths = candidatePaths
+		.slice(0, MAX_MANIFEST_PATH_CANDIDATES)
+		.map((assetPath) => `  - ${assetPath}`)
+		.join("\n");
+	const remainingCount = candidatePaths.length - MAX_MANIFEST_PATH_CANDIDATES;
+	const remainingMessage =
+		remainingCount > 0 ? `\n  ...and ${remainingCount} more` : "";
+	logger.warn(
+		"The Assets API rejected the upload manifest because one or more paths must be URI encoded. " +
+			"The following asset paths contain URI-sensitive characters and may help identify the file that triggered the API error:\n" +
+			displayedPaths +
+			remainingMessage
+	);
+}
 
 function logAssetUpload(line: string, diffCount: number) {
 	const level = logger.loggerLevel ?? "log";

--- a/packages/deploy-helpers/src/deploy/helpers/assets.ts
+++ b/packages/deploy-helpers/src/deploy/helpers/assets.ts
@@ -348,14 +348,10 @@ function logPotentialUriEncodingPaths(e: unknown, manifest: AssetManifest) {
 		return;
 	}
 
-	const candidatePaths = Object.keys(manifest).filter((assetPath) =>
-		assetPath
-			.split("/")
-			.some((segment) => encodeURIComponent(segment) !== segment)
-	);
+	const candidatePaths = Object.keys(manifest).filter(isUriEncodingErrorCandidate);
 	if (candidatePaths.length === 0) {
 		logger.warn(
-			"The Assets API rejected the upload manifest because one or more paths must be URI encoded, but Wrangler could not identify any asset paths with URI-sensitive characters."
+			"The Assets API rejected the upload manifest because one or more paths must be URI encoded, but Wrangler could not identify any asset paths that fail URI decoding."
 		);
 		return;
 	}
@@ -365,9 +361,18 @@ function logPotentialUriEncodingPaths(e: unknown, manifest: AssetManifest) {
 		.join("\n");
 	logger.warn(
 		"The Assets API rejected the upload manifest because one or more paths must be URI encoded. " +
-			"The following asset paths contain URI-sensitive characters and may help identify the file that triggered the API error:\n" +
+			"The following asset paths fail URI decoding and may help identify the file that triggered the API error:\n" +
 			displayedPaths
 	);
+}
+
+function isUriEncodingErrorCandidate(assetPath: string) {
+	try {
+		decodeURIComponent(assetPath);
+		return false;
+	} catch {
+		return true;
+	}
 }
 
 function logAssetUpload(line: string, diffCount: number) {

--- a/packages/deploy-helpers/src/deploy/helpers/assets.ts
+++ b/packages/deploy-helpers/src/deploy/helpers/assets.ts
@@ -67,6 +67,15 @@ export const syncAssets = async (
 	// 1. generate asset manifest
 	logger.info("🌀 Building list of assets...");
 	const manifest = await buildAssetManifest(assetDirectory);
+	const uploadSessionManifest: AssetManifest = {};
+	for (const [assetPath, assetMetadata] of Object.entries(manifest)) {
+		uploadSessionManifest[
+			assetPath
+				.split("/")
+				.map((segment) => encodeURIComponent(segment))
+				.join("/")
+		] = assetMetadata;
+	}
 
 	const url = dispatchNamespace
 		? `/accounts/${accountId}/workers/dispatch/namespaces/${dispatchNamespace}/scripts/${scriptName}/assets-upload-session`
@@ -78,7 +87,7 @@ export const syncAssets = async (
 		await fetchResult<InitializeAssetsResponse | null>(complianceConfig, url, {
 			headers: { "Content-Type": "application/json" },
 			method: "POST",
-			body: JSON.stringify({ manifest: manifest }),
+			body: JSON.stringify({ manifest: uploadSessionManifest }),
 		});
 
 	// In the past we've seen the endpoint return that incorrectly doesn't contain

--- a/packages/deploy-helpers/src/deploy/helpers/assets.ts
+++ b/packages/deploy-helpers/src/deploy/helpers/assets.ts
@@ -54,7 +54,6 @@ const MAX_UPLOAD_ATTEMPTS = 5;
 const MAX_UPLOAD_GATEWAY_ERRORS = 5;
 
 const MAX_DIFF_LINES = 100;
-const MAX_MANIFEST_PATH_CANDIDATES = 20;
 
 export const syncAssets = async (
 	complianceConfig: ComplianceConfig,
@@ -362,17 +361,12 @@ function logPotentialUriEncodingPaths(e: unknown, manifest: AssetManifest) {
 	}
 
 	const displayedPaths = candidatePaths
-		.slice(0, MAX_MANIFEST_PATH_CANDIDATES)
 		.map((assetPath) => `  - ${assetPath}`)
 		.join("\n");
-	const remainingCount = candidatePaths.length - MAX_MANIFEST_PATH_CANDIDATES;
-	const remainingMessage =
-		remainingCount > 0 ? `\n  ...and ${remainingCount} more` : "";
 	logger.warn(
 		"The Assets API rejected the upload manifest because one or more paths must be URI encoded. " +
 			"The following asset paths contain URI-sensitive characters and may help identify the file that triggered the API error:\n" +
-			displayedPaths +
-			remainingMessage
+			displayedPaths
 	);
 }
 

--- a/packages/wrangler/src/__tests__/deploy/assets.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/assets.test.ts
@@ -573,6 +573,7 @@ describe("deploy", () => {
 			const assets = [
 				{ filePath: "file-1.txt", content: "Content of file-1" },
 				{ filePath: "space [file].txt", content: "Content of file-2" },
+				{ filePath: "broken%zz.txt", content: "Content of file-3" },
 			];
 			writeAssets(assets);
 			writeWranglerConfig({
@@ -601,10 +602,11 @@ describe("deploy", () => {
 				code: 10304,
 			});
 			expect(std.warn).toContain(
-				"The following asset paths contain URI-sensitive characters"
+				"The following asset paths fail URI decoding"
 			);
-			expect(std.warn).toContain("  - /space [file].txt");
+			expect(std.warn).toContain("  - /broken%zz.txt");
 			expect(std.warn).not.toContain("  - /file-1.txt");
+			expect(std.warn).not.toContain("  - /space [file].txt");
 		});
 
 		it("should resolve assets directory relative to wrangler.toml if using config", async ({

--- a/packages/wrangler/src/__tests__/deploy/assets.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/assets.test.ts
@@ -516,11 +516,11 @@ describe("deploy", () => {
 			expect(manifestBodies.length).toBe(1);
 			expect(manifestBodies[0]).toEqual({
 				manifest: {
-					"/b%C3%A9%C3%ABp/boo%5Ep.txt": {
+					"/béëp/boo^p.txt": {
 						hash: "ff5016e92f039aa743a4ff7abb3180fa",
 						size: 17,
 					},
-					"/boop/file%231.txt": {
+					"/boop/file#1.txt": {
 						hash: "7574a8cd3094a050388ac9663af1c1d6",
 						size: 17,
 					},
@@ -528,7 +528,7 @@ describe("deploy", () => {
 						hash: "0de3dd5df907418e9730fd2bd747bd5e",
 						size: 17,
 					},
-					"/space%20%5Bfile%5D.txt": {
+					"/space [file].txt": {
 						hash: "361741650531ac969c8ca70a5438e7c1",
 						size: 17,
 					},
@@ -565,6 +565,46 @@ describe("deploy", () => {
 				name: "361741650531ac969c8ca70a5438e7c1",
 				type: "text/plain",
 			});
+		});
+
+		it("should log possible paths when the assets upload session rejects manifest URI encoding", async ({
+			expect,
+		}) => {
+			const assets = [
+				{ filePath: "file-1.txt", content: "Content of file-1" },
+				{ filePath: "space [file].txt", content: "Content of file-2" },
+			];
+			writeAssets(assets);
+			writeWranglerConfig({
+				assets: { directory: "assets" },
+			});
+
+			msw.use(
+				http.post(
+					"*/accounts/some-account-id/workers/scripts/test-name/assets-upload-session",
+					() => {
+						return HttpResponse.json(
+							createFetchResult(null, false, [
+								{
+									code: 10304,
+									message:
+										"Invalid manifest: Manifest path must be URI encoded.",
+								},
+							]),
+							{ status: 400 }
+						);
+					}
+				)
+			);
+
+			await expect(runWrangler("deploy")).rejects.toMatchObject({
+				code: 10304,
+			});
+			expect(std.warn).toContain(
+				"The following asset paths contain URI-sensitive characters"
+			);
+			expect(std.warn).toContain("  - /space [file].txt");
+			expect(std.warn).not.toContain("  - /file-1.txt");
 		});
 
 		it("should resolve assets directory relative to wrangler.toml if using config", async ({

--- a/packages/wrangler/src/__tests__/deploy/assets.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/assets.test.ts
@@ -478,6 +478,7 @@ describe("deploy", () => {
 				{ filePath: "file-1.txt", content: "Content of file-1" },
 				{ filePath: "boop/file#1.txt", content: "Content of file-2" },
 				{ filePath: "béëp/boo^p.txt", content: "Content of file-3" },
+				{ filePath: "space [file].txt", content: "Content of file-4" },
 			];
 			writeAssets(assets);
 			writeWranglerConfig({
@@ -490,6 +491,7 @@ describe("deploy", () => {
 					"ff5016e92f039aa743a4ff7abb3180fa",
 					"7574a8cd3094a050388ac9663af1c1d6",
 					"0de3dd5df907418e9730fd2bd747bd5e",
+					"361741650531ac969c8ca70a5438e7c1",
 				],
 			];
 			await mockAUSRequest(manifestBodies, mockBuckets, "<<aus-token>>");
@@ -514,16 +516,20 @@ describe("deploy", () => {
 			expect(manifestBodies.length).toBe(1);
 			expect(manifestBodies[0]).toEqual({
 				manifest: {
-					"/béëp/boo^p.txt": {
+					"/b%C3%A9%C3%ABp/boo%5Ep.txt": {
 						hash: "ff5016e92f039aa743a4ff7abb3180fa",
 						size: 17,
 					},
-					"/boop/file#1.txt": {
+					"/boop/file%231.txt": {
 						hash: "7574a8cd3094a050388ac9663af1c1d6",
 						size: 17,
 					},
 					"/file-1.txt": {
 						hash: "0de3dd5df907418e9730fd2bd747bd5e",
+						size: 17,
+					},
+					"/space%20%5Bfile%5D.txt": {
+						hash: "361741650531ac969c8ca70a5438e7c1",
 						size: 17,
 					},
 				},
@@ -550,6 +556,13 @@ describe("deploy", () => {
 			).toBeAFileWhichMatches({
 				fileBits: ["Q29udGVudCBvZiBmaWxlLTE="],
 				name: "0de3dd5df907418e9730fd2bd747bd5e",
+				type: "text/plain",
+			});
+			await expect(
+				flatBodies["361741650531ac969c8ca70a5438e7c1"]
+			).toBeAFileWhichMatches({
+				fileBits: ["Q29udGVudCBvZiBmaWxlLTQ="],
+				name: "361741650531ac969c8ca70a5438e7c1",
 				type: "text/plain",
 			});
 		});


### PR DESCRIPTION
Fixes #14461.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bugfix

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
