### PR TITLE
ci: Pin Wrangler E2E to Node 22.23.1

### DIFF
--- a/.github/workflows/e2e-wrangler.yml
+++ b/.github/workflows/e2e-wrangler.yml
@@ -51,6 +51,9 @@ jobs:
         if: steps.changes.outputs.everything_but_markdown == 'true'
         uses: ./.github/actions/install-dependencies
         with:
+          # Pin until `node-version: 22` resolves to 22.23.1 or later. Node 22.23.0
+          # regressed node-fetch@2 chunked/gzip responses with ERR_STREAM_PREMATURE_CLOSE.
+          node-version: 22.23.1
           turbo-api: ${{ secrets.TURBO_API }}
           turbo-team: ${{ secrets.TURBO_TEAM }}
           turbo-token: ${{ secrets.TURBO_TOKEN }}


### PR DESCRIPTION
Fixes n/a.

Pins the Wrangler E2E workflow to Node 22.23.1 to fix CI errors from remote bindings tests:

```sh
 FAIL  e2e/remote-binding/miniflare-remote-resources.test.ts:669:2 > Remote bindings (remote proxy session enabled)
 FetchError: Invalid response body while trying to fetch https://api.cloudflare.com/client/v4/accounts/***/cfd_tunnel: Premature close
```

This was caused by a regression in Node 22.23.0 (https://github.com/nodejs/node/issues/63989) that causes node-fetch to throw `ERR_STREAM_PREMATURE_CLOSE` for some chunked/gzip responses. We can move back to `node-version: 22` once GitHub Actions resolves that version to 22.23.1 or later.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bugfix

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
