### PR TITLE
feat(wrangler): list durable object ids in test harness

### DIFF
--- a/.changeset/clever-donuts-jam.md
+++ b/.changeset/clever-donuts-jam.md
@@ -1,0 +1,8 @@
+---
+"miniflare": minor
+"@cloudflare/vitest-pool-workers": patch
+---
+
+Add `listDurableObjectIds()` to Miniflare
+
+Miniflare now exposes `listDurableObjectIds()` for listing persisted Durable Object instance IDs by binding name. The Vitest pool now uses this shared Miniflare API internally instead of duplicating Miniflare's storage listing logic.

--- a/.changeset/fuzzy-walls-cheer.md
+++ b/.changeset/fuzzy-walls-cheer.md
@@ -1,0 +1,7 @@
+---
+"wrangler": minor
+---
+
+Add `listDurableObjectIds()` to `createTestHarness` Worker handles
+
+Tests using `createTestHarness` can now list persisted Durable Object instance IDs for a Durable Object binding. This helps integration tests discover objects created by app behavior without adding test-only endpoints.

--- a/packages/miniflare/src/index.ts
+++ b/packages/miniflare/src/index.ts
@@ -37,6 +37,7 @@ import {
 	DURABLE_OBJECTS_PLUGIN_NAME,
 	FLAGSHIP_PLUGIN_NAME,
 	getDirectSocketName,
+	getDurableObjectUniqueKey,
 	getGlobalServices,
 	getPersistPath,
 	HELLO_WORLD_PLUGIN_NAME,
@@ -3099,6 +3100,80 @@ export class Miniflare {
 		workerName?: string
 	): Promise<ReplaceWorkersTypes<DurableObjectNamespace>> {
 		return this.#getProxy(DURABLE_OBJECTS_PLUGIN_NAME, bindingName, workerName);
+	}
+	async listDurableObjectIds(
+		bindingName: string,
+		workerName?: string
+	): Promise<string[]> {
+		this.#checkDisposed();
+		await this.ready;
+
+		const workerIndex = this.#findAndAssertWorkerIndex(workerName);
+		const workerOpts = this.#workerOpts[workerIndex];
+		const resolvedWorkerName = workerOpts.core.name ?? "";
+		const durableObject = workerOpts.do.durableObjects?.[bindingName];
+
+		if (durableObject === undefined) {
+			const friendlyWorkerName = resolvedWorkerName
+				? `${JSON.stringify(resolvedWorkerName)} worker`
+				: "the worker";
+			throw new TypeError(
+				`No Durable Object namespace binding named ${JSON.stringify(bindingName)} found in ${friendlyWorkerName}.`
+			);
+		}
+
+		const { className, scriptName } = normaliseDurableObject(durableObject);
+		const serviceName = getUserServiceName(scriptName ?? resolvedWorkerName);
+		const classConfig = getDurableObjectClassNames(this.#workerOpts)
+			.get(serviceName)
+			?.get(className);
+		const unsafeUniqueKey = classConfig?.unsafeUniqueKey;
+
+		const namespaceKey = getDurableObjectUniqueKey(
+			className,
+			scriptName ?? resolvedWorkerName,
+			unsafeUniqueKey
+		);
+
+		if (namespaceKey === undefined) {
+			throw new TypeError(
+				`Cannot list Durable Object ids for ${JSON.stringify(bindingName)} because the namespace uses ephemeral local storage.`
+			);
+		}
+
+		const durableObjectsPersistPath = getPersistPath(
+			DURABLE_OBJECTS_PLUGIN_NAME,
+			this.#tmpPath,
+			this.#sharedOpts.core.defaultPersistRoot,
+			this.#sharedOpts.do.durableObjectsPersist
+		);
+
+		try {
+			const entries = await fs.promises.readdir(
+				path.join(durableObjectsPersistPath, namespaceKey),
+				{ withFileTypes: true }
+			);
+
+			const ids: string[] = [];
+			for (const entry of entries) {
+				const objectId = path.basename(entry.name, ".sqlite");
+				if (
+					entry.isFile() &&
+					path.extname(entry.name) === ".sqlite" &&
+					objectId !== "metadata"
+				) {
+					ids.push(objectId);
+				}
+			}
+
+			return ids.sort();
+		} catch (error) {
+			if (isFileNotFoundError(error)) {
+				return [];
+			}
+
+			throw error;
+		}
 	}
 	getKVNamespace(
 		bindingName: string,

--- a/packages/miniflare/src/plugins/core/index.ts
+++ b/packages/miniflare/src/plugins/core/index.ts
@@ -25,12 +25,14 @@ import { JsonSchema, Log, MiniflareCoreError, PathSchema } from "../../shared";
 import { CoreBindings, CoreHeaders, viewToBuffer } from "../../workers";
 import { RPC_PROXY_SERVICE_NAME } from "../assets/constants";
 import { getCacheServiceName } from "../cache";
-import { DURABLE_OBJECTS_STORAGE_SERVICE_NAME } from "../do";
+import {
+	DURABLE_OBJECTS_STORAGE_SERVICE_NAME,
+	getDurableObjectUniqueKey,
+} from "../do";
 import { IMAGES_PLUGIN_NAME } from "../images";
 import { getR2PublicService, R2_PUBLIC_SERVICE_NAME } from "../r2";
 import {
 	getUserBindingServiceName,
-	kUnsafeEphemeralUniqueKey,
 	parseRoutes,
 	ProxyNodeBinding,
 	remoteProxyClientWorker,
@@ -866,8 +868,14 @@ export const CORE_PLUGIN: Plugin<
 									unsafePreventEviction: preventEviction,
 									container,
 								},
-							]) =>
-								unsafeUniqueKey === kUnsafeEphemeralUniqueKey
+							]) => {
+								const uniqueKey = getDurableObjectUniqueKey(
+									className,
+									options.name,
+									unsafeUniqueKey
+								);
+
+								return uniqueKey === undefined
 									? {
 											className,
 											enableSql,
@@ -878,14 +886,11 @@ export const CORE_PLUGIN: Plugin<
 									: {
 											className,
 											enableSql,
-											// This `uniqueKey` will (among other things) be used as part of the
-											// path when persisting to the file-system. `-` is invalid in
-											// JavaScript class names, but safe on filesystems (incl. Windows).
-											uniqueKey:
-												unsafeUniqueKey ?? `${options.name ?? ""}-${className}`,
+											uniqueKey,
 											preventEviction,
 											container,
-										}
+										};
+							}
 						),
 					durableObjectStorage:
 						classNamesEntries.length === 0

