### PR TITLE
[workers-shared] resolve asset compatibility flags at config build time

### DIFF
--- a/.changeset/assets-resolve-compat-flags.md
+++ b/.changeset/assets-resolve-compat-flags.md
@@ -1,0 +1,9 @@
+---
+"wrangler": patch
+"miniflare": patch
+"@cloudflare/vite-plugin": patch
+---
+
+Resolve the Workers Assets compatibility flags when building the asset worker config, rather than inside the asset worker
+
+The asset worker used to receive `compatibility_date` and resolve date-gated flags (such as `assets_navigation_prefers_asset_serving`) at request time. Because that worker runs under its own fixed compatibility date, the runtime never expands the user's `compatibility_date` for it, so the resolution has to happen where the config is built. Flag resolution now happens up front during deploy, `wrangler dev`, and the Vite plugin, and the asset worker consumes the already-resolved `compatibility_flags`. This is an internal change with no expected difference in behavior.

--- a/packages/deploy-helpers/src/deploy/helpers/assets.ts
+++ b/packages/deploy-helpers/src/deploy/helpers/assets.ts
@@ -2,6 +2,7 @@ import assert from "node:assert";
 import { createReadStream } from "node:fs";
 import { readdir, readFile, stat } from "node:fs/promises";
 import * as path from "node:path";
