### PR TITLE
Support dynamic retry delays for Workflow steps in local dev

### DIFF
--- a/.changeset/workflow-step-dynamic-delay.md
+++ b/.changeset/workflow-step-dynamic-delay.md
@@ -1,0 +1,26 @@
+---
+"wrangler": minor
+"miniflare": minor
+---
+
+Support dynamic retry delays for Workflow steps in local dev
+
+A step's `retries.delay` can now be a function that computes the delay per failed attempt, in addition to a static duration. The function receives `{ ctx, error }` and returns a delay (a number of milliseconds or a duration string like `"30 seconds"`), and its result is fed into the configured `backoff`.
+
+```js
+await step.do(
+	"call flaky API",
+	{
+		retries: {
+			limit: 5,
+			backoff: "constant",
+			delay: ({ ctx }) => ctx.attempt * 1000,
+		},
+	},
+	async () => {
+		/* ... */
+	}
+);
+```
+
+The function is invoked once per failed attempt with a 5 second timeout. If it throws, times out, or returns an invalid value, the step fails without further retries.

--- a/.changeset/workflow-step-dynamic-delay.md
+++ b/.changeset/workflow-step-dynamic-delay.md
@@ -1,5 +1,7 @@
 ---
 "wrangler": minor
+"@cloudflare/vite-plugin": minor
+"@cloudflare/vitest-pool-workers": patch
 "miniflare": minor
 ---
 

