### PR TITLE
[miniflare] Add metadata filtering to hosted images list()

### DIFF
--- a/.changeset/images-metadata-filter.md
+++ b/.changeset/images-metadata-filter.md
@@ -1,0 +1,17 @@
+---
+"miniflare": minor
+---
+
+Add metadata filtering to the local Images binding `hosted.list()`
+
+`env.IMAGES.hosted.list()` now accepts a `metadataFilters` option to filter hosted images by their custom metadata, matching the Cloudflare Images REST API. Each key is a metadata field name and its value is the condition the field must meet. A bare value is shorthand for `eq`, and the `eq`, `in`, `gt`, `gte`, `lt`, and `lte` operators are supported. Field names use dot notation to filter on nested fields, and multiple fields are combined with AND logic.
+
+```js
+await env.IMAGES.hosted.list({
+	metadataFilters: {
+		status: "active",
+		priority: { gte: 2, lte: 8 },
+		"region.name": { in: ["us-east", "eu-west"] },
+	},
+});
+```

--- a/.changeset/images-metadata-filter.md
+++ b/.changeset/images-metadata-filter.md
@@ -4,14 +4,16 @@
 
 Add metadata filtering to the local Images binding `hosted.list()`
 
-`env.IMAGES.hosted.list()` now accepts a `metadataFilters` option to filter hosted images by their custom metadata, matching the Cloudflare Images REST API. Each key is a metadata field name and its value is the condition the field must meet. A bare value is shorthand for `eq`, and the `eq`, `in`, `gt`, `gte`, `lt`, and `lte` operators are supported. Field names use dot notation to filter on nested fields, and multiple fields are combined with AND logic.
+`env.IMAGES.hosted.list()` now accepts a `filter.metadata` option to filter hosted images by their custom metadata, matching the Cloudflare Images REST API. Each key is a metadata field name and its value is the condition the field must meet. A bare value is shorthand for `eq`, and the `eq`, `in`, `gt`, `gte`, `lt`, and `lte` operators are supported. Field names use dot notation to filter on nested fields, and multiple fields are combined with AND logic.
 
 ```js
 await env.IMAGES.hosted.list({
-	metadataFilters: {
-		status: "active",
-		priority: { gte: 2, lte: 8 },
-		"region.name": { in: ["us-east", "eu-west"] },
+	filter: {
+		metadata: {
+			status: "active",
+			priority: { gte: 2, lte: 8 },
+			"region.name": { in: ["us-east", "eu-west"] },
+		},
 	},
 });
 ```

--- a/packages/miniflare/src/workers/images/images.worker.ts
+++ b/packages/miniflare/src/workers/images/images.worker.ts
@@ -70,8 +70,12 @@ type ImageMetadataFilterValue =
 	| boolean
 	| ImageMetadataFilterOperators;
 
+interface ImageListFilter {
+	metadata?: Record<string, ImageMetadataFilterValue>;
+}
+
 interface ImageListOptionsWithFilters extends ImageListOptions {
-	metadataFilters?: Record<string, ImageMetadataFilterValue>;
+	filter?: ImageListFilter;
 }
 
 function resolveMetaPath(
@@ -266,8 +270,8 @@ export default class ImagesService extends WorkerEntrypoint<Env> {
 			);
 		}
 
