### PR TITLE
Add `wrangler list-commands` command

### DIFF
--- a/.changeset/add-list-commands.md
+++ b/.changeset/add-list-commands.md
@@ -1,0 +1,16 @@
+---
+"wrangler": minor
+---
+
+Add `wrangler list-commands` command
+
+A new `list-commands` command displays all available Wrangler commands and subcommands in a tree structure, providing a quick overview of the full CLI surface without the verbosity of `--help`.
+
+Supports the following flags:
+
+- `--json` for machine-readable output
+- `--include-aliases` to optionally show alias commands
+- `--all` to expand the full command tree at every depth instead of only showing top-level commands
+- `--base` to scope output to a specific subtree (e.g. `--base="d1 migrations"`)
+
+When an invalid command is entered, Wrangler now suggests running `list-commands` to discover available commands.

--- a/packages/wrangler/src/__tests__/ai.test.ts
+++ b/packages/wrangler/src/__tests__/ai.test.ts
@@ -68,7 +68,11 @@ describe("ai help", () => {
 			  -h, --help            Show help  [boolean]
 			      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 			      --profile         Use a specific auth profile  [string]
-			  -v, --version         Show version number  [boolean]"
+			  -v, --version         Show version number  [boolean]
+
+			☝️ Tip: Run \`wrangler list-commands\` to see all available commands and subcommands.
+
+			"
 		`);
 	});
 

--- a/packages/wrangler/src/__tests__/d1/d1.test.ts
+++ b/packages/wrangler/src/__tests__/d1/d1.test.ts
@@ -77,7 +77,11 @@ describe("d1", () => {
 			  -h, --help            Show help  [boolean]
 			      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 			      --profile         Use a specific auth profile  [string]
-			  -v, --version         Show version number  [boolean]"
+			  -v, --version         Show version number  [boolean]
+
+			☝️ Tip: Run \`wrangler list-commands\` to see all available commands and subcommands.
+
+			"
 		`);
 	});
 

--- a/packages/wrangler/src/__tests__/hyperdrive.test.ts
+++ b/packages/wrangler/src/__tests__/hyperdrive.test.ts
@@ -85,7 +85,11 @@ describe("hyperdrive help", () => {
 			  -h, --help            Show help  [boolean]
 			      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 			      --profile         Use a specific auth profile  [string]
-			  -v, --version         Show version number  [boolean]"
+			  -v, --version         Show version number  [boolean]
+
+			☝️ Tip: Run \`wrangler list-commands\` to see all available commands and subcommands.
+
+			"
 		`);
 	});
 });

