### PR TITLE
[wrangler] Remove experimental gate for declarative Durable Object exports

### DIFF
--- a/.changeset/devx-2572-wrangler-do-exports.md
+++ b/.changeset/devx-2572-wrangler-do-exports.md
@@ -4,7 +4,7 @@
 "@cloudflare/vitest-pool-workers": minor
 ---
 
-Add experimental support for declarative Durable Object exports
+Add support for declarative Durable Object exports
 
 `wrangler deploy` now accepts an `exports` map in `wrangler.json` as a declarative alternative to the legacy `migrations` array.
 
@@ -41,22 +41,16 @@ Each entry in `exports` is keyed by Durable Object class name. `type` carries th
 }
 ```
 
-Set `X_DO_EXPORTS=true` to opt in:
-
-```sh
-X_DO_EXPORTS=true wrangler deploy
-```
+When a Worker declares Durable Object class bindings but no lifecycle for them (neither a `migrations` array nor an `exports` map), wrangler warns and now suggests a declarative `exports` entry for each class (previously it suggested a legacy `migrations` block).
 
 The deployment response now surfaces the server's reconciliation result — created namespaces, applied tombstones, structured per-scenario info entries, and a `removable_entries` hint for stale tombstones that are safe to delete from the config. Blocking errors return the structured per-class detail with scenario tags, suggested remediation, and any referencing-script context.
 
-`wrangler versions upload` also forwards `exports` under the same `X_DO_EXPORTS=true` gate. Declarative `exports` lifecycle changes are reconciled when the version is deployed (`wrangler versions deploy` or `wrangler deploy`), so a `versions upload` payload can declare new classes in `exports` without immediately provisioning them. An actor binding (`durable_objects.bindings`) to a class declared only in `exports` on the same `versions upload` is rejected with a clear error (code 100406) — the binding cannot be resolved until the namespace is provisioned. Either stage the new class via `ctx.exports.X` (no binding required) on `versions upload` and add the binding at deploy time, or use `wrangler deploy` to provision and bind in one step (the same constraint applies to the `migrations` flow).
+`wrangler versions upload` also forwards `exports`. Declarative `exports` lifecycle changes are reconciled when the version is deployed (`wrangler versions deploy` or `wrangler deploy`), so a `versions upload` payload can declare new classes in `exports` without immediately provisioning them. An actor binding (`durable_objects.bindings`) to a class declared only in `exports` on the same `versions upload` is rejected with a clear error (code 100406) — the binding cannot be resolved until the namespace is provisioned. Either stage the new class via `ctx.exports.X` (no binding required) on `versions upload` and add the binding at deploy time, or use `wrangler deploy` to provision and bind in one step (the same constraint applies to the `migrations` flow).
 
 Multi-version deploys (`wrangler versions deploy A@50% B@50%`) where the selected versions disagree on declarative `exports` are rejected server-side with a clear message: deploy the version that changes `exports` at 100% first, then run the percentage-split deploy. This prevents traffic on one branch routing to code that references unprovisioned or just-deleted DO namespaces. Single-version (100%) deploys are unaffected.
 
 Local development (`wrangler dev`, `vite dev` and `unstable_startWorker`) reads Durable Object SQLite storage settings from the new `exports` field, so applications using the declarative flow get correct local-dev storage without needing to also declare a `migrations` block.
 
-`@cloudflare/vitest-pool-workers` also picks up Durable Object configuration from `exports`, so tests against an `exports`-only Worker run with the correct local SQLite storage and can reach unbound Durable Object classes via `ctx.exports.X`. The `X_DO_EXPORTS` opt-in gate is enforced here too — set `X_DO_EXPORTS=true` (e.g. via `process.env.X_DO_EXPORTS = "true"` at the top of `vitest.config.ts`, before the `cloudflareTest` plugin runs) until the feature stabilises.
+`@cloudflare/vitest-pool-workers` also picks up Durable Object configuration from `exports`, so tests against an `exports`-only Worker run with the correct local SQLite storage and can reach unbound Durable Object classes via `ctx.exports.X`.
 
 `wrangler types` is also aware of `exports`. Live entries (including `expecting-transfer`, the receiving side of a two-phase transfer) are added to `Cloudflare.GlobalProps.durableNamespaces`, which types `ctx.exports.X` for unbound Durable Objects declared only via `exports`.
-
-This new feature is gated behind the `X_DO_EXPORTS` environment variable until stabilized.

--- a/fixtures/durable-objects-exports-app/package.json
+++ b/fixtures/durable-objects-exports-app/package.json
@@ -4,8 +4,8 @@
 	"description": "Fixture demonstrating the declarative Durable Object `exports` config (with `state` for tombstones)",
 	"license": "ISC",
 	"scripts": {
-		"deploy": "cross-env X_DO_EXPORTS=true wrangler deploy",
-		"start": "cross-env X_DO_EXPORTS=true wrangler dev",
+		"deploy": "wrangler deploy",
+		"start": "wrangler dev",
 		"test:ci": "vitest run"
 	},
 	"devDependencies": {

--- a/fixtures/durable-objects-exports-app/tests/index.test.ts
+++ b/fixtures/durable-objects-exports-app/tests/index.test.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { join, resolve } from "node:path";
-import { afterAll, beforeAll, describe, it, vi } from "vitest";
+import { afterAll, beforeAll, describe, it } from "vitest";
 import { unstable_startWorker } from "wrangler";
 
 const basePath = resolve(__dirname, "..");
@@ -10,7 +10,6 @@ describe("durable objects declared via the new `exports` config", () => {
 	const instance = randomUUID();
 
 	beforeAll(async () => {
-		vi.stubEnv("X_DO_EXPORTS", "true");
 		worker = await unstable_startWorker({
 			config: join(basePath, "wrangler.jsonc"),
 		});
@@ -18,7 +17,6 @@ describe("durable objects declared via the new `exports` config", () => {
 
 	afterAll(async () => {
 		await worker?.dispose();
-		vi.unstubAllEnvs();
 	});
 
 	it("starts CounterA at 0 and increments it via SQLite-backed storage", async ({

--- a/fixtures/vitest-pool-workers-examples/durable-objects-exports/README.md
+++ b/fixtures/vitest-pool-workers-examples/durable-objects-exports/README.md
@@ -4,8 +4,6 @@ This Worker mirrors the simple [`durable-objects`](../durable-objects/) fixture,
 
 `Counter` is also declared as a regular binding under `durable_objects.bindings`. `UnboundCounter` has no binding and is reachable only via `ctx.exports.UnboundCounter` from inside the Worker — both forms must work for `exports` to be a full replacement for `migrations`.
 
-`@cloudflare/vitest-pool-workers` enforces the `X_DO_EXPORTS` opt-in gate, so `vitest.config.ts` sets `process.env.X_DO_EXPORTS = "true"` at module load (before the cloudflareTest plugin runs and before the pool process forks).
-
 | Test                                    | Overview                                                                           |
 | --------------------------------------- | ---------------------------------------------------------------------------------- |
 | [exports.test.ts](test/exports.test.ts) | Bound + unbound DOs declared via `exports`, with SQLite storage and direct access. |

--- a/fixtures/vitest-pool-workers-examples/durable-objects-exports/vitest.config.ts
+++ b/fixtures/vitest-pool-workers-examples/durable-objects-exports/vitest.config.ts
@@ -1,8 +1,3 @@
-// Opt in to declarative Durable Object `exports`. This must be set before the
-// `cloudflareTest` plugin runs (and before vitest forks the pool worker), so
-// the wrangler config read inside `@cloudflare/vitest-pool-workers` sees it.
-process.env.X_DO_EXPORTS = "true";
-
 import { cloudflareTest } from "@cloudflare/vitest-pool-workers";
 import { defineProject, mergeConfig } from "vitest/config";
 import configShared from "../../../vitest.shared";

--- a/fixtures/vitest-pool-workers-examples/package.json
+++ b/fixtures/vitest-pool-workers-examples/package.json
@@ -13,7 +13,7 @@
 		"typegen:container-app": "wrangler types ./container-app/src/env.d.ts -c ./container-app/wrangler.jsonc --no-include-runtime",
 		"typegen:d1": "wrangler types ./d1/src/env.d.ts -c ./d1/wrangler.jsonc --no-include-runtime",
 		"typegen:durable-objects": "wrangler types ./durable-objects/src/env.d.ts -c ./durable-objects/wrangler.jsonc --no-include-runtime",
-		"typegen:durable-objects-exports": "X_DO_EXPORTS=true wrangler types ./durable-objects-exports/src/env.d.ts -c ./durable-objects-exports/wrangler.jsonc --no-include-runtime",
+		"typegen:durable-objects-exports": "wrangler types ./durable-objects-exports/src/env.d.ts -c ./durable-objects-exports/wrangler.jsonc --no-include-runtime",
 		"typegen:dynamic-import": "wrangler types ./dynamic-import/src/worker-configuration.d.ts -c ./dynamic-import/wrangler.jsonc --no-include-runtime",
 		"typegen:hyperdrive": "wrangler types ./hyperdrive/src/env.d.ts -c ./hyperdrive/wrangler.jsonc --no-include-runtime",
 		"typegen:images": "wrangler types ./images/src/env.d.ts -c ./images/wrangler.jsonc --no-include-runtime",

--- a/packages/deploy-helpers/src/deploy/helpers/durable.ts
+++ b/packages/deploy-helpers/src/deploy/helpers/durable.ts
@@ -1,17 +1,11 @@
 import assert from "node:assert";
 import {
-	assertDoExportsEnabledIfConfigured,
 	configFileName,
-	getDoExportsEnabledFromEnv,
 	getDurableObjectExports,
 } from "@cloudflare/workers-utils";
 import { fetchResult, logger } from "../../shared/context";
 import { isWorkerNotFoundError } from "./worker-not-found-error";
-import type {
-	CfWorkerInit,
-	Config,
-	DoExportsOptInContext,
-} from "@cloudflare/workers-utils";
+import type { CfWorkerInit, Config } from "@cloudflare/workers-utils";
 
 /**
  * For a given Worker + migrations config, figure out which migrations
@@ -127,19 +121,13 @@ export async function resolveDoLifecyclePayload(props: {
 	useServiceEnvironments: boolean | undefined;
 	env: string | undefined;
 	dispatchNamespace: string | undefined;
-	optInContext?: DoExportsOptInContext;
 }): Promise<{
 	migrations: CfWorkerInit["migrations"];
 	exports: CfWorkerInit["exports"];
 }> {
-	assertDoExportsEnabledIfConfigured(
-		props.config.exports,
-		props.optInContext ?? "deploy"
-	);
-
 	const durableObjectExports = getDurableObjectExports(props.config.exports);
 	const hasDurableObjectExports = Object.keys(durableObjectExports).length > 0;
-	if (getDoExportsEnabledFromEnv() && hasDurableObjectExports) {
+	if (hasDurableObjectExports) {
 		return {
 			migrations: undefined,
 			exports: durableObjectExports,

--- a/packages/deploy-helpers/src/deploy/versions-upload.ts
+++ b/packages/deploy-helpers/src/deploy/versions-upload.ts
@@ -107,12 +107,10 @@ export default async function versionsUpload(
 	}
 
 	// Resolve which Durable Object lifecycle payload to forward — either
-	// the legacy `migrations` steps or the declarative `exports` map.
-	// `exports` is gated behind `X_DO_EXPORTS` (the gate-off error is
-	// raised inside `resolveExportsUploadPayload`). The server's versions
-	// POST controller persists `exports` on the new script_version row
-	// with `SkipDeploy:true`, so reconciliation is deferred to the
-	// subsequent deploy (either `wrangler deploy` or
+	// the legacy `migrations` steps or the declarative `exports` map. The
+	// server's versions POST controller persists `exports` on the new
+	// script_version row with `SkipDeploy:true`, so reconciliation is
+	// deferred to the subsequent deploy (either `wrangler deploy` or
 	// `wrangler versions deploy <id>`).
 	const { migrations, exports } = await resolveExportsUploadPayload({
 		scriptName,
@@ -122,7 +120,6 @@ export default async function versionsUpload(
 		useServiceEnvironments: useServiceEnvironmentsConfig(config),
 		env: props.env,
 		dispatchNamespace: undefined,
-		optInContext: "versions upload",
 	});
 
 	// Upload assets if assets is being used

--- a/packages/vitest-pool-workers/src/pool/config.ts
+++ b/packages/vitest-pool-workers/src/pool/config.ts
@@ -1,5 +1,4 @@
 import path from "node:path";
-import { assertDoExportsEnabledIfConfigured } from "@cloudflare/workers-utils";
 import {
 	formatZodError,
 	getRootPath,
@@ -255,18 +254,13 @@ async function parseCustomPoolOptions(
 		// Lazily import `wrangler` if and when we need it
 		const wrangler = await import("wrangler");
 
-		// Parse the wrangler config once so we can both enforce the
-		// `X_DO_EXPORTS` opt-in gate (before any side effects fire) and pass
-		// the parsed config straight into `unstable_getMiniflareWorkerOptions`
-		// without re-parsing it.
+		// Parse the wrangler config once so we can pass the parsed config
+		// straight into `unstable_getMiniflareWorkerOptions` without
+		// re-parsing it.
 		const wranglerConfig = wrangler.unstable_readConfig({
 			config: configPath,
 			env: options.wrangler.environment,
 		});
-		assertDoExportsEnabledIfConfigured(
-			wranglerConfig.exports,
-			"vitest-pool-workers"
-		);
 
 		const preExistingRemoteProxySessionData = options.wrangler?.configPath
 			? remoteProxySessionsDataMap.get(options.wrangler.configPath)

--- a/packages/vitest-pool-workers/test/do-exports.test.ts
+++ b/packages/vitest-pool-workers/test/do-exports.test.ts
@@ -2,59 +2,11 @@ import dedent from "ts-dedent";
 import { test } from "./helpers";
 
 test(
-	"errors when wrangler config declares `exports` but `X_DO_EXPORTS` is not set",
-	{ timeout: 45_000 },
-	async ({ expect, seed, vitestRun }) => {
-		await seed({
-			"vitest.config.mts": dedent /* javascript */ `
-				import { cloudflareTest } from "@cloudflare/vitest-pool-workers";
-
-				export default {
-					plugins: [
-						cloudflareTest({
-							wrangler: { configPath: "./wrangler.jsonc" },
-						}),
-					],
-					test: { testTimeout: 90_000 },
-				};
-			`,
-			"wrangler.jsonc": dedent`
-				{
-					"name": "do-exports-gate-off",
-					"compatibility_date": "2025-12-02",
-					"compatibility_flags": ["nodejs_compat"],
-					"exports": {
-						"MyDurableObject": { "type": "durable-object", "storage": "sqlite" }
-					}
-				}
-			`,
-			"index.test.ts": dedent /* javascript */ `
-				import { it, expect } from "vitest";
-				it("should never run because the pool fails to start", () => {
-					expect(true).toBe(true);
-				});
-			`,
-		});
-
-		const result = await vitestRun();
-		expect(await result.exitCode).toBe(1);
-		expect(result.stderr).toMatch(
-			/`X_DO_EXPORTS` environment variable is not set/
-		);
-	}
-);
-
-test(
-	"accepts wrangler config with `exports` when `X_DO_EXPORTS` is set in vitest.config",
+	"accepts wrangler config with `exports`",
 	{ timeout: 60_000 },
 	async ({ expect, seed, vitestRun }) => {
 		await seed({
-			// Set `X_DO_EXPORTS` at module-load time (before the cloudflareTest
-			// plugin runs and before the pool worker process forks) so it is
-			// inherited by the pool process which calls into wrangler.
 			"vitest.config.mts": dedent /* javascript */ `