--- a/packages/workflows-shared/src/context.ts
+++ b/packages/workflows-shared/src/context.ts
@@ -3,8 +3,14 @@ import { ms } from "itty-time";
 import { INSTANCE_METADATA, InstanceEvent, InstanceStatus } from "./instance";
 import { computeHash } from "./lib/cache";
 import {
+	DEFAULT_RETRY_DELAY_MS,
+	DELAY_FUNCTION_TIMEOUT_MS,
+	invokeDelayFunction,
+} from "./lib/delay";
+import {
 	ABORT_REASONS,
 	InvalidStepReadableStreamError,
+	NonRetryableDelayError,
 	OversizedStreamChunkError,
 	PreservedNonRetryableError,
 	shouldPreserveNonRetryableError,
@@ -14,7 +20,7 @@ import {
 	WorkflowInternalError,
 	WorkflowTimeoutError,
 } from "./lib/errors";
-import { calcRetryDuration } from "./lib/retries";
+import { calcRetryDuration, DelayFunctionError } from "./lib/retries";
 import {
 	parseRollbackOptions,
 	ROLLBACK_CACHE_KEY_PREFIX,
@@ -40,9 +46,14 @@ import type { InstanceMetadata } from "./instance";
 import type { RollbackFn, WorkflowStepRollbackOptions } from "./lib/rollback";
 import type { StreamOutputMeta } from "./lib/streams";
 import type {
+	WorkflowBackoff,
+	WorkflowDelayDuration,
+	WorkflowDelayFunction,
 	WorkflowSleepDuration,
 	WorkflowStepConfig,
 	WorkflowStepEvent,
+	WorkflowStepSensitivity,
+	WorkflowTimeoutDuration,
 } from "cloudflare:workers";
 
 export type Event = {
@@ -51,10 +62,72 @@ export type Event = {
 	type: string;
 };
 
-export type ResolvedStepConfig = Required<
-	Pick<WorkflowStepConfig, "retries" | "timeout">
-> &
-	Pick<WorkflowStepConfig, "sensitive">;
+// Persisted in place of a dynamic delay function (functions can't be
+// serialized); the live function is re-read from the user's step config on each
+// execution.
+const SERIALIZABLE_DELAY_MARKER = "[dynamic]";
+type SerializableDelayMarker = typeof SERIALIZABLE_DELAY_MARKER;
+
+// The persisted, fully-merged config. A dynamic delay is stored as the marker.
+export type ResolvedStepConfig = {
+	retries: {
+		limit: number;
+		delay: WorkflowDelayDuration | SerializableDelayMarker;
+		backoff?: WorkflowBackoff;
+	};
+	timeout: WorkflowTimeoutDuration;
+	sensitive?: WorkflowStepSensitivity;
+};
+
+// The user-facing config (passed to step callbacks). The dynamic-delay marker is
+// never exposed: `delay` is omitted entirely when the delay is a function.
+export type EngineStepConfig = {
+	retries: {
+		limit: number;
+		delay?: WorkflowDelayDuration;
+		backoff?: WorkflowBackoff;
+	};
+	timeout: WorkflowTimeoutDuration;
+	sensitive?: WorkflowStepSensitivity;
+};
+
+export function toEngineStepConfig(
+	config: ResolvedStepConfig
+): EngineStepConfig {
+	const { delay, ...retries } = config.retries;
+	if (
+		typeof delay === "number" ||
+		(typeof delay === "string" && delay !== SERIALIZABLE_DELAY_MARKER)
+	) {
+		return { ...config, retries: { ...retries, delay } };
+	}
+	return { ...config, retries };
+}
+
+// Signal-aware wrapper around the global `scheduler.wait`. `scheduler.wait`
+// can't itself be cancelled, so an aborted signal resolves the returned promise
+// early and the dangling timer becomes a no-op.
+function schedulerWait(
+	durationMs: number,
+	opts?: { signal?: AbortSignal }
+): Promise<void> {
+	return new Promise<void>((resolve) => {
+		const signal = opts?.signal;
+		if (signal?.aborted) {
+			resolve();
+			return;
+		}
+		let done = false;
+		const finish = (): void => {
+			if (!done) {
+				done = true;
+				resolve();
+			}
+		};
+		void scheduler.wait(durationMs).then(finish);
+		signal?.addEventListener("abort", finish, { once: true });
+	});
+}
 
 const defaultConfig: ResolvedStepConfig = {
 	retries: {
@@ -176,7 +249,7 @@ export type WorkflowStepContext = {
 		count: number;
 	};
 	attempt: number;
-	config: ResolvedStepConfig;
+	config: EngineStepConfig;
 };
 
 const PAUSE_DATETIME = "PAUSE_DATETIME";
@@ -351,12 +424,19 @@ export class Context extends RpcTarget {
 			throw error;
 		}
 
+		let liveDelay: WorkflowDelayDuration | WorkflowDelayFunction =
+			stepConfig.retries?.delay ?? DEFAULT_RETRY_DELAY_MS;
+
 		let config: ResolvedStepConfig = {
 			...defaultConfig,
 			...stepConfig,
 			retries: {
 				...defaultConfig.retries,
 				...stepConfig.retries,
+				delay:
+					typeof liveDelay === "function"
+						? SERIALIZABLE_DELAY_MARKER
+						: liveDelay,
 			},
 		};
 
@@ -422,7 +502,7 @@ export class Context extends RpcTarget {
 				stepContext: {
 					step: { name, count },
 					attempt: cachedState?.attemptedCount ?? 1,
-					config: cachedConfig ?? config,
+					config: toEngineStepConfig(cachedConfig ?? config),
 				},
 				output: result,
 				rollbackConfig,
@@ -446,7 +526,7 @@ export class Context extends RpcTarget {
 				stepContext: {
 					step: { name, count },
 					attempt: cachedState?.attemptedCount ?? 1,
-					config: cachedConfig ?? config,
+					config: toEngineStepConfig(cachedConfig ?? config),
 				},
 				output: result,
 				rollbackConfig,
@@ -466,7 +546,7 @@ export class Context extends RpcTarget {
 				stepContext: {
 					step: { name, count },
 					attempt: cachedState?.attemptedCount ?? 1,
-					config: cachedConfig ?? config,
+					config: toEngineStepConfig(cachedConfig ?? config),
 				},
 				rollbackConfig,
 			});
@@ -479,6 +559,14 @@ export class Context extends RpcTarget {
 			await this.#state.storage.put(configKey, config);
 		} else {
 			config = cachedConfig;
+			// Recover the live delay from the (non-serializable) user config: a
+			// persisted marker means the user passed a function, so re-read it.
+			liveDelay =
+				config.retries.delay === SERIALIZABLE_DELAY_MARKER
+					? typeof stepConfig.retries?.delay === "function"
+						? stepConfig.retries.delay
+						: DEFAULT_RETRY_DELAY_MS
+					: config.retries.delay;
 		}
 
 		if (this.#engine.rollbackPhase === "replay" && !isRollback) {
@@ -489,7 +577,7 @@ export class Context extends RpcTarget {
 				stepContext: {
 					step: { name, count },
 					attempt: cachedState?.attemptedCount ?? 1,
-					config,
+					config: toEngineStepConfig(config),
 				},
 				rollbackConfig,
 			});
@@ -556,7 +644,7 @@ export class Context extends RpcTarget {
 			const forwardStepContext = (): WorkflowStepContext => ({
 				step: { name, count },
 				attempt: stepState.attemptedCount,
-				config,
+				config: toEngineStepConfig(config),
 			});
 
 			// NOTE(caio): this might be a stream returning step - if so cleanup stale data from previous lifetimes
@@ -568,7 +656,7 @@ export class Context extends RpcTarget {
 
 			if (stepState.attemptedCount == 0) {
 				this.#engine.writeLog(events.start, cacheKey, stepNameWithCounter, {
-					config,
+					config: toEngineStepConfig(config),
 					...(!isRollback && rollbackFn ? { hasRollback: true } : {}),
 				});
 			} else {
@@ -771,7 +859,7 @@ export class Context extends RpcTarget {
 						doWrapperClosure({
 							step: { name, count },
 							attempt: stepState.attemptedCount,
-							config: structuredClone(config),
+							config: toEngineStepConfig(config),
 						}),
 						timeoutTask,
 					]);
@@ -987,6 +1075,62 @@ export class Context extends RpcTarget {
 					throw error;
 				}
 
+				await this.#state.storage.put(stepStateKey, stepState);
+
+				const willRetry = stepState.attemptedCount <= config.retries.limit;
+				const priorityQueueHash = `${cacheKey}-${stepState.attemptedCount}`;
+
+				// Resolve the delay once per attempt. A broken delay function turns
+				// the retry into a non-retryable failure.
+				let retryDelayMs: number | undefined;
+				let delayFailure: (Error & UserErrorField) | undefined;
+				if (willRetry) {
+					try {
+						let resolvedDelay: unknown;
+						if (typeof liveDelay === "function") {
+							// @ts-expect-error priorityQueue is initiated in init
+							await this.#engine.priorityQueue.add({
+								hash: priorityQueueHash,
+								targetTimestamp: Date.now() + DEFAULT_RETRY_DELAY_MS,
+								type: "retry",
+							});
+
+							const stepCtx: WorkflowStepContext = {
+								step: { name, count },
+								attempt: stepState.attemptedCount,
+								config: toEngineStepConfig(config),
+							};
+
+							resolvedDelay = await invokeDelayFunction(
+								liveDelay,
+								{ ctx: stepCtx, error },
+								{
+									timeoutMs: DELAY_FUNCTION_TIMEOUT_MS,
+									wait: schedulerWait,
+									signal: this.#engine.engineAbortController.signal,
+								}
+							);
+						} else {
+							resolvedDelay = liveDelay;
+						}
+						retryDelayMs = calcRetryDuration(config, stepState, resolvedDelay);
+					} catch (delayErr) {
+						if (!(delayErr instanceof DelayFunctionError)) {
+							throw delayErr;
+						}
+						// @ts-expect-error priorityQueue is initiated in init
+						this.#engine.priorityQueue.remove({
+							hash: priorityQueueHash,
+							type: "retry",
+						});
+						const userError = new NonRetryableDelayError(
+							`The delay function for step "${stepNameWithCounter}" ${delayErr.message}`
+						) as Error & UserErrorField;
+						userError.isUserError = true;
+						delayFailure = userError;
+					}
+				}
+
 				this.#engine.writeLog(
 					events.attemptFailure,
 					cacheKey,
@@ -999,14 +1143,13 @@ export class Context extends RpcTarget {
 							// TODO (WOR-79): Stacks are all incorrect over RPC and need work
 							// stack: error.stack,
 						},
+						...(retryDelayMs !== undefined ? { retryDelayMs } : {}),
 					}
 				);
 
