### PR TITLE
Enable `@typescript-eslint/no-deprecated` linting rule for `workers-utils` package

### DIFF
--- a/.oxlintrc.jsonc
+++ b/.oxlintrc.jsonc
@@ -211,7 +211,6 @@
 				"packages/miniflare/**",
 				"packages/vite-plugin-cloudflare/**",
 				"packages/vitest-pool-workers/**",
-				"packages/workers-utils/**",
 				"packages/workflows-shared/**",
 				"packages/wrangler/**",
 			],

--- a/packages/workers-utils/src/cloudflared.ts
+++ b/packages/workers-utils/src/cloudflared.ts
@@ -26,7 +26,7 @@ import { fetch } from "undici";
 import { getCloudflaredPathFromEnv } from "./environment-variables/misc-variables";
 import { UserError } from "./errors";
 import { removeDirSync } from "./fs-helpers";
-import { getGlobalWranglerConfigPath } from "./global-wrangler-config-path";
+import { getGlobalConfigPath } from "./global-wrangler-config-path";
 import type { Logger } from "./logger";
 import type { ChildProcess } from "node:child_process";
 
@@ -248,7 +248,7 @@ async function getLatestVersionInfo(options?: {
  * Uses the resolved version so the cache is per-version.
  */
 function getCacheDir(version: string): string {
-	return join(getGlobalWranglerConfigPath(), "cloudflared", version);
+	return join(getGlobalConfigPath(), "cloudflared", version);
 }
 
 /**
@@ -299,7 +299,7 @@ function validateBinary(
 			errorMessage += `  - For Debian/Ubuntu: sudo apt-get install libc6\n`;
 		}
 
-		const cacheDir = join(getGlobalWranglerConfigPath(), "cloudflared");
+		const cacheDir = join(getGlobalConfigPath(), "cloudflared");
 		errorMessage += `\nYou can try:\n`;
 		errorMessage += `  1. Deleting the cache directory: rm -rf ${cacheDir}\n`;
 		errorMessage += `  2. Running the command again to re-download\n`;
@@ -726,7 +726,7 @@ export async function spawnCloudflared(
 export function removeCloudflaredCache(version?: string): string | null {
 	const cacheDir = version
 		? getCacheDir(version)
-		: join(getGlobalWranglerConfigPath(), "cloudflared");
+		: join(getGlobalConfigPath(), "cloudflared");
 	if (existsSync(cacheDir)) {
 		removeDirSync(cacheDir);
 		return cacheDir;

--- a/packages/workers-utils/src/config/validation.ts
+++ b/packages/workers-utils/src/config/validation.ts
@@ -839,7 +839,7 @@ function normalizeAndValidateSite(
 		validateTypedArray(diagnostics, "sites.include", include, "string");
 		validateTypedArray(diagnostics, "sites.exclude", exclude, "string");
 
-		// eslint-disable-next-line typescript-eslint/no-deprecated -- this code handles the deprecated site.entry-point field
+		// eslint-disable-next-line @typescript-eslint/no-deprecated -- this code handles the deprecated site.entry-point field
 		const legacySiteEntryPoint = rawConfig.site["entry-point"];
 
 		validateOptionalProperty(

--- a/packages/workers-utils/src/config/validation.ts
+++ b/packages/workers-utils/src/config/validation.ts
@@ -841,11 +841,15 @@ function normalizeAndValidateSite(
 		validateRequiredProperty(diagnostics, "site", "bucket", bucket, "string");
 		validateTypedArray(diagnostics, "sites.include", include, "string");
 		validateTypedArray(diagnostics, "sites.exclude", exclude, "string");
+
+		// eslint-disable-next-line typescript-eslint/no-deprecated -- this code handles the deprecated site.entry-point field
+		const legacySiteEntryPoint = rawConfig.site["entry-point"];
+
 		validateOptionalProperty(
 			diagnostics,
 			"site",
 			"entry-point",
-			rawConfig.site["entry-point"],
+			legacySiteEntryPoint,
 			"string"
 		);
 
@@ -856,8 +860,8 @@ function normalizeAndValidateSite(
 			`Delete the \`site.entry-point\` field, then add the top level \`main\` field to your configuration file:\n` +
 				`\`\`\`\n` +
 				`main = "${path.join(
-					String(rawConfig.site["entry-point"]) || "workers-site",
-					path.extname(String(rawConfig.site["entry-point"]) || "workers-site")
+					String(legacySiteEntryPoint) || "workers-site",
+					path.extname(String(legacySiteEntryPoint) || "workers-site")
 						? ""
 						: "index.js"
 				)}"\n` +
@@ -867,7 +871,7 @@ function normalizeAndValidateSite(
 			"warning"
 		);
 
-		let siteEntryPoint = rawConfig.site["entry-point"];
+		let siteEntryPoint = legacySiteEntryPoint;
 
 		if (!mainEntryPoint && !siteEntryPoint) {
 			// this means that we're defaulting to "workers-site"
@@ -4458,6 +4462,7 @@ const validateBindingsHaveUniqueNames = (
 ): boolean => {
 	let hasDuplicates = false;
 
+	// eslint-disable-next-line typescript-eslint/no-deprecated -- intentional use of friendlyBindingNames to iterate over the various binding types
 	const bindingNamesArray = Object.entries(friendlyBindingNames) as [
 		ConfigBindingFieldName,
 		string,

--- a/packages/workers-utils/src/config/validation.ts
+++ b/packages/workers-utils/src/config/validation.ts
@@ -114,9 +114,6 @@ export type ConfigBindingFieldName =
 	| "vpc_services"
 	| "vpc_networks";
 
-/**
- * @deprecated new code should use getBindingTypeFriendlyName() instead
- */
 export const friendlyBindingNames: Record<ConfigBindingFieldName, string> = {
 	data_blobs: "Data Blob",
 	durable_objects: "Durable Object",
@@ -4462,7 +4459,6 @@ const validateBindingsHaveUniqueNames = (
 ): boolean => {
 	let hasDuplicates = false;
 
-	// eslint-disable-next-line typescript-eslint/no-deprecated -- intentional use of friendlyBindingNames to iterate over the various binding types
 	const bindingNamesArray = Object.entries(friendlyBindingNames) as [
 		ConfigBindingFieldName,
 		string,

--- a/packages/workers-utils/src/environment-variables/misc-variables.ts
+++ b/packages/workers-utils/src/environment-variables/misc-variables.ts
@@ -1,7 +1,7 @@
 import path from "node:path";
 import { dedent } from "ts-dedent";
 import { UserError } from "../errors";
-import { getGlobalWranglerConfigPath } from "../global-wrangler-config-path";
+import { getGlobalConfigPath } from "../global-wrangler-config-path";
 import {
 	getBooleanEnvironmentVariableFactory,
 	getEnvironmentVariableFactory,
@@ -261,7 +261,7 @@ export const getBuildPlatformFromEnv = getEnvironmentVariableFactory({
 export const getRegistryPath = getEnvironmentVariableFactory({
 	variableName: "WRANGLER_REGISTRY_PATH",
 	defaultValue() {
-		return path.join(getGlobalWranglerConfigPath(), "registry");
+		return path.join(getGlobalConfigPath(), "registry");
 	},
 });
 

--- a/packages/workers-utils/src/index.ts
+++ b/packages/workers-utils/src/index.ts
@@ -51,8 +51,14 @@ export {
 	isValidR2BucketName,
 	bucketFormatMessage,
 } from "./config/validation";
-// eslint-disable-next-line typescript-eslint/no-deprecated -- re-exporting deprecated symbol for backward compatibility
-export { friendlyBindingNames } from "./config/validation";
+
+import * as validation from "./config/validation";
+
+/**
+ * @deprecated new code should use getBindingTypeFriendlyName() instead
+ */
+export const friendlyBindingNames = validation.friendlyBindingNames;
+
 export {
 	type BindingLocalSupport,
 	getBindingLocalSupport,

--- a/packages/workers-utils/src/index.ts
+++ b/packages/workers-utils/src/index.ts
@@ -96,7 +96,7 @@ export {
 export * from "./environment-variables/misc-variables";
 
 export { getGlobalConfigPath } from "./global-wrangler-config-path";
-// eslint-disable-next-line typescript-eslint/no-deprecated -- re-exporting deprecated symbol for backward compatibility
+// eslint-disable-next-line @typescript-eslint/no-deprecated -- re-exporting deprecated symbol for backward compatibility
 export { getGlobalWranglerConfigPath } from "./global-wrangler-config-path";
 export type { GetGlobalConfigPathOptions } from "./global-wrangler-config-path";
 

--- a/packages/workers-utils/src/index.ts
+++ b/packages/workers-utils/src/index.ts
@@ -43,7 +43,6 @@ export {
 	parseByteSize,
 } from "./parse";
 export {
-	friendlyBindingNames,
 	getBindingTypeFriendlyName,
 	isPagesConfig,
 	normalizeAndValidateConfig,
@@ -52,6 +51,8 @@ export {
 	isValidR2BucketName,
 	bucketFormatMessage,
 } from "./config/validation";
+// eslint-disable-next-line typescript-eslint/no-deprecated -- re-exporting deprecated symbol for backward compatibility
+export { friendlyBindingNames } from "./config/validation";
 export {
 	type BindingLocalSupport,
 	getBindingLocalSupport,
@@ -88,10 +89,9 @@ export {
 
 export * from "./environment-variables/misc-variables";
 
-export {
-	getGlobalConfigPath,
-	getGlobalWranglerConfigPath,
-} from "./global-wrangler-config-path";
+export { getGlobalConfigPath } from "./global-wrangler-config-path";
+// eslint-disable-next-line typescript-eslint/no-deprecated -- re-exporting deprecated symbol for backward compatibility
+export { getGlobalWranglerConfigPath } from "./global-wrangler-config-path";
 export type { GetGlobalConfigPathOptions } from "./global-wrangler-config-path";
 
 export { isCompatDate, getTodaysCompatDate } from "./compatibility-date";

--- a/packages/workers-utils/tests/cloudflared.test.ts
+++ b/packages/workers-utils/tests/cloudflared.test.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
-import { getGlobalWranglerConfigPath } from "@cloudflare/workers-utils";
+import { getGlobalConfigPath } from "@cloudflare/workers-utils";
 import { describe, it, vi } from "vitest";
 import {
 	getAssetFilename,
@@ -20,7 +20,7 @@ describe("cloudflared binary management", () => {
 			const version = "2026.1.0";
 			const binPath = getCloudflaredBinPath(version);
 			const expectedDir = path.join(
-				getGlobalWranglerConfigPath(),
+				getGlobalConfigPath(),
 				"cloudflared",
 				version
 			);


### PR DESCRIPTION
This PR enabled the `@typescript-eslint/no-deprecated` linting rule for `workers-utils` package

Followup for https://github.com/cloudflare/workers-sdk/pull/14472

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: internal refactoring

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14491" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->