### PR TITLE
[wrangler] Mention --secrets-file in required-secrets error messages

### DIFF
--- a/.changeset/required-secrets-mention-secrets-file.md
+++ b/.changeset/required-secrets-mention-secrets-file.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Mention `--secrets-file` in required-secrets error messages so first deploys have a working remedy
+
+When a Worker declares `secrets.required` and is deployed for the first time, `wrangler secret put` cannot set those secrets because the Worker does not exist yet (the API rejects it). The first-deploy error now leads with `wrangler deploy --secrets-file <FILE>` as the way to supply required secrets in a single step, and the missing-secret API errors for `deploy` and `versions upload` now mention `--secrets-file` alongside the existing `wrangler secret put` / `wrangler versions secret put` guidance for Workers that already exist.

--- a/packages/deploy-helpers/src/deploy/helpers/secrets-validation.ts
+++ b/packages/deploy-helpers/src/deploy/helpers/secrets-validation.ts
@@ -34,7 +34,8 @@ export function addRequiredSecretsInheritBindings(
 	if (options.type === "deploy" && !options.workerExists) {
 		throw new UserError(
 			`The following required secrets have not been set: ${inheritedSecrets.join(", ")}\n` +
-				`Use \`wrangler secret put <NAME>\` to set secrets before deploying.\n` +
+				`This Worker does not exist yet, so set these secrets at deploy time with \`wrangler deploy --secrets-file <FILE>\`.\n` +
+				`Once the Worker exists, you can also use \`wrangler secret put <NAME>\`.\n` +
 				`See https://developers.cloudflare.com/workers/configuration/secrets/#secrets-on-deployed-workers for more information.`,
 			{ telemetryMessage: "required secrets missing before deploy" }
 		);
@@ -68,9 +69,19 @@ export function handleMissingSecretsError(
 
 	if (missingSecretNames.length > 0) {
 		err.preventReport();
+		const secretPutCommand =
+			options.type === "deploy"
+				? "wrangler secret put"
+				: "wrangler versions secret put";
+		const secretsFileCommand =
+			options.type === "deploy"
+				? "wrangler deploy --secrets-file <FILE>"
+				: "wrangler versions upload --secrets-file <FILE>";
+		const action = options.type === "deploy" ? "deploying" : "uploading";
+		const actionNoun = options.type === "deploy" ? "deploy" : "upload";
 		throw new UserError(
 			`The following required secrets have not been set: ${missingSecretNames.join(", ")}\n` +
-				`Use \`wrangler ${options.type === "deploy" ? "secret put" : "versions secret put"} <NAME>\` to set secrets before ${options.type === "deploy" ? "deploying" : "uploading"}.\n` +
+				`Use \`${secretPutCommand} <NAME>\` to set secrets before ${action}, or provide them at ${actionNoun} time with \`${secretsFileCommand}\`.\n` +
 				`See https://developers.cloudflare.com/workers/configuration/secrets/#secrets-on-deployed-workers for more information.`,
 			{ telemetryMessage: "required secrets missing during upload or deploy" }
 		);

--- a/packages/wrangler/src/__tests__/deploy/secrets.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/secrets.test.ts
@@ -338,7 +338,7 @@ SECRET3=value3`
 				runWrangler("deploy index.js")
 			).rejects.toThrowErrorMatchingInlineSnapshot(
 				`[Error: The following required secrets have not been set: API_KEY, DB_PASSWORD
-Use \`wrangler secret put <NAME>\` to set secrets before deploying.
+Use \`wrangler secret put <NAME>\` to set secrets before deploying, or provide them at deploy time with \`wrangler deploy --secrets-file <FILE>\`.
 See https://developers.cloudflare.com/workers/configuration/secrets/#secrets-on-deployed-workers for more information.]`
 			);
 		});
@@ -358,7 +358,8 @@ See https://developers.cloudflare.com/workers/configuration/secrets/#secrets-on-
 				runWrangler("deploy index.js")
 			).rejects.toThrowErrorMatchingInlineSnapshot(
 				`[Error: The following required secrets have not been set: API_KEY, DB_PASSWORD
-Use \`wrangler secret put <NAME>\` to set secrets before deploying.
+This Worker does not exist yet, so set these secrets at deploy time with \`wrangler deploy --secrets-file <FILE>\`.
+Once the Worker exists, you can also use \`wrangler secret put <NAME>\`.
 See https://developers.cloudflare.com/workers/configuration/secrets/#secrets-on-deployed-workers for more information.]`
 			);
 		});
@@ -432,7 +433,8 @@ See https://developers.cloudflare.com/workers/configuration/secrets/#secrets-on-
 				runWrangler(`deploy --secrets-file ${secretsFile}`)
 			).rejects.toThrowErrorMatchingInlineSnapshot(
 				`[Error: The following required secrets have not been set: SECRET2, SECRET3
-Use \`wrangler secret put <NAME>\` to set secrets before deploying.
+This Worker does not exist yet, so set these secrets at deploy time with \`wrangler deploy --secrets-file <FILE>\`.
+Once the Worker exists, you can also use \`wrangler secret put <NAME>\`.
 See https://developers.cloudflare.com/workers/configuration/secrets/#secrets-on-deployed-workers for more information.]`
 			);
 		});

--- a/packages/wrangler/src/__tests__/versions/secrets.test.ts
+++ b/packages/wrangler/src/__tests__/versions/secrets.test.ts
@@ -331,7 +331,7 @@ SECRET3=value3`
 				runWrangler(`versions upload --name ${workerName}`)
 			).rejects.toThrowErrorMatchingInlineSnapshot(
 				`[Error: The following required secrets have not been set: API_KEY, DB_PASSWORD
-Use \`wrangler versions secret put <NAME>\` to set secrets before uploading.
+Use \`wrangler versions secret put <NAME>\` to set secrets before uploading, or provide them at upload time with \`wrangler versions upload --secrets-file <FILE>\`.
 See https://developers.cloudflare.com/workers/configuration/secrets/#secrets-on-deployed-workers for more information.]`
 			);
 		});


### PR DESCRIPTION
Fixes #14258.

When a Worker declares `secrets.required` and is deployed for the **first time**, the remedies suggested by the error messages don't work: `wrangler secret put` fails because the Worker doesn't exist yet, and the one path that does work — `--secrets-file` — was never mentioned.

This updates the messages emitted by `addRequiredSecretsInheritBindings` and `handleMissingSecretsError` (in `@cloudflare/deploy-helpers`, surfaced through Wrangler) to point at `--secrets-file`:

- **First deploy (Worker does not exist yet):** the error now leads with `wrangler deploy --secrets-file <FILE>` as the way to supply required secrets in a single step, and mentions `wrangler secret put <NAME>` only as the option for once the Worker exists.
- **Missing-secret API errors (`deploy`):** now mention `wrangler deploy --secrets-file <FILE>` alongside the existing `wrangler secret put <NAME>` guidance.
- **Missing-secret API errors (`versions upload`):** now mention `wrangler versions upload --secrets-file <FILE>` alongside the existing `wrangler versions secret put <NAME>` guidance.

This is scoped to the wording of these two error messages, per the actionable item called out in the issue. It does not change how secrets are actually supplied or routed.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: this only refines the wording of existing Wrangler CLI error messages; the `--secrets-file` flag and its behaviour are unchanged and already documented.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14540" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->