### PR TITLE
[create-cloudflare] Preserve existing Nuxt `modules` when adding Cloudflare configuration

### DIFF
--- a/.changeset/autoconfig-nuxt-preserve-modules.md
+++ b/.changeset/autoconfig-nuxt-preserve-modules.md
@@ -1,0 +1,7 @@
+---
+"@cloudflare/autoconfig": patch
+---
+
+Preserve existing Nuxt `modules` when configuring a project for Cloudflare
+
+Configuring an existing Nuxt project whose `nuxt.config.ts` already declares a `modules` array previously overwrote that array when adding `nitro-cloudflare-dev`, dropping modules such as `@nuxt/ui`. Existing entries are now retained and the Cloudflare module is appended instead.

--- a/.changeset/create-cloudflare-nuxt-preserve-modules.md
+++ b/.changeset/create-cloudflare-nuxt-preserve-modules.md
@@ -1,0 +1,7 @@
+---
+"create-cloudflare": patch
+---
+
+Preserve existing Nuxt `modules` when adding Cloudflare configuration
+
+Scaffolding a Nuxt application whose `nuxt.config.ts` already declares a `modules` array (for example the `ui` starter, which registers `@nuxt/ui` and `@nuxt/eslint`) previously overwrote that array when adding `nitro-cloudflare-dev`, dropping the existing modules and breaking the build. Existing entries are now retained and the Cloudflare module is appended instead.

--- a/packages/codemod/src/index.ts
+++ b/packages/codemod/src/index.ts
@@ -139,10 +139,7 @@ function mergeArrayElements(
 ): void {
 	const existingStringValues = new Set(
 		existingArray.elements
-			.filter(
-				(el): el is recast.types.namedTypes.StringLiteral =>
-					el?.type === "StringLiteral"
-			)
+			.filter((el) => el?.type === "StringLiteral")
 			.map((el) => el.value)
 	);
 

--- a/packages/codemod/src/index.ts
+++ b/packages/codemod/src/index.ts
@@ -75,7 +75,8 @@ export function transformFile(filePath: string, methods: recast.types.Visitor) {
 
 /**
  * merges provided properties into a given object (updating the object itself), deeply merging them in case
- * some properties are object themselves
+ * some properties are objects themselves and concatenating them (de-duplicating string entries) in case
+ * some properties are arrays
  *
  * @param sourceObject the object into which merge the new properties
  * @param newProperties the new properties to add/merge
@@ -111,7 +112,48 @@ export function mergeObjectProperties(
 			return;
 		}
 
+		if (
+			existing.type === "ObjectProperty" &&
+			existing.value.type === "ArrayExpression" &&
+			newProp.value.type === "ArrayExpression"
+		) {
+			mergeArrayElements(existing.value, newProp.value);
+			return;
+		}
+
 		sourceObject.properties[indexOfExisting] = newProp;
+	});
+}
+
+/**
+ * concatenates the elements of one array expression onto another (updating the target array itself),
+ * skipping any string literal that is already present so that existing entries are preserved rather
+ * than overwritten
+ *
+ * @param existingArray the array expression to merge new elements into
+ * @param newArray the array expression whose elements should be appended
+ */
+function mergeArrayElements(
+	existingArray: recast.types.namedTypes.ArrayExpression,
+	newArray: recast.types.namedTypes.ArrayExpression
+): void {
+	const existingStringValues = new Set(
+		existingArray.elements
+			.filter(
+				(el): el is recast.types.namedTypes.StringLiteral =>
+					el?.type === "StringLiteral"
+			)
+			.map((el) => el.value)
+	);
+
+	newArray.elements.forEach((el) => {
+		if (el?.type === "StringLiteral") {
+			if (existingStringValues.has(el.value)) {
+				return;
+			}
+			existingStringValues.add(el.value);
+		}
+		existingArray.elements.push(el);
 	});
 }
 

--- a/packages/codemod/tests/index.test.ts
+++ b/packages/codemod/tests/index.test.ts
@@ -85,6 +85,44 @@ describe("mergeObjectProperties", () => {
 				},
 			},
 		},
+		{
+			testName: "concatenates array properties, preserving existing entries",
+			sourcePropertiesObject: {
+				modules: ["@nuxt/ui", "@nuxt/eslint"],
+			},
+			newPropertiesObject: {
+				modules: ["nitro-cloudflare-dev"],
+			},
+			expectedPropertiesObject: {
+				modules: ["@nuxt/ui", "@nuxt/eslint", "nitro-cloudflare-dev"],
+			},
+		},
+		{
+			testName: "de-duplicates string entries when concatenating arrays",
+			sourcePropertiesObject: {
+				modules: ["a"],
+			},
+			newPropertiesObject: {
+				modules: ["a", "b"],
+			},
+			expectedPropertiesObject: {
+				modules: ["a", "b"],
+			},
+		},
+		{
+			testName: "merges array and object properties in the same call",
+			sourcePropertiesObject: {
+				modules: ["@nuxt/ui", "@nuxt/eslint"],
+			},
+			newPropertiesObject: {
+				modules: ["nitro-cloudflare-dev"],
+				nitro: { preset: "cloudflare_module" },
+			},
+			expectedPropertiesObject: {
+				modules: ["@nuxt/ui", "@nuxt/eslint", "nitro-cloudflare-dev"],
+				nitro: { preset: "cloudflare_module" },
+			},
+		},
 	] satisfies {
 		testName: string;
 		sourcePropertiesObject: Record<string, unknown>;

--- a/packages/create-cloudflare/e2e/tests/frameworks/frameworks.test.ts
+++ b/packages/create-cloudflare/e2e/tests/frameworks/frameworks.test.ts
@@ -51,8 +51,14 @@ describe
 				envInterfaceName: "Env",
 				...getFrameworkConfig(testConfig.name),
 			};
