### PR TITLE
fix(workers-utils): validate optional D1 database binding fields

### DIFF
--- a/.changeset/d1-binding-config-validation.md
+++ b/.changeset/d1-binding-config-validation.md
@@ -1,0 +1,7 @@
+---
+"@cloudflare/workers-utils": patch
+---
+
+Validate optional configuration fields for D1 database bindings
+
+Enforce type checks for the optional D1 database properties `database_name`, `migrations_dir`, `migrations_table`, and `database_internal_env` to ensure consistency with other binding types.

--- a/packages/workers-utils/src/config/validation.ts
+++ b/packages/workers-utils/src/config/validation.ts
@@ -4153,6 +4153,42 @@ const validateD1Binding: ValidatorFn = (diagnostics, field, value) => {
 		isValid = false;
 	}
 
+	if (!isOptionalProperty(value, "database_name", "string")) {
+		diagnostics.errors.push(
+			`"${field}" bindings should, optionally, have a string "database_name" field but got ${JSON.stringify(
+				value
+			)}.`
+		);
+		isValid = false;
+	}
+
+	if (!isOptionalProperty(value, "migrations_dir", "string")) {
+		diagnostics.errors.push(
+			`"${field}" bindings should, optionally, have a string "migrations_dir" field but got ${JSON.stringify(
+				value
+			)}.`
+		);
+		isValid = false;
+	}
+
+	if (!isOptionalProperty(value, "migrations_table", "string")) {
+		diagnostics.errors.push(
+			`"${field}" bindings should, optionally, have a string "migrations_table" field but got ${JSON.stringify(
+				value
+			)}.`
+		);
+		isValid = false;
+	}
+
+	if (!isOptionalProperty(value, "database_internal_env", "string")) {
+		diagnostics.errors.push(
+			`"${field}" bindings should, optionally, have a string "database_internal_env" field but got ${JSON.stringify(
+				value
+			)}.`
+		);
+		isValid = false;
+	}
+
 	validateAdditionalProperties(diagnostics, field, Object.keys(value), [
 		"binding",
 		"database_id",

--- a/packages/workers-utils/tests/config/validation/normalize-and-validate-config.test.ts
+++ b/packages/workers-utils/tests/config/validation/normalize-and-validate-config.test.ts
@@ -3701,7 +3701,7 @@ describe("normalizeAndValidateConfig()", () => {
 				expect(diagnostics.hasErrors()).toBe(false);
 			});
 
-			it("should error if D1 database optional config fields have incorrect types", ({
+			it("should error if D1 database database_name has incorrect type", ({
 				expect,
 			}) => {
 				const { diagnostics } = normalizeAndValidateConfig(
@@ -3709,12 +3709,7 @@ describe("normalizeAndValidateConfig()", () => {
 						d1_databases: [
 							{
 								binding: "DB",
-								database_id: 123,
-								preview_database_id: 456,
 								database_name: true,
-								migrations_dir: false,
-								migrations_table: 789,
-								database_internal_env: {},
 							},
 						],
 					} as unknown as RawConfig,
@@ -3727,12 +3722,82 @@ describe("normalizeAndValidateConfig()", () => {
 				expect(diagnostics.hasErrors()).toBe(true);
 				expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
 					"Processing wrangler configuration:
-					  - "d1_databases[0]" bindings must have a "database_id" field but got {"binding":"DB","database_id":123,"preview_database_id":456,"database_name":true,"migrations_dir":false,"migrations_table":789,"database_internal_env":{}}.
-					  - "d1_databases[0]" bindings should, optionally, have a string "preview_database_id" field but got {"binding":"DB","database_id":123,"preview_database_id":456,"database_name":true,"migrations_dir":false,"migrations_table":789,"database_internal_env":{}}.
-					  - "d1_databases[0]" bindings should, optionally, have a string "database_name" field but got {"binding":"DB","database_id":123,"preview_database_id":456,"database_name":true,"migrations_dir":false,"migrations_table":789,"database_internal_env":{}}.
-					  - "d1_databases[0]" bindings should, optionally, have a string "migrations_dir" field but got {"binding":"DB","database_id":123,"preview_database_id":456,"database_name":true,"migrations_dir":false,"migrations_table":789,"database_internal_env":{}}.
-					  - "d1_databases[0]" bindings should, optionally, have a string "migrations_table" field but got {"binding":"DB","database_id":123,"preview_database_id":456,"database_name":true,"migrations_dir":false,"migrations_table":789,"database_internal_env":{}}.
-					  - "d1_databases[0]" bindings should, optionally, have a string "database_internal_env" field but got {"binding":"DB","database_id":123,"preview_database_id":456,"database_name":true,"migrations_dir":false,"migrations_table":789,"database_internal_env":{}}."
+					  - "d1_databases[0]" bindings should, optionally, have a string "database_name" field but got {"binding":"DB","database_name":true}."
+				`);
+			});
+
+			it("should error if D1 database migrations_dir has incorrect type", ({
+				expect,
+			}) => {
+				const { diagnostics } = normalizeAndValidateConfig(
+					{
+						d1_databases: [
+							{
+								binding: "DB",
+								migrations_dir: 123,
+							},
+						],
+					} as unknown as RawConfig,
+					undefined,
+					undefined,
+					{ env: undefined }
+				);
+
+				expect(diagnostics.hasWarnings()).toBe(false);
+				expect(diagnostics.hasErrors()).toBe(true);
+				expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
+					"Processing wrangler configuration:
+					  - "d1_databases[0]" bindings should, optionally, have a string "migrations_dir" field but got {"binding":"DB","migrations_dir":123}."
+				`);
+			});
+
+			it("should error if D1 database migrations_table has incorrect type", ({
+				expect,
+			}) => {
+				const { diagnostics } = normalizeAndValidateConfig(
+					{
+						d1_databases: [
+							{
+								binding: "DB",
+								migrations_table: {},
+							},
+						],
+					} as unknown as RawConfig,
+					undefined,
+					undefined,
+					{ env: undefined }
+				);
+
+				expect(diagnostics.hasWarnings()).toBe(false);
+				expect(diagnostics.hasErrors()).toBe(true);
+				expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
+					"Processing wrangler configuration:
+					  - "d1_databases[0]" bindings should, optionally, have a string "migrations_table" field but got {"binding":"DB","migrations_table":{}}."
+				`);
+			});
+
+			it("should error if D1 database database_internal_env has incorrect type", ({
+				expect,
+			}) => {
+				const { diagnostics } = normalizeAndValidateConfig(
+					{
+						d1_databases: [
+							{
+								binding: "DB",
+								database_internal_env: false,
+							},
+						],
+					} as unknown as RawConfig,
+					undefined,
+					undefined,
+					{ env: undefined }
+				);
+
+				expect(diagnostics.hasWarnings()).toBe(false);
+				expect(diagnostics.hasErrors()).toBe(true);
+				expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
+					"Processing wrangler configuration:
+					  - "d1_databases[0]" bindings should, optionally, have a string "database_internal_env" field but got {"binding":"DB","database_internal_env":false}."
 				`);
 			});
 		});

--- a/packages/workers-utils/tests/config/validation/normalize-and-validate-config.test.ts
+++ b/packages/workers-utils/tests/config/validation/normalize-and-validate-config.test.ts
@@ -3700,6 +3700,41 @@ describe("normalizeAndValidateConfig()", () => {
 				expect(diagnostics.hasWarnings()).toBe(false);
 				expect(diagnostics.hasErrors()).toBe(false);
 			});
+
+			it("should error if D1 database optional config fields have incorrect types", ({
+				expect,
+			}) => {
+				const { diagnostics } = normalizeAndValidateConfig(
+					{
+						d1_databases: [
+							{
+								binding: "DB",
+								database_id: 123,
+								preview_database_id: 456,
+								database_name: true,
+								migrations_dir: false,
+								migrations_table: 789,
+								database_internal_env: {},
+							},
+						],
+					} as unknown as RawConfig,
+					undefined,
+					undefined,
+					{ env: undefined }
+				);
+
+				expect(diagnostics.hasWarnings()).toBe(false);
+				expect(diagnostics.hasErrors()).toBe(true);
+				expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
+					"Processing wrangler configuration:
+					  - "d1_databases[0]" bindings must have a "database_id" field but got {"binding":"DB","database_id":123,"preview_database_id":456,"database_name":true,"migrations_dir":false,"migrations_table":789,"database_internal_env":{}}.
+					  - "d1_databases[0]" bindings should, optionally, have a string "preview_database_id" field but got {"binding":"DB","database_id":123,"preview_database_id":456,"database_name":true,"migrations_dir":false,"migrations_table":789,"database_internal_env":{}}.
+					  - "d1_databases[0]" bindings should, optionally, have a string "database_name" field but got {"binding":"DB","database_id":123,"preview_database_id":456,"database_name":true,"migrations_dir":false,"migrations_table":789,"database_internal_env":{}}.
+					  - "d1_databases[0]" bindings should, optionally, have a string "migrations_dir" field but got {"binding":"DB","database_id":123,"preview_database_id":456,"database_name":true,"migrations_dir":false,"migrations_table":789,"database_internal_env":{}}.
+					  - "d1_databases[0]" bindings should, optionally, have a string "migrations_table" field but got {"binding":"DB","database_id":123,"preview_database_id":456,"database_name":true,"migrations_dir":false,"migrations_table":789,"database_internal_env":{}}.
+					  - "d1_databases[0]" bindings should, optionally, have a string "database_internal_env" field but got {"binding":"DB","database_id":123,"preview_database_id":456,"database_name":true,"migrations_dir":false,"migrations_table":789,"database_internal_env":{}}."
+				`);
+			});
 		});
 
 		describe("[hyperdrive]", () => {


### PR DESCRIPTION
## Description

This PR adds missing type validation for optional D1 database binding configuration fields in `@cloudflare/workers-utils`.

Previously, the following optional fields were recognised by the validator but were not type-checked:

- `database_name`
- `migrations_dir`
- `migrations_table`
- `database_internal_env`

This change validates these fields as optional strings using the existing validation pattern, making D1 binding validation consistent with other binding types such as KV, R2, and Durable Objects.

## Tests

- [x] Tests included/updated
- [ ] Automated tests not possible - manual testing has been completed as follows:
- [ ] Additional testing not necessary because:

## Public documentation

- [ ] Cloudflare docs PR(s):
- [x] Documentation not necessary because: internal validation fix with no user-facing behavior changes.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14530" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg" alt="Open in Devin Review">
  </picture>
</a>

<!-- devin-review-badge-end -->