### PR TITLE
Improve R2 error messages to be clearer and more actionable

### DIFF
--- a/.changeset/improve-r2-error-messages.md
+++ b/.changeset/improve-r2-error-messages.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Improve R2 error messages to be clearer and more actionable
+
+Error messages for `r2 bucket lifecycle`, `r2 bucket lock`, `r2 bucket catalog`, and `r2 sql` commands now include the specific flag or argument that is missing or invalid, along with usage examples showing the correct syntax.

--- a/packages/wrangler/src/__tests__/r2/bucket.test.ts
+++ b/packages/wrangler/src/__tests__/r2/bucket.test.ts
@@ -1249,7 +1249,8 @@ describe("r2", () => {
 								"r2 bucket catalog compaction enable testBucket testNamespace"
 							)
 						).rejects.toThrowErrorMatchingInlineSnapshot(
-							`[Error: Table name is required when namespace is specified]`
+							`[Error: Both namespace and table must be provided together. You specified namespace without table. Retry by running:
+  wrangler r2 bucket catalog compaction enable testBucket <namespace> <table>]`
 						);
 					});
 
@@ -1260,7 +1261,8 @@ describe("r2", () => {
 								'r2 bucket catalog compaction enable testBucket "" testTable'
 							)
 						).rejects.toThrowErrorMatchingInlineSnapshot(
-							`[Error: Namespace is required when table is specified]`
+							`[Error: Both namespace and table must be provided together. You specified table without namespace. Retry by running:
+  wrangler r2 bucket catalog compaction enable testBucket <namespace> <table>]`
 						);
 					});
 				});
@@ -3520,7 +3522,7 @@ describe("r2", () => {
 							`r2 bucket lock add ${bucketName} --name rule-age --prefix prefix-age --retention-days one`
 						)
 					).rejects.toThrowErrorMatchingInlineSnapshot(
-						`[Error: Days must be a number.]`
+						`[Error: The value for --retention-days must be a number. Retry with a numeric value (e.g. --retention-days 30).]`
 					);
 				});
 				it("it should fail an age lock rule using command-line arguments with invalid negative age", async () => {
@@ -3544,7 +3546,7 @@ describe("r2", () => {
 							`r2 bucket lock add ${bucketName} --name rule-age --prefix prefix-age --retention-days -10`
 						)
 					).rejects.toThrowErrorMatchingInlineSnapshot(
-						`[Error: Days must be a positive number: -10]`
+						`[Error: The value for --retention-days must be a positive number, but received '-10'.]`
 					);
 				});
 				it("it should add a date lock rule using command-line arguments", async () => {
@@ -3585,7 +3587,7 @@ describe("r2", () => {
 							`r2 bucket lock add ${bucketName} --name "rule-date" --prefix "prefix-date" --retention-date "January 30, 2025"`
 						)
 					).rejects.toThrowErrorMatchingInlineSnapshot(
-						`[Error: Date must be a valid date in the YYYY-MM-DD format: January 30, 2025]`
+						`[Error: The value for --retention-date must be in YYYY-MM-DD format (e.g. 2025-12-31), but received 'January 30, 2025'.]`
 					);
 				});
 				it("it should add an indefinite lock rule using command-line arguments", async () => {
@@ -3669,7 +3671,7 @@ describe("r2", () => {
 							`r2 bucket lock add ${bucketName} --name rule-indefinite --prefix prefix-indefinite --retention-indefinite false`
 						)
 					).rejects.toThrowErrorMatchingInlineSnapshot(
-						`[Error: Retention must be specified.]`
+						`[Error: No retention specified. Use one of --retention-days <number>, --retention-date <YYYY-MM-DD>, or --retention-indefinite to set a retention.]`
 					);
 				});
 				it("it should fail a lock rule without any command-line arguments", async () => {
@@ -3681,7 +3683,8 @@ describe("r2", () => {
 					await expect(() =>
 						runWrangler(`r2 bucket lock add ${bucketName}`)
 					).rejects.toThrowErrorMatchingInlineSnapshot(
-						`[Error: Must specify a rule name.]`
+						`[Error: Missing required rule name. Provide a name with --name <rule-name> or as a positional argument:
+  wrangler r2 bucket lock add <bucket> <name>]`
 					);
 				});
 			});

