### PR TITLE
[local-explorer-ui] Fix data studio cell keydown swallowing browser shortcuts

### DIFF
--- a/.changeset/data-studio-cell-keydown-swallow.md
+++ b/.changeset/data-studio-cell-keydown-swallow.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/local-explorer-ui": patch
+---
+
+fix: don't swallow unhandled keydown events (e.g. Cmd/Ctrl+<number> tab-switch shortcuts) when a data studio table cell is focused but not being edited

--- a/.changeset/data-studio-cell-keydown-swallow.md
+++ b/.changeset/data-studio-cell-keydown-swallow.md
@@ -2,4 +2,4 @@
 "@cloudflare/local-explorer-ui": patch
 ---
 
-fix: don't swallow unhandled keydown events (e.g. Cmd/Ctrl+<number> tab-switch shortcuts) when a data studio table cell is focused but not being edited
+fix: don't swallow unhandled keydown events (e.g. `Cmd/Ctrl+<number>` tab-switch shortcuts) when a data studio table cell is focused but not being edited

--- a/.changeset/data-studio-cell-keydown-swallow.md
+++ b/.changeset/data-studio-cell-keydown-swallow.md
@@ -2,4 +2,4 @@
 "@cloudflare/local-explorer-ui": patch
 ---
 
-fix: don't swallow unhandled keydown events (e.g. `Cmd/Ctrl+<number>` tab-switch shortcuts) when a data studio table cell is focused but not being edited
+Don't swallow unhandled keydown events (e.g. `Cmd/Ctrl+<number>` tab-switch shortcuts) when a data studio table cell is focused but not being edited

--- a/packages/local-explorer-ui/src/__tests__/components/studio/table-keydown.test.ts
+++ b/packages/local-explorer-ui/src/__tests__/components/studio/table-keydown.test.ts
@@ -1,0 +1,120 @@
+import { describe, test } from "vitest";
+import { handleStudioTableKeyDown } from "../../../components/studio/Table";
+import { StudioTableState } from "../../../components/studio/Table/State";
+import type { StudioTableHeaderInput } from "../../../components/studio/Table/State";
+
+function createHeader(name: string): StudioTableHeaderInput {
+	return {
+		display: { initialSize: 100, text: name },
+		metadata: undefined,
+		name,
+		setting: { readonly: false, resizable: true },
+		store: new Map(),
+	};
+}
+
+function createState(): StudioTableState {
+	const state = new StudioTableState(
+		[createHeader("col1"), createHeader("col2")],
+		[
+			{ col1: "a", col2: "b" },
+			{ col1: "c", col2: "d" },
+		]
+	);
+	state.setFocus(0, 0);
+	return state;
+}
+
+function createKeyboardEvent(
+	key: string,
+	overrides: Partial<
+		Pick<React.KeyboardEvent, "shiftKey" | "metaKey" | "ctrlKey">
+	> = {}
+): React.KeyboardEvent {
+	let prevented = false;
+	return {
+		key,
+		shiftKey: overrides.shiftKey ?? false,
+		metaKey: overrides.metaKey ?? false,
+		ctrlKey: overrides.ctrlKey ?? false,
+		get defaultPrevented() {
+			return prevented;
+		},
+		preventDefault: () => {
+			prevented = true;
+		},
+	} as unknown as React.KeyboardEvent;
+}
+
+describe("handleStudioTableKeyDown", () => {
+	test("does not swallow an unhandled key while a cell is focused (regression for #14524)", ({
+		expect,
+	}) => {
+		const state = createState();
+		const event = createKeyboardEvent("1", { metaKey: true });
+
+		handleStudioTableKeyDown(event, {
+			onShiftKeyDownCallBack: () => {},
+			state,
+		});
+
+		expect(event.defaultPrevented).toBe(false);
+	});
+
+	test("prevents default for a recognized navigation key (ArrowRight)", ({
+		expect,
+	}) => {
+		const state = createState();
+		const event = createKeyboardEvent("ArrowRight");
+
+		handleStudioTableKeyDown(event, {
+			onShiftKeyDownCallBack: () => {},
+			state,
+		});
+
+		expect(event.defaultPrevented).toBe(true);
+	});
+
+	test("prevents default for Enter and enters edit mode", ({ expect }) => {
+		const state = createState();
+		const event = createKeyboardEvent("Enter");
+
+		handleStudioTableKeyDown(event, {
+			onShiftKeyDownCallBack: () => {},
+			state,
+		});
+
+		expect(event.defaultPrevented).toBe(true);
+		expect(state.isInEditMode()).toBe(true);
+	});
+
+	test("does nothing while the state is already in edit mode", ({ expect }) => {
+		const state = createState();
+		state.enterEditMode();
+		const event = createKeyboardEvent("1", { metaKey: true });
+
+		handleStudioTableKeyDown(event, {
+			onShiftKeyDownCallBack: () => {},
+			state,
+		});
+
+		expect(event.defaultPrevented).toBe(false);
+	});
+
+	test("respects a custom key handler that already prevented default (e.g. Cmd+C copy)", ({
+		expect,
+	}) => {
+		const state = createState();
+		const event = createKeyboardEvent("c", { metaKey: true });
+
+		handleStudioTableKeyDown(event, {
+			customKeyDownHandler: (e) => {
+				e.preventDefault();
+			},
+			onShiftKeyDownCallBack: () => {},
+			state,
+		});
+
+		expect(event.defaultPrevented).toBe(true);
+	});
+});

