### PR TITLE
Improve error message when deploying to a non-existent Pages project in non-interactive mode

### DIFF
--- a/.changeset/pages-deploy-nonexistent-project-error.md
+++ b/.changeset/pages-deploy-nonexistent-project-error.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Improve error message when deploying to a non-existent Pages project in non-interactive mode
+
+Previously, running `wrangler pages deploy` with a `--project-name` that doesn't exist in a non-interactive context (e.g. CI, piped input) would fail with a generic "project not found" or "This command cannot be run in a non-interactive context" error. Now it provides a specific error message explaining that the project doesn't exist and suggests how to create it. The error also suggests using `wrangler deploy` to deploy a Worker instead.

--- a/packages/wrangler/src/__tests__/pages/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/pages/deploy.test.ts
@@ -163,7 +163,7 @@ describe("pages deploy", () => {
 
 			If you are targeting an existing Pages project, verify that the project name is correct and that it exists in your account (the account in use has id some-account-id).
 
-			Otherwise, if you are trying to create a new Pages project, start by running: \`wrangler pages project create non-existent-project --production-branch <branch>\` (though we strongly recommend using Workers instead).]
+			Otherwise, if you are trying to create a new Pages project, start by running: \`wrangler pages project create\` (though we strongly recommend using Workers instead).]
 		`
 		);
 	});
@@ -211,7 +211,7 @@ describe("pages deploy", () => {
 
 			If you are targeting an existing Pages project, verify that the project name is correct and that it exists in your account (the account in use is "My Test Account" with id some-account-id).
 
-			Otherwise, if you are trying to create a new Pages project, start by running: \`wrangler pages project create non-existent-project --production-branch <branch>\` (though we strongly recommend using Workers instead).]
+			Otherwise, if you are trying to create a new Pages project, start by running: \`wrangler pages project create\` (though we strongly recommend using Workers instead).]
 		`
 		);
 	});

--- a/packages/wrangler/src/__tests__/pages/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/pages/deploy.test.ts
@@ -123,6 +123,161 @@ describe("pages deploy", () => {
 		);
 	});
 