-				process.env.X_DO_EXPORTS = "true";
-
 				import { cloudflareTest } from "@cloudflare/vitest-pool-workers";
 
 				export default {
@@ -69,7 +21,7 @@ test(
 			`,
 			"wrangler.jsonc": dedent`
 				{
-					"name": "do-exports-gate-on",
+					"name": "do-exports",
 					"main": "./index.ts",
 					"compatibility_date": "2025-12-02",
 					"compatibility_flags": ["nodejs_compat"],
@@ -106,8 +58,5 @@ test(
 
 		const result = await vitestRun();
 		expect(await result.exitCode).toBe(0);
-		expect(result.stderr).not.toMatch(
-			/`X_DO_EXPORTS` environment variable is not set/
-		);
 	}
 );

--- a/packages/workers-utils/src/config/durable-object-exports.ts
+++ b/packages/workers-utils/src/config/durable-object-exports.ts
@@ -1,68 +1,6 @@
-import { getDoExportsEnabledFromEnv } from "../environment-variables/misc-variables";
-import { UserError } from "../errors";
 import { partitionExports } from "./exports";
 import type { Config } from "./config";
 import type { DurableObjectExport } from "./environment";
-
-/**
- * Context label for the {@link assertDoExportsEnabledIfConfigured} helper.
- * Used to build a stable telemetry label so we can tell the deploy / dev /
- * types call sites apart.
- */
-export type DoExportsOptInContext =
-	| "deploy"
-	| "versions upload"
-	| "dev"
-	| "types"
-	| "vitest-pool-workers";
-
-/**
- * If the user's config declares Durable Object `exports` entries but the
- * `X_DO_EXPORTS` environment variable is not set, throw a `UserError` so the
- * user discovers the missing opt-in locally before any side effects fire.
- *
- * Called from the deploy / versions-upload payload resolution (so the
- * declarative payload doesn't get silently downgraded to legacy `migrations`),
- * from the `wrangler dev` config-resolution path (so a local-dev session can't
- * drift from production semantics), from the `wrangler types` flow (so the
- * generated `.d.ts` surface can't drift either), and from
- * `@cloudflare/vitest-pool-workers` (so tests can't drift either).
- */
-export function assertDoExportsEnabledIfConfigured(
-	exports: Config["exports"] | undefined,
-	context: DoExportsOptInContext
-): void {
-	if (!hasDurableObjectExports(exports)) {
-		return;
-	}
-	if (getDoExportsEnabledFromEnv()) {
-		return;
-	}
-
-	let telemetryMessage: string;
-	switch (context) {
-		case "deploy":
-			telemetryMessage = "deploy do exports flag missing";
-			break;
-		case "versions upload":
-			telemetryMessage = "versions upload do exports flag missing";
-			break;
-		case "dev":
-			telemetryMessage = "dev do exports flag missing";
-			break;
-		case "types":
-			telemetryMessage = "types do exports flag missing";
-			break;
-		case "vitest-pool-workers":
-			telemetryMessage = "vitest-pool-workers do exports flag missing";
-			break;
-	}
-
-	throw new UserError(
-		"Your configuration declares Durable Object `exports` but the `X_DO_EXPORTS` environment variable is not set. Set `X_DO_EXPORTS=true` to enable the declarative exports flow, or remove the `exports` entries to fall back to `migrations`.",
-		{ telemetryMessage }
-	);
-}
 
 /**
  * Returns a map of exports that are only of type "durable-object".

--- a/packages/workers-utils/src/config/environment.ts
+++ b/packages/workers-utils/src/config/environment.ts
@@ -577,7 +577,6 @@ interface EnvironmentInheritable {
 	 * Declarative exports configuration — a map of class name to export configuration.
 	 *
 	 * The configuration of Durable Objects via `exports` is mutually exclusive with `migrations`.
-	 * Durable Object exports are gated behind the `X_DO_EXPORTS` environment variable for Wrangler commands.
 	 *
 	 * @default {}
 	 * @inheritable

--- a/packages/workers-utils/src/config/validation.ts
+++ b/packages/workers-utils/src/config/validation.ts
@@ -3,10 +3,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { isValidWorkflowName } from "@cloudflare/workflows-shared/src/lib/validators";
 import { dedent } from "ts-dedent";
-import {
-	getCloudflareEnv,
-	getDoExportsEnabledFromEnv,
-} from "../environment-variables/misc-variables";
+import { getCloudflareEnv } from "../environment-variables/misc-variables";
 import { UserError } from "../errors";
 import { isDirectory } from "../fs-helpers";
 import { isRedirectedRawConfig } from "./config-helpers";
@@ -6414,40 +6411,20 @@ function warnIfDurableObjectsHaveNoLifecycleConfig(
 		(durable) => durable.class_name
 	) as string[];
 
-	const usingExports = exports !== undefined && Object.keys(exports).length > 0;
-	const preferExports = usingExports || getDoExportsEnabledFromEnv();
-
-	if (preferExports) {
-		const suggestedExports: NonNullable<RawConfig["exports"]> = {};
-		for (const className of durableObjectClassnames) {
-			suggestedExports[className] = {
-				type: "durable-object",
-				storage: "sqlite",
-			};
-		}
-
-		diagnostics.warnings.push(dedent`
-		In your ${configFileName(configPath)} file, you have configured \`durable_objects\` exported by this Worker (${durableObjectClassnames.join(", ")}), but no live \`exports\` entry for them. This may not work as expected until you add a live \`durable-object\` entry to \`exports\` for each. Add the following configuration:
-
-		\`\`\`
-		${formatConfigSnippet({ exports: suggestedExports }, configPath)}
-		\`\`\``);
-		return;
+	const suggestedExports: NonNullable<RawConfig["exports"]> = {};
+	for (const className of durableObjectClassnames) {
+		suggestedExports[className] = {
+			type: "durable-object",
+			storage: "sqlite",
+		};
 	}
 
 	diagnostics.warnings.push(dedent`
-	In your ${configFileName(configPath)} file, you have configured \`durable_objects\` exported by this Worker (${durableObjectClassnames.join(", ")}), but no \`migrations\` for them. This may not work as expected until you add a \`migrations\` section to your ${configFileName(configPath)} file. Add the following configuration:
+	In your ${configFileName(configPath)} file, you have configured \`durable_objects\` exported by this Worker (${durableObjectClassnames.join(", ")}), but no live \`exports\` entry for them. This may not work as expected until you add a live \`durable-object\` entry to \`exports\` for each. Add the following configuration:
 
 	\`\`\`
-	${formatConfigSnippet(
-		{
-			migrations: [{ tag: "v1", new_sqlite_classes: durableObjectClassnames }],
-		},
-		configPath
-	)}
-	\`\`\`
-
-	Refer to https://developers.cloudflare.com/durable-objects/reference/durable-objects-migrations/ for more details.`);
+	${formatConfigSnippet({ exports: suggestedExports }, configPath)}
+	\`\`\``);
 }
 
 /**

--- a/packages/workers-utils/src/environment-variables/factory.ts
+++ b/packages/workers-utils/src/environment-variables/factory.ts
@@ -116,8 +116,6 @@ type VariableNames =
 	| "X_LOCAL_EXPLORER"
 	/** Open the browser in headful (visible) mode when using the Browser Run API in local dev (default: false). */
 	| "X_BROWSER_HEADFUL"
-	/** Send declarative Durable Object `exports` to the upload API instead of computing `migrations` steps (experimental, default: false). */
-	| "X_DO_EXPORTS"
 
 	// ## CI-specific Variables (Internal Use)
 

--- a/packages/workers-utils/src/environment-variables/misc-variables.ts
+++ b/packages/workers-utils/src/environment-variables/misc-variables.ts
@@ -374,27 +374,6 @@ export const getBrowserRenderingHeadfulFromEnv =
 	});
 
 /**
- * `X_DO_EXPORTS` enables the experimental declarative Durable Object `exports`
- * flow. When set, `wrangler deploy` and `wrangler versions upload` send the
- * declarative `exports` map to the upload API instead of computing
- * `migrations` steps; the validator's "no lifecycle declared" warning also
- * recommends the `exports` shape rather than the legacy `migrations` array.
- *
- * Set to "true" to enable:
- *
- * ```sh
- * X_DO_EXPORTS=true wrangler deploy
- * ```
- *
- * The flow remains experimental until server-side support is available
- * broadly.
- */
-export const getDoExportsEnabledFromEnv = getBooleanEnvironmentVariableFactory({
-	variableName: "X_DO_EXPORTS",
-	defaultValue: false,
-});
-
-/**
  * `CLOUDFLARE_CF_FETCH_ENABLED` controls whether Miniflare fetches the `cf.json` file
  * containing request.cf properties from workers.cloudflare.com.
  *

--- a/packages/workers-utils/src/index.ts
+++ b/packages/workers-utils/src/index.ts
@@ -10,10 +10,8 @@ export * from "./config/environment";
 export { partitionExports } from "./config/exports";
 export type { ExportType, PartitionedExports } from "./config/exports";
 export {
-	assertDoExportsEnabledIfConfigured,
 	getDurableObjectExports,
 	hasDurableObjectExports,
-	type DoExportsOptInContext,
 } from "./config/durable-object-exports";
 export {
 	type RedirectedRawConfig,

--- a/packages/workers-utils/src/worker.ts
+++ b/packages/workers-utils/src/worker.ts
@@ -478,7 +478,7 @@ export interface CfWorkerInit {
 	migrations: CfDurableObjectMigrations | undefined;
 	/**
 	 * Declarative exports configuration. Durable Object entries are sent instead
-	 * of `migrations` and require the `X_DO_EXPORTS` environment variable.
+	 * of `migrations`.
 	 */
 	exports: CfExports | undefined;
 	compatibility_date: string | undefined;

