### PR TITLE
[autoconfig] Fix Vite version detection for vite+ projects

### DIFF
--- a/.changeset/autoconfig-vite-plus-version-detection.md
+++ b/.changeset/autoconfig-vite-plus-version-detection.md
@@ -4,6 +4,4 @@
 
 Fix Vite version detection for vite+ projects during autoconfiguration
 
-vite+ installs `@voidzero-dev/vite-plus-core` under the `vite` npm alias, so the resolved `node_modules/vite/package.json` reports the wrapper's own version (e.g. `0.2.2`) rather than the underlying Vite version it bundles. This caused autoconfiguration to fail with an error claiming the Vite version was too old to be configured automatically.
-
-`getInstalledPackageVersion` now recognises aliased packages: when the resolved `package.json` name doesn't match the requested package, it reads the underlying version from the package's `bundledVersions` map before falling back to the package's own `version`.
+vite+ installs `@voidzero-dev/vite-plus-core` under the `vite` npm alias, so the resolved `node_modules/vite/package.json` reports the wrapper's own version (e.g. `0.2.2`) rather than the underlying Vite version it bundles. This caused autoconfiguration to fail with an error claiming the Vite version was too old to be configured automatically. Autoconfiguration now detects the correct underlying Vite version for these projects.

--- a/.changeset/autoconfig-vite-plus-version-detection.md
+++ b/.changeset/autoconfig-vite-plus-version-detection.md
@@ -1,0 +1,9 @@
+---
+"@cloudflare/autoconfig": patch
+---
+
+Fix Vite version detection for vite+ projects during autoconfiguration
+
+vite+ installs `@voidzero-dev/vite-plus-core` under the `vite` npm alias, so the resolved `node_modules/vite/package.json` reports the wrapper's own version (e.g. `0.2.2`) rather than the underlying Vite version it bundles. This caused autoconfiguration to fail with an error claiming the Vite version was too old to be configured automatically.
+
+`getInstalledPackageVersion` now recognises aliased packages: when the resolved `package.json` name doesn't match the requested package, it reads the underlying version from the package's `bundledVersions` map before falling back to the package's own `version`.

--- a/packages/autoconfig/src/frameworks/utils/packages.ts
+++ b/packages/autoconfig/src/frameworks/utils/packages.ts
@@ -50,9 +50,13 @@ export function getInstalledPackageVersion(
 		// The requested package may be installed under an alias (e.g. vite+
 		// installs `@voidzero-dev/vite-plus-core` under the `vite` alias). In that
 		// case the resolved package.json belongs to the aliased package, so its
-		// `version` is not the version of the requested package. Prefer the version
-		// declared in `bundledVersions` for the requested package when the name
-		// doesn't match.
+		// `version` is not the version of the requested package.
+		//
+		// `bundledVersions` is NOT a standard package.json field (it is not the
+		// standard `bundledDependencies`) — it is a vite+ convention that maps the
+		// names of the tools it bundles to the versions it provides. When the
+		// resolved package name doesn't match the requested one, prefer the version
+		// declared there for the requested package.
 		if (packageJson.name !== packageName) {
 			const bundledVersion = packageJson.bundledVersions?.[packageName];
 			if (bundledVersion !== undefined) {

--- a/packages/autoconfig/src/frameworks/utils/packages.ts
+++ b/packages/autoconfig/src/frameworks/utils/packages.ts
@@ -47,6 +47,18 @@ export function getInstalledPackageVersion(
 			readFileSync(packageJsonPath),
 			packageJsonPath
 		);
+		// The requested package may be installed under an alias (e.g. vite+
+		// installs `@voidzero-dev/vite-plus-core` under the `vite` alias). In that
+		// case the resolved package.json belongs to the aliased package, so its
+		// `version` is not the version of the requested package. Prefer the version
+		// declared in `bundledVersions` for the requested package when the name
+		// doesn't match.
+		if (packageJson.name !== packageName) {
+			const bundledVersion = packageJson.bundledVersions?.[packageName];
+			if (bundledVersion !== undefined) {
+				return bundledVersion;
+			}
+		}
 		return packageJson.version;
 	} catch {}
 }

--- a/packages/autoconfig/tests/get-installed-package-version.test.ts
+++ b/packages/autoconfig/tests/get-installed-package-version.test.ts
@@ -23,4 +23,59 @@ describe("getInstalledPackageVersion()", () => {
 			getInstalledPackageVersion("react-router", process.cwd())
 		).toBeUndefined();
 	});