+	it("should error if the specified project does not exist in non-interactive mode", async ({
+		expect,
+	}) => {
+		mkdirSync("public");
+		writeFileSync("public/index.html", "hello");
+		msw.use(
+			http.get(
+				"*/accounts/:accountId/pages/projects/:projectName",
+				async ({ params }) => {
+					expect(params.accountId).toEqual("some-account-id");
+					expect(params.projectName).toEqual("non-existent-project");
+
+					return HttpResponse.json(
+						{
+							success: false,
+							errors: [
+								{
+									code: 8000007,
+									message:
+										"Project not found. The specified project name does not match any of your existing projects.",
+								},
+							],
+							result: null,
+						},
+						{ status: 404 }
+					);
+				},
+				{ once: true }
+			)
+		);
+
+		await expect(
+			runWrangler("pages deploy public --project-name non-existent-project")
+		).rejects.toThrowErrorMatchingInlineSnapshot(
+			`
+			[Error: The Pages project "non-existent-project" does not exist.
+			Maybe you intended to deploy a Worker project instead? Workers are the recommended way to deploy all new projects. If so, run \`wrangler deploy\`.
+
+			If you are targeting an existing Pages project, verify that the project name is correct and that it exists in your account (the account in use has id some-account-id).
+
+			Otherwise, if you are trying to create a new Pages project, start by running: \`wrangler pages project create non-existent-project --production-branch <branch>\` (though we strongly recommend using Workers instead).]
+		`
+		);
+	});
+
+	it("should include the account name in the error when it is available in cache", async ({
+		expect,
+	}) => {
+		mkdirSync("public");
+		writeFileSync("public/index.html", "hello");
+		saveToConfigCache("wrangler-account.json", {
+			account: { id: "some-account-id", name: "My Test Account" },
+		});
+		msw.use(
+			http.get(
+				"*/accounts/:accountId/pages/projects/:projectName",
+				async ({ params }) => {
+					expect(params.accountId).toEqual("some-account-id");
+					expect(params.projectName).toEqual("non-existent-project");
+
+					return HttpResponse.json(
+						{
+							success: false,
+							errors: [
+								{
+									code: 8000007,
+									message:
+										"Project not found. The specified project name does not match any of your existing projects.",
+								},
+							],
+							result: null,
+						},
+						{ status: 404 }
+					);
+				},
+				{ once: true }
+			)
+		);
+
+		await expect(
+			runWrangler("pages deploy public --project-name non-existent-project")
+		).rejects.toThrowErrorMatchingInlineSnapshot(
+			`
+			[Error: The Pages project "non-existent-project" does not exist.
+			Maybe you intended to deploy a Worker project instead? Workers are the recommended way to deploy all new projects. If so, run \`wrangler deploy\`.
+
+			If you are targeting an existing Pages project, verify that the project name is correct and that it exists in your account (the account in use is "My Test Account" with id some-account-id).
+
+			Otherwise, if you are trying to create a new Pages project, start by running: \`wrangler pages project create non-existent-project --production-branch <branch>\` (though we strongly recommend using Workers instead).]
+		`
+		);
+	});
+
+	it("should suggest `wrangler deploy` if a Workers config is detected when deploying to a non-existent Pages project", async ({
+		expect,
+	}) => {
+		mkdirSync("public");
+		writeFileSync("public/index.html", "hello");
+		writeWranglerConfig({ name: "my-worker" });
+		msw.use(
+			http.get(
+				"*/accounts/:accountId/pages/projects/:projectName",
+				async ({ params }) => {
+					expect(params.accountId).toEqual("some-account-id");
+					expect(params.projectName).toEqual("non-existent-project");
+
+					return HttpResponse.json(
+						{
+							success: false,
+							errors: [
+								{
+									code: 8000007,
+									message:
+										"Project not found. The specified project name does not match any of your existing projects.",
+								},
+							],
+							result: null,
+						},
+						{ status: 404 }
+					);
+				},
+				{ once: true }
+			)
+		);
+
+		let errorMessage = "";
+		try {
+			await runWrangler(
+				"pages deploy public --project-name non-existent-project"
+			);
+			expect.unreachable("Expected command to throw");
+		} catch (e) {
+			errorMessage = (e as Error).message;
+		}
+
+		expect(errorMessage).toContain(
+			'The Pages project "non-existent-project" does not exist.'
+		);
+		expect(errorMessage).toMatch(
+			/A configuration file was found at .+wrangler\.toml that does not appear to be for a Pages project/
+		);
+		expect(errorMessage).toContain(
+			"Did you mean to run `wrangler deploy` (to deploy a Worker) instead?"
+		);
+		expect(errorMessage).toContain(
+			"If you are targeting an existing Pages project"
+		);
+		expect(errorMessage).toContain(
+			"Otherwise, if you are trying to create a new Pages project"
+		);
+
+		// The error already mentions the config file, so the warning should not be emitted
+		expect(std.warn).not.toContain("We detected a configuration file");
+	});
+
 	it("should error if the [--config] command line arg was specififed", async ({
 		expect,
 	}) => {

--- a/packages/wrangler/src/pages/deploy.ts
+++ b/packages/wrangler/src/pages/deploy.ts
@@ -363,7 +363,7 @@ export const pagesDeployCommand = createCommand({
 				? `the account in use is "${accountName}" with id ${accountId}`
 				: `the account in use has id ${accountId}`;
 			message += `\n\nIf you are targeting an existing Pages project, verify that the project name is correct and that it exists in your account (${accountDescription}).`;
-			message += `\n\nOtherwise, if you are trying to create a new Pages project, start by running: \`wrangler pages project create ${projectName} --production-branch <branch>\``;
+			message += `\n\nOtherwise, if you are trying to create a new Pages project, start by running: \`wrangler pages project create\``;
 			message += ` (though we strongly recommend using Workers instead).`;
 
 			throw new UserError(message, {

--- a/packages/wrangler/src/pages/deploy.ts
+++ b/packages/wrangler/src/pages/deploy.ts
@@ -19,7 +19,7 @@ import { prompt, select } from "../dialogs";
 import { logger } from "../logger";
 import * as metrics from "../metrics";
 import { writeOutput } from "../output";
-import { requireAuth } from "../user";
+import { getAccountFromCache, requireAuth } from "../user";
 import { getCloudflareAccountIdFromEnv } from "../user/auth-variables";
 import { diagnoseStartupError } from "../utils/friendly-validator-errors";
 import {
@@ -163,22 +163,9 @@ export const pagesDeployCommand = createCommand({
 			}
 		}
 
-		/*
-		 * If we found a `wrangler.toml` config file that doesn't specify
-		 * `pages_build_output_dir`, we'll ignore the file, but inform users
-		 * that we did find one, just not valid for Pages.
-		 */
-		if (configPath && config === undefined) {
-			logger.warn(
-				`Pages now has ${configFileName(configPath)} support.\n` +
-					`We detected a configuration file at ${configPath} but it is missing the "pages_build_output_dir" field, required by Pages.\n` +
-					`If you would like to use this configuration file to deploy your project, please use "pages_build_output_dir" to specify the directory of static files to upload.\n` +
-					`Ignoring configuration file for now, and proceeding with project deploy.`
-			);
-		}
-
 		const directory = args.directory ?? config?.pages_build_output_dir;
 		if (!directory) {
+			maybeWarnAboutIgnoredConfigFile(configPath, config);
 			throw new FatalError(
 				`Must specify a directory of assets to deploy. Please specify the [<directory>] argument in the \`pages deploy\` command, or configure \`pages_build_output_dir\` in your ${configFileName(configPath)} file.`,
 				{ code: 1, telemetryMessage: "pages deploy missing directory" }
@@ -207,6 +194,7 @@ export const pagesDeployCommand = createCommand({
 			} catch (err) {
 				// code `8000007` corresponds to project not found
 				if ((err as { code: number }).code !== 8000007) {
+					maybeWarnAboutIgnoredConfigFile(configPath, config);
 					throw err;
 				} else {
 					isExistingProject = false;
@@ -280,6 +268,7 @@ export const pagesDeployCommand = createCommand({
 						projectName = await prompt("Enter the name of your new project:");
 
 						if (!projectName) {
+							maybeWarnAboutIgnoredConfigFile(configPath, config);
 							throw new UserError(
 								"Missing Pages project name. Use --project-name <name> or set the name in your Wrangler configuration file.",
 								{
@@ -328,6 +317,7 @@ export const pagesDeployCommand = createCommand({
 					});
 
 					if (!productionBranch) {
+						maybeWarnAboutIgnoredConfigFile(configPath, config);
 						throw new UserError(
 							"Missing production branch. Specify the production branch for your new Pages project when prompted, or re-run with the required information.",
 							{
@@ -360,12 +350,36 @@ export const pagesDeployCommand = createCommand({
 			}
 		}
 
+		if (projectName && !isExistingProject && !isInteractive) {
+			let message = `The Pages project "${projectName}" does not exist.`;
+			if (configPath && config === undefined) {
+				message += `\nA configuration file was found at ${configPath} that does not appear to be for a Pages project (missing "pages_build_output_dir"). Did you mean to run \`wrangler deploy\` (to deploy a Worker) instead?`;
+			} else {
+				message += `\nMaybe you intended to deploy a Worker project instead? Workers are the recommended way to deploy all new projects. If so, run \`wrangler deploy\`.`;
+			}
+
+			const accountName = getAccountFromCache()?.name;
+			const accountDescription = accountName
+				? `the account in use is "${accountName}" with id ${accountId}`
+				: `the account in use has id ${accountId}`;
+			message += `\n\nIf you are targeting an existing Pages project, verify that the project name is correct and that it exists in your account (${accountDescription}).`;
+			message += `\n\nOtherwise, if you are trying to create a new Pages project, start by running: \`wrangler pages project create ${projectName} --production-branch <branch>\``;
+			message += ` (though we strongly recommend using Workers instead).`;
+
+			throw new UserError(message, {
+				telemetryMessage: "pages deploy project not found non interactive",
+			});
+		}
+
 		if (!projectName) {
+			maybeWarnAboutIgnoredConfigFile(configPath, config);
 			throw new UserError(
 				"Missing Pages project name. Use --project-name <name> or set the name in your Wrangler configuration file.",
 				{ telemetryMessage: "pages deploy missing project name" }
 			);
 		}
+
+		maybeWarnAboutIgnoredConfigFile(configPath, config);
 
 		// We infer git info by default is not passed in
 		logger.debug("pages deploy: Detecting git repository information...");
@@ -609,4 +623,30 @@ function promptSelectExistingOrNewProject(
 	return select(message, {
 		choices: items.map((i) => ({ title: i.label, value: i.value })),
 	});
+}
+
+/**
+ * Logs a warning that a config file was found but is missing `pages_build_output_dir`,
+ * so it was ignored by `pages deploy`.
+ *
+ * The warning is only emitted when a config file exists at {@link configPath} but
+ * {@link config} is `undefined`, indicating the file was detected yet not parsed
+ * into a valid Pages configuration.
+ *
+ * @param configPath - The path to the detected config file, or `undefined` if none was found.
+ * @param config - The parsed configuration object, or `undefined` if the config file
+ *   was not usable (e.g. missing `pages_build_output_dir`).
+ */
+function maybeWarnAboutIgnoredConfigFile(
+	configPath: string | undefined,
+	config: Config | undefined
+) {
+	if (configPath && config === undefined) {
+		logger.warn(
+			`Pages now has ${configFileName(configPath)} support.\n` +
+				`We detected a configuration file at ${configPath} but it is missing the "pages_build_output_dir" field, required by Pages.\n` +
+				`If you would like to use this configuration file to deploy your project, please use "pages_build_output_dir" to specify the directory of static files to upload.\n` +
+				`Ignoring configuration file for now, and proceeding with project deploy.`
+		);
+	}
 }


### PR DESCRIPTION
Previously, running `wrangler pages deploy` with a `--project-name` that doesn't exist in a non-interactive context (e.g. CI, piped input) would fail with a generic "project not found" or "This command cannot be run in a non-interactive context" error. Now it provides a specific error message explaining that the project doesn't exist and suggests how to create it. The error also suggests using `wrangler deploy` to deploy a Worker instead.


Before:
<img width="1050" height="479" alt="Screenshot of error message before the changes (not too helpful)" src="https://github.com/user-attachments/assets/543ef86f-8aca-4bdb-8607-659487efb2e7" />

After:
<img width="957" height="415" alt="Screenshot of error message after the changes (helpful, suggest potential solutions and to use Workers)" src="https://github.com/user-attachments/assets/0f443fce-8116-4fa9-9c77-7bae098dd831" />


---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: better error message

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