--- a/packages/workers-utils/tests/config/validation/normalize-and-validate-config.test.ts
+++ b/packages/workers-utils/tests/config/validation/normalize-and-validate-config.test.ts
@@ -1082,16 +1082,14 @@ describe("normalizeAndValidateConfig()", () => {
 			expect(diagnostics.renderWarnings()).toMatchInlineSnapshot(`
 				"Processing wrangler.toml configuration:
 				  - "unsafe" fields are experimental and may change or break at any time.
-				  - In your wrangler.toml file, you have configured \`durable_objects\` exported by this Worker (CLASS1), but no \`migrations\` for them. This may not work as expected until you add a \`migrations\` section to your wrangler.toml file. Add the following configuration:
+				  - In your wrangler.toml file, you have configured \`durable_objects\` exported by this Worker (CLASS1), but no live \`exports\` entry for them. This may not work as expected until you add a live \`durable-object\` entry to \`exports\` for each. Add the following configuration:
 
 				    \`\`\`
-				    [[migrations]]
-				    tag = "v1"
-				    new_sqlite_classes = [ "CLASS1" ]
+				    [exports.CLASS1]
+				    type = "durable-object"
+				    storage = "sqlite"
 
-				    \`\`\`
-
-				    Refer to https://developers.cloudflare.com/durable-objects/reference/durable-objects-migrations/ for more details."
+				    \`\`\`"
 			`);
 		});
 