--- a/packages/miniflare/src/plugins/do/index.ts
+++ b/packages/miniflare/src/plugins/do/index.ts
@@ -91,6 +91,18 @@ export function normaliseDurableObject(
 	};
 }
 
+export function getDurableObjectUniqueKey(
+	className: string,
+	workerName: string | undefined,
+	unsafeUniqueKey: UnsafeUniqueKey | undefined
+): string | undefined {
+	if (unsafeUniqueKey === kUnsafeEphemeralUniqueKey) {
+		return undefined;
+	}
+
+	return unsafeUniqueKey ?? `${workerName ?? ""}-${className}`;
+}
+
 export const DURABLE_OBJECTS_PLUGIN_NAME = "do";
 
 export const DURABLE_OBJECTS_STORAGE_SERVICE_NAME = `${DURABLE_OBJECTS_PLUGIN_NAME}:storage`;

--- a/packages/miniflare/test/plugins/do/index.spec.ts
+++ b/packages/miniflare/test/plugins/do/index.spec.ts
@@ -149,6 +149,33 @@ test("persists Durable Object data on file-system", async ({ expect }) => {
 	expect(await res.text()).toBe("2");
 });
 
+test("lists Durable Object ids with persisted storage", async ({ expect }) => {
+	const tmp = await useTmp();
+	const mf = new Miniflare({
+		defaultPersistRoot: tmp,
+		name: "worker",
+		modules: true,
+		script: COUNTER_SCRIPT(),
+		durableObjects: { COUNTER: "Counter" },
+	});
+	useDispose(mf);
+
+	const namespace = await mf.getDurableObjectNamespace("COUNTER");
+	const firstId = namespace.idFromName("/first").toString();
+	const secondId = namespace.idFromName("/second").toString();
+
+	await expect(mf.listDurableObjectIds("COUNTER")).resolves.toEqual([]);
+
+	let res = await mf.dispatchFetch("http://localhost/first");
+	expect(await res.text()).toBe("1");
+	res = await mf.dispatchFetch("http://localhost/second");
+	expect(await res.text()).toBe("1");
+
+	await expect(mf.listDurableObjectIds("COUNTER")).resolves.toEqual(
+		[firstId, secondId].sort()
+	);
+});
+
 test("multiple Workers access same Durable Object data", async ({ expect }) => {
 	const tmp = await useTmp();
 	const mf = new Miniflare({
@@ -493,6 +520,10 @@ test("colo-local actors", async ({ expect }) => {
 	const stub = ns.get("thing2");
 	res = await stub.fetch("http://localhost");
 	expect(await res.text()).toBe("body:thing2");
+
+	await expect(mf.listDurableObjectIds("OBJECT")).rejects.toThrow(
+		`Cannot list Durable Object ids for "OBJECT" because the namespace uses ephemeral local storage.`
+	);
 });
 
 test("multiple workers with DO conflicting useSQLite booleans cause options error", async ({

--- a/packages/vitest-pool-workers/src/pool/loopback.ts
+++ b/packages/vitest-pool-workers/src/pool/loopback.ts
@@ -1,4 +1,3 @@
-import assert from "node:assert";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { Response } from "miniflare";
@@ -60,35 +59,14 @@ export async function listDurableObjectIds(
 	if (request.method !== "GET") {
 		return new Response(null, { status: 405 });
 	}
-	const persistPaths = mf.unsafeGetPersistPaths();
-	const durableObjectPersistPath = persistPaths.get("do");
-	assert(
-		durableObjectPersistPath !== undefined,
-		"Expected Durable Object persist path"
-	);
 
-	const uniqueKey = url.searchParams.get("unique_key");
-	if (uniqueKey === null) {
+	const bindingName = url.searchParams.get("binding_name");
+	if (bindingName === null) {
 		return new Response(null, { status: 400 });
 	}
-	const namespacePath = path.join(durableObjectPersistPath, uniqueKey);
 
-	const ids: string[] = [];
-	try {
-		const names = await fs.readdir(namespacePath);
-		for (const name of names) {
-			// Exclude metadata.sqlite, added by newer workerd versions for
-			// per-namespace metadata. Only include files whose stem is a
-			// valid 64-hex-digit Durable Object ID.
-			if (name.endsWith(".sqlite") && name !== "metadata.sqlite") {
-				ids.push(name.substring(0, name.length - 7 /* ".sqlite".length */));
-			}
-		}
-	} catch (e) {
-		if (!isFileNotFoundError(e)) {
-			throw e;
-		}
-	}
+	const workerName = url.searchParams.get("worker_name") ?? undefined;
+	const ids = await mf.listDurableObjectIds(bindingName, workerName);
 	return Response.json(ids);
 }
 

--- a/packages/vitest-pool-workers/src/worker/durable-objects.ts
+++ b/packages/vitest-pool-workers/src/worker/durable-objects.ts
@@ -256,27 +256,20 @@ export async function listDurableObjectIds(
 	// namespace to the test runner worker, since `DurableObjectNamespace` has no
 	// user-accessible constructor. This means `namespace` must be in `globalEnv`.
 	// We can use this to find the bound name for this binding. We inject a
-	// mapping between bound names and unique keys for namespaces. We then use
-	// this to get a unique key and find all IDs on disk.
+	// mapping between bound names and Durable Object designators. We pass the
+	// bound name to Miniflare's Node-side loopback to find all IDs on disk.
 	const boundName = Object.entries(env).find(
 		(entry) => namespace === entry[1]
 	)?.[0];
 	assert(boundName !== undefined, "Expected to find bound name for namespace");
 
 	const options = getSerializedOptions();
-	const designator = options.durableObjectBindingDesignators?.get(boundName);
-	assert(designator !== undefined, "Expected to find designator for namespace");
-
-	let uniqueKey = designator.unsafeUniqueKey;
-	if (uniqueKey === undefined) {
-		const scriptName = designator.scriptName ?? options.selfName;
-		const className = designator.className;
-		uniqueKey = `${scriptName}-${className}`;
+	const searchParams = new URLSearchParams({ binding_name: boundName });
+	if (options.selfName !== undefined) {
+		searchParams.set("worker_name", options.selfName);
 	}
 
-	const url = `http://placeholder/durable-objects?unique_key=${encodeURIComponent(
-		uniqueKey
-	)}`;
+	const url = `http://placeholder/durable-objects?${searchParams.toString()}`;
 	const res = await env.__VITEST_POOL_WORKERS_LOOPBACK_SERVICE.fetch(url);
 	assert.strictEqual(res.status, 200);
 	const ids = await res.json();

--- a/packages/wrangler/e2e/createTestHarness.test.ts
+++ b/packages/wrangler/e2e/createTestHarness.test.ts
@@ -22,7 +22,7 @@ import type {
 	DurableObjectNamespace,
 	KVNamespace,
 	R2Bucket,
-} from "@cloudflare/workers-types/experimental";
+} from "@cloudflare/workers-types";
 
 const { createTestHarness } = await importWrangler();
 

--- a/packages/wrangler/e2e/createTestHarness.test.ts
+++ b/packages/wrangler/e2e/createTestHarness.test.ts
@@ -1599,6 +1599,76 @@ describe("createTestHarness", () => {
 		`);
 	});
 
+	it("lists Durable Object ids", async ({ expect }) => {
+		await helper.seed({
+			"wrangler.jsonc": dedent`
+				{
+					"name": "durable-object-list-worker",
+					"main": "src/index.ts",
+					"compatibility_date": "2026-05-20",
+					"durable_objects": {
+						"bindings": [
+							{ "name": "COUNTER", "class_name": "Counter" }
+						]
+					},
+					"migrations": [
+						{ "tag": "v1", "new_sqlite_classes": ["Counter"] }
+					]
+				}
+			`,
+			"src/index.ts": dedent`
+				export class Counter {
+					constructor(ctx) {
+						this.ctx = ctx;
+					}
+
+					async fetch() {
+						await this.ctx.storage.put("count", 1);
+						return new Response("stored");
+					}
+				}
+
+				export default {
+					fetch(request, env) {
+						const name = new URL(request.url).searchParams.get("name") ?? "default";
+						const id = env.COUNTER.idFromName(name);
+						return env.COUNTER.get(id).fetch("https://counter.example");
+					}
+				};
+			`,
+		});
+
+		const server = createTestHarness({
+			root: helper.tmpPath,
+			workers: [{ configPath: "./wrangler.jsonc" }],
+		});
+		onTestFinished(server.close);
+
+		await server.listen();
+
+		const worker = server.getWorker<{
+			COUNTER: DurableObjectNamespace;
+		}>();
+		const env = await worker.getEnv();
+		const firstId = env.COUNTER.idFromName("first").toString();
+		const secondId = env.COUNTER.idFromName("second").toString();
+
+		await expect(worker.listDurableObjectIds("COUNTER")).resolves.toEqual([]);
+
+		await expect(server.fetch("/?name=first")).resolves.toHaveProperty(
+			"status",
+			200
+		);
+		await expect(server.fetch("/?name=second")).resolves.toHaveProperty(
+			"status",
+			200
+		);
+
+		await expect(worker.listDurableObjectIds("COUNTER")).resolves.toEqual(
+			[firstId, secondId].sort()
+		);
+	});
+
 	it("does not reload on source changes by default", async ({ expect }) => {
 		await helper.seed({
 			"wrangler.jsonc": dedent`

--- a/packages/wrangler/src/api/test-harness.ts
+++ b/packages/wrangler/src/api/test-harness.ts
@@ -32,6 +32,7 @@ import type { ErrorEvent } from "./startDevWorker/events";
 import type { WranglerStartDevWorkerInput } from "./startDevWorker/types";
 import type {
 	D1Database,
+	DurableObjectNamespace,
 	ExportedHandler,
 	Rpc,
 	Service,
@@ -137,6 +138,12 @@ export type WorkerHandle<
 	 * ```
 	 */
 	getEnv(): Promise<Env>;
+	/**
+	 * Lists the string IDs of Durable Object instances with persisted storage for a binding.
+	 */
+	listDurableObjectIds(
+		bindingName: BindingName<Env, DurableObjectNamespace>
+	): Promise<string[]>;
 	/**
 	 * Applies D1 migration files that have not already run to a D1 binding on this Worker.
 	 *
@@ -694,6 +701,19 @@ export function createTestHarness(options?: TestHarnessOptions): TestHarness {
 		return miniflare;
 	}
 
+	function getWorkerDevEnv(session: ServerSession, workerName: string) {
+		const devEnv = session.devEnvs.find(
+			(d) => d.config.latestConfig?.name === workerName
+		);
+
+		assert(
+			devEnv,
+			`Worker ${JSON.stringify(workerName)} config is not available.`
+		);
+
+		return devEnv;
+	}
+
 	function getInputUrl(input: RequestInfo) {
 		if (typeof input === "string") {
 			return input;
@@ -778,11 +798,8 @@ export function createTestHarness(options?: TestHarnessOptions): TestHarness {
 				const session = await resolveSession();
 				const miniflare = await getRuntimeMiniflare(session);
 				const workerName = resolveWorkerName(session, name);
-				const devEnv = session.devEnvs.find(
-					(d) => d.config.latestConfig?.name === workerName
-				);
-				const bindingConfig =
-					devEnv?.config.latestConfig?.bindings?.[bindingName];
+				const bindingConfig = getWorkerDevEnv(session, workerName).config
+					.latestConfig?.bindings?.[bindingName];
 
 				if (bindingConfig?.type !== "workflow") {
 					throw new TypeError(
@@ -853,13 +870,37 @@ export function createTestHarness(options?: TestHarnessOptions): TestHarness {
 
 					return result as FetcherScheduledResult;
 				},
+				async listDurableObjectIds(bindingName) {
+					const session = await resolveSession();
+					const miniflare = await getRuntimeMiniflare(session);
+					const workerName = resolveWorkerName(session, name);
+
+					debugLog(`durable object ids - ${bindingName} - started`, workerName);
+
+					try {
+						const ids = await miniflare.listDurableObjectIds(
+							bindingName,
+							workerName
+						);
+						debugLog(
+							`durable object ids - ${bindingName} - completed (${ids.length} found)`,
+							workerName
+						);
+						return ids;
+					} catch (error) {
+						debugLog(
+							`durable object ids - ${bindingName} - failed`,
+							workerName
+						);
+						throw error;
+					}
+				},
 				async applyD1Migrations(bindingName) {
 					const session = await resolveSession();
 					const miniflare = await getRuntimeMiniflare(session);
 					const workerName = resolveWorkerName(session, name);
-					const workerConfig = session.devEnvs.find(
-						(devEnv) => devEnv.config.latestConfig?.name === workerName
-					)?.config.latestWranglerConfig;
+					const workerConfig = getWorkerDevEnv(session, workerName).config
+						.latestWranglerConfig;
 
 					assert(
 						workerConfig,


### PR DESCRIPTION
Fixes n/a

Adds a Durable Object ID listing helper for local test harnesses.

`Miniflare.listDurableObjectIds(bindingName, workerName?)` now owns the storage lookup for persisted Durable Object instance IDs. `createTestHarness` exposes this through `worker.listDurableObjectIds(bindingName)`, so integration tests can discover DOs created by app behavior without adding test-only routes.

The Vitest pool now delegates its existing `listDurableObjectIds()` implementation to the new Miniflare API instead of duplicating the persistence directory lookup.

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: it will be included with the rest of the test harness docs

*A picture of a cute animal (not mandatory, but encouraged)*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14489" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->