### PR TITLE
[create-cloudflare] Stop pre-approving sharp's build script in generated projects

### DIFF
--- a/.changeset/c3-drop-sharp-build-approval.md
+++ b/.changeset/c3-drop-sharp-build-approval.md
@@ -1,0 +1,7 @@
+---
+"create-cloudflare": patch
+---
+
+Stop pre-approving `sharp`'s build script in generated projects
+
+`miniflare` 0.35+ ships `sharp` 0.35, which no longer has an `install` lifecycle script, so generated `pnpm-workspace.yaml` files no longer pre-approve `sharp` under `allowBuilds`. `esbuild` and `workerd` are still pre-approved because they retain their install/`postinstall` scripts.

--- a/packages/create-cloudflare/src/helpers/__tests__/pnpmBuildApprovals.test.ts
+++ b/packages/create-cloudflare/src/helpers/__tests__/pnpmBuildApprovals.test.ts
@@ -40,7 +40,6 @@ describe("writePnpmBuildApprovals", () => {
 		expect(calledContent).toMatch(/^allowBuilds:$/m);
 		expect(calledContent).toMatch(/^ {2}esbuild: true$/m);
 		expect(calledContent).toMatch(/^ {2}workerd: true$/m);
-		expect(calledContent).toMatch(/^ {2}sharp: true$/m);
 	});
 
 	test("writes the yaml for pnpm 10 as well (no version gate)", ({
@@ -113,12 +112,12 @@ describe("writePnpmBuildApprovals", () => {
 		const written = vi.mocked(writeFile).mock.calls[0][1] as string;
 		// Our keys: placeholders → `true`; missing keys are added.
 		expect(written).toMatch(/^ {2}esbuild: true$/m);
-		expect(written).toMatch(/^ {2}sharp: true$/m);
 		expect(written).toMatch(/^ {2}workerd: true$/m);
-		// Framework key: untouched.
+		// Framework keys (incl. `sharp`, no longer pre-approved): untouched.
 		expect(written).toMatch(
 			/^ {2}'@parcel\/watcher': set this to true or false$/m
 		);
+		expect(written).toMatch(/^ {2}sharp: set this to true or false$/m);
 	});
 
 	test("respects an explicit `false` for one of our keys", ({ expect }) => {
@@ -127,13 +126,7 @@ describe("writePnpmBuildApprovals", () => {
 			(path) => path.toString() === yamlPath
 		);
 		vi.mocked(readFile).mockReturnValue(
-			[
-				"allowBuilds:",
-				"  esbuild: false",
-				"  workerd: true",
-				"  sharp: true",
-				"",
-			].join("\n")
+			["allowBuilds:", "  esbuild: false", "  workerd: true", ""].join("\n")
 		);
 
 		writePnpmBuildApprovals(projectPath);
@@ -147,13 +140,7 @@ describe("writePnpmBuildApprovals", () => {
 			(path) => path.toString() === yamlPath
 		);
 		vi.mocked(readFile).mockReturnValue(
-			[
-				"allowBuilds:",
-				"  esbuild: true",
-				"  workerd: true",
-				"  sharp: true",
-				"",
-			].join("\n")
+			["allowBuilds:", "  esbuild: true", "  workerd: true", ""].join("\n")
 		);
 
 		writePnpmBuildApprovals(projectPath);
@@ -179,7 +166,6 @@ describe("writePnpmBuildApprovals", () => {
 		expect(written).toMatch(/^allowBuilds:$/m);
 		expect(written).toMatch(/^ {2}esbuild: true$/m);
 		expect(written).toMatch(/^ {2}workerd: true$/m);
-		expect(written).toMatch(/^ {2}sharp: true$/m);
 	});
 });
 
@@ -189,7 +175,6 @@ describe("mergeAllowBuilds", () => {
 			"allowBuilds:",
 			"  esbuild: set this to true or false",
 			"  workerd: set this to true or false",
-			"  sharp: set this to true or false",
 			"",
 		].join("\r\n");
 
@@ -204,7 +189,6 @@ describe("mergeAllowBuilds", () => {
 			"allowBuilds:",
 			"  esbuild: false",
 			"  workerd: true",
-			"  sharp: true",
 			"",
 		].join("\n");
 

--- a/packages/create-cloudflare/src/helpers/pnpmBuildApprovals.ts
+++ b/packages/create-cloudflare/src/helpers/pnpmBuildApprovals.ts
@@ -4,9 +4,8 @@ import { readFile, writeFile } from "./files";
 import { detectPackageManager } from "./packageManagers";
 
 // Build-script packages C3 pre-approves: wrangler depends on `esbuild` and
-// `workerd`, and (via miniflare) on `sharp`. Framework-introduced build
-// scripts are out of scope.
-const APPROVED_BUILDS = ["esbuild", "workerd", "sharp"] as const;
+// `workerd`. Framework-introduced build scripts are out of scope.
+const APPROVED_BUILDS = ["esbuild", "workerd"] as const;
 const APPROVED_BUILDS_SET = new Set<string>(APPROVED_BUILDS);
 
 /**
@@ -37,9 +36,9 @@ export const writePnpmBuildApprovals = (projectPath: string) => {
 
 const FRESH_HEADER = [
 	"# Pre-approve build scripts for the packages C3 itself installs that need",
-	"# them: `workerd` downloads the platform binary, `esbuild` and `sharp`",
-	"# (via miniflare) download/build native bindings. Without these, pnpm 11+",
-	"# aborts the install with ERR_PNPM_IGNORED_BUILDS.",
+	"# them: `workerd` downloads the platform binary and `esbuild` downloads/",
+	"# builds native bindings. Without these, pnpm 11+ aborts the install with",
+	"# ERR_PNPM_IGNORED_BUILDS.",
 ];
 
 // Quote scoped names (`@…`) so YAML 1.1 doesn't treat `@` as a node anchor.


### PR DESCRIPTION
Completes the `sharp` build-script work: create-cloudflare no longer pre-approves `sharp` in the `pnpm-workspace.yaml` it writes into generated projects.

`miniflare` 0.35+ ships `sharp` 0.35, which [removed its `install` lifecycle script](https://sharp.pixelplumbing.com/changelog/v0.35.0), so package managers that block dependency build scripts (pnpm 11+) no longer need `sharp` pre-approved. `esbuild` and `workerd` stay pre-approved because they keep their install/`postinstall` scripts. If a framework generator adds `sharp` itself, it's now treated like any other framework-introduced build script (left untouched).

> [!IMPORTANT]
> **Draft — blocked on two PRs landing in `main` first:**
> - #14493 — `[miniflare] Update sharp to 0.35.2` (so the published miniflare has no sharp install script)
> - #14504 — `[mock-npm-registry] Exempt first-party packages from the release-age cooldown` (so the C3 e2e installs the **local** miniflare, letting this be validated)
>
> Until both are in `main`, the C3 e2e installs a **published** miniflare with `sharp` 0.34.x (which has an install script), so removing the pre-approval trips `ERR_PNPM_IGNORED_BUILDS` on the pnpm 11 matrix. The unit tests pass now; I'll rebase and take this out of draft once the dependencies merge.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: internal packaging/build-script change; no user-facing API or documented behavior change (generated projects simply omit a now-unnecessary `allowBuilds` entry).

*A picture of a cute animal (not mandatory, but encouraged)*