@@ -2323,33 +2321,7 @@ describe("normalizeAndValidateConfig()", () => {
 				expect(rendered).not.toContain("new_sqlite_classes");
 			});
 
-			it("warns and suggests an `exports` entry when neither lifecycle is declared and `X_DO_EXPORTS` is set", ({
-				expect,
-			}) => {
-				vi.stubEnv("X_DO_EXPORTS", "true");
-				try {
-					const { diagnostics } = normalizeAndValidateConfig(
-						{
-							durable_objects: {
-								bindings: [{ name: "DO", class_name: "MyDO" }],
-							},
-						},
-						undefined,
-						undefined,
-						{ env: undefined }
-					);
-
-					expect(diagnostics.hasWarnings()).toBe(true);
-					const rendered = diagnostics.renderWarnings();
-					expect(rendered).toContain("no live `exports` entry for them");
-					expect(rendered).toContain('"type": "durable-object"');
-					expect(rendered).not.toContain("new_sqlite_classes");
-				} finally {
-					vi.unstubAllEnvs();
-				}
-			});
-
-			it("warns and suggests `migrations` when neither lifecycle is declared and `X_DO_EXPORTS` is unset", ({
+			it("warns and suggests an `exports` entry when neither lifecycle is declared", ({
 				expect,
 			}) => {
 				const { diagnostics } = normalizeAndValidateConfig(
@@ -2365,9 +2337,10 @@ describe("normalizeAndValidateConfig()", () => {
 
 				expect(diagnostics.hasWarnings()).toBe(true);
 				const rendered = diagnostics.renderWarnings();
-				expect(rendered).toContain("`migrations`");
-				expect(rendered).toContain("new_sqlite_classes");
-				expect(rendered).not.toContain("no live `exports` entry for them");
+				expect(rendered).toContain("no live `exports` entry for them");
+				expect(rendered).toContain('"type": "durable-object"');
+				expect(rendered).toContain('"storage": "sqlite"');
+				expect(rendered).not.toContain("new_sqlite_classes");
 			});
 		});
 

--- a/packages/wrangler/e2e/durable-objects-exports.test.ts
+++ b/packages/wrangler/e2e/durable-objects-exports.test.ts
@@ -51,9 +51,7 @@ describe.skipIf(!CLOUDFLARE_ACCOUNT_ID)(
 					`,
 				});
 
-				const output = await helper.run(`wrangler deploy`, {
-					env: { ...process.env, X_DO_EXPORTS: "true" },
-				});
+				const output = await helper.run(`wrangler deploy`);
 
 				expect(output.stdout).toContain(
 					"Durable Object exports reconciliation"
@@ -64,9 +62,7 @@ describe.skipIf(!CLOUDFLARE_ACCOUNT_ID)(
 			it("scenario 2: re-deploying with the same config is a no-op", async ({
 				expect,
 			}) => {
-				const output = await helper.run(`wrangler deploy`, {
-					env: { ...process.env, X_DO_EXPORTS: "true" },
-				});
+				const output = await helper.run(`wrangler deploy`);
 
 				expect(output.stdout).not.toContain("Created: ");
 				expect(output.stdout).not.toContain("Deleted: ");
@@ -93,9 +89,7 @@ describe.skipIf(!CLOUDFLARE_ACCOUNT_ID)(
 					`,
 				});
 
-				const output = await helper.run(`wrangler deploy`, {
-					env: { ...process.env, X_DO_EXPORTS: "true" },
-				});
+				const output = await helper.run(`wrangler deploy`);
 
 				expect(output.stdout).toContain("Deleted: MyDO");
 			});
@@ -103,9 +97,7 @@ describe.skipIf(!CLOUDFLARE_ACCOUNT_ID)(
 			it("scenario T3: emits a stale-tombstone info and a removable_entries hint", async ({
 				expect,
 			}) => {
-				const output = await helper.run(`wrangler deploy`, {
-					env: { ...process.env, X_DO_EXPORTS: "true" },
-				});
+				const output = await helper.run(`wrangler deploy`);
 
 				expect(output.stdout).toContain("[stale_tombstone] MyDO");
 				expect(output.stdout).toContain("Safe to remove from `exports`: MyDO");
@@ -132,9 +124,7 @@ describe.skipIf(!CLOUDFLARE_ACCOUNT_ID)(
 					`,
 				});
 
-				const result = await helper.run(`wrangler deploy`, {
-					env: { ...process.env, X_DO_EXPORTS: "true" },
-				});
+				const result = await helper.run(`wrangler deploy`);
 
 				expect(result.status).not.toBe(0);
 				expect(result.stderr).toContain(
@@ -185,9 +175,7 @@ describe.skipIf(!CLOUDFLARE_ACCOUNT_ID)(
 					`,
 				});
 
-				const output = await helper.run(`wrangler deploy`, {
-					env: { ...process.env, X_DO_EXPORTS: "true" },
-				});
+				const output = await helper.run(`wrangler deploy`);
 
 				expect(output.stdout).toContain("Created: Counter");
 			});
@@ -223,9 +211,7 @@ describe.skipIf(!CLOUDFLARE_ACCOUNT_ID)(
 					`,
 				});
 
-				const output = await helper.run(`wrangler deploy`, {
-					env: { ...process.env, X_DO_EXPORTS: "true" },
-				});
+				const output = await helper.run(`wrangler deploy`);
 
 				expect(output.stdout).toContain("Renamed: Counter → CounterV2");
 				expect(output.stdout).not.toContain("Created: CounterV2");
@@ -257,9 +243,7 @@ describe.skipIf(!CLOUDFLARE_ACCOUNT_ID)(
 					`,
 				});
 