+			// A third `:`-segment in the test name (e.g. `nuxt:pages:minimal`)
+			// is a variant label that disambiguates tests sharing the same
+			// framework id + platform. getFrameworkConfig ignores it.
+			const variantLabel = testConfig.name.split(":")[2];
 			test.runIf(shouldRunTest(testConfig))(
-				`${frameworkConfig.id} (${frameworkConfig.platform ?? "pages"})`,
+				`${frameworkConfig.id} (${frameworkConfig.platform ?? "pages"})${
+					variantLabel ? ` [${variantLabel}]` : ""
+				}`,
 				{
 					retry: testRetries,
 					timeout: testConfig.timeout || TEST_TIMEOUT,

--- a/packages/create-cloudflare/e2e/tests/frameworks/test-config.ts
+++ b/packages/create-cloudflare/e2e/tests/frameworks/test-config.ts
@@ -881,6 +881,7 @@ function getExperimentalFrameworkTestConfig(
 			argv: ["--platform", "workers"],
 			testCommitMessage: true,
 			timeout: LONG_TIMEOUT,
+			unsupportedPms: ["yarn"], // Currently nitro requires youch which expects Node 20+, and yarn will fail hard since we run on Node 18
 			unsupportedOSs: ["win32"],
 			// See note on nuxt:pages above.
 			unsupportedPmRanges: { pnpm: "<11.0.0" },
@@ -908,6 +909,8 @@ function getExperimentalFrameworkTestConfig(
 			argv: ["--platform", "workers"],
 			testCommitMessage: true,
 			timeout: LONG_TIMEOUT,
+			// See notes on nuxt:pages:minimal in getFrameworkTestConfig.
+			unsupportedPms: ["yarn", "npm"],
 			unsupportedOSs: ["win32"],
 			// The ui variant covers pnpm 11+ (see nuxt:pages:minimal in
 			// getFrameworkTestConfig); this variant runs on pnpm 10.
@@ -1160,7 +1163,10 @@ function getExperimentalFrameworkTestConfig(
  *
  * @param options - An object containing the following properties:
  *   - isExperimentalMode: A boolean indicating if experimental mode is enabled.
- *   - FrameworkTestFilter: A string that can be used to filter the tests by "name" or "name:(pages|workers)".
+ *   - FrameworkTestFilter: A string that can be used to filter the tests by
+ *     "name" (e.g. "nuxt"), "name:(pages|workers)" (e.g. "nuxt:pages"), or a
+ *     full variant name (e.g. "nuxt:pages:minimal"). A "name:platform" filter
+ *     also matches variant tests of the form "name:platform:variant".
  */
 export function getFrameworksTests(): NamedFrameworkTestConfig[] {
 	const packageManager = detectPackageManager();
@@ -1172,7 +1178,12 @@ export function getFrameworksTests(): NamedFrameworkTestConfig[] {
 			return true;
 		}
 		if (frameworkToTestFilter.includes(":")) {
-			return testConfig.name === frameworkToTestFilter;
+			// Match the exact name, and also treat a "name:platform" filter as a
+			// prefix so it includes variant tests like "name:platform:minimal".
+			return (
+				testConfig.name === frameworkToTestFilter ||
+				testConfig.name.startsWith(`${frameworkToTestFilter}:`)
+			);
 		}
 		return testConfig.name.split(":")[0] === frameworkToTestFilter;
 	});

--- a/packages/create-cloudflare/e2e/tests/frameworks/test-config.ts
+++ b/packages/create-cloudflare/e2e/tests/frameworks/test-config.ts
@@ -416,6 +416,67 @@ function getFrameworkTestConfig(pm: string): NamedFrameworkTestConfig[] {
 			flags: ["--template", "ui"],
 		},
 		{
+			name: "nuxt:pages:minimal",
+			promptHandlers: [
+				{
+					matcher: /Would you like to .* install .*modules\?/,
+					input: [keys.enter],
+				},
+			],
+			argv: ["--platform", "pages"],
+			testCommitMessage: true,
+			timeout: LONG_TIMEOUT,
+			// yarn: nitro requires youch which expects Node 20+, and yarn fails
+			// hard since we run on Node 18. npm: the `nuxt:pages` (ui) test
+			// already covers npm, so skip it here to avoid running Nuxt twice.
+			unsupportedPms: ["yarn", "npm"],
+			unsupportedOSs: ["win32"],
+			// Nuxt's deps trip `ERR_PNPM_IGNORED_BUILDS` on pnpm 11; the e2e
+			// harness has closed stdin by the time C3's recovery prompt fires
+			// (real-TTY users are unaffected). The `nuxt:pages` (ui) test covers
+			// pnpm 11+, so this `minimal` variant runs on pnpm 10 to keep the
+			// pre-pnpm-11 install path (and the default template) under test.
+			unsupportedPmRanges: { pnpm: ">=11.0.0" },
+			verifyDeploy: {
+				route: "/",
+				expectedText: "Welcome to Nuxt!",
+			},
+			nodeCompat: false,
+			verifyPreview: {
+				previewArgs: ["--inspector-port=0"],
+				route: "/test",
+				expectedText: "C3_TEST",
+			},
+			flags: ["--template", "minimal"],
+		},
+		{
+			name: "nuxt:workers:minimal",
+			promptHandlers: [
+				{
+					matcher: /Would you like to .* install .*modules\?/,
+					input: [keys.enter],
+				},
+			],
+			argv: ["--platform", "workers"],
+			testCommitMessage: true,
+			timeout: LONG_TIMEOUT,
+			// See notes on nuxt:pages:minimal above.
+			unsupportedPms: ["yarn", "npm"],
+			unsupportedOSs: ["win32"],
+			unsupportedPmRanges: { pnpm: ">=11.0.0" },
+			verifyDeploy: {
+				route: "/",
+				expectedText: "Welcome to Nuxt!",
+			},
+			verifyPreview: {
+				previewArgs: ["--inspector-port=0"],
+				route: "/test",
+				expectedText: "C3_TEST",
+			},
+			nodeCompat: false,
+			flags: ["--template", "minimal"],
+		},
+		{
 			name: "react:pages",
 			argv: ["--platform", "pages"],
 			promptHandlers: [
@@ -835,6 +896,34 @@ function getExperimentalFrameworkTestConfig(
 			nodeCompat: false,
 			verifyTypes: false,
 			flags: ["--template", "ui"],
+		},
+		{
+			name: "nuxt:workers:minimal",
+			promptHandlers: [
+				{
+					matcher: /Would you like to .* install .*modules\?/,
+					input: [keys.enter],
+				},
+			],
+			argv: ["--platform", "workers"],
+			testCommitMessage: true,
+			timeout: LONG_TIMEOUT,
+			unsupportedOSs: ["win32"],
+			// The ui variant covers pnpm 11+ (see nuxt:pages:minimal in
+			// getFrameworkTestConfig); this variant runs on pnpm 10.
+			unsupportedPmRanges: { pnpm: ">=11.0.0" },
+			verifyDeploy: {
+				route: "/",
+				expectedText: "Welcome to Nuxt!",
+			},
+			verifyPreview: {
+				previewArgs: ["--inspector-port=0"],
+				route: "/test",
+				expectedText: "C3_TEST",
+			},
+			nodeCompat: false,
+			verifyTypes: false,
+			flags: ["--template", "minimal"],
 		},
 		{
 			name: "solid",

--- a/packages/create-cloudflare/e2e/tests/frameworks/test-config.ts
+++ b/packages/create-cloudflare/e2e/tests/frameworks/test-config.ts
@@ -378,7 +378,7 @@ function getFrameworkTestConfig(pm: string): NamedFrameworkTestConfig[] {
 			unsupportedPmRanges: { pnpm: ">=11.0.0" },
 			verifyDeploy: {
 				route: "/",
-				expectedText: "Welcome to Nuxt!",
+				expectedText: "Nuxt UI - Starter",
 			},
 			nodeCompat: false,
 			verifyPreview: {
@@ -386,7 +386,7 @@ function getFrameworkTestConfig(pm: string): NamedFrameworkTestConfig[] {
 				route: "/test",
 				expectedText: "C3_TEST",
 			},
-			flags: ["--template", "minimal"],
+			flags: ["--template", "ui"],
 		},
 		{
 			name: "nuxt:workers",
@@ -405,7 +405,7 @@ function getFrameworkTestConfig(pm: string): NamedFrameworkTestConfig[] {
 			unsupportedPmRanges: { pnpm: ">=11.0.0" },
 			verifyDeploy: {
 				route: "/",
-				expectedText: "Welcome to Nuxt!",
+				expectedText: "Nuxt UI - Starter",
 			},
 			verifyPreview: {
 				previewArgs: ["--inspector-port=0"],
@@ -413,7 +413,7 @@ function getFrameworkTestConfig(pm: string): NamedFrameworkTestConfig[] {
 				expectedText: "C3_TEST",
 			},
 			nodeCompat: false,
-			flags: ["--template", "minimal"],
+			flags: ["--template", "ui"],
 		},
 		{
 			name: "react:pages",
@@ -825,7 +825,7 @@ function getExperimentalFrameworkTestConfig(
 			unsupportedPmRanges: { pnpm: ">=11.0.0" },
 			verifyDeploy: {
 				route: "/",
-				expectedText: "Welcome to Nuxt!",
+				expectedText: "Nuxt UI - Starter",
 			},
 			verifyPreview: {
 				previewArgs: ["--inspector-port=0"],
@@ -834,7 +834,7 @@ function getExperimentalFrameworkTestConfig(
 			},
 			nodeCompat: false,
 			verifyTypes: false,
-			flags: ["--template", "minimal"],
+			flags: ["--template", "ui"],
 		},
 		{
 			name: "solid",

--- a/packages/create-cloudflare/e2e/tests/frameworks/test-config.ts
+++ b/packages/create-cloudflare/e2e/tests/frameworks/test-config.ts
@@ -372,10 +372,10 @@ function getFrameworkTestConfig(pm: string): NamedFrameworkTestConfig[] {
 			timeout: LONG_TIMEOUT,
 			unsupportedPms: ["yarn"], // Currently nitro requires youch which expects Node 20+, and yarn will fail hard since we run on Node 18
 			unsupportedOSs: ["win32"],
-			// Nuxt's deps trip `ERR_PNPM_IGNORED_BUILDS` on pnpm 11; the e2e
-			// harness has closed stdin by the time C3's recovery prompt fires
-			// (real-TTY users are unaffected).
-			unsupportedPmRanges: { pnpm: ">=11.0.0" },
+			// The Nuxt `ui` template pins `packageManager: pnpm@11.9.0`, so run
+			// it only on pnpm 11+: under pnpm 10 the cross-version self-provision
+			// recurses and fails with ENAMETOOLONG.
+			unsupportedPmRanges: { pnpm: "<11.0.0" },
 			verifyDeploy: {
 				route: "/",
 				expectedText: "Nuxt UI - Starter",
@@ -402,7 +402,7 @@ function getFrameworkTestConfig(pm: string): NamedFrameworkTestConfig[] {
 			unsupportedPms: ["yarn"], // Currently nitro requires youch which expects Node 20+, and yarn will fail hard since we run on Node 18
 			unsupportedOSs: ["win32"],
 			// See note on nuxt:pages above.
-			unsupportedPmRanges: { pnpm: ">=11.0.0" },
+			unsupportedPmRanges: { pnpm: "<11.0.0" },
 			verifyDeploy: {
 				route: "/",
 				expectedText: "Nuxt UI - Starter",
@@ -822,7 +822,7 @@ function getExperimentalFrameworkTestConfig(
 			timeout: LONG_TIMEOUT,
 			unsupportedOSs: ["win32"],
 			// See note on nuxt:pages above.
-			unsupportedPmRanges: { pnpm: ">=11.0.0" },
+			unsupportedPmRanges: { pnpm: "<11.0.0" },
 			verifyDeploy: {
 				route: "/",
 				expectedText: "Nuxt UI - Starter",


### PR DESCRIPTION
Fixes #14513

C3 and `@cloudflare/autoconfig` overwrote a Nuxt project's existing `modules` array in `nuxt.config.ts` when adding `nitro-cloudflare-dev`. For starters that ship a `modules` array — such as `nuxt/starter@ui`, which registers `@nuxt/ui` and `@nuxt/eslint` — this dropped those modules, so `@import "@nuxt/ui"` in `assets/css/main.css` no longer resolved and the build failed.

The root cause is in the shared `@cloudflare/codemod` `mergeObjectProperties` helper: it deep-merged object properties but **overwrote** array properties. It now concatenates new elements onto the existing array, de-duplicating string entries, so existing modules are preserved and the Cloudflare module is appended.

#### What changed

- `@cloudflare/codemod`: `mergeObjectProperties` now merges (concatenates + de-dupes) array properties instead of overwriting them, with unit tests covering concat, de-dupe, and mixed array+object merges.
- `create-cloudflare` and `@cloudflare/autoconfig` both bundle the codemod, so both pick up the fix (a patch changeset is added for each).
- The Nuxt framework e2e tests now use the `ui` template (which ships a `modules` array) so this regression is covered — the previous `minimal` template had no `modules` array and could not reproduce the bug.

#### Before / after

C3's exact transform run against the real `ui` starter `nuxt.config.ts`:

- Before: `modules: ["nitro-cloudflare-dev"]` — `@nuxt/ui` and `@nuxt/eslint` dropped
- After: `modules: ['@nuxt/ui', '@nuxt/eslint', "nitro-cloudflare-dev"]`

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: this fixes incorrect scaffolding/configuration behaviour; there is no user-facing API or documented behaviour change.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14534" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->