+
+	test("aliased package returns the bundled version of the requested package", async ({
+		expect,
+	}) => {
+		// vite+ installs `@voidzero-dev/vite-plus-core` under the `vite` alias, so
+		// the resolved package.json has a different `name` and its own `version`.
+		await seed({
+			"node_modules/vite/package.json": JSON.stringify({
+				name: "@voidzero-dev/vite-plus-core",
+				version: "0.2.2",
+				bundledVersions: {
+					vite: "8.1.2",
+					rolldown: "1.0.0",
+					tsdown: "0.15.0",
+				},
+				main: "index.js",
+			}),
+			"node_modules/vite/index.js": "console.log(1)",
+		});
+		expect(getInstalledPackageVersion("vite", process.cwd())).toBe("8.1.2");
+	});
+
+	test("aliased package without a matching bundled version falls back to its own version", async ({
+		expect,
+	}) => {
+		await seed({
+			"node_modules/vite/package.json": JSON.stringify({
+				name: "@voidzero-dev/vite-plus-core",
+				version: "0.2.2",
+				bundledVersions: {
+					rolldown: "1.0.0",
+				},
+				main: "index.js",
+			}),
+			"node_modules/vite/index.js": "console.log(1)",
+		});
+		expect(getInstalledPackageVersion("vite", process.cwd())).toBe("0.2.2");
+	});
+
+	test("package whose name matches ignores bundledVersions and returns its own version", async ({
+		expect,
+	}) => {
+		await seed({
+			"node_modules/vite/package.json": JSON.stringify({
+				name: "vite",
+				version: "6.3.0",
+				bundledVersions: {
+					vite: "8.1.2",
+				},
+				main: "index.js",
+			}),
+			"node_modules/vite/index.js": "console.log(1)",
+		});
+		expect(getInstalledPackageVersion("vite", process.cwd())).toBe("6.3.0");
+	});
 });

--- a/packages/workers-utils/src/parse.ts
+++ b/packages/workers-utils/src/parse.ts
@@ -135,10 +135,15 @@ export type PackageJSON = {
 	dependencies?: Record<string, unknown>;
 	scripts?: Record<string, unknown>;
 	/**
-	 * Versions of packages bundled/re-exported by this package, keyed by package
-	 * name. Used by wrapper packages that alias another dependency (e.g. vite+,
-	 * which installs `@voidzero-dev/vite-plus-core` under the `vite` alias) to
-	 * declare the underlying version they provide.
+	 * NOTE: This is **not** a standard `package.json` field — don't confuse it
+	 * with the standard `bundledDependencies`. It is a convention introduced by
+	 * vite+ (https://viteplus.dev): vite+ installs `@voidzero-dev/vite-plus-core`
+	 * under the `vite` npm alias and records the versions of the tools it bundles
+	 * here, keyed by package name
+	 * (e.g. `{ "vite": "8.1.2", "rolldown": "...", "tsdown": "..." }`).
+	 *
+	 * We read it to recover the underlying Vite version when Vite is installed via
+	 * such an alias. It is optional and absent for the vast majority of packages.
 	 */
 	bundledVersions?: Record<string, string | undefined>;
 };

--- a/packages/workers-utils/src/parse.ts
+++ b/packages/workers-utils/src/parse.ts
@@ -134,6 +134,13 @@ export type PackageJSON = {
 	devDependencies?: Record<string, unknown>;
 	dependencies?: Record<string, unknown>;
 	scripts?: Record<string, unknown>;
+	/**
+	 * Versions of packages bundled/re-exported by this package, keyed by package
+	 * name. Used by wrapper packages that alias another dependency (e.g. vite+,
+	 * which installs `@voidzero-dev/vite-plus-core` under the `vite` alias) to
+	 * declare the underlying version they provide.
+	 */
+	bundledVersions?: Record<string, string | undefined>;
 };
 
 /**


### PR DESCRIPTION
Fixes #14541.

vite+ installs `@voidzero-dev/vite-plus-core` under the `vite` npm alias (`"vite": "npm:@voidzero-dev/vite-plus-core@0.2.2"`). As a result, the resolved `node_modules/vite/package.json` reports the wrapper's own version (e.g. `0.2.2`) rather than the underlying Vite version it bundles. Autoconfiguration then failed with:

> The version of Vite used in the project ("0.2.2") cannot be automatically configured. Please update the Vite version to at least "6.0.0" and try again.

vite+ declares the version it bundles in a `bundledVersions` map in its `package.json` (e.g. `{ "vite": "8.1.2", "rolldown": ..., "tsdown": ... }`). This mirrors how `vitest-pool-workers` already reads `bundledVersions.vitest`.

This change makes `getInstalledPackageVersion` alias-aware: when the resolved `package.json` `name` doesn't match the requested package, it reads the underlying version from `bundledVersions[packageName]` before falling back to the package's own `version`. The behaviour is unchanged for regularly-installed packages.

- A new `bundledVersions?: Record<string, string | undefined>` field is added to the shared `PackageJSON` type in `@cloudflare/workers-utils`.
- The Vite `frameworkPackageInfo` already accepts major version `8`, so the resolved `8.1.2` passes validation, and the `^6.1.0` bump in `installCloudflareVitePlugin` is correctly skipped.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: this is a bug fix that restores the intended automatic-configuration behaviour; there is no user-facing API or documented behaviour change.

*A picture of a cute animal (not mandatory, but encouraged)*

![otter](https://octodex.github.com/images/class-act.png)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14548" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->