-				const output = await helper.run(`wrangler deploy`, {
-					env: { ...process.env, X_DO_EXPORTS: "true" },
-				});
+				const output = await helper.run(`wrangler deploy`);
 
 				expect(output.stdout).not.toContain("Renamed: ");
 				expect(output.stdout).not.toContain("Created: ");
@@ -308,9 +292,7 @@ describe.skipIf(!CLOUDFLARE_ACCOUNT_ID)(
 					`,
 				});
 
-				const output = await helperA.run(`wrangler deploy`, {
-					env: { ...process.env, X_DO_EXPORTS: "true" },
-				});
+				const output = await helperA.run(`wrangler deploy`);
 
 				expect(output.stdout).toContain("Created: Widget");
 			});
@@ -351,9 +333,7 @@ describe.skipIf(!CLOUDFLARE_ACCOUNT_ID)(
 					`,
 				});
 
-				const output = await helperB.run(`wrangler deploy`, {
-					env: { ...process.env, X_DO_EXPORTS: "true" },
-				});
+				const output = await helperB.run(`wrangler deploy`);
 
 				expect(output.stdout).toContain(
 					`Transfer pending: Widget ← ${workerA}`
@@ -385,9 +365,7 @@ describe.skipIf(!CLOUDFLARE_ACCOUNT_ID)(
 					`,
 				});
 
-				const output = await helperA.run(`wrangler deploy`, {
-					env: { ...process.env, X_DO_EXPORTS: "true" },
-				});
+				const output = await helperA.run(`wrangler deploy`);
 
 				expect(output.stdout).toContain(
 					`Transferred (committed): Widget → ${workerB}`
@@ -421,9 +399,7 @@ describe.skipIf(!CLOUDFLARE_ACCOUNT_ID)(
 					`,
 				});
 