--- a/packages/local-explorer-ui/src/components/studio/Table/index.tsx
+++ b/packages/local-explorer-ui/src/components/studio/Table/index.tsx
@@ -1,4 +1,4 @@
-import {
+import React, {
 	useCallback,
 	useRef,
 	type JSX,
@@ -7,6 +7,7 @@ import {
 } from "react";
 import { StudioBaseTable } from "./BaseTable";
 import type { StudioTableProps } from "./BaseTable";
+import type { StudioTableState } from "./State";
 
 export function StudioTable<T = unknown>(
 	props: StudioTableProps<T>
@@ -79,91 +80,12 @@ export function StudioTable<T = unknown>(
 
 	// Provide key navigation
 	const onKeyDown = useCallback(
-		(e: KeyboardEvent): void => {
-			if (state.isInEditMode()) {
-				return;
-			}
-
-			if (customKeyDownHandler) {
-				customKeyDownHandler(e);
-			}
-
-			if (e.defaultPrevented) {
-				return;
-			}
-
-			if (e.key === "ArrowRight") {
-				if (e.shiftKey) {
-					onShiftKeyDownCallBack(e);
-				} else {
-					const focus = state.getFocus();
-					if (focus && focus.x + 1 < state.getHeaderCount()) {
-						state.setFocus(focus.y, focus.x + 1);
-						state.scrollToCell("right", "top", { y: focus.y, x: focus.x + 1 });
-					}
-				}
-			} else if (e.key === "ArrowLeft") {
-				if (e.shiftKey) {
-					onShiftKeyDownCallBack(e);
-				} else {
-					const focus = state.getFocus();
-					if (focus && focus.x - 1 >= 0) {
-						state.setFocus(focus.y, focus.x - 1);
-						state.scrollToCell("left", "top", { y: focus.y, x: focus.x - 1 });
-					}
-				}
-			} else if (e.key === "ArrowUp") {
-				if (e.shiftKey) {
-					onShiftKeyDownCallBack(e);
-				} else {
-					const focus = state.getFocus();
-					if (focus && focus.y - 1 >= 0) {
-						state.setFocus(focus.y - 1, focus.x);
-						state.scrollToCell("left", "top", { y: focus.y - 1, x: focus.x });
-					}
-				}
-			} else if (e.key === "ArrowDown") {
-				if (e.shiftKey) {
-					onShiftKeyDownCallBack(e);
-				} else {
-					const focus = state.getFocus();
-					if (focus && focus.y + 1 < state.getRowsCount()) {
-						state.setFocus(focus.y + 1, focus.x);
-						state.scrollToCell("left", "bottom", {
-							y: focus.y + 1,
-							x: focus.x,
-						});
-					}
-				}
-			} else if (e.key === "Tab") {
-				const direction = e.shiftKey ? -1 : 1;
-				const focus = state.getFocus();
-
-				if (focus) {
-					const colCount = state.getHeaderCount();
-					const n = focus.y * colCount + focus.x + direction;
-					const x = n % colCount;
-					const y = Math.floor(n / colCount);
-					if (y >= state.getRowsCount() || y < 0) {
-						return;
-					}
-					state.setFocus(y, x);
-					state.scrollToCell(
-						x === 0 || (e.shiftKey && x < colCount - 1) ? "left" : "right",
-						e.shiftKey ? "top" : "bottom",
-						{
-							y: y,
-							x: x,
-						}
-					);
-				}
-			} else if (e.key === "Enter") {
-				state.enterEditMode();
-			} else {
-				return;
-			}
-
-			e.preventDefault();
+		(e: React.KeyboardEvent): void => {
+			handleStudioTableKeyDown(e, {
+				customKeyDownHandler,
+				onShiftKeyDownCallBack,
+				state,
+			});
 		},
 		[onShiftKeyDownCallBack, customKeyDownHandler, state]
 	);
@@ -232,4 +154,102 @@ export function StudioTable<T = unknown>(
 			onKeyUp={onKeyUp}
 		/>
 	);
+}
+
+export function handleStudioTableKeyDown<HeaderMetadata = unknown>(
+	e: React.KeyboardEvent,
+	{
+		customKeyDownHandler,
+		onShiftKeyDownCallBack,
+		state,
+	}: {
+		customKeyDownHandler?: (e: React.KeyboardEvent) => void;
+		onShiftKeyDownCallBack: (e: React.KeyboardEvent) => void;
+		state: StudioTableState<HeaderMetadata>;
+	}
+): void {
+	if (state.isInEditMode()) {
+		return;
+	}
+
+	if (customKeyDownHandler) {
+		customKeyDownHandler(e);
+	}
+
+	if (e.defaultPrevented) {
+		return;
+	}
+
+	if (e.key === "ArrowRight") {
+		if (e.shiftKey) {
+			onShiftKeyDownCallBack(e);
+		} else {
+			const focus = state.getFocus();
+			if (focus && focus.x + 1 < state.getHeaderCount()) {
+				state.setFocus(focus.y, focus.x + 1);
+				state.scrollToCell("right", "top", { y: focus.y, x: focus.x + 1 });
+			}
+		}
+	} else if (e.key === "ArrowLeft") {
+		if (e.shiftKey) {
+			onShiftKeyDownCallBack(e);
+		} else {
+			const focus = state.getFocus();
+			if (focus && focus.x - 1 >= 0) {
+				state.setFocus(focus.y, focus.x - 1);
+				state.scrollToCell("left", "top", { y: focus.y, x: focus.x - 1 });
+			}
+		}
+	} else if (e.key === "ArrowUp") {
+		if (e.shiftKey) {
+			onShiftKeyDownCallBack(e);
+		} else {
+			const focus = state.getFocus();
+			if (focus && focus.y - 1 >= 0) {
+				state.setFocus(focus.y - 1, focus.x);
+				state.scrollToCell("left", "top", { y: focus.y - 1, x: focus.x });
+			}
+		}
+	} else if (e.key === "ArrowDown") {
+		if (e.shiftKey) {
+			onShiftKeyDownCallBack(e);
+		} else {
+			const focus = state.getFocus();
+			if (focus && focus.y + 1 < state.getRowsCount()) {
+				state.setFocus(focus.y + 1, focus.x);
+				state.scrollToCell("left", "bottom", {
+					y: focus.y + 1,
+					x: focus.x,
+				});
+			}
+		}
+	} else if (e.key === "Tab") {
+		const direction = e.shiftKey ? -1 : 1;
+		const focus = state.getFocus();
+
+		if (focus) {
+			const colCount = state.getHeaderCount();
+			const n = focus.y * colCount + focus.x + direction;
+			const x = n % colCount;
+			const y = Math.floor(n / colCount);
+			if (y >= state.getRowsCount() || y < 0) {
+				return;
+			}
+			state.setFocus(y, x);
+			state.scrollToCell(
+				x === 0 || (e.shiftKey && x < colCount - 1) ? "left" : "right",
+				e.shiftKey ? "top" : "bottom",
+				{
+					y: y,
+					x: x,
+				}
+			);
+		}
+	} else if (e.key === "Enter") {
+		state.enterEditMode();
+	} else {
+		return;
+	}
+
+	e.preventDefault();
 }

--- a/packages/local-explorer-ui/src/components/studio/Table/index.tsx
+++ b/packages/local-explorer-ui/src/components/studio/Table/index.tsx
@@ -159,6 +159,8 @@ export function StudioTable<T = unknown>(
 				}
 			} else if (e.key === "Enter") {
 				state.enterEditMode();
+			} else {
+				return;
 			}
 
 			e.preventDefault();


### PR DESCRIPTION
Fixes #14524

In the data studio table for D1 databases / Durable Objects, clicking a table cell (read-only, not editing) and then pressing a browser shortcut like `Cmd+1` did nothing — the keydown was swallowed instead of reaching the browser.

`StudioTable`'s `onKeyDown` handler (`packages/local-explorer-ui/src/components/studio/Table/index.tsx`) called `e.preventDefault()` unconditionally after its `if/else-if` chain of recognized navigation keys (arrows, Tab, Enter). Any other key — including all `Cmd/Ctrl+<key>` browser shortcuts — fell through to that same `preventDefault()` since there was no `else` branch and no check on `e.metaKey`/`e.ctrlKey`.

Fix: added an `else { return; }` before the `preventDefault()`, so it only fires for the keys the grid itself handles. Everything else now passes through untouched.

Also extracted the key-handling logic into an exported `handleStudioTableKeyDown` function (dependency-injected, no closures) so it's unit-testable without rendering the component — this package has no React render-test infra (no testing-library/jsdom), so this keeps the new test a plain Vitest unit test consistent with the rest of the package's tests.

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: internal bug fix to an existing UI, no user-facing docs to update
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14531" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->