### PR TITLE
[ci] Pin CI Node.js to node-fetch@2-safe versions (22.23.1 / 24.18.0)

### DIFF
--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -2,9 +2,13 @@ name: "Install Dependencies"
 description: "Install dependencies, fetching from cache when possible"
 inputs:
   # We run all jobs on Node.js 22 by default, as this is the most stable and supported version right now.
+  #
+  # Pinned to 22.23.1 (rather than floating `22`) until it's safe to float back:
+  # Node 22.23.0 regressed node-fetch@2 keep-alive responses with
+  # ERR_STREAM_PREMATURE_CLOSE (nodejs/node#63989, fixed in 22.23.1).
   node-version:
     description: the version of Node.js to install
-    default: 22
+    default: 22.23.1
   turbo-api:
     description: the api URL for connecting to the turbo remote cache
   turbo-team:

--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -37,7 +37,10 @@ jobs:
         # rather than restoring from a (potentially poisoned) cache.
         uses: ./.github/actions/install-dependencies
         with:
-          node-version: 24
+          # Pinned to 24.18.0 (rather than floating `24`) until it's safe to
+          # float back: Node 24.17.0 regressed node-fetch@2 keep-alive responses
+          # with ERR_STREAM_PREMATURE_CLOSE (nodejs/node#63989, fixed in 24.18.0).
+          node-version: 24.18.0
           disable-cache: "true"
 
       - name: Check npm version
@@ -74,7 +77,10 @@ jobs:
       - name: Switch to Node 22 for non-npm package deployments
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 22
+          # Pinned to 22.23.1 (rather than floating `22`) until it's safe to
+          # float back: Node 22.23.0 regressed node-fetch@2 keep-alive responses
+          # with ERR_STREAM_PREMATURE_CLOSE (nodejs/node#63989, fixed in 22.23.1).
+          node-version: 22.23.1
 
       - name: Deploy non-NPM Packages
         id: deploy

--- a/.github/workflows/e2e-wrangler.yml
+++ b/.github/workflows/e2e-wrangler.yml
@@ -51,9 +51,6 @@ jobs:
         if: steps.changes.outputs.everything_but_markdown == 'true'
         uses: ./.github/actions/install-dependencies
         with:
-          # Pin until `node-version: 22` resolves to 22.23.1 or later. Node 22.23.0
-          # regressed node-fetch@2 chunked/gzip responses with ERR_STREAM_PREMATURE_CLOSE.
-          node-version: 22.23.1
           turbo-api: ${{ secrets.TURBO_API }}
           turbo-team: ${{ secrets.TURBO_TEAM }}
           turbo-token: ${{ secrets.TURBO_TOKEN }}

--- a/.github/workflows/test-and-check-other-node.yml
+++ b/.github/workflows/test-and-check-other-node.yml
@@ -23,8 +23,17 @@ jobs:
         # expected_to_fail: if true, tests may fail on this Node version.
         # These versions are skipped on normal PRs but run on Version Packages PRs
         # (changeset-release/main) or when the 'ci:test-all-node-versions' label is added.
+        #
+        # Node 24 is pinned to 24.18.0 (rather than floating `24`): Node 24.17.0
+        # regressed node-fetch@2 keep-alive responses with ERR_STREAM_PREMATURE_CLOSE
+        # (nodejs/node#63989, fixed in 24.18.0). `description` stays "Node 24" to
+        # keep the job/check name stable.
         include:
-          - { node_version: 24, description: "Node 24", expected_to_fail: true }
+          - {
+              node_version: 24.18.0,
+              description: "Node 24",
+              expected_to_fail: true,
+            }
           - { node_version: 25, description: "Node 25", expected_to_fail: true }
 
     steps:


### PR DESCRIPTION
Node 22.23.0 and 24.17.0 shipped a security backport that regressed `node-fetch@2` keep-alive responses, causing spurious `ERR_STREAM_PREMATURE_CLOSE` errors ([nodejs/node#63989](https://github.com/nodejs/node/issues/63989), fixed by [nodejs/node#64004](https://github.com/nodejs/node/pull/64004) in 22.23.1 / 24.18.0). This was already flaking the **Handle Changesets** job (`ERR_STREAM_PREMATURE_CLOSE` during publish/deploy).

#14476 pinned only the Wrangler E2E workflow. This rolls the pin out across the rest of CI, pinning to the `node-fetch@2`-safe patch releases:

- **`install-dependencies` action**: default `node-version` `22` → `22.23.1` (fixes every workflow that uses the default in one place, including the C3 E2E and main test jobs).
- **`changesets.yml`**: build/publish install `24` → `24.18.0`, and the non-npm-deploy Node switch `22` → `22.23.1`.
- **`test-and-check-other-node.yml`**: matrix Node `24` → `24.18.0` (kept `description: "Node 24"` so the required-check name stays stable; `25` left as-is).
- **`e2e-wrangler.yml`**: removed the now-redundant explicit `22.23.1` pin — it inherits the shared default.

Left intentionally unpinned: Node `20` in `test-and-check.yml` (old-Node error-message check, no HTTP) and Node `25` in the other-node matrix (bleeding-edge canary).

These pins should be floated back to `22` / `24` once the runners' default resolution is safely past the regressed patches.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: this only changes CI workflow/action Node.js version pins (no product or library code) — the change is exercised by CI itself running on the pinned versions.
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: internal CI-only configuration change with no user-facing impact.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14523" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->