-				const output = await helperB.run(`wrangler deploy`, {
-					env: { ...process.env, X_DO_EXPORTS: "true" },
-				});
+				const output = await helperB.run(`wrangler deploy`);
 
 				expect(output.stdout).toContain("env.WIDGET (Widget)");
 				expect(output.stdout).not.toContain("Created: ");
@@ -476,9 +452,7 @@ describe.skipIf(!CLOUDFLARE_ACCOUNT_ID)(
 					`,
 				});
 
-				const output = await helper.run(`wrangler deploy`, {
-					env: { ...process.env, X_DO_EXPORTS: "true" },
-				});
+				const output = await helper.run(`wrangler deploy`);
 
 				expect(output.stdout).toContain("Created: SomeClass");
 			});
@@ -530,9 +504,7 @@ describe.skipIf(!CLOUDFLARE_ACCOUNT_ID)(
 					`,
 				});
 
-				const output = await helper.run(`wrangler versions upload`, {
-					env: { ...process.env, X_DO_EXPORTS: "true" },
-				});
+				const output = await helper.run(`wrangler versions upload`);
 
 				expect(output.stdout).toContain("Worker Version ID:");
 				expect(output.stdout).not.toContain(
@@ -551,27 +523,10 @@ describe.skipIf(!CLOUDFLARE_ACCOUNT_ID)(
 				expect,
 			}) => {
 				const output = await helper.run(
-					`wrangler versions deploy ${versionId}@100% --yes`,
-					{
-						env: { ...process.env, X_DO_EXPORTS: "true" },
-					}
+					`wrangler versions deploy ${versionId}@100% --yes`
 				);
 
 				expect(output.stdout).toContain("SUCCESS");
-			});
-
-			it("rejects `exports` when `X_DO_EXPORTS` is off on the versions path", async ({
-				expect,
-			}) => {
-				// Symmetric to the deploy-side gate-off coverage above —
-				// pin down that the same `assertDoExportsEnabledIfConfigured`
-				// validator fires on the versions-upload path.
-				const result = await helper.run(`wrangler versions upload`);
-
-				expect(result.status).not.toBe(0);
-				expect(result.stderr).toContain(
-					"X_DO_EXPORTS` environment variable is not set"
-				);
 			});
 		});
 	}