-				await this.#state.storage.put(stepStateKey, stepState);
-
-				if (stepState.attemptedCount <= config.retries.limit) {
+				if (willRetry && delayFailure === undefined) {
 					// TODO (WOR-71): Think through if every Error should transition
-					const durationMs = calcRetryDuration(config, stepState);
+					const durationMs = retryDelayMs ?? DEFAULT_RETRY_DELAY_MS;
 					const disableAllRetryDelays = await this.#state.storage.get(
 						MODIFIER_KEYS.DISABLE_ALL_RETRY_DELAYS
 					);
@@ -1016,13 +1159,19 @@ export class Context extends RpcTarget {
 						disableAllRetryDelays || disableThisRetryDelay;
 					const effectiveDuration = disableRetryDelay ? 0 : durationMs;
 
-					const priorityQueueHash = `${cacheKey}-${stepState.attemptedCount}`;
-					// @ts-expect-error priorityQueue is initiated in init
-					await this.#engine.priorityQueue.add({
-						hash: priorityQueueHash,
-						targetTimestamp: Date.now() + effectiveDuration,
-						type: "retry",
-					});
+					// A dynamic delay already parked its retry entry under this hash
+					// above (the append-only PQ rejects re-adding the same hash), so
+					// only static delays add here. The live wait below uses
+					// effectiveDuration regardless; the parked entry's timestamp only
+					// drives crash recovery.
+					if (typeof liveDelay !== "function") {
+						// @ts-expect-error priorityQueue is initiated in init
+						await this.#engine.priorityQueue.add({
+							hash: priorityQueueHash,
+							targetTimestamp: Date.now() + effectiveDuration,
+							type: "retry",
+						});
+					}
 					await this.#engine.timeoutHandler.release(this.#engine);
 					// Race retry wait against the pause signal so pause
 					// takes effect immediately during retries
@@ -1086,8 +1235,9 @@ export class Context extends RpcTarget {
 						rollbackConfig,
 					});
 
-					await this.#state.storage.put(errorKey, error);
-					throw error;
+					const finalError = delayFailure ?? error;
+					await this.#state.storage.put(errorKey, finalError);
+					throw finalError;
 				}
 			}
 