--- a/packages/wrangler/src/__tests__/index.test.ts
+++ b/packages/wrangler/src/__tests__/index.test.ts
@@ -43,59 +43,62 @@ describe("wrangler", () => {
 				"wrangler
 
 				COMMANDS
-				  wrangler docs [search..]        📚 Open Wrangler's command documentation in your browser
-				  wrangler complete [shell]       ⌨️ Generate and handle shell completions
-				  wrangler list-commands          List all available commands and subcommands
+				  wrangler docs [search..]         📚 Open Wrangler's command documentation in your browser
+				  wrangler complete [shell]        ⌨️ Generate and handle shell completions
+				  wrangler list-commands [base..]  List all available commands and subcommands
 
-				  wrangler email                  Manage Cloudflare Email services [open beta]
+				  wrangler email                   Manage Cloudflare Email services [open beta]
+				  wrangler list-cmds [base..]      List all available commands and subcommands
+
+				                                   Alias for "wrangler list-commands".
 
 				ACCOUNT
-				  wrangler auth                   🔐 Manage authentication
-				  wrangler login                  🔓 Login to Cloudflare
-				  wrangler logout                 🚪 Logout from Cloudflare
-				  wrangler whoami                 🕵️ Retrieve your user information
+				  wrangler auth                    🔐 Manage authentication
+				  wrangler login                   🔓 Login to Cloudflare
+				  wrangler logout                  🚪 Logout from Cloudflare
+				  wrangler whoami                  🕵️ Retrieve your user information
 
 				COMPUTE & AI
-				  wrangler agent-memory           🧠 Manage Agent Memory namespaces [private beta]
-				  wrangler ai                     🤖 Manage AI models
-				  wrangler ai-search              🔍 Manage AI Search instances [open beta]
-				  wrangler browser                🌐 Manage Browser Run sessions [open beta]
-				  wrangler containers             📦 Manage Containers
-				  wrangler delete [name]          🗑️ Delete a Worker from Cloudflare
-				  wrangler deploy [path]          🆙 Deploy a Worker to Cloudflare
-				  wrangler deployments            🚢 List and view the current and past deployments for your Worker
-				  wrangler dev [script]           👂 Start a local server for developing your Worker
-				  wrangler dispatch-namespace     🏗️ Manage dispatch namespaces
-				  wrangler flagship               🚩 Manage Flagship apps and feature flags [open beta]
-				  wrangler init [name]            📥 Initialize a basic Worker
-				  wrangler pages                  ⚡️ Configure Cloudflare Pages
-				  wrangler preview [script]       👀 Create a Preview deployment of the current Worker [private beta]
-				  wrangler queues                 📬 Manage Workers Queues
-				  wrangler rollback [version-id]  🔙 Rollback a deployment for a Worker
-				  wrangler secret                 🤫 Generate a secret that can be referenced in a Worker
-				  wrangler setup                  🪄 Setup a project to work on Cloudflare
-				  wrangler tail [worker]          🦚 Start a log tailing session for a Worker
-				  wrangler triggers               🎯 Updates the triggers of your current deployment [experimental]
-				  wrangler types [path]           📝 Generate types from your Worker configuration
-				  wrangler versions               🫧 List, view, upload and deploy Versions of your Worker to Cloudflare
-				  wrangler vpc                    🌐 Manage VPC [open beta]
-				  wrangler websearch              🔎 Run queries against Cloudflare Web Search [experimental]
-				  wrangler workflows              🔁 Manage Workflows
+				  wrangler agent-memory            🧠 Manage Agent Memory namespaces [private beta]
+				  wrangler ai                      🤖 Manage AI models
+				  wrangler ai-search               🔍 Manage AI Search instances [open beta]
+				  wrangler browser                 🌐 Manage Browser Run sessions [open beta]
+				  wrangler containers              📦 Manage Containers
+				  wrangler delete [name]           🗑️ Delete a Worker from Cloudflare
+				  wrangler deploy [path]           🆙 Deploy a Worker to Cloudflare
+				  wrangler deployments             🚢 List and view the current and past deployments for your Worker
+				  wrangler dev [script]            👂 Start a local server for developing your Worker
+				  wrangler dispatch-namespace      🏗️ Manage dispatch namespaces
+				  wrangler flagship                🚩 Manage Flagship apps and feature flags [open beta]
+				  wrangler init [name]             📥 Initialize a basic Worker
+				  wrangler pages                   ⚡️ Configure Cloudflare Pages
+				  wrangler preview [script]        👀 Create a Preview deployment of the current Worker [private beta]
+				  wrangler queues                  📬 Manage Workers Queues
+				  wrangler rollback [version-id]   🔙 Rollback a deployment for a Worker
+				  wrangler secret                  🤫 Generate a secret that can be referenced in a Worker
+				  wrangler setup                   🪄 Setup a project to work on Cloudflare
+				  wrangler tail [worker]           🦚 Start a log tailing session for a Worker
+				  wrangler triggers                🎯 Updates the triggers of your current deployment [experimental]
+				  wrangler types [path]            📝 Generate types from your Worker configuration
+				  wrangler versions                🫧 List, view, upload and deploy Versions of your Worker to Cloudflare
+				  wrangler vpc                     🌐 Manage VPC [open beta]
+				  wrangler websearch               🔎 Run queries against Cloudflare Web Search [experimental]
+				  wrangler workflows               🔁 Manage Workflows
 
 				STORAGE & DATABASES
-				  wrangler artifacts              🧱 Manage Artifacts namespaces and repos [private beta]
-				  wrangler d1                     🗄️ Manage Workers D1 databases
-				  wrangler hyperdrive             🚀 Manage Hyperdrive databases
-				  wrangler kv                     🗂️ Manage Workers KV Namespaces
-				  wrangler pipelines              🚰 Manage Cloudflare Pipelines [open beta]
-				  wrangler r2                     📦 Manage R2 buckets & objects
-				  wrangler secrets-store          🔐 Manage the Secrets Store [open beta]
-				  wrangler vectorize              🧮 Manage Vectorize indexes
+				  wrangler artifacts               🧱 Manage Artifacts namespaces and repos [private beta]
+				  wrangler d1                      🗄️ Manage Workers D1 databases
+				  wrangler hyperdrive              🚀 Manage Hyperdrive databases
+				  wrangler kv                      🗂️ Manage Workers KV Namespaces
+				  wrangler pipelines               🚰 Manage Cloudflare Pipelines [open beta]
+				  wrangler r2                      📦 Manage R2 buckets & objects
+				  wrangler secrets-store           🔐 Manage the Secrets Store [open beta]
+				  wrangler vectorize               🧮 Manage Vectorize indexes
 
 				NETWORKING & SECURITY
-				  wrangler cert                   🪪 Manage client mTLS certificates and CA certificate chains used for secured connections [open beta]
-				  wrangler mtls-certificate       🪪 Manage certificates used for mTLS connections
-				  wrangler tunnel                 🚇 Manage Cloudflare Tunnels [experimental]
+				  wrangler cert                    🪪 Manage client mTLS certificates and CA certificate chains used for secured connections [open beta]
+				  wrangler mtls-certificate        🪪 Manage certificates used for mTLS connections
+				  wrangler tunnel                  🚇 Manage Cloudflare Tunnels [experimental]
 
 				GLOBAL FLAGS
 				  -c, --config          Path to Wrangler configuration file  [string]
@@ -145,59 +148,62 @@ describe("wrangler", () => {
 				wrangler
 
 				COMMANDS
-				  wrangler docs [search..]        📚 Open Wrangler's command documentation in your browser
-				  wrangler complete [shell]       ⌨️ Generate and handle shell completions
-				  wrangler list-commands          List all available commands and subcommands
+				  wrangler docs [search..]         📚 Open Wrangler's command documentation in your browser
+				  wrangler complete [shell]        ⌨️ Generate and handle shell completions
+				  wrangler list-commands [base..]  List all available commands and subcommands
 
-				  wrangler email                  Manage Cloudflare Email services [open beta]
+				  wrangler email                   Manage Cloudflare Email services [open beta]
+				  wrangler list-cmds [base..]      List all available commands and subcommands
+
+				                                   Alias for "wrangler list-commands".
 
 				ACCOUNT
-				  wrangler auth                   🔐 Manage authentication
-				  wrangler login                  🔓 Login to Cloudflare
-				  wrangler logout                 🚪 Logout from Cloudflare
-				  wrangler whoami                 🕵️ Retrieve your user information
+				  wrangler auth                    🔐 Manage authentication
+				  wrangler login                   🔓 Login to Cloudflare
+				  wrangler logout                  🚪 Logout from Cloudflare
+				  wrangler whoami                  🕵️ Retrieve your user information
 
 				COMPUTE & AI
-				  wrangler agent-memory           🧠 Manage Agent Memory namespaces [private beta]
-				  wrangler ai                     🤖 Manage AI models
-				  wrangler ai-search              🔍 Manage AI Search instances [open beta]
-				  wrangler browser                🌐 Manage Browser Run sessions [open beta]
-				  wrangler containers             📦 Manage Containers
-				  wrangler delete [name]          🗑️ Delete a Worker from Cloudflare
-				  wrangler deploy [path]          🆙 Deploy a Worker to Cloudflare
-				  wrangler deployments            🚢 List and view the current and past deployments for your Worker
-				  wrangler dev [script]           👂 Start a local server for developing your Worker
-				  wrangler dispatch-namespace     🏗️ Manage dispatch namespaces
-				  wrangler flagship               🚩 Manage Flagship apps and feature flags [open beta]
-				  wrangler init [name]            📥 Initialize a basic Worker
-				  wrangler pages                  ⚡️ Configure Cloudflare Pages
-				  wrangler preview [script]       👀 Create a Preview deployment of the current Worker [private beta]
-				  wrangler queues                 📬 Manage Workers Queues
-				  wrangler rollback [version-id]  🔙 Rollback a deployment for a Worker
-				  wrangler secret                 🤫 Generate a secret that can be referenced in a Worker
-				  wrangler setup                  🪄 Setup a project to work on Cloudflare
-				  wrangler tail [worker]          🦚 Start a log tailing session for a Worker
-				  wrangler triggers               🎯 Updates the triggers of your current deployment [experimental]
-				  wrangler types [path]           📝 Generate types from your Worker configuration
-				  wrangler versions               🫧 List, view, upload and deploy Versions of your Worker to Cloudflare
-				  wrangler vpc                    🌐 Manage VPC [open beta]
-				  wrangler websearch              🔎 Run queries against Cloudflare Web Search [experimental]
-				  wrangler workflows              🔁 Manage Workflows
+				  wrangler agent-memory            🧠 Manage Agent Memory namespaces [private beta]
+				  wrangler ai                      🤖 Manage AI models
+				  wrangler ai-search               🔍 Manage AI Search instances [open beta]
+				  wrangler browser                 🌐 Manage Browser Run sessions [open beta]
+				  wrangler containers              📦 Manage Containers
+				  wrangler delete [name]           🗑️ Delete a Worker from Cloudflare
+				  wrangler deploy [path]           🆙 Deploy a Worker to Cloudflare
+				  wrangler deployments             🚢 List and view the current and past deployments for your Worker
+				  wrangler dev [script]            👂 Start a local server for developing your Worker
+				  wrangler dispatch-namespace      🏗️ Manage dispatch namespaces
+				  wrangler flagship                🚩 Manage Flagship apps and feature flags [open beta]
+				  wrangler init [name]             📥 Initialize a basic Worker
+				  wrangler pages                   ⚡️ Configure Cloudflare Pages
+				  wrangler preview [script]        👀 Create a Preview deployment of the current Worker [private beta]
+				  wrangler queues                  📬 Manage Workers Queues
+				  wrangler rollback [version-id]   🔙 Rollback a deployment for a Worker
+				  wrangler secret                  🤫 Generate a secret that can be referenced in a Worker
+				  wrangler setup                   🪄 Setup a project to work on Cloudflare
+				  wrangler tail [worker]           🦚 Start a log tailing session for a Worker
+				  wrangler triggers                🎯 Updates the triggers of your current deployment [experimental]
+				  wrangler types [path]            📝 Generate types from your Worker configuration
+				  wrangler versions                🫧 List, view, upload and deploy Versions of your Worker to Cloudflare
+				  wrangler vpc                     🌐 Manage VPC [open beta]
+				  wrangler websearch               🔎 Run queries against Cloudflare Web Search [experimental]
+				  wrangler workflows               🔁 Manage Workflows
 
 				STORAGE & DATABASES
-				  wrangler artifacts              🧱 Manage Artifacts namespaces and repos [private beta]
-				  wrangler d1                     🗄️ Manage Workers D1 databases
-				  wrangler hyperdrive             🚀 Manage Hyperdrive databases
-				  wrangler kv                     🗂️ Manage Workers KV Namespaces
-				  wrangler pipelines              🚰 Manage Cloudflare Pipelines [open beta]
-				  wrangler r2                     📦 Manage R2 buckets & objects
-				  wrangler secrets-store          🔐 Manage the Secrets Store [open beta]
-				  wrangler vectorize              🧮 Manage Vectorize indexes
+				  wrangler artifacts               🧱 Manage Artifacts namespaces and repos [private beta]
+				  wrangler d1                      🗄️ Manage Workers D1 databases
+				  wrangler hyperdrive              🚀 Manage Hyperdrive databases
+				  wrangler kv                      🗂️ Manage Workers KV Namespaces
+				  wrangler pipelines               🚰 Manage Cloudflare Pipelines [open beta]
+				  wrangler r2                      📦 Manage R2 buckets & objects
+				  wrangler secrets-store           🔐 Manage the Secrets Store [open beta]
+				  wrangler vectorize               🧮 Manage Vectorize indexes
 
 				NETWORKING & SECURITY
-				  wrangler cert                   🪪 Manage client mTLS certificates and CA certificate chains used for secured connections [open beta]
-				  wrangler mtls-certificate       🪪 Manage certificates used for mTLS connections
-				  wrangler tunnel                 🚇 Manage Cloudflare Tunnels [experimental]
+				  wrangler cert                    🪪 Manage client mTLS certificates and CA certificate chains used for secured connections [open beta]
+				  wrangler mtls-certificate        🪪 Manage certificates used for mTLS connections
+				  wrangler tunnel                  🚇 Manage Cloudflare Tunnels [experimental]
 
 				GLOBAL FLAGS
 				  -c, --config          Path to Wrangler configuration file  [string]

--- a/packages/wrangler/src/__tests__/index.test.ts
+++ b/packages/wrangler/src/__tests__/index.test.ts
@@ -48,9 +48,6 @@ describe("wrangler", () => {
 				  wrangler list-commands [base..]  List all available commands and subcommands
 
 				  wrangler email                   Manage Cloudflare Email services [open beta]
-				  wrangler list-cmds [base..]      List all available commands and subcommands
-
-				                                   Alias for "wrangler list-commands".
 
 				ACCOUNT
 				  wrangler auth                    🔐 Manage authentication
@@ -153,9 +150,6 @@ describe("wrangler", () => {
 				  wrangler list-commands [base..]  List all available commands and subcommands
 
 				  wrangler email                   Manage Cloudflare Email services [open beta]
-				  wrangler list-cmds [base..]      List all available commands and subcommands
-
-				                                   Alias for "wrangler list-commands".
 
 				ACCOUNT
 				  wrangler auth                    🔐 Manage authentication

--- a/packages/wrangler/src/__tests__/index.test.ts
+++ b/packages/wrangler/src/__tests__/index.test.ts
@@ -45,6 +45,7 @@ describe("wrangler", () => {
 				COMMANDS
 				  wrangler docs [search..]        📚 Open Wrangler's command documentation in your browser
 				  wrangler complete [shell]       ⌨️ Generate and handle shell completions
+				  wrangler list-commands          List all available commands and subcommands
 
 				  wrangler email                  Manage Cloudflare Email services [open beta]
 
@@ -146,6 +147,7 @@ describe("wrangler", () => {
 				COMMANDS
 				  wrangler docs [search..]        📚 Open Wrangler's command documentation in your browser
 				  wrangler complete [shell]       ⌨️ Generate and handle shell completions
+				  wrangler list-commands          List all available commands and subcommands
 
 				  wrangler email                  Manage Cloudflare Email services [open beta]
 
@@ -207,7 +209,11 @@ describe("wrangler", () => {
 				      --profile         Use a specific auth profile  [string]
 				  -v, --version         Show version number  [boolean]
 
-				Please report any issues to https://github.com/cloudflare/workers-sdk/issues/new/choose"
+				Please report any issues to https://github.com/cloudflare/workers-sdk/issues/new/choose
+
+				☝️ Tip: Run \`wrangler list-commands\` to see all available commands and subcommands.
+
+				"
 			`);
 			expect(std.err).toMatchInlineSnapshot(`
 			        "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mUnknown argument: invalid-command[0m

--- a/packages/wrangler/src/__tests__/kv/help.test.ts
+++ b/packages/wrangler/src/__tests__/kv/help.test.ts
@@ -104,7 +104,11 @@ describe("kv", () => {
 				  -h, --help            Show help  [boolean]
 				      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 				      --profile         Use a specific auth profile  [string]
-				  -v, --version         Show version number  [boolean]"
+				  -v, --version         Show version number  [boolean]
+
+				☝️ Tip: Run \`wrangler list-commands\` to see all available commands and subcommands.
+
+				"
 			`);
 		});
 	});

--- a/packages/wrangler/src/__tests__/kv/namespace.test.ts
+++ b/packages/wrangler/src/__tests__/kv/namespace.test.ts
@@ -120,7 +120,11 @@ describe("kv", () => {
 					      --preview        Interact with a preview namespace  [boolean]
 					      --use-remote     Use a remote binding when adding the newly created resource to your config  [boolean]
 					      --update-config  Automatically update your config file with the newly added resource  [boolean]
-					      --binding        The binding name of this resource in your Worker  [string]"
+					      --binding        The binding name of this resource in your Worker  [string]
+
+					☝️ Tip: Run \`wrangler list-commands\` to see all available commands and subcommands.
+
+					"
 				`);
 				expect(std.err).toMatchInlineSnapshot(`
 			          "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mUnknown arguments: def, ghi[0m

--- a/packages/wrangler/src/__tests__/list-commands.test.ts
+++ b/packages/wrangler/src/__tests__/list-commands.test.ts
@@ -121,9 +121,9 @@ describe("list-commands", () => {
 		});
 	});
 
-	describe("--base", () => {
+	describe("positional base", () => {
 		it("should scope output to a specific base command", async ({ expect }) => {
-			await runWrangler('list-commands --base="d1"');
+			await runWrangler("list-commands d1");
 
 			// Root should be "wrangler d1"
 			expect(std.out).toContain("wrangler d1");
@@ -140,7 +140,7 @@ describe("list-commands", () => {
 		});
 
 		it("should support multi-segment base paths", async ({ expect }) => {
-			await runWrangler('list-commands --base="ai-search jobs"');
+			await runWrangler("list-commands ai-search jobs");
 
 			// Root should be the full path
 			expect(std.out).toContain("wrangler ai-search jobs");
@@ -156,7 +156,7 @@ describe("list-commands", () => {
 		it("should show ellipsis for nested commands when not using --all", async ({
 			expect,
 		}) => {
-			await runWrangler('list-commands --base="d1"');
+			await runWrangler("list-commands d1");
 
 			// "migrations" has subcommands, so it should show "..."
 			expect(std.out).toMatch(/migrations\s+.*\.\.\./);
@@ -165,7 +165,7 @@ describe("list-commands", () => {
 		it("should show full depth when combined with --all", async ({
 			expect,
 		}) => {
-			await runWrangler('list-commands --base="d1" --all');
+			await runWrangler("list-commands d1 --all");
 
 			// migrations subcommands should be visible
 			expect(std.out).toContain("apply");
@@ -176,12 +176,12 @@ describe("list-commands", () => {
 
 		it("should throw an error for an invalid base path", async ({ expect }) => {
 			await expect(
-				runWrangler('list-commands --base="nonexistent-command"')
+				runWrangler("list-commands nonexistent-command")
 			).rejects.toThrowError(/Unknown command/);
 		});
 
 		it("should work with --json", async ({ expect }) => {
-			await runWrangler('list-commands --base="d1" --json --all');
+			await runWrangler("list-commands d1 --json --all");
 
 			const output = JSON.parse(std.out);
 

--- a/packages/wrangler/src/__tests__/list-commands.test.ts
+++ b/packages/wrangler/src/__tests__/list-commands.test.ts
@@ -1,0 +1,328 @@
+import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
+import { describe, it } from "vitest";
+import { mockConsoleMethods } from "./helpers/mock-console";
+import { runWrangler } from "./helpers/run-wrangler";
+
+describe("list-commands", () => {
+	runInTempDir();
+	const std = mockConsoleMethods();
+
+	describe("default (depth 1)", () => {
+		it("should display only top-level commands", async ({ expect }) => {
+			await runWrangler("list-commands");
+
+			// Verify root
+			expect(std.out).toContain("wrangler");
+
+			// Verify tree structure characters are present
+			// Note: normalizeTables() in test helpers collapses "├──" to "├─" and "└──" to "└─"
+			expect(std.out).toContain("├─");
+			expect(std.out).toContain("└─");
+
+			// Verify some known top-level commands are present
+			expect(std.out).toContain("deploy");
+			expect(std.out).toContain("dev");
+			expect(std.out).toContain("d1");
+			expect(std.out).toContain("kv");
+			expect(std.out).toContain("r2");
+
+			// Verify descriptions are present (without emojis)
+			expect(std.out).toMatch(/deploy\s+Deploy a Worker to Cloudflare/);
+			expect(std.out).toMatch(
+				/dev\s+Start a local server for developing your Worker/
+			);
+
+			// Verify no errors
+			expect(std.err).toBe("");
+		});
+
+		it("should not show nested subcommands by default", async ({ expect }) => {
+			await runWrangler("list-commands");
+
+			// Without --all, subcommands like "d1 list" should not appear as nested entries
+			// There should be no "│" indentation characters (the tree is flat)
+			const lines = std.out.split("\n");
+			const indentedLines = lines.filter((line: string) =>
+				line.match(/│\s+[├└]/)
+			);
+			expect(indentedLines).toHaveLength(0);
+		});
+
+		it("should show ellipsis for commands that have subcommands", async ({
+			expect,
+		}) => {
+			await runWrangler("list-commands");
+
+			// Commands with subcommands should have a trailing "..." indicator
+			expect(std.out).toMatch(/d1\s+Manage Workers D1 databases \.\.\./);
+			expect(std.out).toMatch(/kv\s+Manage Workers KV Namespaces \.\.\./);
+		});
+
+		it("should not show ellipsis for leaf commands", async ({ expect }) => {
+			await runWrangler("list-commands");
+
+			// Leaf commands (no subcommands) should not have "..."
+			expect(std.out).toMatch(/deploy\s+Deploy a Worker to Cloudflare$/m);
+			expect(std.out).not.toMatch(
+				/deploy\s+Deploy a Worker to Cloudflare \.\.\./
+			);
+		});
+
+		it("should show status badges for non-stable commands", async ({
+			expect,
+		}) => {
+			await runWrangler("list-commands");
+
+			expect(std.out).toMatch(/\[open beta\]/);
+		});
+
+		it("should not include hidden commands", async ({ expect }) => {
+			await runWrangler("list-commands");
+
+			// hello-world is a hidden command used for testing
+			expect(std.out).not.toContain("hello-world");
+		});
+
+		it("should not include alias commands by default", async ({ expect }) => {
+			await runWrangler("list-commands");
+
+			expect(std.out).not.toContain("alias of");
+		});
+	});
+
+	describe("--all", () => {
+		it("should show the full command tree with all nesting levels", async ({
+			expect,
+		}) => {
+			await runWrangler("list-commands --all");
+
+			// With --all, nested subcommands should appear
+			// "│" indicates nested tree structure
+			const lines = std.out.split("\n");
+			const indentedLines = lines.filter((line: string) => line.includes("│"));
+			expect(indentedLines.length).toBeGreaterThan(0);
+
+			// Verify specific nested commands
+			expect(std.out).toMatch(/d1\s+Manage Workers D1 databases/);
+
+			// d1 subcommands should appear nested
+			expect(std.out).toContain("list");
+			expect(std.out).toContain("create");
+			expect(std.out).toContain("migrations");
+		});
+
+		it("should not show ellipsis when all subcommands are visible", async ({
+			expect,
+		}) => {
+			await runWrangler("list-commands --all");
+
+			// With --all, no truncation happens, so no "..." should appear
+			expect(std.out).not.toContain("...");
+		});
+	});
+
+	describe("--base", () => {
+		it("should scope output to a specific base command", async ({ expect }) => {
+			await runWrangler('list-commands --base="d1"');
+
+			// Root should be "wrangler d1"
+			expect(std.out).toContain("wrangler d1");
+
+			// Direct children of d1 should appear
+			expect(std.out).toContain("list");
+			expect(std.out).toContain("create");
+			expect(std.out).toContain("execute");
+			expect(std.out).toContain("migrations");
+
+			// Top-level commands like "deploy" should NOT appear
+			expect(std.out).not.toMatch(/├─ deploy/);
+			expect(std.out).not.toMatch(/└─ deploy/);
+		});
+
+		it("should support multi-segment base paths", async ({ expect }) => {
+			await runWrangler('list-commands --base="ai-search jobs"');
+
+			// Root should be the full path
+			expect(std.out).toContain("wrangler ai-search jobs");
+
+			// Direct children of ai-search jobs should appear
+			expect(std.out).toContain("cancel");
+			expect(std.out).toContain("create");
+			expect(std.out).toContain("get");
+			expect(std.out).toContain("list");
+			expect(std.out).toContain("logs");
+		});
+
+		it("should show ellipsis for nested commands when not using --all", async ({
+			expect,
+		}) => {
+			await runWrangler('list-commands --base="d1"');
+
+			// "migrations" has subcommands, so it should show "..."
+			expect(std.out).toMatch(/migrations\s+.*\.\.\./);
+		});
+
+		it("should show full depth when combined with --all", async ({
+			expect,
+		}) => {
+			await runWrangler('list-commands --base="d1" --all');
+
+			// migrations subcommands should be visible
+			expect(std.out).toContain("apply");
+
+			// No ellipsis should appear
+			expect(std.out).not.toContain("...");
+		});
+
+		it("should throw an error for an invalid base path", async ({ expect }) => {
+			await expect(
+				runWrangler('list-commands --base="nonexistent-command"')
+			).rejects.toThrowError(/Unknown command/);
+		});
+
+		it("should work with --json", async ({ expect }) => {
+			await runWrangler('list-commands --base="d1" --json --all');
+
+			const output = JSON.parse(std.out);
+
+			expect(output).toHaveProperty("commands");
+			expect(output.commands.length).toBeGreaterThan(0);
+
+			// All entries should be d1 subcommands
+			const commandNames = output.commands.map(
+				(cmd: { command: string }) => cmd.command
+			);
+			expect(commandNames).toContain("list");
+			expect(commandNames).toContain("create");
+			expect(commandNames).toContain("migrations");
+
+			// Should NOT contain top-level commands
+			expect(commandNames).not.toContain("deploy");
+			expect(commandNames).not.toContain("dev");
+		});
+	});
+
+	describe("--include-aliases", () => {
+		it("should include alias commands when flag is set", async ({ expect }) => {
+			await runWrangler("list-commands --include-aliases --all");
+
+			// With --include-aliases, alias markers should appear
+			expect(std.out).toContain("alias of");
+		});
+	});
+
+	describe("--json", () => {
+		it("should output valid JSON with correct structure", async ({
+			expect,
+		}) => {
+			await runWrangler("list-commands --json");
+
+			const output = JSON.parse(std.out);
+
+			// Root structure
+			expect(output).toHaveProperty("commands");
+			expect(Array.isArray(output.commands)).toBe(true);
+			expect(output.commands.length).toBeGreaterThan(0);
+
+			// Each entry should have the expected fields
+			const firstCommand = output.commands[0];
+			expect(firstCommand).toHaveProperty("command");
+			expect(firstCommand).toHaveProperty("fullCommand");
+			expect(firstCommand).toHaveProperty("description");
+			expect(firstCommand).toHaveProperty("status");
+			expect(firstCommand).toHaveProperty("deprecated");
+			expect(firstCommand).toHaveProperty("hasSubcommands");
+			expect(firstCommand).toHaveProperty("subcommands");
+			expect(Array.isArray(firstCommand.subcommands)).toBe(true);
+		});
+
+		it("should have empty subcommands without --all", async ({ expect }) => {
+			await runWrangler("list-commands --json");
+
+			const output = JSON.parse(std.out);
+
+			// Find d1 which is known to have subcommands
+			const d1 = output.commands.find(
+				(cmd: { command: string }) => cmd.command === "d1"
+			);
+			expect(d1).toBeDefined();
+			expect(d1.hasSubcommands).toBe(true);
+			expect(d1.subcommands).toHaveLength(0);
+		});
+
+		it("should include nested subcommands with --all", async ({ expect }) => {
+			await runWrangler("list-commands --json --all");
+
+			const output = JSON.parse(std.out);
+
+			const d1 = output.commands.find(
+				(cmd: { command: string }) => cmd.command === "d1"
+			);
+			expect(d1).toBeDefined();
+			expect(d1.fullCommand).toBe("wrangler d1");
+			expect(d1.subcommands.length).toBeGreaterThan(0);
+
+			// Verify a known d1 subcommand
+			const d1List = d1.subcommands.find(
+				(cmd: { command: string }) => cmd.command === "list"
+			);
+			expect(d1List).toBeDefined();
+			expect(d1List.fullCommand).toBe("wrangler d1 list");
+		});
+
+		it("should not include hidden commands in JSON", async ({ expect }) => {
+			await runWrangler("list-commands --json");
+
+			const output = JSON.parse(std.out);
+
+			const helloWorld = output.commands.find(
+				(cmd: { command: string }) => cmd.command === "hello-world"
+			);
+			expect(helloWorld).toBeUndefined();
+		});
+
+		it("should include aliases in JSON when --include-aliases is set", async ({
+			expect,
+		}) => {
+			await runWrangler("list-commands --json --include-aliases --all");
+
+			const output = JSON.parse(std.out);
+
+			// Check that at least one command has an aliasOf property
+			const allCommands = flattenCommands(output.commands);
+			const aliases = allCommands.filter(
+				(cmd: { aliasOf?: string }) => cmd.aliasOf
+			);
+			expect(aliases.length).toBeGreaterThan(0);
+		});
+	});
+});
+
+/**
+ * Recursively flatten a nested command tree into a flat array.
+ *
+ * @param commands - Array of command entries with potential subcommands
+ * @returns A flat array of all commands at all depths
+ */
+function flattenCommands(
+	commands: Array<{
+		subcommands: Array<unknown>;
+		[key: string]: unknown;
+	}>
+): Array<{ [key: string]: unknown }> {
+	const result: Array<{ [key: string]: unknown }> = [];
+	for (const cmd of commands) {
+		result.push(cmd);
+		if (cmd.subcommands && cmd.subcommands.length > 0) {
+			result.push(
+				...flattenCommands(
+					cmd.subcommands as Array<{
+						subcommands: Array<unknown>;
+						[key: string]: unknown;
+					}>
+				)
+			);
+		}
+	}
+	return result;
+}

--- a/packages/wrangler/src/__tests__/metrics/sanitization.test.ts
+++ b/packages/wrangler/src/__tests__/metrics/sanitization.test.ts
@@ -140,13 +140,15 @@ describe("COMMAND_ARG_ALLOW_LIST", () => {
 	it("should pass list-commands arg values through the full sanitisation pipeline", ({
 		expect,
 	}) => {
-		// Simulate: wrangler list-commands --json --include-aliases --all --base "d1 migrations"
+		// Simulate: wrangler list-commands d1 migrations --json --include-aliases --all
+		// "base" is a positional arg — it doesn't appear as "--base" in argv,
+		// but sanitizeArgKeys accepts positionalArgs to pass them through.
 		const args = {
 			json: true,
 			"include-aliases": true,
 			includeAliases: true,
 			all: true,
-			base: "d1 migrations",
+			base: ["d1", "migrations"],
 			$0: "wrangler",
 			_: [],
 		};
@@ -154,14 +156,14 @@ describe("COMMAND_ARG_ALLOW_LIST", () => {
 			"node",
 			"wrangler",
 			"list-commands",
+			"d1",
+			"migrations",
 			"--json",
 			"--include-aliases",
 			"--all",
-			"--base",
-			"d1 migrations",
 		];
 
-		const argsWithSanitizedKeys = sanitizeArgKeys(args, argv);
+		const argsWithSanitizedKeys = sanitizeArgKeys(args, argv, ["base"]);
 		const allowedArgs = getAllowedArgs(COMMAND_ARG_ALLOW_LIST, "list-commands");
 		const sanitizedArgs = sanitizeArgValues(argsWithSanitizedKeys, allowedArgs);
 
@@ -169,7 +171,7 @@ describe("COMMAND_ARG_ALLOW_LIST", () => {
 			json: true,
 			includeAliases: true,
 			all: true,
-			base: "d1 migrations",
+			base: ["d1", "migrations"],
 		});
 	});
 

--- a/packages/wrangler/src/__tests__/metrics/sanitization.test.ts
+++ b/packages/wrangler/src/__tests__/metrics/sanitization.test.ts
@@ -137,6 +137,42 @@ describe("getAllowedArgs", () => {
 });
 
 describe("COMMAND_ARG_ALLOW_LIST", () => {
+	it("should pass list-commands arg values through the full sanitisation pipeline", ({
+		expect,
+	}) => {
+		// Simulate: wrangler list-commands --json --include-aliases --all --base "d1 migrations"
+		const args = {
+			json: true,
+			"include-aliases": true,
+			includeAliases: true,
+			all: true,
+			base: "d1 migrations",
+			$0: "wrangler",
+			_: [],
+		};
+		const argv = [
+			"node",
+			"wrangler",
+			"list-commands",
+			"--json",
+			"--include-aliases",
+			"--all",
+			"--base",
+			"d1 migrations",
+		];
+
+		const argsWithSanitizedKeys = sanitizeArgKeys(args, argv);
+		const allowedArgs = getAllowedArgs(COMMAND_ARG_ALLOW_LIST, "list-commands");
+		const sanitizedArgs = sanitizeArgValues(argsWithSanitizedKeys, allowedArgs);
+
+		expect(sanitizedArgs).toEqual({
+			json: true,
+			includeAliases: true,
+			all: true,
+			base: "d1 migrations",
+		});
+	});
+
 	it("should pass boolean flag values through the full sanitisation pipeline for any command", ({
 		expect,
 	}) => {

--- a/packages/wrangler/src/__tests__/r2/help.test.ts
+++ b/packages/wrangler/src/__tests__/r2/help.test.ts
@@ -68,7 +68,11 @@ describe("r2", () => {
 				  -h, --help            Show help  [boolean]
 				      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 				      --profile         Use a specific auth profile  [string]
-				  -v, --version         Show version number  [boolean]"
+				  -v, --version         Show version number  [boolean]
+
+				☝️ Tip: Run \`wrangler list-commands\` to see all available commands and subcommands.
+
+				"
 			`);
 		});
 	});

--- a/packages/wrangler/src/__tests__/secrets-store.test.ts
+++ b/packages/wrangler/src/__tests__/secrets-store.test.ts
@@ -76,7 +76,11 @@ describe("secrets-store help", () => {
 			  -h, --help            Show help  [boolean]
 			      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 			      --profile         Use a specific auth profile  [string]
-			  -v, --version         Show version number  [boolean]"
+			  -v, --version         Show version number  [boolean]
+
+			☝️ Tip: Run \`wrangler list-commands\` to see all available commands and subcommands.
+
+			"
 		`);
 	});
 });

--- a/packages/wrangler/src/__tests__/unknown-command-tip.test.ts
+++ b/packages/wrangler/src/__tests__/unknown-command-tip.test.ts
@@ -1,0 +1,140 @@
+import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
+import { detectAgenticEnvironment } from "am-i-vibing";
+import { beforeEach, describe, it, vi } from "vitest";
+import { mockConsoleMethods } from "./helpers/mock-console";
+import { runWrangler } from "./helpers/run-wrangler";
+
+vi.mock("am-i-vibing");
+
+describe("unknown command tip", () => {
+	runInTempDir();
+	const std = mockConsoleMethods();
+
+	describe("when not in an agentic environment", () => {
+		beforeEach(() => {
+			vi.mocked(detectAgenticEnvironment).mockReturnValue({
+				isAgentic: false,
+				id: null,
+				name: null,
+				type: null,
+			});
+		});
+
+		it("should show a short tip for human users", async ({ expect }) => {
+			await expect(runWrangler("invalid-command")).rejects.toThrowError(
+				/Unknown argument/
+			);
+
+			expect(std.out).toContain(
+				"Tip: Run `wrangler list-commands` to see all available commands and subcommands."
+			);
+
+			// Should NOT contain the detailed agentic message
+			expect(std.out).not.toContain('--base="<cmd>"');
+			expect(std.out).not.toContain("Examples:");
+		});
+
+		it("should show a short tip for invalid subcommands of a valid namespace", async ({
+			expect,
+		}) => {
+			await expect(runWrangler("d1 invalid-subcommand")).rejects.toThrow(
+				/Unknown argument/
+			);
+
+			expect(std.out).toContain(
+				"Tip: Run `wrangler list-commands` to see all available commands and subcommands."
+			);
+
+			// Should NOT contain the detailed agentic message
+			expect(std.out).not.toContain('--base="<cmd>"');
+			expect(std.out).not.toContain("Examples:");
+		});
+	});
+
+	describe("when in an agentic environment", () => {
+		beforeEach(() => {
+			vi.mocked(detectAgenticEnvironment).mockReturnValue({
+				isAgentic: true,
+				id: "opencode",
+				name: "OpenCode",
+				type: "agent",
+			});
+		});
+
+		it("should show a detailed tip with flag descriptions and examples", async ({
+			expect,
+		}) => {
+			await expect(runWrangler("invalid-command")).rejects.toThrowError(
+				/Unknown argument/
+			);
+
+			// Should contain the detailed agentic message
+			expect(std.out).toContain(
+				"Use `wrangler list-commands` to explore all available commands and subcommands."
+			);
+
+			// Should describe the flags
+			expect(std.out).toContain("--all");
+			expect(std.out).toContain('--base="<cmd>"');
+			expect(std.out).toContain("--json");
+
+			// Should include usage examples
+			expect(std.out).toContain("Examples:");
+			expect(std.out).toContain('wrangler list-commands --base="d1"');
+			expect(std.out).toContain('wrangler list-commands --base="kv"');
+			expect(std.out).toContain(
+				'wrangler list-commands --base="ai-search jobs"'
+			);
+			expect(std.out).toContain("wrangler list-commands --all");
+			expect(std.out).toContain("wrangler list-commands --json");
+
+			// Tip should only appear once (not duplicated)
+			const tipMatches = std.out.match(
+				/Use `wrangler list-commands` to explore/g
+			);
+			expect(tipMatches).toHaveLength(1);
+		});
+
+		it("should show a detailed tip for invalid subcommands of a valid namespace", async ({
+			expect,
+		}) => {
+			await expect(runWrangler("d1 invalid-subcommand")).rejects.toThrowError(
+				/Unknown argument/
+			);
+
+			// Should contain the detailed agentic message
+			expect(std.out).toContain(
+				"Use `wrangler list-commands` to explore all available commands and subcommands."
+			);
+
+			// Should describe the flags
+			expect(std.out).toContain("--all");
+			expect(std.out).toContain('--base="<cmd>"');
+			expect(std.out).toContain("--json");
+
+			// Should include usage examples
+			expect(std.out).toContain("Examples:");
+		});
+	});
+
+	describe("when detectAgenticEnvironment throws", () => {
+		beforeEach(() => {
+			vi.mocked(detectAgenticEnvironment).mockImplementation(() => {
+				throw new Error("detection failed");
+			});
+		});
+
+		it("should fall back to the short tip", async ({ expect }) => {
+			await expect(runWrangler("invalid-command")).rejects.toThrowError(
+				/Unknown argument/
+			);
+
+			expect(std.out).toContain(
+				"Tip: Run `wrangler list-commands` to see all available commands and subcommands."
+			);
+
+			// Should NOT contain the detailed agentic message
+			expect(std.out).not.toContain("Examples:");
+		});
+	});
+});

--- a/packages/wrangler/src/__tests__/unknown-command-tip.test.ts
+++ b/packages/wrangler/src/__tests__/unknown-command-tip.test.ts
@@ -30,7 +30,7 @@ describe("unknown command tip", () => {
 			);
 
 			// Should NOT contain the detailed agentic message
-			expect(std.out).not.toContain('--base="<cmd>"');
+			expect(std.out).not.toContain("<base..>");
 			expect(std.out).not.toContain("Examples:");
 		});
 
@@ -46,7 +46,7 @@ describe("unknown command tip", () => {
 			);
 
 			// Should NOT contain the detailed agentic message
-			expect(std.out).not.toContain('--base="<cmd>"');
+			expect(std.out).not.toContain("<base..>");
 			expect(std.out).not.toContain("Examples:");
 		});
 	});
