### PR TITLE
Add `@typescript-eslint/no-deprecated` lint rule to prevent the use of deprecated APIs

### DIFF
--- a/.oxlintrc.jsonc
+++ b/.oxlintrc.jsonc
@@ -52,6 +52,7 @@
 		"workers-sdk/no-unsafe-command-execution": "error",
 		"workers-sdk/no-direct-recursive-rm": "error",
 		"workers-sdk/require-description-when-disabling": "error",
+		"@typescript-eslint/no-deprecated": "error",
 
 		"no-unused-vars": [
 			"error",
@@ -199,6 +200,23 @@
 			"files": ["packages/vite-plugin-cloudflare/**"],
 			"rules": {
 				"workers-sdk/no-wrangler-named-imports": "error",
+			},
+		},
+		// Gradually rolling out @typescript-eslint/no-deprecated.
+		// TODO: Remove the following overrides, one package at a time.
+		{
+			"files": [
+				"packages/edge-preview-authenticated-proxy/**",
+				"packages/local-explorer-ui/**",
+				"packages/miniflare/**",
+				"packages/vite-plugin-cloudflare/**",
+				"packages/vitest-pool-workers/**",
+				"packages/workers-utils/**",
+				"packages/workflows-shared/**",
+				"packages/wrangler/**",
+			],
+			"rules": {
+				"@typescript-eslint/no-deprecated": "off",
 			},
 		},
 	],

--- a/packages/containers-shared/tests/utils.test.ts
+++ b/packages/containers-shared/tests/utils.test.ts
@@ -141,7 +141,7 @@ describe("verifyDockerInstalled", () => {
 				operation: "running dev",
 				imageNoun: "the configured image",
 			})
-		).rejects.toThrowError(
+		).rejects.toThrow(
 			/The Docker CLI is needed to build the configured image before running dev but could not be launched/
 		);
 	});
@@ -156,7 +156,7 @@ describe("verifyDockerInstalled", () => {
 				dockerPath: "docker",
 				imageNoun: "the image",
 			})
-		).rejects.toThrowError(
+		).rejects.toThrow(
 			/The Docker CLI is needed to build the image but could not be launched/
 		);
 	});
@@ -173,7 +173,7 @@ describe("verifyDockerInstalled", () => {
 				imageNoun: "the configured images",
 				hint: "Set enable_containers to false.",
 			})
-		).rejects.toThrowError(/Set enable_containers to false\./);
+		).rejects.toThrow(/Set enable_containers to false\./);
 	});
 
 	it("omits the hint paragraph when no hint is provided", async ({
@@ -215,7 +215,7 @@ describe("verifyDockerInstalled", () => {
 				operation: "deploying (even in dry-run mode)",
 				imageNoun: "the configured images",
 			})
-		).rejects.toThrowError(
+		).rejects.toThrow(
 			/The Docker CLI is needed to build the configured images before deploying \(even in dry-run mode\) but could not be launched/
 		);
 	});

--- a/packages/deploy-helpers/src/deploy/helpers/print-bindings.ts
+++ b/packages/deploy-helpers/src/deploy/helpers/print-bindings.ts
@@ -731,8 +731,11 @@ export function printBindings(
 			...vars.map((variable) => {
 				const { binding, type: varType, value: varValue } = variable;
 				let parsedValue;
-				/**
-				 * @see packages/workers-utils/src/types.ts for details on the hidden property
+				/* eslint-disable-next-line @typescript-eslint/no-deprecated --
+				 *    hidden is a deprecated property, but still needs to be supported for backwards compatibility
+				 *    so we need to handle appropriately here
+				 *
+				 *    see packages/workers-utils/src/types.ts for details on the hidden property
 				 */
 				if (varType === "plain_text" && variable.hidden !== true) {
 					parsedValue = `"${truncate(varValue)}"`;

--- a/packages/quick-edit-extension/src/cfs.ts
+++ b/packages/quick-edit-extension/src/cfs.ts
@@ -482,7 +482,7 @@ declare module "*.bin" {
 			return "";
 		}
 
-		return path.substr(path.lastIndexOf("/") + 1);
+		return path.substring(path.lastIndexOf("/") + 1);
 	}
 
 	private _dirname(path: string): string {
@@ -491,7 +491,7 @@ declare module "*.bin" {
 			return "/";
 		}
 
-		return path.substr(0, path.lastIndexOf("/"));
+		return path.substring(0, path.lastIndexOf("/"));
 	}
 
 	private _rtrim(haystack: string, needle: string): string {

--- a/packages/workers-auth/src/credentials.ts
+++ b/packages/workers-auth/src/credentials.ts
@@ -110,9 +110,11 @@ export function getAPIToken(
 		storage: options.storage,
 		warningLogger: options.warningLogger,
 	});
+	/* eslint-disable @typescript-eslint/no-deprecated -- deprecatedApiToken is a deprecated property, but still needs to be supported for backwards compatibility so we need to handle appropriately here */
 	if (stored.deprecatedApiToken) {
 		return { apiToken: stored.deprecatedApiToken };
 	}
+	/* eslint-enable @typescript-eslint/no-deprecated */
 	if (stored.accessToken?.value) {
 		return { apiToken: stored.accessToken.value };
 	}

--- a/packages/workers-auth/src/flow.ts
+++ b/packages/workers-auth/src/flow.ts
@@ -360,6 +360,7 @@ export function createOAuthFlow(ctx: OAuthFlowContext): OAuthFlowAPI {
 			warningLogger: ctx.logger,
 			storage: getStorage(props.profile),
 		});
+		// eslint-disable-next-line @typescript-eslint/no-deprecated -- deprecatedApiToken is a deprecated property, but still needs to be supported for backwards compatibility so we need to handle appropriately here */
 		if (!stored.accessToken && !stored.deprecatedApiToken) {
 			// Not logged in.
 			// If we are not interactive, we cannot ask the user to login

--- a/packages/workers-auth/src/state.ts
+++ b/packages/workers-auth/src/state.ts
@@ -82,6 +82,7 @@ export function readStoredAuthState(options: {
 		return {};
 	}
 
+	// eslint-disable-next-line @typescript-eslint/no-deprecated -- api_token is a deprecated property, but still needs to be supported for backwards compatibility so we need to handle appropriately here
 	const { oauth_token, refresh_token, expiration_time, scopes, api_token } =
 		parsed;
 

--- a/packages/workers-shared/router-worker/tests/index.test.ts
+++ b/packages/workers-shared/router-worker/tests/index.test.ts
@@ -1,8 +1,5 @@
-import {
-	SELF,
-	createExecutionContext,
-	env as runtimeEnv,
-} from "cloudflare:test";
+import { createExecutionContext } from "cloudflare:test";
+import { exports, env as runtimeEnv } from "cloudflare:workers";
 import { describe, it } from "vitest";
 import { RouterInnerEntrypoint } from "../src/worker";
 import type { Env } from "../src/worker";
@@ -31,7 +28,9 @@ describe("runtime loopback", () => {
 			},
 		} as Env["ASSET_WORKER"];
 
-		const response = await SELF.fetch("https://example.com");
+		const response = await (exports as { default: Fetcher }).default.fetch(
+			"https://example.com"
+		);
 
 		expect(response.status).toBe(200);
 		expect(await response.text()).toBe("loopback asset worker");


### PR DESCRIPTION
Just an idea, what do we think on having a linting rule to prevent us from using deprecated APIs? 🙂 

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: internal linting change, no user facing changes

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
