### PR TITLE
[wrangler] Allow max_concurrency: null on Queues consumers

### DIFF
--- a/.changeset/fix-queues-consumer-max-concurrency-null.md
+++ b/.changeset/fix-queues-consumer-max-concurrency-null.md
@@ -1,0 +1,19 @@
+---
+"wrangler": patch
+"@cloudflare/workers-utils": patch
+---
+
+Allow `max_concurrency: null` on Queues consumers
+
+Setting `max_concurrency` to `null` on a `[[queues.consumers]]` entry opts the consumer in to the platform's maximum concurrency (auto-scaling), as documented [here](https://developers.cloudflare.com/queues/configuration/consumer-concurrency/). Wrangler's config validation was incorrectly rejecting this value with an error, even though the config type allows `number | null`:
+
+```jsonc
+// wrangler.json
+{
+	"queues": {
+		"consumers": [{ "queue": "my-queue", "max_concurrency": null }]
+	}
+}
+```
+
+`max_concurrency: null` is now accepted.

--- a/packages/workers-utils/src/config/validation.ts
+++ b/packages/workers-utils/src/config/validation.ts
@@ -4976,17 +4976,25 @@ const validateConsumer: ValidatorFn = (diagnostics, field, value, _config) => {
 	const options: {
 		key: string;
 		type: "number" | "string" | "boolean";
+		nullable?: boolean;
 	}[] = [
 		{ key: "type", type: "string" },
 		{ key: "max_batch_size", type: "number" },
 		{ key: "max_batch_timeout", type: "number" },
 		{ key: "max_retries", type: "number" },
 		{ key: "dead_letter_queue", type: "string" },
-		{ key: "max_concurrency", type: "number" },
+		// `null` opts the consumer in to the platform's maximum concurrency (auto-scaling)
+		{ key: "max_concurrency", type: "number", nullable: true },
 		{ key: "visibility_timeout_ms", type: "number" },
 		{ key: "retry_delay", type: "number" },
 	];
 	for (const optionalOpt of options) {
+		if (
+			optionalOpt.nullable &&
+			(value as Record<string, unknown>)[optionalOpt.key] === null
+		) {
+			continue;
+		}
 		if (!isOptionalProperty(value, optionalOpt.key, optionalOpt.type)) {
 			diagnostics.errors.push(
 				`"${field}" should, optionally, have a ${optionalOpt.type} "${

--- a/packages/workers-utils/tests/config/validation/normalize-and-validate-config.test.ts
+++ b/packages/workers-utils/tests/config/validation/normalize-and-validate-config.test.ts
@@ -4495,6 +4495,23 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
+			it("should allow queues consumer max_concurrency to be null", ({
+				expect,
+			}) => {
+				const { diagnostics } = normalizeAndValidateConfig(
+					{
+						queues: {
+							consumers: [{ queue: "myQueue", max_concurrency: null }],
+						},
+					} as unknown as RawConfig,
+					undefined,
+					undefined,
+					{ env: undefined }
+				);
+
+				expect(diagnostics.hasErrors()).toBe(false);
+			});
+
 			it("should warn if delivery_delay is set on a queue producer", ({
 				expect,
 			}) => {


### PR DESCRIPTION
## What this PR solves

Wrangler's config validation rejects `max_concurrency: null` on a Queues consumer with a spurious "should have a number" error, blocking deploy, even though the config type is `max_concurrency?: number | null` and `null` is the documented way to opt a consumer into the platform's maximum concurrency ([auto-scaling docs](https://developers.cloudflare.com/queues/configuration/consumer-concurrency/)).

`validateConsumer` validated each optional field with `isOptionalProperty(value, key, "number")`; for `null`, `typeof null === "object"` fails the numeric check. The documented `null` sentinel was never accounted for.

## Fix

Flag `max_concurrency` as `nullable` in the options table and skip the numeric check when the value is exactly `null`. Every other value (including bad types like `"hello"`) still validates unchanged.

## Test

Added a case to `tests/config/validation/normalize-and-validate-config.test.ts` mirroring the adjacent consumer-validation tests. It fails before the change (validation wrongly reports an error) and passes after; the file stays green.

A changeset is included (`wrangler` / `@cloudflare/workers-utils`: patch).

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14515" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->