### PR TITLE
[wrangler] Add --json to ai-search jobs cancel

### DIFF
--- a/.changeset/ai-search-jobs.md
+++ b/.changeset/ai-search-jobs.md
@@ -14,4 +14,4 @@ wrangler ai-search jobs cancel <instance> <job-id>
 wrangler ai-search jobs logs <instance> <job-id>
 ```
 
-All commands accept `--namespace`/`-n` (defaults to `default`). All commands except `cancel` also accept `--json` for clean machine-readable output.
+All commands accept `--namespace`/`-n` (defaults to `default`) and `--json` for machine-readable output.

--- a/packages/wrangler/src/__tests__/ai-search.test.ts
+++ b/packages/wrangler/src/__tests__/ai-search.test.ts
@@ -2387,6 +2387,20 @@ describe("ai-search commands", () => {
 					'Successfully cancelled indexing job "job-001"'
 				);
 			});
+
+			it("should cancel and output JSON when --json is passed", async ({
+				expect,
+			}) => {
+				const requests = mockCancelJob(MOCK_JOB);
+				await runWrangler(
+					"ai-search jobs cancel my-instance job-001 --force --json"
+				);
+				expect(requests.count).toBe(1);
+				const parsed = JSON.parse(std.out);
+				expect(parsed.id).toBe("job-001");
+				expect(std.out).not.toContain("Cancelling indexing job");
+				expect(std.out).not.toContain("Successfully cancelled");
+			});
 		});
 
 		describe("logs", () => {

--- a/packages/wrangler/src/ai-search/jobs/cancel.ts
+++ b/packages/wrangler/src/ai-search/jobs/cancel.ts
@@ -9,6 +9,9 @@ export const aiSearchJobsCancelCommand = createCommand({
 		status: "open beta",
 		owner: "Product: AI Search",
 	},
+	behaviour: {
+		printBanner: (args) => !args.json,
+	},
 	args: {
 		name: {
 			type: "string",
@@ -32,21 +35,37 @@ export const aiSearchJobsCancelCommand = createCommand({
 			default: false,
 			description: "Skip confirmation",
 		},
+		json: {
+			type: "boolean",
+			default: false,
+			description: "Return output as JSON",
+		},
 	},
 	positionalArgs: ["name", "job-id"],
-	async handler({ name, jobId, namespace, force }, { config }) {
+	async handler({ name, jobId, namespace, force, json }, { config }) {
 		if (!force) {
 			const confirmedCancellation = await confirm(
 				`OK to cancel the indexing job "${jobId}" on AI Search instance "${name}"?`
 			);
 			if (!confirmedCancellation) {
-				logger.log("Cancellation aborted.");
+				if (!json) {
+					logger.log("Cancellation aborted.");
+				}
 				return;
 			}
 		}
 
-		logger.log(`Cancelling indexing job "${jobId}"...`);
-		await cancelJob(config, namespace, name, jobId);
+		if (!json) {
+			logger.log(`Cancelling indexing job "${jobId}"...`);
+		}
+
+		const job = await cancelJob(config, namespace, name, jobId);
+
+		if (json) {
+			logger.log(JSON.stringify(job, null, 2));
+			return;
+		}
+
 		logger.log(`Successfully cancelled indexing job "${jobId}"`);
 	},
 });

--- a/packages/wrangler/src/ai-search/jobs/create.ts
+++ b/packages/wrangler/src/ai-search/jobs/create.ts
@@ -30,7 +30,7 @@ export const aiSearchJobsCreateCommand = createCommand({
 		json: {
 			type: "boolean",
 			default: false,
-			description: "Return output as clean JSON",
+			description: "Return output as JSON",
 		},
 	},
 	positionalArgs: ["name"],

--- a/packages/wrangler/src/ai-search/jobs/get.ts
+++ b/packages/wrangler/src/ai-search/jobs/get.ts
@@ -31,7 +31,7 @@ export const aiSearchJobsGetCommand = createCommand({
 		json: {
 			type: "boolean",
 			default: false,
-			description: "Return output as clean JSON",
+			description: "Return output as JSON",
 		},
 	},
 	positionalArgs: ["name", "job-id"],

--- a/packages/wrangler/src/ai-search/jobs/list.ts
+++ b/packages/wrangler/src/ai-search/jobs/list.ts
@@ -26,7 +26,7 @@ export const aiSearchJobsListCommand = createCommand({
 		json: {
 			type: "boolean",
 			default: false,
-			description: "Return output as clean JSON",
+			description: "Return output as JSON",
 		},
 		page: {
 			describe:

--- a/packages/wrangler/src/ai-search/jobs/logs.ts
+++ b/packages/wrangler/src/ai-search/jobs/logs.ts
@@ -31,7 +31,7 @@ export const aiSearchJobsLogsCommand = createCommand({
 		json: {
 			type: "boolean",
 			default: false,
-			description: "Return output as clean JSON",
+			description: "Return output as JSON",
 		},
 		page: {
 			describe:


### PR DESCRIPTION
Follow-up to #14367 addressing review feedback (Devin Review + @petebacondarwin).

Adds a `--json` flag to `wrangler ai-search jobs cancel` so it is consistent with the other `ai-search jobs` commands (`list`, `create`, `get`, `logs`) and with the changelog for the (as-yet unreleased) jobs feature. Previously `cancel` had no `--json` flag, so passing it would fail with `Unknown argument: json` under yargs strict mode.

With `--json`, the cancelled job is printed as JSON and the human-readable log lines/banner are suppressed (consistent with the sibling commands).

Also:

- Drop "clean" from the `--json` arg descriptions across the jobs commands (review nit).
- Update the pending `ai-search-jobs` changeset to reflect that all commands (including `cancel`) accept `--json`.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: these subcommands are in open beta and follow the existing `wrangler ai-search` command patterns; `--json` mirrors the flag already present on the sibling jobs commands.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14480" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->