-		if (options?.metadataFilters) {
-			const filters = options.metadataFilters;
+		if (options?.filter?.metadata) {
+			const filters = options.filter.metadata;
 			allImages.splice(
 				0,
 				allImages.length,

--- a/packages/miniflare/src/workers/images/images.worker.ts
+++ b/packages/miniflare/src/workers/images/images.worker.ts
@@ -55,6 +55,86 @@ async function base64DecodeStream(
 	return base64DecodeArrayBuffer(buffer);
 }
 
+type ImageMetadataFilterOperators = {
+	eq?: string | number | boolean;
+	in?: Array<string | number | boolean>;
+	gt?: number;
+	gte?: number;
+	lt?: number;
+	lte?: number;
+};
+
+type ImageMetadataFilterValue =
+	| string
+	| number
+	| boolean
+	| ImageMetadataFilterOperators;
+
+interface ImageListOptionsWithFilters extends ImageListOptions {
+	metadataFilters?: Record<string, ImageMetadataFilterValue>;
+}
+
+function resolveMetaPath(
+	meta: Record<string, unknown> | undefined,
+	path: string
+): unknown {
+	return path.split(".").reduce<unknown>((acc, key) => {
+		if (acc && typeof acc === "object") {
+			return (acc as Record<string, unknown>)[key];
+		}
+		return undefined;
+	}, meta);
+}
+
+function matchesCondition(
+	actual: unknown,
+	condition: ImageMetadataFilterValue
+): boolean {
+	if (typeof condition !== "object" || condition === null) {
+		return actual === condition;
+	}
+	if (condition.eq !== undefined && actual !== condition.eq) {
+		return false;
+	}
+	if (condition.in !== undefined && !condition.in.some((v) => v === actual)) {
+		return false;
+	}
+	if (
+		condition.gt !== undefined &&
+		!(typeof actual === "number" && actual > condition.gt)
+	) {
+		return false;
+	}
+	if (
+		condition.gte !== undefined &&
+		!(typeof actual === "number" && actual >= condition.gte)
+	) {
+		return false;
+	}
+	if (
+		condition.lt !== undefined &&
+		!(typeof actual === "number" && actual < condition.lt)
+	) {
+		return false;
+	}
+	if (
+		condition.lte !== undefined &&
+		!(typeof actual === "number" && actual <= condition.lte)
+	) {
+		return false;
+	}
+	return true;
+}
+
+function matchesMetadataFilters(
+	image: ImageMetadata,
+	filters: Record<string, ImageMetadataFilterValue>
+): boolean {
+	return Object.entries(filters).every(([field, condition]) =>
+		matchesCondition(resolveMetaPath(image.meta, field), condition)
+	);
+}
+
 class ImageHandleImpl extends RpcTarget {
 	readonly #imageId: string;
 	readonly #env: Env;
@@ -160,7 +240,7 @@ export default class ImagesService extends WorkerEntrypoint<Env> {
 		return withResolvedVariants(metadata, this.env);
 	}
 
-	async list(options?: ImageListOptions): Promise<ImageList> {
+	async list(options?: ImageListOptionsWithFilters): Promise<ImageList> {
 		const limit = options?.limit ?? 50;
 
 		// Fetch all keys so we can filter and sort accurately
@@ -183,6 +263,15 @@ export default class ImagesService extends WorkerEntrypoint<Env> {
 				0,
 				allImages.length,
 				...allImages.filter((i) => i.creator === options.creator)
+			);
+		}
+
+		if (options?.metadataFilters) {
+			const filters = options.metadataFilters;
+			allImages.splice(
+				0,
+				allImages.length,
+				...allImages.filter((image) => matchesMetadataFilters(image, filters))
 			);
 		}
 

--- a/packages/miniflare/test/plugins/images/index.spec.ts
+++ b/packages/miniflare/test/plugins/images/index.spec.ts
@@ -277,7 +277,7 @@ describe("Images hosted CRUD", () => {
 		});
 
 		const list = await sendCmd<ImageList>(mf, "list", {
-			options: { metadataFilters: { status: "active" } },
+			options: { filter: { metadata: { status: "active" } } },
 		});
 		expect(list.images).toHaveLength(1);
 		expect(list.images[0].id).toBe("active");
@@ -302,7 +302,7 @@ describe("Images hosted CRUD", () => {
 
 		const list = await sendCmd<ImageList>(mf, "list", {
 			options: {
-				metadataFilters: { region: { in: ["us-east", "eu-west"] } },
+				filter: { metadata: { region: { in: ["us-east", "eu-west"] } } },
 			},
 		});
 		expect(list.images.map((i) => i.id).sort()).toEqual(["a", "b"]);
@@ -319,7 +319,7 @@ describe("Images hosted CRUD", () => {
 		await upload(mf, TEST_IMAGE_BYTES, { id: "p5", metadata: { priority: 5 } });
 
 		const list = await sendCmd<ImageList>(mf, "list", {
-			options: { metadataFilters: { priority: { gte: 2, lte: 4 } } },
+			options: { filter: { metadata: { priority: { gte: 2, lte: 4 } } } },
 		});
 		expect(list.images).toHaveLength(1);
 		expect(list.images[0].id).toBe("p3");
@@ -339,7 +339,7 @@ describe("Images hosted CRUD", () => {
 		});
 
 		const list = await sendCmd<ImageList>(mf, "list", {
-			options: { metadataFilters: { "config.region": "eu-west" } },
+			options: { filter: { metadata: { "config.region": "eu-west" } } },
 		});
 		expect(list.images).toHaveLength(1);
 		expect(list.images[0].id).toBe("eu");
@@ -362,7 +362,7 @@ describe("Images hosted CRUD", () => {
 
 		const list = await sendCmd<ImageList>(mf, "list", {
 			options: {
-				metadataFilters: { status: "active", priority: { gte: 5 } },
+				filter: { metadata: { status: "active", priority: { gte: 5 } } },
 			},
 		});
 		expect(list.images).toHaveLength(1);
@@ -381,7 +381,7 @@ describe("Images hosted CRUD", () => {
 		});
 
 		const list = await sendCmd<ImageList>(mf, "list", {
-			options: { metadataFilters: { status: "missing" } },
+			options: { filter: { metadata: { status: "missing" } } },
 		});
 		expect(list.images).toHaveLength(0);
 		expect(list.listComplete).toBe(true);

--- a/packages/miniflare/test/plugins/images/index.spec.ts
+++ b/packages/miniflare/test/plugins/images/index.spec.ts
@@ -263,6 +263,130 @@ describe("Images hosted CRUD", () => {
 		expect(list.images[0].id).toBe("img2");
 	});
 
+	test("list images filtered by metadata (implicit eq)", async ({ expect }) => {
+		const mf = createMiniflare();
+		useDispose(mf);
+
+		await upload(mf, TEST_IMAGE_BYTES, {
+			id: "active",
+			metadata: { status: "active" },
+		});
+		await upload(mf, TEST_IMAGE_BYTES, {
+			id: "archived",
+			metadata: { status: "archived" },
+		});
+
+		const list = await sendCmd<ImageList>(mf, "list", {
+			options: { metadataFilters: { status: "active" } },
+		});
+		expect(list.images).toHaveLength(1);
+		expect(list.images[0].id).toBe("active");
+	});
+
+	test("list images filtered by metadata (in)", async ({ expect }) => {
+		const mf = createMiniflare();
+		useDispose(mf);
+
+		await upload(mf, TEST_IMAGE_BYTES, {
+			id: "a",
+			metadata: { region: "us-east" },
+		});
+		await upload(mf, TEST_IMAGE_BYTES, {
+			id: "b",
+			metadata: { region: "eu-west" },
+		});
+		await upload(mf, TEST_IMAGE_BYTES, {
+			id: "c",
+			metadata: { region: "ap-south" },
+		});
+
+		const list = await sendCmd<ImageList>(mf, "list", {
+			options: {
+				metadataFilters: { region: { in: ["us-east", "eu-west"] } },
+			},
+		});
+		expect(list.images.map((i) => i.id).sort()).toEqual(["a", "b"]);
+	});
+
+	test("list images filtered by metadata range (gte/lte)", async ({
+		expect,
+	}) => {
+		const mf = createMiniflare();
+		useDispose(mf);
+
+		await upload(mf, TEST_IMAGE_BYTES, { id: "p1", metadata: { priority: 1 } });
+		await upload(mf, TEST_IMAGE_BYTES, { id: "p3", metadata: { priority: 3 } });
+		await upload(mf, TEST_IMAGE_BYTES, { id: "p5", metadata: { priority: 5 } });
+
+		const list = await sendCmd<ImageList>(mf, "list", {
+			options: { metadataFilters: { priority: { gte: 2, lte: 4 } } },
+		});
+		expect(list.images).toHaveLength(1);
+		expect(list.images[0].id).toBe("p3");
+	});
+
+	test("list images filtered by nested metadata", async ({ expect }) => {
+		const mf = createMiniflare();
+		useDispose(mf);
+
+		await upload(mf, TEST_IMAGE_BYTES, {
+			id: "eu",
+			metadata: { config: { region: "eu-west" } },
+		});
+		await upload(mf, TEST_IMAGE_BYTES, {
+			id: "us",
+			metadata: { config: { region: "us-east" } },
+		});
+
+		const list = await sendCmd<ImageList>(mf, "list", {
+			options: { metadataFilters: { "config.region": "eu-west" } },
+		});
+		expect(list.images).toHaveLength(1);
+		expect(list.images[0].id).toBe("eu");
+	});
+
+	test("list images with multiple metadata filters (AND)", async ({
+		expect,
+	}) => {
+		const mf = createMiniflare();
+		useDispose(mf);
+
+		await upload(mf, TEST_IMAGE_BYTES, {
+			id: "match",
+			metadata: { status: "active", priority: 5 },
+		});
+		await upload(mf, TEST_IMAGE_BYTES, {
+			id: "wrong-priority",
+			metadata: { status: "active", priority: 1 },
+		});
+
+		const list = await sendCmd<ImageList>(mf, "list", {
+			options: {
+				metadataFilters: { status: "active", priority: { gte: 5 } },
+			},
+		});
+		expect(list.images).toHaveLength(1);
+		expect(list.images[0].id).toBe("match");
+	});
+
+	test("metadata filter with no matches returns empty list", async ({
+		expect,
+	}) => {
+		const mf = createMiniflare();
+		useDispose(mf);
+
+		await upload(mf, TEST_IMAGE_BYTES, {
+			id: "only",
+			metadata: { status: "active" },
+		});
+
+		const list = await sendCmd<ImageList>(mf, "list", {
+			options: { metadataFilters: { status: "missing" } },
+		});
+		expect(list.images).toHaveLength(0);
+		expect(list.listComplete).toBe(true);
+	});
+
 	test("list images with cursor pagination", async ({ expect }) => {
 		const mf = createMiniflare();
 		useDispose(mf);


### PR DESCRIPTION
Adds `metadataFilters` to the local Miniflare simulator for
`env.IMAGES.hosted.list()`, bringing `wrangler dev` to parity with the
production Images binding. Companion to the workerd type change [#6851](https://github.com/cloudflare/workerd/pull/6851).

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: brings the local dev simulator to parity with the production Images binding; docs for the new option ship with the binding API change.

*🐼*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14510" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->