### PR TITLE
[mock-npm-registry] Exempt first-party packages from the release-age cooldown in e2e installs

### DIFF
--- a/packages/mock-npm-registry/src/index.ts
+++ b/packages/mock-npm-registry/src/index.ts
@@ -59,6 +59,46 @@ export async function startMockNpmRegistry(...targetPackages: string[]) {
 	`
 	);
 
+	// pnpm reads array settings such as `minimumReleaseAgeExclude` only from a
+	// config *file* (never from an env var), and the file differs by pnpm major:
+	// pnpm 10 reads the global `<configDir>/rc` (npmrc/INI), while pnpm 11 reads
+	// the global `<configDir>/config.yaml`. `<configDir>` resolves to
+	// `$XDG_CONFIG_HOME/pnpm` on all platforms when XDG_CONFIG_HOME is set, so we
+	// write both files into an isolated config dir and point pnpm at it below.
+	// Freshly-published first-party packages carry a "now" timestamp, so the
+	// inherited `minimumReleaseAge` cooldown (leaked from the workspace via the
+	// `npm_config_minimum_release_age` env var) would otherwise reject them.
+	// Excluding them by name installs their local versions while the cooldown
+	// still applies to third-party deps pulled via the npm uplink.
+	const configHome = path.join(registryPath, "config");
+	const pnpmConfigDir = path.join(configHome, "pnpm");
+	await fs.mkdir(pnpmConfigDir, { recursive: true });
+	const minimumReleaseAgeExclude = [
+		...pkgs.keys(),
+		// workerd and @cloudflare/workers-types are pulled in transitively (e.g.
+		// via miniflare) and may have been bumped same-day. Keep this list in sync
+		// with `minimumReleaseAgeExclude` in the root pnpm-workspace.yaml.
+		"workerd",
+		"@cloudflare/workerd-*",
+		"@cloudflare/workers-types",
+	];
+	// pnpm 10 reads this from the npmrc/INI-format global `rc` file.
+	await writeFile(
+		path.join(pnpmConfigDir, "rc"),
+		minimumReleaseAgeExclude
+			.map((name) => `minimum-release-age-exclude[]=${name}`)
+			.join("\n") + "\n"
+	);
+	// pnpm 11 reads this from the YAML global `config.yaml` file. Quote the
+	// scalars so leading `@` / `*` aren't misparsed by the YAML loader.
+	await writeFile(
+		path.join(pnpmConfigDir, "config.yaml"),
+		[
+			"minimumReleaseAgeExclude:",
+			...minimumReleaseAgeExclude.map((name) => `  - "${name}"`),
+		].join("\n") + "\n"
+	);
+
 	if (debugLog.enabled) {
 		debugLog("Original");
 		debugLog(execSync("pnpm config list", { encoding: "utf8" }));
@@ -76,23 +116,15 @@ export async function startMockNpmRegistry(...targetPackages: string[]) {
 		"npm_config_registry",
 		`http://localhost:${registryPort}`
 	);
-	// `pnpm run` exports `npm_config_minimum_release_age` from the workspace
-	// pnpm-workspace.yaml to subprocess env vars, but does NOT export the
-	// matching `minimumReleaseAgeExclude` array. Tests using this mock registry
-	// install freshly-published first-party packages, so the 24h cooldown would
-	// reject them. Set the exclude list as a comma-separated env var so the
-	// constraint still applies to other (third-party) deps pulled via uplinks.
-	const revert_npm_config_minimum_release_age_exclude = overrideProcessEnv(
-		"npm_config_minimum_release_age_exclude",
-		[
-			...pkgs.keys(),
-			// workerd and @cloudflare/workers-types are pulled in transitively
-			// (e.g. via miniflare) and may have been bumped same-day. Keep this
-			// list in sync with `minimumReleaseAgeExclude` in pnpm-workspace.yaml.
-			"workerd",
-			"@cloudflare/workerd-*",
-			"@cloudflare/workers-types",
-		].join(",")
+	// Point pnpm at the isolated config dir written above so its
+	// `minimumReleaseAgeExclude` list is honored. The scalar
+	// `npm_config_minimum_release_age` inherited from the parent `pnpm run`
+	// still applies to third-party deps; the two settings merge because they are
+	// different keys. (An array cannot be passed via a single env var, and pnpm
+	// only reads this setting from config files — hence the redirect.)
+	const revert_XDG_CONFIG_HOME = overrideProcessEnv(
+		"XDG_CONFIG_HOME",
+		configHome
 	);
 
 	if (debugLog.enabled) {
@@ -123,7 +155,7 @@ export async function startMockNpmRegistry(...targetPackages: string[]) {
 		revert_NPM_CONFIG_USERCONFIG();
 		revert_npm_config_registry();
 		revert_npm_config_userconfig();
-		revert_npm_config_minimum_release_age_exclude();
+		revert_XDG_CONFIG_HOME();
 		if (debugLog.enabled) {
 			debugLog("After");
 			debugLog(execSync("pnpm config list", { encoding: "utf8" }));


### PR DESCRIPTION
Makes the e2e suites that use `@cloudflare/mock-npm-registry` actually install the **locally-built** first-party packages (wrangler, miniflare, etc.) instead of the published ones.

#### Background

The root `pnpm-workspace.yaml` sets `minimumReleaseAge: 1440` (a 24h supply-chain cooldown). When the e2e suites run via `pnpm run`, pnpm exports that setting to subprocess installs as the `npm_config_minimum_release_age` env var — but it does **not** export the matching `minimumReleaseAgeExclude` array (pnpm's script-env builder skips array-valued settings). The mock registry tried to compensate by setting a comma-joined `npm_config_minimum_release_age_exclude` env var, but pnpm never parses an array from a single env var (it lands as one bogus string and is matched character-by-character), so it was **inert**.

Net effect since the cooldown was introduced (#13998): the freshly-published local packages (age ≈ 0) were rejected by the cooldown, and `create-cloudflare`, `vitest-pool-workers`, and `vite-plugin-cloudflare` e2e all silently installed the **published** wrangler/miniflare rather than the local build under test.

#### Fix

`minimumReleaseAgeExclude` is only read from a config **file**, and the file differs by pnpm major (pnpm 10 → npmrc-format `rc`; pnpm 11 → `config.yaml`). Both live under `$XDG_CONFIG_HOME/pnpm` on all platforms. The mock registry now writes the exclude list (the first-party packages it publishes, plus the same-day transitive `workerd` / `@cloudflare/workers-types`) as a real array into both files in an isolated temp dir and points pnpm at it via `XDG_CONFIG_HOME`. The inherited scalar `npm_config_minimum_release_age` still applies to third-party deps pulled via the npm uplink, so the cooldown is preserved for them.

Verified the exclude array is parsed correctly by both pnpm 10.33 and pnpm 11.5.1.

This also unblocks a follow-up to drop `sharp` from create-cloudflare's `APPROVED_BUILDS` (see #14493): once the C3 e2e installs the local miniflare, the sharp-0.35 build-script change can be validated.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: this is e2e test-harness infrastructure (private package, no unit tests). Its behavior is directly exercised by the three e2e suites that consume it (create-cloudflare, vitest-pool-workers, vite-plugin-cloudflare), and I verified the `minimumReleaseAgeExclude` array is parsed from the written config files by both pnpm 10.33 and 11.5.1.
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: internal e2e test-harness change with no user-facing behavior.

*A picture of a cute animal (not mandatory, but encouraged)*

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14504" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->