### PR TITLE
Enable `@typescript-eslint/no-deprecated` linting rule for `miniflare` and `vitest-pool-workers`

### DIFF
--- a/.oxlintrc.jsonc
+++ b/.oxlintrc.jsonc
@@ -208,7 +208,6 @@
 			"files": [
 				"packages/edge-preview-authenticated-proxy/**",
 				"packages/local-explorer-ui/**",
-				"packages/miniflare/**",
 				"packages/vite-plugin-cloudflare/**",
 				"packages/vitest-pool-workers/**",
 				"packages/workflows-shared/**",

--- a/.oxlintrc.jsonc
+++ b/.oxlintrc.jsonc
@@ -209,7 +209,6 @@
 				"packages/edge-preview-authenticated-proxy/**",
 				"packages/local-explorer-ui/**",
 				"packages/vite-plugin-cloudflare/**",
-				"packages/vitest-pool-workers/**",
 				"packages/workflows-shared/**",
 				"packages/wrangler/**",
 			],

--- a/packages/miniflare/src/plugins/images/fetcher.ts
+++ b/packages/miniflare/src/plugins/images/fetcher.ts
@@ -46,6 +46,7 @@ export async function imagesLocalFetcher(request: Request): Promise<Response> {
 		);
 	}
 
+	// eslint-disable-next-line @typescript-eslint/no-deprecated -- formData() is the standard Workers API for parsing multipart bodies; only deprecated on undici's server-side Request
 	const data = await request.formData();
 
 	const body = data.get("image");
@@ -349,6 +350,7 @@ export async function cfImageLocalFetcher(request: Request): Promise<Response> {
 	let body: unknown;
 	let options: RequestInitCfPropertiesImage;
 	try {
+		// eslint-disable-next-line @typescript-eslint/no-deprecated -- formData() is the standard Workers API for parsing multipart bodies; only deprecated on undici's server-side Request
 		const data = await request.formData();
 		body = data.get("image");
 		const optionsJson = data.get("options");


### PR DESCRIPTION
This PR enabled the `@typescript-eslint/no-deprecated` linting rule for the `miniflare` and `vitest-pool-workers` packages (PS: no changes were needed for `vitest-pool-workers`, I didn't notice before that it didn't have any violations for the rule 😅)

Followup for https://github.com/cloudflare/workers-sdk/pull/14472 and https://github.com/cloudflare/workers-sdk/pull/14491

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: internal refactoring

*A picture of a cute animal (not mandatory, but encouraged)*