### PR TITLE
feat(wrangler): test harness build output support

### DIFF
--- a/.changeset/friendly-hounds-smile.md
+++ b/.changeset/friendly-hounds-smile.md
@@ -1,0 +1,7 @@
+---
+"wrangler": minor
+---
+
+Add Build Output API support to `createTestHarness()`
+
+The test harness can now load Workers from a Build Output API root directory, for example `createTestHarness({ workers: [{ buildOutput: "./.cloudflare/output" }] })`. This lets tests run against prebuilt Workers emitted under `.cloudflare/output/v0/workers`.

--- a/packages/wrangler/src/__tests__/test-harness.test.ts
+++ b/packages/wrangler/src/__tests__/test-harness.test.ts
@@ -1,0 +1,200 @@
+import assert from "node:assert";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import {
+	BUILD_OUTPUT_VERSION,
+	WORKER_CONFIG_FILENAME,
+} from "@cloudflare/config";
+import { runInTempDir, seed } from "@cloudflare/workers-utils/test-helpers";
+import { beforeEach, describe, it, vi } from "vitest";
+import { createTestHarness } from "../api/test-harness";
+import type { WranglerStartDevWorkerInput } from "../api/startDevWorker/types";
+import type { Config } from "@cloudflare/workers-utils";
+import type { EventEmitter } from "node:events";
+import type { Mock } from "vitest";
+
+type MockDevEnv = EventEmitter & {
+	config: {
+		latestConfig?: Config;
+		latestWranglerConfig?: { configPath?: string };
+		set: Mock<
+			(input: WranglerStartDevWorkerInput, initial: boolean) => Promise<void>
+		>;
+	};
+	runtimes: [{ mf: Record<string, never> }];
+	proxy: {
+		ready: { promise: Promise<{ url: string }> };
+		proxyWorker: { dispatchFetch: Mock<() => Promise<Response>> };
+	};
+	teardown: Mock<() => Promise<void>>;
+};
+
+const mockState = vi.hoisted(() => ({
+	instances: [] as MockDevEnv[],
+}));
+
+vi.mock("../api/startDevWorker/DevEnv", async () => {
+	const { EventEmitter } = await import("node:events");
+
+	class DevEnv extends EventEmitter implements MockDevEnv {
+		config: MockDevEnv["config"];
+		runtimes: MockDevEnv["runtimes"] = [{ mf: {} }];
+		proxy: MockDevEnv["proxy"] = {
+			ready: { promise: Promise.resolve({ url: "http://127.0.0.1:8787" }) },
+			proxyWorker: {
+				dispatchFetch: vi.fn(async () => new Response("ok")),
+			},
+		};
+		teardown = vi.fn(async () => {});
+
+		constructor() {
+			super();
+			this.config = {
+				set: vi.fn(async (input: WranglerStartDevWorkerInput) => {
+					if (typeof input.config === "object") {
+						this.config.latestConfig = input.config;
+					} else {
+						this.config.latestWranglerConfig = { configPath: input.config };
+					}
+					if (mockState.instances[0] === this) {
+						queueMicrotask(() => this.emit("reloadComplete"));
+					}
+				}),
+			};
+			mockState.instances.push(this);
+		}
+	}
+
+	return { DevEnv };
+});
+
+function outputWorkerDir(workerName: string): string {
+	return path.join(
+		".cloudflare/output",
+		BUILD_OUTPUT_VERSION,
+		"workers",
+		workerName
+	);
+}
+
+async function seedBuildOutputWorker(
+	workerName: string,
+	options: { assets?: boolean } = {}
+) {
+	const workerDir = outputWorkerDir(workerName);
+	await seed({
+		[path.join(workerDir, WORKER_CONFIG_FILENAME)]: JSON.stringify({
+			name: workerName,
+			compatibilityDate: "2026-06-01",
+			env: {},
+			manifest: {
+				mainModule: "index.js",
+				modules: { "index.js": { type: "esm" } },
+			},
+		}),
+		[path.join(workerDir, "bundle/index.js")]: `export default {};`,
+		...(options.assets
+			? { [path.join(workerDir, "assets/index.html")]: "<h1>Hello</h1>" }
+			: {}),
+	});
+}
+
+function getSetInput(index: number): WranglerStartDevWorkerInput {
+	const input = mockState.instances[index]?.config.set.mock.calls[0]?.[0];
+	assert(input);
+	return input;
+}
+
+function getInlineConfig(input: WranglerStartDevWorkerInput): Config {
+	assert(typeof input.config === "object");
+	return input.config;
+}
+
+describe("createTestHarness buildOutput", () => {
+	runInTempDir();
+
+	beforeEach(() => {
+		mockState.instances.length = 0;
+	});
+
+	it("expands a Build Output API worker into a no-bundle worker input", async ({
+		expect,
+	}) => {
+		await seedBuildOutputWorker("api", { assets: true });
+
+		const server = createTestHarness({
+			workers: [{ buildOutput: "./.cloudflare/output" }],
+		});
+
+		await server.listen();
+
+		const input = getSetInput(0);
+		const config = getInlineConfig(input);
+		expect(config.name).toBe("api");
+		expect(config.main).toBe(
+			path.resolve(outputWorkerDir("api"), "bundle/index.js")
+		);
+		expect(config.no_bundle).toBe(true);
+		expect(config.assets?.directory).toBe(
+			path.resolve(outputWorkerDir("api"), "assets")
+		);
+		expect(input.build?.bundle).toBe(false);
+		expect(input.build?.moduleRoot).toBe(
+			path.resolve(outputWorkerDir("api"), "bundle")
+		);
+		expect(input.dev?.multiworkerPrimary).toBeUndefined();
+	});
+
+	it("expands all Build Output API workers in deterministic order", async ({
+		expect,
+	}) => {
+		await seedBuildOutputWorker("worker-b");
+		await seedBuildOutputWorker("worker-a");
+
+		const server = createTestHarness({
+			workers: [
+				{ buildOutput: pathToFileURL(path.resolve(".cloudflare/output")) },
+			],
+		});
+
+		await server.listen();
+
+		const firstInput = getSetInput(0);
+		const secondInput = getSetInput(1);
+		expect(getInlineConfig(firstInput).name).toBe("worker-a");
+		expect(getInlineConfig(secondInput).name).toBe("worker-b");
+		expect(firstInput.dev?.multiworkerPrimary).toBe(true);
+		expect(secondInput.dev?.multiworkerPrimary).toBe(false);
+	});
+
+	it("throws when the Build Output API workers directory is missing", async ({
+		expect,
+	}) => {
+		const server = createTestHarness({
+			workers: [{ buildOutput: "./.cloudflare/output" }],
+		});
+
+		await expect(server.listen()).rejects.toThrow(
+			"No Build Output API tree found"
+		);
+		expect(mockState.instances).toHaveLength(0);
+	});
+
+	it("throws when a Build Output API worker config is missing", async ({
+		expect,
+	}) => {
+		await seed({
+			[path.join(outputWorkerDir("api"), "bundle/index.js")]:
+				`export default {};`,
+		});
+
+		const server = createTestHarness({
+			workers: [{ buildOutput: "./.cloudflare/output" }],
+		});
+
+		await expect(server.listen()).rejects.toThrow(
+			'Build Output API: missing `worker.config.json` for Worker "api"'
+		);
+		expect(mockState.instances).toHaveLength(0);
+	});
+});