--- a/packages/wrangler/src/__tests__/deploy/durable-objects.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/durable-objects.test.ts
@@ -93,7 +93,7 @@ describe("deploy", () => {
 	});
 
 	describe("durable object migrations", () => {
-		it("should warn when you try to deploy durable objects without migrations", async ({
+		it("should warn when you try to deploy durable objects without a lifecycle declared", async ({
 			expect,
 		}) => {
 			writeWranglerConfig({
@@ -128,19 +128,15 @@ describe("deploy", () => {
 				"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mProcessing wrangler.toml configuration:[0m
 
 				    - In your wrangler.toml file, you have configured \`durable_objects\` exported by this Worker
-				  (SomeClass), but no \`migrations\` for them. This may not work as expected until you add a
-				  \`migrations\` section to your wrangler.toml file. Add the following configuration:
+				  (SomeClass), but no live \`exports\` entry for them. This may not work as expected until you add a
+				  live \`durable-object\` entry to \`exports\` for each. Add the following configuration:
 
 				      \`\`\`
-				      [[migrations]]
-				      tag = "v1"
-				      new_sqlite_classes = [ "SomeClass" ]
+				      [exports.SomeClass]
+				      type = "durable-object"
+				      storage = "sqlite"
 
 				      \`\`\`
-
-				      Refer to
-				  [4mhttps://developers.cloudflare.com/durable-objects/reference/durable-objects-migrations/[0m for more
-				  details.
 
 				"
 			`);
@@ -761,28 +757,9 @@ describe("deploy", () => {
 	});
 
 	describe("durable object exports (declarative)", () => {
-		it("errors when `exports` is set but the `X_DO_EXPORTS` env var is off", async ({
+		it("sends the `exports` payload (and omits `migrations`)", async ({
 			expect,
 		}) => {
-			writeWranglerConfig({
-				durable_objects: {
-					bindings: [{ name: "DO", class_name: "MyDO" }],
-				},
-				exports: {
-					MyDO: { type: "durable-object", storage: "sqlite" },
-				},
-			});
-			fs.writeFileSync("index.js", `export class MyDO {}; export default {};`);
-
-			await expect(runWrangler("deploy index.js")).rejects.toThrow(
-				/`X_DO_EXPORTS` environment variable is not set/
-			);
-		});
-
-		it("sends the `exports` payload (and omits `migrations`) when `X_DO_EXPORTS=true`", async ({
-			expect,
-		}) => {
-			vi.stubEnv("X_DO_EXPORTS", "true");
 			writeWranglerConfig({
 				durable_objects: {
 					bindings: [{ name: "DO", class_name: "MyDO" }],
@@ -809,7 +786,6 @@ describe("deploy", () => {
 		it("renders the success-side reconciliation envelope", async ({
 			expect,
 		}) => {
-			vi.stubEnv("X_DO_EXPORTS", "true");
 			writeWranglerConfig({
 				durable_objects: {
 					bindings: [{ name: "DO", class_name: "MyDO" }],
@@ -858,7 +834,6 @@ describe("deploy", () => {
 		it("renders the error-side reconciliation envelope with per-class detail", async ({
 			expect,
 		}) => {
-			vi.stubEnv("X_DO_EXPORTS", "true");
 			writeWranglerConfig({
 				durable_objects: {
 					bindings: [{ name: "DO", class_name: "MyDO" }],

--- a/packages/wrangler/src/__tests__/dev.test.ts
+++ b/packages/wrangler/src/__tests__/dev.test.ts
@@ -1688,7 +1688,7 @@ describe.sequential("wrangler dev", () => {
 	});
 
 	describe("durable_objects", () => {
-		it("should warn if there are remote Durable Objects, or missing migrations for local Durable Objects", async ({
+		it("should warn if there are remote Durable Objects, or a missing lifecycle for local Durable Objects", async ({
 			expect,
 		}) => {
 			writeWranglerConfig({
@@ -1735,48 +1735,26 @@ describe.sequential("wrangler dev", () => {
 				"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mProcessing wrangler.toml configuration:[0m
 
 				    - In your wrangler.toml file, you have configured \`durable_objects\` exported by this Worker
-				  (CLASS_1, CLASS_3), but no \`migrations\` for them. This may not work as expected until you add a
-				  \`migrations\` section to your wrangler.toml file. Add the following configuration:
+				  (CLASS_1, CLASS_3), but no live \`exports\` entry for them. This may not work as expected until you
+				  add a live \`durable-object\` entry to \`exports\` for each. Add the following configuration:
 
 				      \`\`\`
-				      [[migrations]]
-				      tag = "v1"
-				      new_sqlite_classes = [ "CLASS_1", "CLASS_3" ]
+				      [exports.CLASS_1]
+				      type = "durable-object"
+				      storage = "sqlite"
+
+				      [exports.CLASS_3]
+				      type = "durable-object"
+				      storage = "sqlite"
 
 				      \`\`\`
-
-				      Refer to
-				  [4mhttps://developers.cloudflare.com/durable-objects/reference/durable-objects-migrations/[0m for more
-				  details.
 
 				"
 			`);
 		});
 
-		describe("declarative `exports` opt-in", () => {
-			it("errors when `exports` is set but the `X_DO_EXPORTS` env var is off", async ({
-				expect,
-			}) => {
-				writeWranglerConfig({
-					main: "index.js",
-					durable_objects: {
-						bindings: [{ name: "DO", class_name: "MyDO" }],
-					},
-					exports: {
-						MyDO: { type: "durable-object", storage: "sqlite" },
-					},
-				});
-				fs.writeFileSync("index.js", `export default {};`);
-
-				await expect(runWranglerUntilConfig("dev")).rejects.toThrow(
-					/`X_DO_EXPORTS` environment variable is not set/
-				);
-			});
-
-			it("starts dev when `exports` is set and `X_DO_EXPORTS=true`", async ({
-				expect,
-			}) => {
-				vi.stubEnv("X_DO_EXPORTS", "true");
+		describe("declarative `exports`", () => {
+			it("starts dev when `exports` is set", async ({ expect }) => {
 				writeWranglerConfig({
 					name: "test-do-exports-dev",
 					main: "index.js",

--- a/packages/wrangler/src/__tests__/type-generation.test.ts
+++ b/packages/wrangler/src/__tests__/type-generation.test.ts
@@ -3720,8 +3720,6 @@ describe("generate types - CLI", () => {
 		it("populates `durableNamespaces` from live `exports` entries (including unbound + `expecting-transfer`) and excludes tombstones", async ({
 			expect,
 		}) => {
-			vi.stubEnv("X_DO_EXPORTS", "true");
-
 			// `UnboundDO` and `IncomingDO` are reachable only through `ctx.exports`.
 			fs.writeFileSync(
 				"./index.ts",
@@ -3787,36 +3785,6 @@ export default { async fetch() { return new Response("ok"); } };`
 				📣 Remember to rerun 'wrangler types' after you change your wrangler.jsonc file.
 				"
 			`);
-		});
-
-		it("rejects when `exports` is configured but `X_DO_EXPORTS` is unset", async ({
-			expect,
-		}) => {
-			fs.writeFileSync(
-				"./index.ts",
-				`import { DurableObject } from "cloudflare:workers";
-export class MyDO extends DurableObject {}
-export default { async fetch() { return new Response("ok"); } };`
-			);
-			fs.writeFileSync(
-				"./wrangler.jsonc",
-				JSON.stringify({
-					compatibility_date: "2026-01-01",
-					name: "test-exports-types-gate",
-					main: "./index.ts",
-					durable_objects: {
-						bindings: [{ name: "MY_DO", class_name: "MyDO" }],
-					},
-					exports: {
-						MyDO: { type: "durable-object", storage: "sqlite" },
-					},
-				}),
-				"utf-8"
-			);
-
-			await expect(
-				runWrangler("types --include-runtime=false")
-			).rejects.toThrow(/`X_DO_EXPORTS` environment variable is not set/);
 		});
 	});
 });

--- a/packages/wrangler/src/__tests__/versions/versions.upload.test.ts
+++ b/packages/wrangler/src/__tests__/versions/versions.upload.test.ts
@@ -2311,35 +2311,13 @@ describe("versions upload", () => {
 			setIsTTY(false);
 		});
 
-		test("errors when `exports` is set but the `X_DO_EXPORTS` env var is off", async ({
-			expect,
-		}) => {
-			mockGetScript();
-			writeWranglerConfig({
-				name: "test-name",
-				main: "./index.js",
-				durable_objects: {
-					bindings: [{ name: "MY_DO", class_name: "MyDurableObject" }],
-				},
-				exports: {
-					MyDurableObject: { type: "durable-object", storage: "sqlite" },
-				},
-			});
-			writeWorkerSource({ durableObjects: ["MyDurableObject"] });
-
-			await expect(runWrangler("versions upload")).rejects.toThrow(
-				/`X_DO_EXPORTS` environment variable is not set/
-			);
-		});
-
-		test("sends the `exports` payload (and omits `migrations`) when `X_DO_EXPORTS=true`", async ({
+		test("sends the `exports` payload (and omits `migrations`)", async ({
 			expect,
 		}) => {
 			// The versions POST controller (EWC) accepts `exports` and
 			// persists it on the new script_version row with
 			// `SkipDeploy:true`; reconciliation runs at deploy time
 			// (`wrangler deploy` or `wrangler versions deploy <id>`).
-			vi.stubEnv("X_DO_EXPORTS", "true");
 			mockGetScript();
 			const requests = mockUploadVersion(false, 0);
 
@@ -2377,7 +2355,6 @@ describe("versions upload", () => {
 			// `exports` but not yet provisioned — reconciliation defers to
 			// deploy, so the namespace can't exist at upload time. The message
 			// is already actionable, so wrangler surfaces it verbatim.
-			vi.stubEnv("X_DO_EXPORTS", "true");
 			mockGetScript();
 
 			const serverMessage =
@@ -2431,7 +2408,6 @@ describe("versions upload", () => {
 		}) => {
 			// A different EWC error code must pass through untransformed — the
 			// 100406 branch falls through and the original APIError surfaces.
-			vi.stubEnv("X_DO_EXPORTS", "true");
 			mockGetScript();
 
 			msw.use(

--- a/packages/wrangler/src/api/startDevWorker/ConfigController.ts
+++ b/packages/wrangler/src/api/startDevWorker/ConfigController.ts
@@ -3,7 +3,6 @@ import path from "node:path";
 import { resolveDockerHost } from "@cloudflare/containers-shared";
 import { extractBindingsOfType } from "@cloudflare/deploy-helpers";
 import {
-	assertDoExportsEnabledIfConfigured,
 	configFileName,
 	formatConfigSnippet,
 	getTodaysCompatDate,
@@ -505,9 +504,6 @@ async function resolveConfig(
 			"Queues are not yet supported in wrangler dev remote mode."
 		);
 	}
-
-	// Keep dev aligned with deploy when declarative `exports` is configured.
-	assertDoExportsEnabledIfConfigured(resolved.exports, "dev");
 
 	if (resolved.dev.remote) {
 		// We're in remote mode (`--remote`)

--- a/packages/wrangler/src/type-generation/index.ts
+++ b/packages/wrangler/src/type-generation/index.ts
@@ -2,7 +2,6 @@ import { createHash } from "node:crypto";
 import * as fs from "node:fs";
 import { basename, dirname, extname, join, relative, resolve } from "node:path";
 import {
-	assertDoExportsEnabledIfConfigured,
 	CommandLineArgsError,
 	configFileName,
 	experimental_readRawConfig,
@@ -485,9 +484,6 @@ async function generateTypesFromResolvedOptions(
 	options: ResolvedGenerateTypesOptions,
 	log: boolean
 ): Promise<GeneratedTypesResult> {
-	// Keep generated types aligned with the deploy / dev opt-in contract.
-	assertDoExportsEnabledIfConfigured(options.config.exports, "types");
-
 	const entrypoint = await getTypesEntrypoint(options.config);
 	const entrypointFormat = entrypoint?.format ?? "modules";
 


### PR DESCRIPTION
Follow-up to #14382, which added declarative Durable Object `exports` behind the `X_DO_EXPORTS` opt-in env var. Internal ref: DEVX-2572.

This graduates declarative Durable Object `exports` to GA:

- Removes the `X_DO_EXPORTS` opt-in env var and all associated gate machinery (`getDoExportsEnabledFromEnv`, `assertDoExportsEnabledIfConfigured`, `DoExportsOptInContext`) as dead code across `workers-utils`, `deploy-helpers`, `wrangler`, and `@cloudflare/vitest-pool-workers`. Declarative `exports` now works out of the box in `deploy`, `versions upload`, `dev`, `vite dev`, `unstable_startWorker`, `wrangler types`, and `vitest-pool-workers` with no opt-in required.
- Defaults the "Durable Object bindings declared with no lifecycle" config warning to suggest a declarative `exports` entry instead of a legacy `migrations` block. Configs that already declare `migrations` are unaffected (they return early before this suggestion).
- Amends the still-pending changeset from #14382 rather than adding a second one, so the next release ships a single coherent GA entry (the experimental version was never published).
- Removes the gate-negative test cases and `X_DO_EXPORTS` env seeds from unit, e2e, and integration tests, and updates affected snapshots to the `exports` suggestion.

Net diff is `+75 / -456` (mostly gate/dead-code removal).

Verified locally: `oxlint --deny-warnings --type-aware` (0/0), `oxfmt --check` (clean), and `check:type` + `type:tests` for all touched packages (25/25). Targeted suites pass: `workers-utils` normalize-and-validate-config (434), `wrangler` durable-objects (32), versions.upload (86), type-generation (112), and the updated `dev`/`durable-objects` warning snapshots. The `vitest-pool-workers` `do-exports` integration test and the `wrangler` e2e suite are left to CI (they require the mock-registry setup / real credentials).

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: this PR removes an experimental opt-in gate and changes a config-validation suggestion string; the declarative `exports` config surface is fully described in the changeset. Public docs for the GA rollout are tracked separately under DEVX-2572.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14526" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->