@@ -73,18 +73,16 @@ describe("unknown command tip", () => {
 				"Use `wrangler list-commands` to explore all available commands and subcommands."
 			);
 
-			// Should describe the flags
+			// Should describe the options
+			expect(std.out).toContain("<base..>");
 			expect(std.out).toContain("--all");
-			expect(std.out).toContain('--base="<cmd>"');
 			expect(std.out).toContain("--json");
 
 			// Should include usage examples
 			expect(std.out).toContain("Examples:");
-			expect(std.out).toContain('wrangler list-commands --base="d1"');
-			expect(std.out).toContain('wrangler list-commands --base="kv"');
-			expect(std.out).toContain(
-				'wrangler list-commands --base="ai-search jobs"'
-			);
+			expect(std.out).toContain("wrangler list-commands d1");
+			expect(std.out).toContain("wrangler list-commands kv");
+			expect(std.out).toContain("wrangler list-commands ai-search jobs");
 			expect(std.out).toContain("wrangler list-commands --all");
 			expect(std.out).toContain("wrangler list-commands --json");
 
@@ -107,9 +105,9 @@ describe("unknown command tip", () => {
 				"Use `wrangler list-commands` to explore all available commands and subcommands."
 			);
 
-			// Should describe the flags
+			// Should describe the options
+			expect(std.out).toContain("<base..>");
 			expect(std.out).toContain("--all");
-			expect(std.out).toContain('--base="<cmd>"');
 			expect(std.out).toContain("--json");
 
 			// Should include usage examples

--- a/packages/wrangler/src/__tests__/vectorize/vectorize.test.ts
+++ b/packages/wrangler/src/__tests__/vectorize/vectorize.test.ts
@@ -94,7 +94,11 @@ describe("vectorize help", () => {
 			  -h, --help            Show help  [boolean]
 			      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 			      --profile         Use a specific auth profile  [string]
-			  -v, --version         Show version number  [boolean]"
+			  -v, --version         Show version number  [boolean]
+
+			☝️ Tip: Run \`wrangler list-commands\` to see all available commands and subcommands.
+
+			"
 		`);
 	});
 

--- a/packages/wrangler/src/core/handle-errors.ts
+++ b/packages/wrangler/src/core/handle-errors.ts
@@ -20,6 +20,7 @@ import {
 } from "../deployment-bundle/build-failures";
 import { logBuildFailure, logger } from "../logger";
 import { captureGlobalException } from "../sentry";
+import { logUnknownCommandTip } from "../unknown-command-tip";
 import { getAuthFromEnv } from "../user";
 import { whoami } from "../user/whoami";
 import { logPossibleBugMessage } from "../utils/logPossibleBugMessage";
@@ -505,6 +506,16 @@ export async function handleError(
 
 		const isRootLevelError = isUnknownArgOrCommand && isUnknownCommand;
 
+		// Check if the error is an unknown subcommand under a valid namespace
+		// (e.g., `wrangler d1 foobar`). This is true when the unknown arg matches
+		// a non-flag arg that isn't the first one (the first is the valid parent).
+		const isSubcommandError =
+			!isRootLevelError &&
+			isUnknownArgOrCommand &&
+			unknownArgs.some(
+				(arg) => nonFlagArgs.includes(arg) && !arg.startsWith("-")
+			);
+
 		const { wrangler, showHelpWithCategories } = createCLIParser([
 			...(isRootLevelError ? [] : nonFlagArgs),
 			"--help",
@@ -512,10 +523,15 @@ export async function handleError(
 
 		if (isRootLevelError) {
 			await showHelpWithCategories();
+			logUnknownCommandTip();
 			return;
 		}
 
 		await wrangler.parse();
+
+		if (isSubcommandError) {
+			logUnknownCommandTip();
+		}
 	} else if (isAuthenticationError(e) || isContainersAuthenticationError(e)) {
 		mayReport = false;
 		if (e.cause instanceof ApiError) {

--- a/packages/wrangler/src/core/register-yargs-command.ts
+++ b/packages/wrangler/src/core/register-yargs-command.ts
@@ -297,7 +297,9 @@ function createHandler(def: InternalCommandDefinition, argv: string[]) {
 				const argsWithSanitizedKeys = sanitizeArgKeys(
 					args,
 					argv,
-					def.positionalArgs
+					def.behaviour?.includePositionalArgsInMetrics
+						? def.positionalArgs
+						: undefined
 				);
 				const sanitizedArgs = sanitizeArgValues(
 					argsWithSanitizedKeys,

--- a/packages/wrangler/src/core/register-yargs-command.ts
+++ b/packages/wrangler/src/core/register-yargs-command.ts
@@ -294,7 +294,11 @@ function createHandler(def: InternalCommandDefinition, argv: string[]) {
 					COMMAND_ARG_ALLOW_LIST,
 					sanitizedCommand
 				);
-				const argsWithSanitizedKeys = sanitizeArgKeys(args, argv);
+				const argsWithSanitizedKeys = sanitizeArgKeys(
+					args,
+					argv,
+					def.positionalArgs
+				);
 				const sanitizedArgs = sanitizeArgValues(
 					argsWithSanitizedKeys,
 					allowedArgs

--- a/packages/wrangler/src/core/types.ts
+++ b/packages/wrangler/src/core/types.ts
@@ -256,6 +256,16 @@ export type CommandDefinition<
 		 * @default true
 		 */
 		printActiveProfile?: boolean;
+
+		/**
+		 * Whether to include positional args in metrics reporting.
+		 * By default, positional args are excluded from `argsUsed` and `sanitizedArgs`.
+		 * Set to `true` to opt in for commands where positional arg usage is useful
+		 * for telemetry (e.g. `list-commands d1 migrations`).
+		 *
+		 * @default false
+		 */
+		includePositionalArgsInMetrics?: boolean;
 	};
 
 	/**

--- a/packages/wrangler/src/index.ts
+++ b/packages/wrangler/src/index.ts
@@ -241,6 +241,7 @@ import {
 	kvNamespaceNamespace,
 	kvNamespaceRenameCommand,
 } from "./kv";
+import { listCommandsCommand } from "./list-commands";
 import { logger, LOGGER_LEVELS } from "./logger";
 import { allMetricsDispatchesCompleted, getMetricsDispatcher } from "./metrics";
 import {
@@ -866,6 +867,15 @@ export function createCLIParser(argv: string[]) {
 		},
 	]);
 	registry.registerNamespace("complete");
+
+	// list-commands
+	registry.define([
+		{
+			command: "wrangler list-commands",
+			definition: listCommandsCommand,
+		},
+	]);
+	registry.registerNamespace("list-commands");
 
 	/******************** CMD GROUP ***********************/
 

--- a/packages/wrangler/src/index.ts
+++ b/packages/wrangler/src/index.ts
@@ -241,7 +241,7 @@ import {
 	kvNamespaceNamespace,
 	kvNamespaceRenameCommand,
 } from "./kv";
-import { listCommandsCommand } from "./list-commands";
+import { listCmdsAlias, listCommandsCommand } from "./list-commands";
 import { logger, LOGGER_LEVELS } from "./logger";
 import { allMetricsDispatchesCompleted, getMetricsDispatcher } from "./metrics";
 import {
@@ -873,6 +873,10 @@ export function createCLIParser(argv: string[]) {
 		{
 			command: "wrangler list-commands",
 			definition: listCommandsCommand,
+		},
+		{
+			command: "wrangler list-cmds",
+			definition: listCmdsAlias,
 		},
 	]);
 	registry.registerNamespace("list-commands");

--- a/packages/wrangler/src/list-commands.ts
+++ b/packages/wrangler/src/list-commands.ts
@@ -289,22 +289,22 @@ export const listCommandsCommand = createCommand({
 			type: "boolean",
 			default: false,
 			description:
-				"Show all subcommands at every depth. Warning: this can be very token-intensive at the top level when run by AI agents — consider using --base to scope the output",
+				"Show all subcommands at every depth. Warning: this can be very token-intensive at the top level when run by AI agents — consider scoping to a subtree instead (e.g. `wrangler list-commands d1`)",
 		},
 		base: {
 			type: "string",
+			array: true,
 			description:
 				'Show commands under a specific base command (e.g. "d1 migrations")',
 		},
 	},
+	positionalArgs: ["base"],
 	handler(args) {
 		const { registry } = experimental_getWranglerCommands();
 
-		// Navigate to the base node if --base is provided
+		// Navigate to the base node if positional segments are provided
 		let rootNode = registry;
-		const baseSegments = args.base
-			? args.base.split(/\s+/).filter(Boolean)
-			: [];
+		const baseSegments = args.base ?? [];
 		if (baseSegments.length > 0) {
 			rootNode = navigateToBase(registry, baseSegments);
 		}

--- a/packages/wrangler/src/list-commands.ts
+++ b/packages/wrangler/src/list-commands.ts
@@ -1,5 +1,5 @@
 import { CommandLineArgsError } from "@cloudflare/workers-utils";
-import { createCommand } from "./core/create-command";
+import { createAlias, createCommand } from "./core/create-command";
 import { experimental_getWranglerCommands } from "./experimental-commands-api";
 import { logger } from "./logger";
 import { stripAnsi } from "./utils/box";
@@ -326,4 +326,8 @@ export const listCommandsCommand = createCommand({
 		const lines = [basePath.join(" "), ...renderTree(tree)];
 		logger.log(lines.join("\n"));
 	},
+});
+
+export const listCmdsAlias = createAlias({
+	aliasOf: "wrangler list-commands",
 });

--- a/packages/wrangler/src/list-commands.ts
+++ b/packages/wrangler/src/list-commands.ts
@@ -330,4 +330,7 @@ export const listCommandsCommand = createCommand({
 
 export const listCmdsAlias = createAlias({
 	aliasOf: "wrangler list-commands",
+	metadata: {
+		hidden: true,
+	},
 });

--- a/packages/wrangler/src/list-commands.ts
+++ b/packages/wrangler/src/list-commands.ts
@@ -273,6 +273,7 @@ export const listCommandsCommand = createCommand({
 	behaviour: {
 		printBanner: (args) => !args.json,
 		provideConfig: false,
+		includePositionalArgsInMetrics: true,
 	},
 	args: {
 		json: {

--- a/packages/wrangler/src/list-commands.ts
+++ b/packages/wrangler/src/list-commands.ts
@@ -1,0 +1,329 @@
+import { CommandLineArgsError } from "@cloudflare/workers-utils";
+import { createCommand } from "./core/create-command";
+import { experimental_getWranglerCommands } from "./experimental-commands-api";
+import { logger } from "./logger";
+import { stripAnsi } from "./utils/box";
+import type { DefinitionTreeNode, InternalDefinition } from "./core/types";
+
+/**
+ * Strip leading emoji characters and trailing status badges from a description.
+ * Descriptions in the command tree may have:
+ * - Leading emojis (e.g. "📚 Open Wrangler's docs")
+ * - Trailing chalk-decorated status badges (e.g. " [open beta]")
+ * - Alias suffixes (e.g. "\n\nAlias for ...")
+ *
+ * @param description - The raw description string (may contain ANSI codes)
+ * @returns The cleaned description string
+ */
+function cleanDescription(description: string): string {
+	// Strip ANSI escape codes first
+	let cleaned = stripAnsi(description);
+
+	// Remove trailing status badges like " [open beta]", " [experimental]", etc.
+	cleaned = cleaned.replace(
+		/\s*\[(experimental|alpha|private beta|open beta)\]\s*$/,
+		""
+	);
+
+	// Remove alias suffixes
+	cleaned = cleaned.replace(/\n\nAlias for ".*"\./, "");
+
+	// Strip leading emoji characters and following whitespace
+	cleaned = cleaned.replace(
+		/^[\p{Emoji_Presentation}\p{Extended_Pictographic}\uFE0F]+\s*/u,
+		""
+	);
+
+	return cleaned.trim();
+}
+
+/**
+ * Represents a single command entry in the tree output.
+ */
+interface CommandEntry {
+	/** The command segment name (e.g. "list", "create") */
+	command: string;
+	/** The full command path (e.g. "wrangler d1 list") */
+	fullCommand: string;
+	/** The human-readable description */
+	description: string;
+	/** The maturity status of the command */
+	status: string;
+	/** Whether this command is deprecated */
+	deprecated: boolean;
+	/** Whether this command is an alias for another command */
+	aliasOf?: string;
+	/** Whether this command has subcommands in the full tree (even if truncated) */
+	hasSubcommands: boolean;
+	/** Nested subcommands (may be empty when depth is truncated) */
+	subcommands: CommandEntry[];
+}
+
+/**
+ * Recursively walk the definition tree and build a structured list of command entries.
+ * Skips hidden commands and optionally skips aliases.
+ *
+ * @param node - The current tree node to walk
+ * @param parentPath - The command path segments leading to this node
+ * @param includeAliases - Whether to include alias commands in the output
+ * @returns An array of command entries
+ */
+function buildCommandTree(
+	node: DefinitionTreeNode,
+	parentPath: string[] = ["wrangler"],
+	includeAliases: boolean = false
+): CommandEntry[] {
+	const entries: CommandEntry[] = [];
+
+	const sortedChildren = [...node.subtree.entries()].sort(([a], [b]) =>
+		a.localeCompare(b)
+	);
+
+	for (const [name, childNode] of sortedChildren) {
+		const def = childNode.definition;
+
+		// Skip nodes without definitions
+		if (!def) {
+			continue;
+		}
+
+		// Skip hidden commands
+		if (def.metadata?.hidden) {
+			continue;
+		}
+
+		// Skip aliases unless explicitly requested
+		if (def.type === "alias" && !includeAliases) {
+			continue;
+		}
+
+		const fullCommand = [...parentPath, name].join(" ");
+		const description = def.metadata?.description
+			? cleanDescription(def.metadata.description)
+			: "";
+		const status = getStatus(def);
+		const deprecated = def.metadata?.deprecated === true;
+
+		const subcommands = buildCommandTree(
+			childNode,
+			[...parentPath, name],
+			includeAliases
+		);
+
+		const entry: CommandEntry = {
+			command: name,
+			fullCommand,
+			description,
+			status,
+			deprecated,
+			hasSubcommands: subcommands.length > 0,
+			subcommands,
+		};
+
+		if (def.type === "alias") {
+			entry.aliasOf = def.aliasOf;
+		}
+
+		entries.push(entry);
+	}
+
+	return entries;
+}
+
+/**
+ * Truncate a command tree to a maximum depth, clearing subcommands beyond the limit.
+ * The `hasSubcommands` field is preserved so callers can indicate truncation.
+ *
+ * @param entries - The command entries to truncate
+ * @param maxDepth - The maximum number of nesting levels to keep (0 = no children, 1 = direct children only)
+ * @returns A new array of command entries with subcommands cleared beyond maxDepth
+ */
+function truncateDepth(
+	entries: CommandEntry[],
+	maxDepth: number
+): CommandEntry[] {
+	if (maxDepth <= 0) {
+		return entries.map((entry) => ({
+			...entry,
+			subcommands: [],
+		}));
+	}
+
+	return entries.map((entry) => ({
+		...entry,
+		subcommands: truncateDepth(entry.subcommands, maxDepth - 1),
+	}));
+}
+
+/**
+ * Navigate the definition tree to a specific subtree node using path segments.
+ * Throws a descriptive error if any segment in the path is not found.
+ *
+ * @param root - The root tree node to start navigation from
+ * @param segments - The path segments to follow (e.g. ["ai-search", "jobs"])
+ * @returns The tree node at the end of the path
+ */
+function navigateToBase(
+	root: DefinitionTreeNode,
+	segments: string[]
+): DefinitionTreeNode {
+	let node = root;
+	const visited: string[] = [];
+
+	for (const segment of segments) {
+		const child = node.subtree.get(segment);
+		if (!child) {
+			const available = [...node.subtree.keys()]
+				.filter((key) => {
+					const def = node.subtree.get(key)?.definition;
+					return def && !def.metadata?.hidden;
+				})
+				.sort()
+				.join(", ");
+
+			const pathSoFar = ["wrangler", ...visited].join(" ");
+			throw new CommandLineArgsError(
+				`Unknown command: "wrangler ${[...visited, segment].join(" ")}". ` +
+					`Available commands under "${pathSoFar}": ${available}`,
+				{ telemetryMessage: "list-commands unknown base path" }
+			);
+		}
+		visited.push(segment);
+		node = child;
+	}
+
+	return node;
+}
+
+/**
+ * Get the status string from a command definition.
+ *
+ * @param def - The internal command/namespace/alias definition
+ * @returns The status string (e.g. "stable", "open beta")
+ */
+function getStatus(def: InternalDefinition): string {
+	if (def.type === "alias") {
+		return "stable";
+	}
+	return def.metadata?.status ?? "stable";
+}
+
+/**
+ * Render the command tree as a human-readable ASCII tree.
+ * Uses box-drawing characters for the tree structure.
+ *
+ * @param entries - The command entries to render
+ * @param prefix - The indentation prefix for the current level
+ * @returns An array of formatted lines
+ */
+function renderTree(entries: CommandEntry[], prefix: string = ""): string[] {
+	const lines: string[] = [];
+
+	for (let i = 0; i < entries.length; i++) {
+		const entry = entries[i];
+		const isLast = i === entries.length - 1;
+		const connector = isLast ? "└── " : "├── ";
+		const childPrefix = isLast ? "    " : "│   ";
+
+		let label = entry.command;
+
+		// Add status/deprecated markers
+		if (entry.deprecated) {
+			label += " [deprecated]";
+		} else if (entry.status !== "stable") {
+			label += ` [${entry.status}]`;
+		}
+
+		// Add alias marker
+		if (entry.aliasOf) {
+			label += ` (alias of ${entry.aliasOf})`;
+		}
+
+		// Build the line with description
+		let line = `${prefix}${connector}${label}`;
+		if (entry.description) {
+			// Pad to align descriptions
+			const nameWidth = stripAnsi(line).length;
+			const padding = Math.max(2, 40 - nameWidth);
+			line += " ".repeat(padding) + entry.description;
+		}
+
+		// Add ellipsis when subcommands exist but are truncated
+		if (entry.hasSubcommands && entry.subcommands.length === 0) {
+			line += " ...";
+		}
+
+		lines.push(line);
+
+		// Render subcommands
+		if (entry.subcommands.length > 0) {
+			lines.push(...renderTree(entry.subcommands, `${prefix}${childPrefix}`));
+		}
+	}
+
+	return lines;
+}
+
+export const listCommandsCommand = createCommand({
+	metadata: {
+		description: "List all available commands and subcommands",
+		status: "stable",
+		owner: "Workers: Authoring and Testing",
+	},
+	behaviour: {
+		printBanner: (args) => !args.json,
+		provideConfig: false,
+	},
+	args: {
+		json: {
+			type: "boolean",
+			default: false,
+			description: "Return output as JSON",
+		},
+		"include-aliases": {
+			type: "boolean",
+			default: false,
+			description: "Include alias commands in the output",
+		},
+		all: {
+			type: "boolean",
+			default: false,
+			description:
+				"Show all subcommands at every depth. Warning: this can be very token-intensive at the top level when run by AI agents — consider using --base to scope the output",
+		},
+		base: {
+			type: "string",
+			description:
+				'Show commands under a specific base command (e.g. "d1 migrations")',
+		},
+	},
+	handler(args) {
+		const { registry } = experimental_getWranglerCommands();
+
+		// Navigate to the base node if --base is provided
+		let rootNode = registry;
+		const baseSegments = args.base
+			? args.base.split(/\s+/).filter(Boolean)
+			: [];
+		if (baseSegments.length > 0) {
+			rootNode = navigateToBase(registry, baseSegments);
+		}
+
+		const basePath = ["wrangler", ...baseSegments];
+		let tree = buildCommandTree(rootNode, basePath, args.includeAliases);
+
+		// By default, show only the immediate commands (no nested subcommands).
+		// With --all, show the full tree at every depth.
+		if (!args.all) {
+			tree = truncateDepth(tree, 0);
+		}
+
+		if (args.json) {
+			logger.json({ commands: tree });
+			return;
+		}
+
+		const lines = [basePath.join(" "), ...renderTree(tree)];
+		logger.log(lines.join("\n"));
+	},
+});

--- a/packages/wrangler/src/metrics/sanitization.ts
+++ b/packages/wrangler/src/metrics/sanitization.ts
@@ -99,6 +99,11 @@ export const COMMAND_ARG_ALLOW_LIST: AllowList = {
 	deploy: {
 		containersRollout: ["immediate", "gradual"],
 	},
+	"list-commands": {
+		includeAliases: ALLOW,
+		all: ALLOW,
+		base: ALLOW,
+	},
 };
 
 /**

--- a/packages/wrangler/src/metrics/sanitization.ts
+++ b/packages/wrangler/src/metrics/sanitization.ts
@@ -2,23 +2,42 @@ import { UserError } from "@cloudflare/workers-utils";
 import { getErrorType } from "../core/handle-errors";
 
 /**
- * Sanitizes the non-positional args provided to the command for metrics reporting.
+ * Sanitizes the args provided to the command for metrics reporting.
  *
  * Removes non-canonical args and filters out args that were not provided on the command line.
+ * Positional args bypass the argv check since they don't appear as `--flag` in the raw argv.
+ *
+ * @param args - The parsed yargs arguments object
+ * @param argv - The raw command line arguments (used to detect which flags were explicitly provided)
+ * @param positionalArgs - Names of positional args that should bypass the argv flag check
  */
 export function sanitizeArgKeys(
 	args: Record<string, unknown>,
-	argv: string[] | undefined
+	argv: string[] | undefined,
+	positionalArgs?: ReadonlyArray<string>
 ) {
 	const special = new Set(["$0", "_"]);
+	const positionals = new Set(positionalArgs ?? []);
 	const sanitizedArgs: Record<string, unknown> = {};
 
 	for (const arg of Object.keys(args)) {
+		if (special.has(arg)) {
+			continue;
+		}
+
+		// Positional args don't appear as --flag in argv, so we include them
+		// if their value is defined (meaning the user provided them).
+		if (positionals.has(arg)) {
+			if (args[arg] !== undefined) {
+				sanitizedArgs[canonicalArg(arg)] = args[arg];
+			}
+			continue;
+		}
+
 		if (
-			!special.has(arg) &&
-			(argv === undefined ||
-				argv.includes(`--${arg}`) ||
-				argv.includes(`-${arg[0]}`))
+			argv === undefined ||
+			argv.includes(`--${arg}`) ||
+			argv.includes(`-${arg[0]}`)
 		) {
 			sanitizedArgs[canonicalArg(arg)] = args[arg];
 		}

--- a/packages/wrangler/src/unknown-command-tip.ts
+++ b/packages/wrangler/src/unknown-command-tip.ts
@@ -23,16 +23,16 @@ export function logUnknownCommandTip(): void {
 
 			Tip: Use \`wrangler list-commands\` to explore all available commands and subcommands.
 
-			By default, only top-level commands are shown. Use these flags to dig deeper:
+			By default, only top-level commands are shown. Use these options to dig deeper:
+			  <base..>           Scope to a specific command subtree
 			  --all              Show the full command tree (all nesting levels)
-			  --base="<cmd>"     Scope to a specific command subtree
 			  --json             Output as JSON
 
 			Examples:
 			  wrangler list-commands                          List all top-level commands
-			  wrangler list-commands --base="d1"              Show d1 subcommands
-			  wrangler list-commands --base="kv"              Show kv subcommands
-			  wrangler list-commands --base="ai-search jobs"  Show ai-search jobs subcommands
+			  wrangler list-commands d1                       Show d1 subcommands
+			  wrangler list-commands kv                       Show kv subcommands
+			  wrangler list-commands ai-search jobs           Show ai-search jobs subcommands
 			  wrangler list-commands --all                    Show entire command tree (token-intensive)
 			  wrangler list-commands --json                   Machine-readable output
 		`);

--- a/packages/wrangler/src/unknown-command-tip.ts
+++ b/packages/wrangler/src/unknown-command-tip.ts
@@ -1,0 +1,45 @@
+import { detectAgenticEnvironment } from "am-i-vibing";
+import dedent from "ts-dedent";
+import { logger } from "./logger";
+
+/**
+ * Log a tip suggesting `wrangler list-commands` after an unknown command error.
+ *
+ * When an AI agent is detected (via `am-i-vibing`), shows a detailed message
+ * with flag descriptions and usage examples to help the agent self-correct.
+ * Otherwise, shows a short one-line tip for human users.
+ */
+export function logUnknownCommandTip(): void {
+	let isAgentic = false;
+	try {
+		isAgentic = detectAgenticEnvironment().isAgentic;
+	} catch {
+		// Silent failure — agent detection is best-effort
+	}
+
+	if (isAgentic) {
+		logger.log(dedent`
+			\n${"-".repeat(10)}\n
+
+			Tip: Use \`wrangler list-commands\` to explore all available commands and subcommands.
+
+			By default, only top-level commands are shown. Use these flags to dig deeper:
+			  --all              Show the full command tree (all nesting levels)
+			  --base="<cmd>"     Scope to a specific command subtree
+			  --json             Output as JSON
+
+			Examples:
+			  wrangler list-commands                          List all top-level commands
+			  wrangler list-commands --base="d1"              Show d1 subcommands
+			  wrangler list-commands --base="kv"              Show kv subcommands
+			  wrangler list-commands --base="ai-search jobs"  Show ai-search jobs subcommands
+			  wrangler list-commands --all                    Show entire command tree (token-intensive)
+			  wrangler list-commands --json                   Machine-readable output
+		`);
+	} else {
+		logger.log(
+			"\n☝️ Tip: Run `wrangler list-commands` to see all available commands and subcommands."
+		);
+	}
+	logger.log("\n");
+}


### PR DESCRIPTION
Hopefully helps with https://jira.cfdata.org/browse/DEVX-2595

This PR introduces a new command from wrangler: `list-commands` this can be used by devs and agents to see all the available commands in a single concise view (by default only a sub-set is shown an opt-in flag allows the whole list with all sub-commands to be presented as well).

The command's output is like:
```
$ npx wrangler list-commands      

 ⛅️ wrangler 4.107.0
───────────────────────────────────────────────
wrangler
├── agent-memory [private beta]         Manage Agent Memory namespaces ...
├── ai                                  Manage AI models ...
├── ai-search [open beta]               Manage AI Search instances ...
├── artifacts [private beta]            Manage Artifacts namespaces and repos ...
├── auth                                Manage authentication ...
├── browser [open beta]                 Manage Browser Run sessions ...
...
```
or
```
$ npx wrangler list-commands --json
{
    "commands": [
        {
            "command": "agent-memory",
            "fullCommand": "wrangler agent-memory",
            "description": "Manage Agent Memory namespaces",
            "status": "private beta",
            "deprecated": false,
            "hasSubcommands": true,
            "subcommands": []
        },
        {
            "command": "ai",
            "fullCommand": "wrangler ai",
            "description": "Manage AI models",
            "status": "stable",
            "deprecated": false,
            "hasSubcommands": true,
            "subcommands": []
        },
        {
            "command": "ai-search",
            "fullCommand": "wrangler ai-search",
            "description": "Manage AI Search instances",
            "status": "open beta",
            "deprecated": false,
            "hasSubcommands": true,
            "subcommands": []
        },
...
```

___

Besides the above if Wrangler is run by an agent with an unrecognized command the following suggestion is presented to it:
```
----------


Tip: Use `wrangler list-commands` to explore all available commands and subcommands.

By default, only top-level commands are shown. Use these flags to dig deeper:
  --all              Show the full command tree (all nesting levels)
  --base="<cmd>"     Scope to a specific command subtree
  --json             Output as JSON

Examples:
  wrangler list-commands                          List all top-level commands
  wrangler list-commands --base="d1"              Show d1 subcommands
  wrangler list-commands --base="kv"              Show kv subcommands
  wrangler list-commands --base="ai-search jobs"  Show ai-search jobs subcommands
  wrangler list-commands --all                    Show entire command tree (token-intensive)
  wrangler list-commands --json                   Machine-readable output
```

Allowing agents to easily list all commands and see what the got wrong.



---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: the docs will be automatically updated

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