+import { resolveCompatibilityFlags } from "@cloudflare/workers-shared/utils/compatibility-flags";
 import { parseStaticRouting } from "@cloudflare/workers-shared/utils/configuration/parseStaticRouting";
 import {
 	CF_ASSETS_IGNORE_FILENAME,
@@ -559,8 +560,10 @@ export function resolveAssetOptions(
 		html_handling: config.assets?.html_handling,
 		not_found_handling: config.assets?.not_found_handling,
 		// The _redirects and _headers files are parsed in Miniflare in dev and parsing is not required for deploy
-		compatibility_date: config.compatibility_date,
-		compatibility_flags: config.compatibility_flags,
+		compatibility_flags: resolveCompatibilityFlags({
+			compatibilityDate: config.compatibility_date,
+			compatibilityFlags: config.compatibility_flags,
+		}),
 	};
 
 	return {

--- a/packages/miniflare/src/plugins/assets/index.ts
+++ b/packages/miniflare/src/plugins/assets/index.ts
@@ -13,6 +13,7 @@ import {
 	PATH_HASH_OFFSET,
 	PATH_HASH_SIZE,
 } from "@cloudflare/workers-shared";
+import { resolveCompatibilityFlags } from "@cloudflare/workers-shared/utils/compatibility-flags";
 import {
 	constructHeaders,
 	constructRedirects,
@@ -172,8 +173,10 @@ export const ASSETS_PLUGIN: Plugin<typeof AssetsOptionsSchema> = {
 		}
 
 		const assetConfig: AssetConfig = {
-			compatibility_date: options.compatibilityDate,
-			compatibility_flags: options.compatibilityFlags,
+			compatibility_flags: resolveCompatibilityFlags({
+				compatibilityDate: options.compatibilityDate,
+				compatibilityFlags: options.compatibilityFlags,
+			}),
 			...options.assets.assetConfig,
 			redirects: parsedRedirects,
 			headers: parsedHeaders,

--- a/packages/miniflare/src/plugins/assets/schema.ts
+++ b/packages/miniflare/src/plugins/assets/schema.ts
@@ -15,7 +15,6 @@ export const AssetsOptionsSchema = z.object({
 			binding: z.string().optional(),
 			routerConfig: RouterConfigSchema.optional(),
 			assetConfig: AssetConfigSchema.omit({
-				compatibility_date: true,
 				compatibility_flags: true,
 			}).optional(),
 		})

--- a/packages/vite-plugin-cloudflare/src/asset-config.ts
+++ b/packages/vite-plugin-cloudflare/src/asset-config.ts
@@ -1,4 +1,5 @@
 import * as path from "node:path";
+import { resolveCompatibilityFlags } from "@cloudflare/workers-shared/utils/compatibility-flags";
 import {
 	constructHeaders,
 	constructRedirects,
@@ -58,20 +59,16 @@ export function getAssetsConfig(
 	const compatibilityOptions =
 		resolvedPluginConfig.type === "assets-only"
 			? {
-					compatibility_date: resolvedPluginConfig.config.compatibility_date,
-					compatibility_flags: resolvedPluginConfig.config.compatibility_flags,
+					compatibilityDate: resolvedPluginConfig.config.compatibility_date,
+					compatibilityFlags: resolvedPluginConfig.config.compatibility_flags,
 				}
 			: {
-					...(entryWorkerConfig?.compatibility_date
-						? { compatibility_date: entryWorkerConfig.compatibility_date }
-						: {}),
-					...(entryWorkerConfig?.compatibility_flags
-						? { compatibility_flags: entryWorkerConfig.compatibility_flags }
-						: {}),
+					compatibilityDate: entryWorkerConfig?.compatibility_date,
+					compatibilityFlags: entryWorkerConfig?.compatibility_flags,
 				};
 
 	const config = {
-		...compatibilityOptions,
+		compatibility_flags: resolveCompatibilityFlags(compatibilityOptions),
 		...assetsConfig,
 		has_static_routing:
 			resolvedPluginConfig.type === "workers" &&

--- a/packages/workers-shared/asset-worker/src/compatibility-flags.ts
+++ b/packages/workers-shared/asset-worker/src/compatibility-flags.ts
@@ -1,55 +1,5 @@
-import type { AssetConfig } from "../../utils/types";
-
-interface CompatibilityFlag {
-	enable: `assets_${string}`;
-	disable: `assets_${string}`;
-	onByDefaultAfter?: string;
-}
-
-export const SEC_FETCH_MODE_NAVIGATE_HEADER_PREFERS_ASSET_SERVING = {
-	enable: "assets_navigation_prefers_asset_serving",
-	disable: "assets_navigation_has_no_effect",
-	onByDefaultAfter: "2025-04-01",
-} satisfies CompatibilityFlag;
-
-const COMPATIBILITY_FLAGS = [
+export {
+	flagIsEnabled,
 	SEC_FETCH_MODE_NAVIGATE_HEADER_PREFERS_ASSET_SERVING,
-] as const;
-
-export type ENABLEMENT_COMPATIBILITY_FLAGS =
-	(typeof COMPATIBILITY_FLAGS)[number]["enable"];
-
-export const resolveCompatibilityOptions = (configuration?: AssetConfig) => {
-	const compatibilityDate = configuration?.compatibility_date ?? "2021-11-02";
-	const compatibilityFlags = configuration?.compatibility_flags ?? [];
-
-	const resolvedCompatibilityFlags = compatibilityFlags;
-	for (const compatibilityFlag of COMPATIBILITY_FLAGS) {
-		if (
-			compatibilityFlag.onByDefaultAfter &&
-			compatibilityDate >= compatibilityFlag.onByDefaultAfter &&
-			!resolvedCompatibilityFlags.find(
-				(flag) => flag === compatibilityFlag.disable
-			) &&
-			!resolvedCompatibilityFlags.find(
-				(flag) => flag === compatibilityFlag.enable
-			)
-		) {
-			resolvedCompatibilityFlags.push(compatibilityFlag.enable);
-		}
-	}
-
-	return {
-		compatibilityDate,
-		compatibilityFlags: resolvedCompatibilityFlags,
-	};
-};
-
-export const flagIsEnabled = (
-	configuration: Required<AssetConfig>,
-	compatibilityFlag: (typeof COMPATIBILITY_FLAGS)[number]
-) => {
-	return !!configuration.compatibility_flags.find(
-		(flag) => flag === compatibilityFlag.enable
-	);
-};
+} from "../../utils/compatibility-flags";
+export type { ENABLEMENT_COMPATIBILITY_FLAGS } from "../../utils/compatibility-flags";

--- a/packages/workers-shared/asset-worker/src/configuration.ts
+++ b/packages/workers-shared/asset-worker/src/configuration.ts
@@ -1,14 +1,10 @@
-import { resolveCompatibilityOptions } from "./compatibility-flags";
 import type { AssetConfig } from "../../utils/types";
 
 export const normalizeConfiguration = (
 	configuration?: AssetConfig
 ): Required<AssetConfig> => {
-	const compatibilityOptions = resolveCompatibilityOptions(configuration);
-
 	return {
-		compatibility_date: compatibilityOptions.compatibilityDate,
-		compatibility_flags: compatibilityOptions.compatibilityFlags,
+		compatibility_flags: configuration?.compatibility_flags ?? [],
 		html_handling: configuration?.html_handling ?? "auto-trailing-slash",
 		not_found_handling: configuration?.not_found_handling ?? "none",
 		redirects: configuration?.redirects ?? {

--- a/packages/workers-shared/asset-worker/src/worker.ts
+++ b/packages/workers-shared/asset-worker/src/worker.ts
@@ -285,9 +285,7 @@ async function runFetchRequest(
 
 		const config = normalizeConfiguration(env.CONFIG);
 		sentry?.setContext("compatibilityOptions", {
-			compatibilityDate: config.compatibility_date,
 			compatibilityFlags: config.compatibility_flags,
-			originalCompatibilityFlags: env.CONFIG.compatibility_flags,
 		});
 		const userAgent = request.headers.get("user-agent") ?? "UA UNKNOWN";
 

--- a/packages/workers-shared/asset-worker/tests/compatibility-flags.test.ts
+++ b/packages/workers-shared/asset-worker/tests/compatibility-flags.test.ts
@@ -1,28 +1,23 @@
 import { describe, test } from "vitest";
-import { resolveCompatibilityOptions } from "../src/compatibility-flags";
+import { resolveCompatibilityFlags } from "../../utils/compatibility-flags";
 
-describe("resolveCompatibilityOptions", () => {
+describe("resolveCompatibilityFlags", () => {
 	test("it does not interfere with existing flags", ({ expect }) => {
-		expect(resolveCompatibilityOptions({ compatibility_flags: ["foo", "bar"] }))
+		expect(resolveCompatibilityFlags({ compatibilityFlags: ["foo", "bar"] }))
 			.toMatchInlineSnapshot(`
-			{
-			  "compatibilityDate": "2021-11-02",
-			  "compatibilityFlags": [
-			    "foo",
-			    "bar",
-			  ],
-			}
+			[
+			  "foo",
+			  "bar",
+			]
 		`);
 	});
 
 	test("it opts you into new flags if you have a future date", ({ expect }) => {
-		const { compatibilityDate, compatibilityFlags } =
-			resolveCompatibilityOptions({
-				compatibility_flags: ["foo", "bar"],
-				compatibility_date: "2099-12-12",
-			});
+		const compatibilityFlags = resolveCompatibilityFlags({
+			compatibilityFlags: ["foo", "bar"],
+			compatibilityDate: "2099-12-12",
+		});
 
-		expect(compatibilityDate).toEqual("2099-12-12");
 		expect(compatibilityFlags).toContain("foo");
 		expect(compatibilityFlags).toContain("bar");
 		expect(compatibilityFlags).toContain(
@@ -33,17 +28,15 @@ describe("resolveCompatibilityOptions", () => {
 	test("it doesn't double you up if you've already opted into new flags and have a future date", ({
 		expect,
 	}) => {
-		const { compatibilityDate, compatibilityFlags } =
-			resolveCompatibilityOptions({
-				compatibility_flags: [
-					"foo",
-					"bar",
-					"assets_navigation_prefers_asset_serving",
-				],
-				compatibility_date: "2099-12-12",
-			});
+		const compatibilityFlags = resolveCompatibilityFlags({
+			compatibilityFlags: [
+				"foo",
+				"bar",
+				"assets_navigation_prefers_asset_serving",
+			],
+			compatibilityDate: "2099-12-12",
+		});
 
-		expect(compatibilityDate).toEqual("2099-12-12");
 		expect(compatibilityFlags).toContain("foo");
 		expect(compatibilityFlags).toContain("bar");
 		expect(
@@ -56,17 +49,25 @@ describe("resolveCompatibilityOptions", () => {
 	test("it doesn't opt you into new flags if you have a future date and have disabled it", ({
 		expect,
 	}) => {
-		const { compatibilityDate, compatibilityFlags } =
-			resolveCompatibilityOptions({
-				compatibility_flags: ["foo", "bar", "assets_navigation_has_no_effect"],
-				compatibility_date: "2099-12-12",
-			});
+		const compatibilityFlags = resolveCompatibilityFlags({
+			compatibilityFlags: ["foo", "bar", "assets_navigation_has_no_effect"],
+			compatibilityDate: "2099-12-12",
+		});
 
-		expect(compatibilityDate).toEqual("2099-12-12");
 		expect(compatibilityFlags).toContain("foo");
 		expect(compatibilityFlags).toContain("bar");
 		expect(compatibilityFlags).not.toContain(
 			"assets_navigation_prefers_asset_serving"
 		);
+	});
+
+	test("it does not mutate the passed-in flags array", ({ expect }) => {
+		const input = ["foo"];
+		resolveCompatibilityFlags({
+			compatibilityFlags: input,
+			compatibilityDate: "2099-12-12",
+		});
+
+		expect(input).toEqual(["foo"]);
 	});
 });

--- a/packages/workers-shared/asset-worker/tests/handler.test.ts
+++ b/packages/workers-shared/asset-worker/tests/handler.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, vi } from "vitest";
+import { resolveCompatibilityFlags } from "../../utils/compatibility-flags";
 import { mockJaegerBinding } from "../../utils/tracing";
 import { Analytics } from "../src/analytics";
 import { SEC_FETCH_MODE_NAVIGATE_HEADER_PREFERS_ASSET_SERVING } from "../src/compatibility-flags";
@@ -1494,14 +1495,19 @@ describe("[Asset Worker] `canFetch`", () => {
 				},
 				{ expect }
 			) => {
+				// Date-based flag resolution now happens at CONFIG-construction
+				// time (deploy/dev/vite), so mirror that here before normalizing.
+				const compatibility_flags = resolveCompatibilityFlags({
+					compatibilityDate,
+					compatibilityFlags,
+				});
 				expect(
 					await canFetch(
 						new Request("https://example.com/foo", { headers }),
 						// @ts-expect-error Empty config default to using mocked jaeger
 						mockEnv,
 						normalizeConfiguration({
-							compatibility_date: compatibilityDate,
-							compatibility_flags: compatibilityFlags,
+							compatibility_flags,
 							not_found_handling: notFoundHandling,
 							has_static_routing: hasStaticRouting,
 						}),
@@ -1515,8 +1521,7 @@ describe("[Asset Worker] `canFetch`", () => {
 						// @ts-expect-error Empty config default to using mocked jaeger
 						mockEnv,
 						normalizeConfiguration({
-							compatibility_date: compatibilityDate,
-							compatibility_flags: compatibilityFlags,
+							compatibility_flags,
 							not_found_handling: notFoundHandling,
 							has_static_routing: hasStaticRouting,
 						}),
@@ -1530,8 +1535,7 @@ describe("[Asset Worker] `canFetch`", () => {
 						// @ts-expect-error Empty config default to using mocked jaeger
 						mockEnv,
 						normalizeConfiguration({
-							compatibility_date: compatibilityDate,
-							compatibility_flags: compatibilityFlags,
+							compatibility_flags,
 							not_found_handling: notFoundHandling,
 							has_static_routing: hasStaticRouting,
 						}),
@@ -1545,8 +1549,7 @@ describe("[Asset Worker] `canFetch`", () => {
 						// @ts-expect-error Empty config default to using mocked jaeger
 						mockEnv,
 						normalizeConfiguration({
-							compatibility_date: compatibilityDate,
-							compatibility_flags: compatibilityFlags,
+							compatibility_flags,
 							not_found_handling: notFoundHandling,
 							has_static_routing: hasStaticRouting,
 						}),

--- a/packages/workers-shared/utils/compatibility-flags.ts
+++ b/packages/workers-shared/utils/compatibility-flags.ts
@@ -1,0 +1,56 @@
+import type { AssetConfig } from "./types";
+
+interface CompatibilityFlag {
+	enable: `assets_${string}`;
+	disable: `assets_${string}`;
+	onByDefaultAfter?: string;
+}
+
+export const SEC_FETCH_MODE_NAVIGATE_HEADER_PREFERS_ASSET_SERVING = {
+	enable: "assets_navigation_prefers_asset_serving",
+	disable: "assets_navigation_has_no_effect",
+	onByDefaultAfter: "2025-04-01",
+} satisfies CompatibilityFlag;
+
+const COMPATIBILITY_FLAGS = [
+	SEC_FETCH_MODE_NAVIGATE_HEADER_PREFERS_ASSET_SERVING,
+] as const;
+
+export type ENABLEMENT_COMPATIBILITY_FLAGS =
+	(typeof COMPATIBILITY_FLAGS)[number]["enable"];
+
+/**
+ * Resolves the effective set of asset compatibility flags for a Worker, given
+ * its compatibility date and any explicitly-set compatibility flags.
+ *
+ * Date-based defaults are applied here so that the asset worker only ever needs
+ * to reason about a concrete list of enabled flags. This is called at
+ * CONFIG-construction time (deploy, dev/miniflare, vite), not at request time.
+ */
+export const resolveCompatibilityFlags = (options?: {
+	compatibilityDate?: string;
+	compatibilityFlags?: string[];
+}): string[] => {
+	const compatibilityDate = options?.compatibilityDate ?? "2021-11-02";
+	const resolvedCompatibilityFlags = [...(options?.compatibilityFlags ?? [])];
+
+	for (const compatibilityFlag of COMPATIBILITY_FLAGS) {
+		if (
+			compatibilityFlag.onByDefaultAfter &&
+			compatibilityDate >= compatibilityFlag.onByDefaultAfter &&
+			!resolvedCompatibilityFlags.includes(compatibilityFlag.disable) &&
+			!resolvedCompatibilityFlags.includes(compatibilityFlag.enable)
+		) {
+			resolvedCompatibilityFlags.push(compatibilityFlag.enable);
+		}
+	}
+
+	return resolvedCompatibilityFlags;
+};
+
+export const flagIsEnabled = (
+	configuration: Pick<Required<AssetConfig>, "compatibility_flags">,
+	compatibilityFlag: (typeof COMPATIBILITY_FLAGS)[number]
+) => {
+	return configuration.compatibility_flags.includes(compatibilityFlag.enable);
+};

--- a/packages/workers-shared/utils/types.ts
+++ b/packages/workers-shared/utils/types.ts
@@ -67,7 +67,6 @@ export const HeadersSchema = z
 	.optional();
 
 export const AssetConfigSchema = z.object({
-	compatibility_date: z.string().optional(),
 	compatibility_flags: z.array(z.string()).optional(),
 	html_handling: z
 		.enum([


### PR DESCRIPTION
The asset worker runs under its own fixed compatibility date, so the runtime never expands the user's `compatibility_date` for it. Move date-gated flag resolution (e.g. `assets_navigation_prefers_asset_serving`) upstream to where the CONFIG is built — deploy, dev, and vite — and have the asset worker consume pre-resolved `compatibility_flags`. Internal refactor, no behavior change.

Fixes #[insert GH or internal issue link(s)].

_Describe your change..._

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: Non-functional change

*A picture of a cute animal (not mandatory, but encouraged)*
<img width="3072" height="2048" alt="image" src="https://github.com/user-attachments/assets/9f805f4d-8ed9-45ee-a1f6-245530329e40" />


<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14529" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->