--- a/packages/workflows-shared/src/context.ts
+++ b/packages/workflows-shared/src/context.ts
@@ -1088,6 +1088,12 @@ export class Context extends RpcTarget {
 					try {
 						let resolvedDelay: unknown;
 						if (typeof liveDelay === "function") {
+							// Park a default-delayed retry before invoking the user's
+							// delay function so a crash while the function is in flight
+							// still reschedules the step. The PQ table is append-only
+							// with a UNIQUE(action, entryType, hash) constraint, so this
+							// exact entry is reused as the retry entry below — it is
+							// never removed and re-added (that would violate UNIQUE).
 							// @ts-expect-error priorityQueue is initiated in init
 							await this.#engine.priorityQueue.add({
 								hash: priorityQueueHash,
@@ -1164,6 +1170,16 @@ export class Context extends RpcTarget {
 					// only static delays add here. The live wait below uses
 					// effectiveDuration regardless; the parked entry's timestamp only
 					// drives crash recovery.
+					//
+					// Known trade-off: for a dynamic delay the parked entry keeps the
+					// DEFAULT_RETRY_DELAY_MS placeholder timestamp set before the delay
+					// function ran (see the add above) — the UNIQUE(action, entryType,
+					// hash) constraint means it can't be overwritten in place with the
+					// computed value without a remove+re-add that would violate the
+					// constraint. So if the engine crashes mid-wait, recovery resumes
+					// the step at the placeholder delay rather than the computed one.
+					// This is accepted for local dev: the step still retries with the
+					// correct semantics, only the post-crash wait can be shorter.
 					if (typeof liveDelay !== "function") {
 						// @ts-expect-error priorityQueue is initiated in init
 						await this.#engine.priorityQueue.add({

--- a/packages/workflows-shared/src/lib/delay.ts
+++ b/packages/workflows-shared/src/lib/delay.ts
@@ -1,0 +1,79 @@
+import { ms } from "itty-time";
+import { DelayFunctionError } from "./retries";
+import type {
+	WorkflowDelayDuration,
+	WorkflowDelayFunction,
+	WorkflowDynamicDelayContext,
+} from "cloudflare:workers";
+
+export const DEFAULT_RETRY_DELAY_MS = 1000;
+
+export const DELAY_FUNCTION_TIMEOUT_MS = ms("5 seconds");
+
+type DelayLogger = {
+	warn(...msgs: unknown[]): void;
+	debug(...msgs: unknown[]): void;
+};
+
+type Waiter = (ms: number, opts?: { signal?: AbortSignal }) => Promise<void>;
+
+export async function invokeDelayFunction(
+	delay: WorkflowDelayFunction,
+	input: WorkflowDynamicDelayContext,
+	options: {
+		timeoutMs: number;
+		wait: Waiter;
+		signal?: AbortSignal;
+		logger?: DelayLogger;
+	}
+): Promise<WorkflowDelayDuration> {
+	const { wait, signal, logger } = options;
+	const logFields = { step: input.ctx.step.name, attempt: input.ctx.attempt };
+
+	const settled = new AbortController();
+	const timeoutSignal = signal
+		? AbortSignal.any([signal, settled.signal])
+		: settled.signal;
+
+	type Raced =
+		| { timedOut: true }
+		| { timedOut: false; value: WorkflowDelayDuration };
+
+	try {
+		const result = await Promise.race<Raced>([
+			Promise.resolve(delay(input)).then((value) => ({
+				timedOut: false,
+				value,
+			})),
+			wait(options.timeoutMs, { signal: timeoutSignal })
+				.then((): Raced => ({ timedOut: true }))
+				.catch((): Raced => ({ timedOut: true })),
+		]);
+		if (result.timedOut) {
+			if (signal?.aborted) {
+				logger?.debug(
+					"delay function aborted by engine shutdown; using default delay",
+					logFields
+				);
+				return DEFAULT_RETRY_DELAY_MS;
+			}
+			logger?.warn(
+				`delay function did not resolve within ${options.timeoutMs}ms`,
+				logFields
+			);
+			throw new DelayFunctionError(
+				`did not return within ${options.timeoutMs / 1000} seconds`
+			);
+		}
+		return result.value;
+	} catch (e) {
+		if (e instanceof DelayFunctionError) {
+			throw e;
+		}
+		const message = e instanceof Error ? e.message : String(e);
+		logger?.warn("delay function threw", { ...logFields, error: message });
+		throw new DelayFunctionError(`threw an error: ${message}`);
+	} finally {
+		settled.abort();
+	}
+}

--- a/packages/workflows-shared/src/lib/errors.ts
+++ b/packages/workflows-shared/src/lib/errors.ts
@@ -17,6 +17,10 @@ export class WorkflowFatalError extends Error {
 	}
 }
 
+export class NonRetryableDelayError extends WorkflowFatalError {
+	name = "NonRetryableDelayError";
+}
+
 export class PreservedNonRetryableError extends WorkflowFatalError {
 	name = "NonRetryableError";
 

--- a/packages/workflows-shared/src/lib/retries.ts
+++ b/packages/workflows-shared/src/lib/retries.ts
@@ -1,26 +1,46 @@
 import { ms } from "itty-time";
-// @ts-expect-error workflows "shared" package will be pulled in later
-import type { ResolvedStepConfig, StepState } from "shared";
+import type { ResolvedStepConfig, StepState } from "../context";
+import type { WorkflowSleepDuration } from "cloudflare:workers";
+
+export class DelayFunctionError extends Error {
+	constructor(reason: string) {
+		super(reason);
+		this.name = "DelayFunctionError";
+	}
+}
 
 export function calcRetryDuration(
 	config: ResolvedStepConfig,
-	stepState: StepState
+	stepState: StepState,
+	delayValue: unknown
 ): number {
 	const { attemptedCount: attemptCount } = stepState;
 	const { retries } = config;
 
-	const delay = ms(retries.delay);
+	let base: number;
+	try {
+		base = ms(delayValue as WorkflowSleepDuration);
+	} catch {
+		throw new DelayFunctionError(
+			'returned an invalid delay value (expected a number of ms or a duration string like "30 seconds")'
+		);
+	}
+	if (!Number.isFinite(base) || base < 0) {
+		throw new DelayFunctionError(
+			'returned an invalid delay value (expected a number of ms or a duration string like "30 seconds")'
+		);
+	}
 
 	switch (retries.backoff) {
 		case "exponential": {
-			return delay * Math.pow(2, attemptCount - 1);
+			return base * Math.pow(2, attemptCount - 1);
 		}
 		case "linear": {
-			return delay * attemptCount;
+			return base * attemptCount;
 		}
 		case "constant":
 		default: {
-			return delay;
+			return base;
 		}
 	}
 }

--- a/packages/workflows-shared/src/lib/validators.ts
+++ b/packages/workflows-shared/src/lib/validators.ts
@@ -51,7 +51,7 @@ const STEP_CONFIG_SCHEMA = z
 	.object({
 		retries: z
 			.object({
-				delay: z.number().gte(0).or(z.string()),
+				delay: z.number().gte(0).or(z.string()).or(z.function()),
 				limit: z.number().gte(0),
 				backoff: z.enum(["constant", "linear", "exponential"]).optional(),
 			})
@@ -70,6 +70,7 @@ export function isValidStepConfig(stepConfig: unknown): boolean {
 
 	if (
 		config.data.retries !== undefined &&
+		typeof config.data.retries.delay !== "function" &&
 		Number.isNaN(ms(config.data.retries.delay))
 	) {
 		return false;

--- a/packages/workflows-shared/tests/engine.test.ts
+++ b/packages/workflows-shared/tests/engine.test.ts
@@ -197,7 +197,7 @@ describe("Engine", () => {
 				"dynamic-delay-step",
 				{
 					retries: { limit: 3, delay: dynamicDelay, backoff: "constant" },
-				} as unknown as WorkflowStepConfig,
+				},
 				async () => {
 					attempts++;
 					if (attempts < 2) {

--- a/packages/workflows-shared/tests/engine.test.ts
+++ b/packages/workflows-shared/tests/engine.test.ts
@@ -18,7 +18,12 @@ import type {
 	RollbackFn,
 	WorkflowStepRollbackOptions,
 } from "../src/lib/rollback";
-import type { WorkflowStep, WorkflowStepConfig } from "cloudflare:workers";
+import type {
+	WorkflowDelayFunction,
+	WorkflowStep,
+	WorkflowStepConfig,
+	WorkflowStepContext,
+} from "cloudflare:workers";
 
 afterEach(async () => {
 	await workerdUnsafe.abortAllDurableObjects();
@@ -178,6 +183,170 @@ describe("Engine", () => {
 		expect(
 			logs.logs.filter((val) => val.event == InstanceEvent.ATTEMPT_FAILURE)
 		).toHaveLength(1);
+	});
+
+	it("applies a dynamic delay function and succeeds after retries", async ({
+		expect,
+	}) => {
+		const instanceId = "DYNAMIC-DELAY-APPLIED";
+		const dynamicDelay: WorkflowDelayFunction = () => 50;
+		let attempts = 0;
+
+		const engineStub = await runWorkflow(instanceId, async (_event, step) => {
+			await step.do(
+				"dynamic-delay-step",
+				{
+					retries: { limit: 3, delay: dynamicDelay, backoff: "constant" },
+				} as unknown as WorkflowStepConfig,
+				async () => {
+					attempts++;
+					if (attempts < 2) {
+						throw new Error("transient");
+					}
+					return "ok";
+				}
+			);
+			return "done";
+		});
+
+		await vi.waitUntil(
+			async () => {
+				const logs = (await engineStub.readLogs()) as EngineLogs;
+				return logs.logs.some(
+					(val) => val.event === InstanceEvent.WORKFLOW_SUCCESS
+				);
+			},
+			{ timeout: 5000 }
+		);
+
+		const logs = (await engineStub.readLogs()) as EngineLogs;
+		const attemptFailures = logs.logs.filter(
+			(val) => val.event === InstanceEvent.ATTEMPT_FAILURE
+		);
+
+		expect(attemptFailures.length).toBeGreaterThanOrEqual(1);
+		expect(attemptFailures[0]?.metadata).toMatchObject({ retryDelayMs: 50 });
+	});
+
+	it("fails non-retryably when the delay function throws", async ({
+		expect,
+	}) => {
+		const instanceId = "DYNAMIC-DELAY-BROKEN";
+		const throwingDelay: WorkflowDelayFunction = () => {
+			throw new Error("delay boom");
+		};
+
+		const engineStub = await runWorkflow(instanceId, async (_event, step) => {
+			await step.do(
+				"broken-delay-step",
+				{
+					retries: { limit: 5, delay: throwingDelay, backoff: "constant" },
+				},
+				async () => {
+					throw new Error("step failed");
+				}
+			);
+			return "done";
+		});
+
+		await vi.waitUntil(
+			async () => {
+				const logs = (await engineStub.readLogs()) as EngineLogs;
+				return logs.logs.some(
+					(val) => val.event === InstanceEvent.WORKFLOW_FAILURE
+				);
+			},
+			{ timeout: 5000 }
+		);
+
+		const logs = (await engineStub.readLogs()) as EngineLogs;
+
+		// The broken delay function turns the retry into a non-retryable failure,
+		// so the step is only attempted once.
+		expect(
+			logs.logs.filter((val) => val.event === InstanceEvent.ATTEMPT_START)
+		).toHaveLength(1);
+
+		// The NonRetryableDelayError crosses the engine<->workflow RPC boundary,
+		// which collapses the custom error class to name "Error" and folds the
+		// original class name into the message.
+		const workflowFailure = logs.logs.find(
+			(val) => val.event === InstanceEvent.WORKFLOW_FAILURE
+		);
+		expect(workflowFailure?.metadata.error.message).toContain(
+			"NonRetryableDelayError"
+		);
+		expect(workflowFailure?.metadata.error.message).toContain("delay function");
+		expect(workflowFailure?.metadata.error.message).toContain("delay boom");
+	});
+
+	it("omits delay from ctx.config for a dynamic delay but includes it for a static delay", async ({
+		expect,
+	}) => {
+		const dynamicDelay: WorkflowDelayFunction = () => 10;
+		let dynamicConfig:
+			| WorkflowStepContext<WorkflowDelayFunction>["config"]
+			| undefined;
+		let staticConfig: WorkflowStepContext<number>["config"] | undefined;
+
+		const dynamicStub = await runWorkflow(
+			"DYNAMIC-DELAY-CTX-HIDDEN",
+			async (_event, step) => {
+				await step.do(
+					"dynamic-config-step",
+					{
+						retries: { limit: 1, delay: dynamicDelay, backoff: "constant" },
+					},
+					async (ctx) => {
+						dynamicConfig = ctx.config;
+						return "ok";
+					}
+				);
+				return "done";
+			}
+		);
+
+		await vi.waitUntil(
+			async () => {
+				const logs = (await dynamicStub.readLogs()) as EngineLogs;
+				return logs.logs.some(
+					(val) => val.event === InstanceEvent.WORKFLOW_SUCCESS
+				);
+			},
+			{ timeout: 5000 }
+		);
+
+		const staticStub = await runWorkflow(
+			"STATIC-DELAY-CTX-VISIBLE",
+			async (_event, step) => {
+				await step.do(
+					"static-config-step",
+					{
+						retries: { limit: 1, delay: 1234, backoff: "constant" },
+					},
+					async (ctx) => {
+						staticConfig = ctx.config;
+						return "ok";
+					}
+				);
+				return "done";
+			}
+		);
+
+		await vi.waitUntil(
+			async () => {
+				const logs = (await staticStub.readLogs()) as EngineLogs;
+				return logs.logs.some(
+					(val) => val.event === InstanceEvent.WORKFLOW_SUCCESS
+				);
+			},
+			{ timeout: 5000 }
+		);
+
+		const dynamicRetries = dynamicConfig?.retries;
+		expect(dynamicRetries).toBeDefined();
+		expect(dynamicRetries && "delay" in dynamicRetries).toBe(false);
+		expect(staticConfig?.retries?.delay).toBe(1234);
 	});
 
 	it("waitForEvent should receive events while active", async ({ expect }) => {
@@ -1528,7 +1697,7 @@ describe("Rollback", () => {
 		const rollbackConfig = {
 			retries: { limit: 0, delay: 0, backoff: "constant" },
 			timeout: "30 seconds",
-		};
+		} satisfies WorkflowStepConfig;
 		const stub = await runWorkflowAndAwait("RB-CONFIG", async (_e, step) => {
 			await doWithRollback(
 				step,
@@ -1977,6 +2146,79 @@ describe("Rollback", () => {
 					(log) => log.event === InstanceEvent.WORKFLOW_TERMINATED
 				)
 		);
+		expect(targetsOf(logs, InstanceEvent.ROLLBACK_STEP_SUCCESS)).toEqual([
+			"failed-setup-1",
+		]);
+		expect(countOf(logs, InstanceEvent.ROLLBACK_COMPLETE)).toBe(1);
+	});
+
+	it("omits dynamic delay from rollback ctx.config on cached-error replay", async ({
+		expect,
+	}) => {
+		const dynamicDelay: WorkflowDelayFunction = () => 1000;
+		const instanceId = "RB-TERMINATE-FAILED-REPLAY-DYNAMIC-DELAY";
+		const engineStub = await runWorkflow(instanceId, async (_e, step) => {
+			try {
+				await doWithRollback(
+					step,
+					"failed-setup",
+					{ retries: { limit: 0, delay: dynamicDelay, backoff: "constant" } },
+					async () => {
+						throw new Error("step-boom");
+					},
+					rollbackOptions(async (ctx) => {
+						// A dynamic delay must be omitted from the user-facing config,
+						// never surfaced as the internal "[dynamic]" marker string.
+						if ("delay" in ctx.ctx.config.retries) {
+							throw new Error(
+								"dynamic delay marker leaked into rollback ctx.config"
+							);
+						}
+					})
+				);
+			} catch {
+				// Keep the workflow running so terminate rollback can replay the cached
+				// failed step and re-register its rollback handler.
+			}
+			await step.sleep("wait-forever", "1 hour");
+		});
+
+		await readLogsAfter(engineStub, (currentLogs) =>
+			currentLogs.logs.some(
+				(log) =>
+					log.event === InstanceEvent.STEP_FAILURE &&
+					log.target === "failed-setup-1"
+			)
+		);
+
+		await runInDurableObject(engineStub, async (engine) => {
+			engine.rollbackRegistry.clear();
+		});
+
+		try {
+			await runInDurableObject(engineStub, async (engine) => {
+				await engine.changeInstanceStatus("terminate", undefined, {
+					rollback: true,
+				});
+			});
+		} catch (error) {
+			if (
+				!(error instanceof Error) ||
+				!error.message.startsWith("Aborting engine:")
+			) {
+				throw error;
+			}
+		}
+
+		const logs = await readLogsAfter(
+			env.ENGINE.get(env.ENGINE.idFromName(instanceId)),
+			(currentLogs) =>
+				currentLogs.logs.some(
+					(log) => log.event === InstanceEvent.WORKFLOW_TERMINATED
+				)
+		);
+		// ROLLBACK_STEP_SUCCESS only fires if the rollback fn did not throw, i.e.
+		// the leaked marker was stripped by toEngineStepConfig on the replay path.
 		expect(targetsOf(logs, InstanceEvent.ROLLBACK_STEP_SUCCESS)).toEqual([
 			"failed-setup-1",
 		]);

--- a/packages/workflows-shared/tests/lib/delay.test.ts
+++ b/packages/workflows-shared/tests/lib/delay.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, vi } from "vitest";
+import {
+	DEFAULT_RETRY_DELAY_MS,
+	invokeDelayFunction,
+} from "../../src/lib/delay";
+import { DelayFunctionError } from "../../src/lib/retries";
+import type { WorkflowDynamicDelayContext } from "cloudflare:workers";
+
+const input: WorkflowDynamicDelayContext = {
+	ctx: {
+		step: { name: "step", count: 1 },
+		attempt: 1,
+		config: { retries: { limit: 5, backoff: "constant" }, timeout: 0 },
+	},
+	error: new Error("boom"),
+};
+
+const makeLogger = () => ({ warn: vi.fn(), debug: vi.fn() });
+
+const noTimeout =
+	(): ((ms: number, opts?: { signal?: AbortSignal }) => Promise<void>) => () =>
+		new Promise<void>(() => {});
+
+describe("invokeDelayFunction", () => {
+	it("returns the value a synchronous delay function produces", async ({
+		expect,
+	}) => {
+		const logger = makeLogger();
+		const result = await invokeDelayFunction(() => 1234, input, {
+			timeoutMs: 5000,
+			wait: noTimeout(),
+			logger,
+		});
+		expect(result).toBe(1234);
+		expect(logger.warn).not.toHaveBeenCalled();
+		expect(logger.debug).not.toHaveBeenCalled();
+	});
+
+	it("awaits an asynchronous delay function", async ({ expect }) => {
+		const logger = makeLogger();
+		const result = await invokeDelayFunction(async () => 1234, input, {
+			timeoutMs: 5000,
+			wait: noTimeout(),
+			logger,
+		});
+		expect(result).toBe(1234);
+		expect(logger.warn).not.toHaveBeenCalled();
+		expect(logger.debug).not.toHaveBeenCalled();
+	});
+
+	it("throws when the delay function never resolves (timeout)", async ({
+		expect,
+	}) => {
+		const logger = makeLogger();
+		const promise = invokeDelayFunction(
+			() => new Promise<number>(() => {}),
+			input,
+			{
+				timeoutMs: 5000,
+				wait: () => Promise.resolve(),
+				logger,
+			}
+		);
+		await expect(promise).rejects.toThrow(
+			new DelayFunctionError("did not return within 5 seconds")
+		);
+		expect(logger.warn).toHaveBeenCalledTimes(1);
+		expect(logger.warn).toHaveBeenCalledWith(
+			expect.stringContaining("did not resolve"),
+			{ step: "step", attempt: 1 }
+		);
+		expect(logger.debug).not.toHaveBeenCalled();
+	});
+
+	it("throws when the delay function throws synchronously", async ({
+		expect,
+	}) => {
+		const logger = makeLogger();
+		const promise = invokeDelayFunction(
+			() => {
+				throw new Error("sync boom");
+			},
+			input,
+			{
+				timeoutMs: 5000,
+				wait: noTimeout(),
+				logger,
+			}
+		);
+		await expect(promise).rejects.toThrow(
+			new DelayFunctionError("threw an error: sync boom")
+		);
+		expect(logger.warn).toHaveBeenCalledWith(
+			expect.stringContaining("threw"),
+			expect.objectContaining({ error: "sync boom" })
+		);
+	});
+
+	it("throws when the delay function rejects", async ({ expect }) => {
+		const logger = makeLogger();
+		const promise = invokeDelayFunction(
+			async () => {
+				throw new Error("async boom");
+			},
+			input,
+			{
+				timeoutMs: 5000,
+				wait: noTimeout(),
+				logger,
+			}
+		);
+		await expect(promise).rejects.toThrow(
+			new DelayFunctionError("threw an error: async boom")
+		);
+		expect(logger.warn).toHaveBeenCalledWith(
+			expect.stringContaining("threw"),
+			expect.objectContaining({ error: "async boom" })
+		);
+	});
+
+	it("logs a debug (not a warn) when the provided signal aborts before the function resolves", async ({
+		expect,
+	}) => {
+		const logger = makeLogger();
+		const abort = new AbortController();
+		const promise = invokeDelayFunction(
+			() => new Promise<number>(() => {}),
+			input,
+			{
+				timeoutMs: 5000,
+				wait: (_ms, opts) =>
+					new Promise<void>((resolve) => {
+						opts?.signal?.addEventListener("abort", () => resolve(), {
+							once: true,
+						});
+					}),
+				signal: abort.signal,
+				logger,
+			}
+		);
+		abort.abort();
+		await expect(promise).resolves.toBe(DEFAULT_RETRY_DELAY_MS);
+		expect(logger.debug).toHaveBeenCalledTimes(1);
+		expect(logger.debug).toHaveBeenCalledWith(
+			expect.stringContaining("engine shutdown"),
+			{ step: "step", attempt: 1 }
+		);
+		expect(logger.warn).not.toHaveBeenCalled();
+	});
+
+	it("throws without a logger", async ({ expect }) => {
+		const promise = invokeDelayFunction(
+			() => {
+				throw new Error("sync boom");
+			},
+			input,
+			{
+				timeoutMs: 5000,
+				wait: noTimeout(),
+			}
+		);
+		await expect(promise).rejects.toThrow(DelayFunctionError);
+	});
+});

--- a/packages/workflows-shared/tests/validators.test.ts
+++ b/packages/workflows-shared/tests/validators.test.ts
@@ -88,8 +88,24 @@ describe("Workflow step config validation", () => {
 				"i-like-trains": "yes".repeat(100),
 			},
 		},
+		{
+			retries: { limit: 3, delay: "i like trains", backoff: "constant" },
+			timeout: "10 minutes",
+		},
+		{
+			retries: { limit: 3, delay: 10, backoff: "constant" },
+			timeout: 0,
+		},
 	])("should reject invalid step configs", (value, { expect }) => {
 		expect(isValidStepConfig(value)).toBe(false);
+	});
+
+	it("should accept a dynamic delay function", ({ expect }) => {
+		const config = {
+			retries: { limit: 3, delay: () => "10 seconds", backoff: "constant" },
+			timeout: "10 minutes",
+		};
+		expect(isValidStepConfig(config)).toBe(true);
 	});
 
 	it.for([


### PR DESCRIPTION
Bump @cloudflare/workers-types to 5.x for the published WorkflowDelayFunction and WorkflowDynamicDelayContext types, and implement dynamic step-retry delays in the workflows-shared engine: retries.delay may be a function that computes the delay per failed attempt (invoked with { ctx, error }, 5s timeout), fed into the configured backoff. Invalid/throwing/timed-out functions fail the step without further retries.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [x] Cloudflare docs PR(s): https://github.com/cloudflare/cloudflare-docs/pull/31850
  - [ ] Documentation not necessary because:

*A picture of a cute animal (not mandatory, but encouraged)*

No cute animal pictures on hand so [stock](https://www.dreamstime.com/photos-images/cute-tortoise.html) photo:
<img width="800" height="800" alt="image" src="https://github.com/user-attachments/assets/ceb04437-d230-4cb7-8027-48760c056897" />


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14535" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->