--- a/packages/wrangler/src/__tests__/r2/sql.test.ts
+++ b/packages/wrangler/src/__tests__/r2/sql.test.ts
@@ -70,7 +70,7 @@ describe("r2 sql", () => {
 		it("should validate warehouse name format", async ({ expect }) => {
 			await expect(
 				runWrangler(`r2 sql query invalidwarehouse "${mockQuery}"`)
-			).rejects.toThrow("Warehouse name has invalid format");
+			).rejects.toThrow("Invalid warehouse name format");
 		});
 
 		it("should execute a successful query and display results", async ({

--- a/packages/wrangler/src/r2/catalog.ts
+++ b/packages/wrangler/src/r2/catalog.ts
@@ -23,6 +23,40 @@ import {
 	upsertR2CatalogCredential,
 } from "./helpers/catalog";
 
+/**
+ * Validates that namespace and table positional args are either both provided or both omitted.
+ * Throws a {@link UserError} if only one of the two is given.
+ *
+ * @param namespace The namespace argument value
+ * @param table The table argument value
+ * @param bucket The bucket name (used in the retry hint)
+ * @param subcommand The subcommand path after "wrangler r2 bucket catalog" (e.g. "compaction enable")
+ */
+function validateNamespaceAndTable(
+	namespace: string | undefined,
+	table: string | undefined,
+	bucket: string,
+	subcommand: string
+): void {
+	const telemetryBase = `r2 catalog ${subcommand.replace("-", " ")}`;
+	if (namespace && !table) {
+		throw new UserError(
+			`Both namespace and table must be provided together. You specified namespace without table. Retry by running:\n  wrangler r2 bucket catalog ${subcommand} ${bucket} <namespace> <table>`,
+			{
+				telemetryMessage: `${telemetryBase} missing table`,
+			}
+		);
+	}
+	if (!namespace && table) {
+		throw new UserError(
+			`Both namespace and table must be provided together. You specified table without namespace. Retry by running:\n  wrangler r2 bucket catalog ${subcommand} ${bucket} <namespace> <table>`,
+			{
+				telemetryMessage: `${telemetryBase} missing namespace`,
+			}
+		);
+	}
+}
+
 export const r2BucketCatalogNamespace = createNamespace({
 	metadata: {
 		description:
@@ -219,20 +253,12 @@ export const r2BucketCatalogCompactionEnableCommand = createCommand({
 	async handler(args, { config }) {
 		const accountId = await requireAuth(config);
 
-		// Validate namespace and table are provided together
-		if (args.namespace && !args.table) {
-			throw new UserError(
-				"Table name is required when namespace is specified",
-				{
-					telemetryMessage: "r2 catalog compaction enable missing table",
-				}
-			);
-		}
-		if (!args.namespace && args.table) {
-			throw new UserError("Namespace is required when table is specified", {
-				telemetryMessage: "r2 catalog compaction enable missing namespace",
-			});
-		}
+		validateNamespaceAndTable(
+			args.namespace,
+			args.table,
+			args.bucket,
+			"compaction enable"
+		);
 
 		if (args.namespace && args.table) {
 			// Table-level compaction
@@ -312,20 +338,12 @@ export const r2BucketCatalogCompactionDisableCommand = createCommand({
 	async handler(args, { config }) {
 		const accountId = await requireAuth(config);
 
-		// Validate namespace and table are provided together
-		if (args.namespace && !args.table) {
-			throw new UserError(
-				"Table name is required when namespace is specified",
-				{
-					telemetryMessage: "r2 catalog compaction disable missing table",
-				}
-			);
-		}
-		if (!args.namespace && args.table) {
-			throw new UserError("Namespace is required when table is specified", {
-				telemetryMessage: "r2 catalog compaction disable missing namespace",
-			});
-		}
+		validateNamespaceAndTable(
+			args.namespace,
+			args.table,
+			args.bucket,
+			"compaction disable"
+		);
 
 		if (args.namespace && args.table) {
 			// Table-level compaction
@@ -422,22 +440,12 @@ export const r2BucketCatalogSnapshotExpirationEnableCommand = createCommand({
 	async handler(args, { config }) {
 		const accountId = await requireAuth(config);
 
-		// Validate namespace and table are provided together
-		if (args.namespace && !args.table) {
-			throw new UserError(
-				"Table name is required when namespace is specified",
-				{
-					telemetryMessage:
-						"r2 catalog snapshot expiration enable missing table",
-				}
-			);
-		}
-		if (!args.namespace && args.table) {
-			throw new UserError("Namespace is required when table is specified", {
-				telemetryMessage:
-					"r2 catalog snapshot expiration enable missing namespace",
-			});
-		}
+		validateNamespaceAndTable(
+			args.namespace,
+			args.table,
+			args.bucket,
+			"snapshot-expiration enable"
+		);
 
 		if (args.namespace && args.table) {
 			// Table-level snapshot expiration
@@ -526,22 +534,12 @@ export const r2BucketCatalogSnapshotExpirationDisableCommand = createCommand({
 	async handler(args, { config }) {
 		const accountId = await requireAuth(config);
 
-		// Validate namespace and table are provided together
-		if (args.namespace && !args.table) {
-			throw new UserError(
-				"Table name is required when namespace is specified",
-				{
-					telemetryMessage:
-						"r2 catalog snapshot expiration disable missing table",
-				}
-			);
-		}
-		if (!args.namespace && args.table) {
-			throw new UserError("Namespace is required when table is specified", {
-				telemetryMessage:
-					"r2 catalog snapshot expiration disable missing namespace",
-			});
-		}
+		validateNamespaceAndTable(
+			args.namespace,
+			args.table,
+			args.bucket,
+			"snapshot-expiration disable"
+		);
 
 		if (args.namespace && args.table) {
 			// Table-level snapshot expiration

--- a/packages/wrangler/src/r2/lifecycle.ts
+++ b/packages/wrangler/src/r2/lifecycle.ts
@@ -165,9 +165,12 @@ export const r2BucketLifecycleAddCommand = createCommand({
 		}
 
 		if (!name) {
-			throw new UserError("Must specify a rule name.", {
-				telemetryMessage: "r2 lifecycle add missing rule name",
-			});
+			throw new UserError(
+				"Missing required rule name. Provide a name with --name <rule-name> or as a positional argument:\n  wrangler r2 bucket lifecycle add <bucket> <name>",
+				{
+					telemetryMessage: "r2 lifecycle add missing rule name",
+				}
+			);
 		}
 
 		const newRule: LifecycleRule = {
@@ -212,9 +215,12 @@ export const r2BucketLifecycleAddCommand = createCommand({
 		}
 
 		if (selectedActions.length === 0) {
-			throw new UserError("Must specify at least one action.", {
-				telemetryMessage: "r2 lifecycle add missing action",
-			});
+			throw new UserError(
+				"No lifecycle action specified. Use at least one of --expire-days, --expire-date, --ia-transition-days, --ia-transition-date, or --abort-multipart-days.",
+				{
+					telemetryMessage: "r2 lifecycle add missing action",
+				}
+			);
 		}
 
 		for (const action of selectedActions) {
@@ -222,17 +228,22 @@ export const r2BucketLifecycleAddCommand = createCommand({
 			let conditionValue: number | string;
 
 			if (action === "abort-multipart") {
+				let conditionValueFrom: "args" | "prompt" = "args";
 				if (abortMultipartDays !== undefined) {
 					conditionValue = abortMultipartDays;
 				} else {
 					conditionValue = await prompt(
 						`Enter the number of days after which to ${formatActionDescription(action)}`
 					);
+					conditionValueFrom = "prompt";
 				}
 				if (!isNonNegativeNumber(String(conditionValue))) {
-					throw new UserError("Must be a positive number.", {
-						telemetryMessage: "r2 lifecycle add invalid abort multipart days",
-					});
+					throw new UserError(
+						`The number of days ${conditionValueFrom === "args" ? "passed to --abort-multipart-days" : "for aborting incomplete multipart uploads"} must be a positive number (e.g. 7), but received '${String(conditionValue)}'.`,
+						{
+							telemetryMessage: "r2 lifecycle add invalid abort multipart days",
+						}
+					);
 				}
 
 				conditionType = "Age";
@@ -266,7 +277,7 @@ export const r2BucketLifecycleAddCommand = createCommand({
 						!isValidDate(String(conditionValue))
 					) {
 						throw new UserError(
-							"Must be a positive number or a valid date in the YYYY-MM-DD format.",
+							`Invalid value '${String(conditionValue)}' for ${action === "expire" ? "expiration" : "transition"} condition. Provide a positive number of days or a date in YYYY-MM-DD format (e.g. 30 or 2025-12-31).`,
 							{
 								telemetryMessage: "r2 lifecycle add invalid action condition",
 							}
@@ -282,9 +293,12 @@ export const r2BucketLifecycleAddCommand = createCommand({
 					const date = new Date(`${conditionValue}T00:00:00.000Z`);
 					conditionValue = date.toISOString();
 				} else {
-					throw new UserError("Invalid condition input.", {
-						telemetryMessage: "r2 lifecycle add invalid condition input",
-					});
+					throw new UserError(
+						`Invalid value '${String(conditionValue)}' for ${action === "expire" ? "expiration" : "transition"} condition. Expected a positive number of days or a date in YYYY-MM-DD format (e.g. --expire-days 30 or --expire-date 2025-12-31).`,
+						{
+							telemetryMessage: "r2 lifecycle add invalid condition input",
+						}
+					);
 				}
 
 				if (action === "expire") {

--- a/packages/wrangler/src/r2/lock.ts
+++ b/packages/wrangler/src/r2/lock.ts
@@ -145,9 +145,12 @@ export const r2BucketLockAddCommand = createCommand({
 		}
 
 		if (!name) {
-			throw new UserError("Must specify a rule name.", {
-				telemetryMessage: "r2 lock add missing rule name",
-			});
+			throw new UserError(
+				"Missing required rule name. Provide a name with --name <rule-name> or as a positional argument:\n  wrangler r2 bucket lock add <bucket> <name>",
+				{
+					telemetryMessage: "r2 lock add missing rule name",
+				}
+			);
 		}
 
 		const newRule: BucketLockRule = {
@@ -204,16 +207,19 @@ export const r2BucketLockAddCommand = createCommand({
 					};
 				} else {
 					throw new UserError(
-						`Days must be a positive number: ${retentionDays}`,
+						`The value for --retention-days must be a positive number, but received '${retentionDays}'.`,
 						{
 							telemetryMessage: "Retention days not a positive number.",
 						}
 					);
 				}
 			} else {
-				throw new UserError(`Days must be a number.`, {
-					telemetryMessage: "Retention days not a positive number.",
-				});
+				throw new UserError(
+					"The value for --retention-days must be a number. Retry with a numeric value (e.g. --retention-days 30).",
+					{
+						telemetryMessage: "Retention days not a positive number.",
+					}
+				);
 			}
 		} else if (retentionDate !== undefined) {
 			if (isValidDate(retentionDate)) {
@@ -225,7 +231,7 @@ export const r2BucketLockAddCommand = createCommand({
 				};
 			} else {
 				throw new UserError(
-					`Date must be a valid date in the YYYY-MM-DD format: ${String(retentionDate)}`,
+					`The value for --retention-date must be in YYYY-MM-DD format (e.g. 2025-12-31), but received '${String(retentionDate)}'.`,
 					{
 						telemetryMessage:
 							"Retention date not a valid date in the YYYY-MM-DD format.",
@@ -240,9 +246,12 @@ export const r2BucketLockAddCommand = createCommand({
 				type: "Indefinite",
 			};
 		} else {
-			throw new UserError(`Retention must be specified.`, {
-				telemetryMessage: "Lock retention not specified.",
-			});
+			throw new UserError(
+				"No retention specified. Use one of --retention-days <number>, --retention-date <YYYY-MM-DD>, or --retention-indefinite to set a retention.",
+				{
+					telemetryMessage: "Lock retention not specified.",
+				}
+			);
 		}
 		rules.push(newRule);
 		logger.log(`Adding lock rule '${name}' to bucket '${bucket}'...`);

--- a/packages/wrangler/src/r2/sql.ts
+++ b/packages/wrangler/src/r2/sql.ts
@@ -117,9 +117,12 @@ export const r2SqlQueryCommand = createCommand({
 
 		const splitIndex = warehouse.indexOf("_");
 		if (splitIndex === -1) {
-			throw new UserError("Warehouse name has invalid format", {
-				telemetryMessage: "r2 sql query invalid warehouse format",
-			});
+			throw new UserError(
+				`Invalid warehouse name format '${warehouse}'. Expected the format '<account-id>_<bucket-name>' (e.g. 'abc123_my-bucket'). You can find the warehouse name by running: wrangler r2 bucket catalog get <bucket>`,
+				{
+					telemetryMessage: "r2 sql query invalid warehouse format",
+				}
+			);
 		}
 		const [accountId, bucketName] = [
 			warehouse.slice(0, splitIndex),


### PR DESCRIPTION
Error messages for `r2 bucket lifecycle`, `r2 bucket lock`, `r2 bucket catalog`, and `r2 sql` commands now include the specific flag or argument that is missing or invalid, along with usage examples showing the correct syntax.


---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: improved error messages

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14479" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->