--- a/packages/wrangler/src/api/test-harness.ts
+++ b/packages/wrangler/src/api/test-harness.ts
@@ -2,6 +2,12 @@ import assert from "node:assert";
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import {
+	BUILD_OUTPUT_VERSION,
+	WORKER_CONFIG_FILENAME,
+	convertToWranglerConfig,
+	OutputWorkerSchema,
+} from "@cloudflare/config";
 import { convertConfigToBindings } from "@cloudflare/deploy-helpers";
 import {
 	normalizeAndValidateConfig,
@@ -41,7 +47,7 @@ import type {
 	Service,
 	Workflow,
 } from "@cloudflare/workers-types/latest";
-import type { Config, RawConfig } from "@cloudflare/workers-utils";
+import type { Binding, Config, RawConfig } from "@cloudflare/workers-utils";
 import type {
 	WorkflowBinding,
 	WorkflowInstanceIntrospector,
@@ -300,6 +306,12 @@ type WorkerInput =
 			 * Inline Wrangler config for this Worker.
 			 */
 			config: InlineConfig;
+	  }
+	| {
+			/**
+			 * Path to a Build Output API root directory, for example `./.cloudflare/output`.
+			 */
+			buildOutput: string | URL;
 	  };
 
 type ServerSession = {
@@ -396,6 +408,146 @@ export function createTestHarness(options?: TestHarnessOptions): TestHarness {
 		return normalizedConfig;
 	}
 
+	function normalizeBuildOutputWorkerConfig(
+		config: RawConfig,
+		configPath: string
+	): Config {
+		const { config: normalizedConfig, diagnostics } =
+			normalizeAndValidateConfig(config, configPath, configPath, {}, true);
+
+		if (diagnostics.hasWarnings()) {
+			debugLog(diagnostics.renderWarnings(), normalizedConfig.name);
+		}
+
+		if (diagnostics.hasErrors()) {
+			throw new UserError(diagnostics.renderErrors(), {
+				telemetryMessage: "create server build output config validation failed",
+			});
+		}
+
+		return normalizedConfig;
+	}
+
+	function readBuildOutputWorkerInputs(
+		buildOutput: string | URL,
+		root: string
+	): WranglerStartDevWorkerInput[] {
+		const outputRoot = resolvePath(root, buildOutput);
+		const workersDir = path.join(outputRoot, BUILD_OUTPUT_VERSION, "workers");
+
+		if (!fs.existsSync(workersDir)) {
+			throw new Error(`No Build Output API tree found at ${workersDir}.`);
+		}
+
+		const workerNames = fs
+			.readdirSync(workersDir, { withFileTypes: true })
+			.filter((entry) => entry.isDirectory())
+			.map((entry) => entry.name)
+			.sort();
+
+		if (workerNames.length === 0) {
+			throw new Error(
+				`Build Output API tree at ${workersDir} contains no Worker directories.`
+			);
+		}
+
+		return workerNames.map((workerName) => {
+			const workerDir = path.join(workersDir, workerName);
+			const configPath = path.join(workerDir, WORKER_CONFIG_FILENAME);
+			if (!fs.existsSync(configPath)) {
+				throw new Error(
+					`Build Output API: missing \`${WORKER_CONFIG_FILENAME}\` for Worker ${JSON.stringify(workerName)} at ${configPath}.`
+				);
+			}
+
+			const outputConfig = OutputWorkerSchema.parse(
+				JSON.parse(fs.readFileSync(configPath, "utf-8"))
+			);
+			const { manifest, ...inputShape } = outputConfig;
+			const rawConfig = convertToWranglerConfig(inputShape);
+			const build: WranglerStartDevWorkerInput["build"] = {
+				nodejsCompatMode: (workerConfig) => {
+					return validateNodeCompatMode(
+						workerConfig.compatibility_date,
+						workerConfig.compatibility_flags ?? [],
+						{ noBundle: workerConfig.no_bundle }
+					);
+				},
+			};
+
+			if (manifest) {
+				const bundleDir = path.join(workerDir, "bundle");
+				rawConfig.main = path.join(bundleDir, manifest.mainModule);
+				rawConfig.no_bundle = true;
+				build.bundle = false;
+				build.moduleRoot = bundleDir;
+			}
+
+			const assetsDir = path.join(workerDir, "assets");
+			if (fs.existsSync(assetsDir)) {
+				rawConfig.assets = {
+					...(rawConfig.assets ?? {}),
+					directory: assetsDir,
+				};
+			}
+
+			return createWorkerInput({
+				config: normalizeBuildOutputWorkerConfig(rawConfig, configPath),
+				build,
+			});
+		});
+	}
+
+	function createWorkerInput({
+		config,
+		env,
+		bindings = {},
+		build,
+	}: {
+		config: Config | string;
+		env?: string;
+		bindings?: Record<string, Binding>;
+		build?: WranglerStartDevWorkerInput["build"];
+	}): WranglerStartDevWorkerInput {
+		return {
+			config,
+			env,
+			bindings,
+			dev: {
+				auth: serverAuthHook,
+				server: { hostname: "127.0.0.1", port: 0 },
+				logLevel: "none",
+				watch: false,
+				persist: false,
+				inspector: false,
+				registry: undefined,
+				structuredLogsHandler: (log: WorkerdStructuredLog) =>
+					captureStructuredLog(log),
+				outboundService: (request) => {
+					/**
+					 * Miniflare passes its own undici-based Request here. Pass the URL as
+					 * RequestInfo and the request as RequestInit so method, headers, body,
+					 * and duplex are preserved by global fetch.
+					 */
+					return globalThis.fetch(request.url, request);
+				},
+				multiworkerPrimary: undefined,
+				inferOriginFromRoutes: false,
+				routeRequestsByRoutes: true,
+			},
+			build: {
+				nodejsCompatMode: (workerConfig) => {
+					return validateNodeCompatMode(
+						workerConfig.compatibility_date,
+						workerConfig.compatibility_flags ?? [],
+						{ noBundle: workerConfig.no_bundle }
+					);
+				},
+				...build,
+			},
+		};
+	}
+
 	function resolveWorkerInputs(
 		serverOptions: TestHarnessOptions
 	): WranglerStartDevWorkerInput[] {
@@ -405,9 +557,11 @@ export function createTestHarness(options?: TestHarnessOptions): TestHarness {
 
 		const root = serverOptions.root ?? process.cwd();
 
-		return serverOptions.workers.map((input, index, list) => {
-			const isPrimaryWorker = index === 0;
-			const isMultiworker = list.length > 1;
+		const inputs = serverOptions.workers.flatMap((input) => {
+			if ("buildOutput" in input) {
+				return readBuildOutputWorkerInputs(input.buildOutput, root);
+			}
+
 			const workerBindingOverrides =
 				"configPath" in input ? input.bindingOverrides : undefined;
 			const bindings = convertConfigToBindings(
@@ -422,46 +576,23 @@ export function createTestHarness(options?: TestHarnessOptions): TestHarness {
 				bindings[key] = { type: "service", service: value };
 			}
 
-			return {
+			return createWorkerInput({
 				config:
 					"config" in input
 						? normalizeInlineWorkerConfig(input.config, root)
 						: resolvePath(root, input.configPath),
 				env: "env" in input ? input.env : undefined,
 				bindings,
-				dev: {
-					auth: serverAuthHook,
-					server: { hostname: "127.0.0.1", port: 0 },
-					logLevel: "none",
-					watch: false,
-					persist: false,
-					inspector: false,
-					registry: undefined,
-					structuredLogsHandler: (log: WorkerdStructuredLog) =>
-						captureStructuredLog(log),
-					outboundService: (request) => {
-						/**
-						 * Miniflare passes its own undici-based Request here. Pass the URL as
-						 * RequestInfo and the request as RequestInit so method, headers, body,
-						 * and duplex are preserved by global fetch.
-						 */
-						return globalThis.fetch(request.url, request);
-					},
-					multiworkerPrimary: isMultiworker ? isPrimaryWorker : undefined,
-					inferOriginFromRoutes: false,
-					routeRequestsByRoutes: true,
-				},
-				build: {
-					nodejsCompatMode: (config) => {
-						return validateNodeCompatMode(
-							config.compatibility_date,
-							config.compatibility_flags ?? [],
-							{ noBundle: config.no_bundle }
-						);
-					},
-				},
-			};
+			});
 		});
+		const isMultiworker = inputs.length > 1;
+		return inputs.map((input, index) => ({
+			...input,
+			dev: {
+				...input.dev,
+				multiworkerPrimary: isMultiworker ? index === 0 : undefined,
+			},
+		}));
 	}
 
 	async function createSession(


### PR DESCRIPTION
Fixes n/a

Add Build Output API support to `createTestHarness()`.

This lets test harness callers pass `workers: [{ buildOutput: "./.cloudflare/output" }]` and load every Worker in the Build Output API tree under `v0/workers`.

Workers with a manifest are started from their emitted bundle without rebundling, and any emitted assets directory is wired into the normalized config.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: this is draft support for the experimental Build Output API path in the test harness; public docs can follow once the API shape is confirmed.

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->