### PR TITLE
[vite-plugin] Avoid worker export inspection in middleware mode

### DIFF
--- a/.changeset/sharp-bikes-matter.md
+++ b/.changeset/sharp-bikes-matter.md
@@ -1,0 +1,7 @@
+---
+"@cloudflare/vite-plugin": patch
+---
+
+Avoid live Worker export inspection when Vite runs in middleware mode
+
+Storybook and other embedded Vite servers run without a Vite-owned HTTP server. In that mode, the plugin now keeps using config-derived Worker export types instead of inspecting the live Worker module graph during startup.

--- a/packages/vite-plugin-cloudflare/src/__tests__/dev-plugin.spec.ts
+++ b/packages/vite-plugin-cloudflare/src/__tests__/dev-plugin.spec.ts
@@ -1,0 +1,173 @@
+import { beforeEach, describe, it, vi } from "vitest";
+import { PluginContext } from "../context";
+import { devPlugin } from "../plugins/dev";
+import type { SharedContext } from "../context";
+import type { ExportTypes } from "../export-types";
+import type {
+	ResolvedWorkerConfig,
+	WorkersResolvedConfig,
+} from "../plugin-config";
+import type * as vite from "vite";
+
+const getDevMiniflareOptionsMock = vi.hoisted(() => vi.fn());
+const initRunnersMock = vi.hoisted(() => vi.fn());
+const getCurrentWorkerNameToExportTypesMapMock = vi.hoisted(() => vi.fn());
+const compareWorkerNameToExportTypesMapsMock = vi.hoisted(() => vi.fn());
+const compareExportTypesMock = vi.hoisted(() => vi.fn());
+const handleWebSocketMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../miniflare-options", () => ({
+	getDevMiniflareOptions: getDevMiniflareOptionsMock,
+}));
+
+vi.mock("../cloudflare-environment", () => ({
+	initRunners: initRunnersMock,
+}));
+
+vi.mock("../export-types", () => ({
+	compareExportTypes: compareExportTypesMock,
+	compareWorkerNameToExportTypesMaps: compareWorkerNameToExportTypesMapsMock,
+	getCurrentWorkerNameToExportTypesMap:
+		getCurrentWorkerNameToExportTypesMapMock,
+}));
+
+vi.mock("../websockets", () => ({
+	handleWebSocket: handleWebSocketMock,
+}));
+
+const exportTypesMap = new Map<string, ExportTypes>([["worker", {}]]);
+
+function createMockContext(): PluginContext {
+	const ctx = new PluginContext({
+		hasShownWorkerConfigWarnings: false,
+		restartingDevServerCount: 0,
+		tunnelHostnames: new Set(),
+	} satisfies SharedContext);
+	const workerConfig = {
+		name: "worker",
+	} as ResolvedWorkerConfig;
+	const resolvedPluginConfig = {
+		type: "workers",
+		entryWorkerEnvironmentName: "worker",
+		environmentNameToWorkerMap: new Map([
+			[
+				"worker",
+				{
+					config: workerConfig,
+				},
+			],
+		]),
+		environmentNameToChildEnvironmentNamesMap: new Map(),
+	} as unknown as WorkersResolvedConfig;
+
+	Object.defineProperty(ctx, "entryWorkerConfig", { value: workerConfig });
+	Object.defineProperty(ctx, "miniflare", { value: {} });
+	Object.defineProperty(ctx, "resolvedPluginConfig", {
+		value: resolvedPluginConfig,
+	});
+	Object.defineProperty(ctx, "workerNameToExportTypesMap", {
+		value: exportTypesMap,
+	});
+	vi.spyOn(ctx, "getWorkerConfig").mockReturnValue(workerConfig);
+	vi.spyOn(ctx, "setWorkerNameToExportTypesMap").mockReturnValue();
+	vi.spyOn(ctx, "startOrUpdateMiniflare").mockResolvedValue();
+
+	return ctx;
+}
+
+function createMockViteDevServer(
+	httpServer: vite.ViteDevServer["httpServer"]
+): vite.ViteDevServer {
+	return {
+		config: {
+			logger: {
+				info: vi.fn(),
+			},
+		},
+		environments: {
+			worker: {
+				hot: {
+					on: vi.fn(),
+				},
+			},
+		},
+		httpServer,
+		middlewares: {
+			use: vi.fn(),
+		},
+	} as unknown as vite.ViteDevServer;
+}
+
+function getWorkerHotOn(viteDevServer: vite.ViteDevServer) {
+	const environment = viteDevServer.environments.worker;
+	if (!environment) {
+		throw new Error("Expected worker environment to be defined");
+	}
+
+	return environment.hot.on;
+}
+
+async function configureServer(
+	plugin: vite.Plugin,
+	viteDevServer: vite.ViteDevServer
+) {
+	type ConfigureServerFunction = (
+		this: unknown,
+		server: vite.ViteDevServer
+	) => unknown;
+
+	const hook = plugin.configureServer;
+	if (typeof hook === "function") {
+		await (hook as ConfigureServerFunction).call({}, viteDevServer);
+	} else {
+		await (hook?.handler as ConfigureServerFunction | undefined)?.call(
+			{},
+			viteDevServer
+		);
+	}
+}
+
+describe("devPlugin", () => {
+	beforeEach(() => {
+		vi.resetAllMocks();
+		getDevMiniflareOptionsMock.mockResolvedValue({
+			containerTagToOptionsMap: new Map(),
+			miniflareOptions: {},
+		});
+		initRunnersMock.mockResolvedValue(undefined);
+		getCurrentWorkerNameToExportTypesMapMock.mockResolvedValue(exportTypesMap);
+		compareWorkerNameToExportTypesMapsMock.mockReturnValue(false);
+		compareExportTypesMock.mockReturnValue(false);
+	});
+
+	it("skips live export inspection in middleware mode", async ({ expect }) => {
+		const plugin = devPlugin(createMockContext());
+		const viteDevServer = createMockViteDevServer(null);
+		const hotOn = getWorkerHotOn(viteDevServer);
+
+		await configureServer(plugin, viteDevServer);
+
+		expect(initRunnersMock).toHaveBeenCalledTimes(1);
+		expect(getCurrentWorkerNameToExportTypesMapMock).not.toHaveBeenCalled();
+		expect(hotOn).not.toHaveBeenCalled();
+	});
+
+	it("runs live export inspection when Vite owns an HTTP server", async ({
+		expect,
+	}) => {
+		const plugin = devPlugin(createMockContext());
+		const httpServer = {
+			on: vi.fn(),
+		} as unknown as vite.ViteDevServer["httpServer"];
+		const viteDevServer = createMockViteDevServer(httpServer);
+		const hotOn = getWorkerHotOn(viteDevServer);
+
+		await configureServer(plugin, viteDevServer);
+
+		expect(getCurrentWorkerNameToExportTypesMapMock).toHaveBeenCalledTimes(1);
+		expect(hotOn).toHaveBeenCalledWith(
+			"vite-plugin-cloudflare:worker-export-types",
+			expect.any(Function)
+		);
+	});
+});

--- a/packages/vite-plugin-cloudflare/src/plugins/dev.ts
+++ b/packages/vite-plugin-cloudflare/src/plugins/dev.ts
@@ -102,16 +102,21 @@ export const devPlugin = createPlugin("dev", (ctx) => {
 					viteDevServer,
 					ctx.miniflare
 				);
-				const currentWorkerNameToExportTypesMap =
-					await getCurrentWorkerNameToExportTypesMap(
-						ctx.resolvedPluginConfig,
-						viteDevServer,
-						ctx.miniflare
+
+				const isMiddlewareMode = !viteDevServer.httpServer;
+				const currentWorkerNameToExportTypesMap = isMiddlewareMode
+					? ctx.workerNameToExportTypesMap
+					: await getCurrentWorkerNameToExportTypesMap(
+							ctx.resolvedPluginConfig,
+							viteDevServer,
+							ctx.miniflare
+						);
+				const hasChanged =
+					!isMiddlewareMode &&
+					compareWorkerNameToExportTypesMaps(
+						ctx.workerNameToExportTypesMap,
+						currentWorkerNameToExportTypesMap
 					);
-				const hasChanged = compareWorkerNameToExportTypesMaps(
-					ctx.workerNameToExportTypesMap,
-					currentWorkerNameToExportTypesMap
-				);
 
 				if (hasChanged) {
 					ctx.setWorkerNameToExportTypesMap(currentWorkerNameToExportTypesMap);
@@ -128,7 +133,11 @@ export const devPlugin = createPlugin("dev", (ctx) => {
 					);
 				}
 
-				for (const environmentName of ctx.resolvedPluginConfig.environmentNameToWorkerMap.keys()) {
+				const workerExportTypeEnvironmentNames: Iterable<string> =
+					isMiddlewareMode
+						? []
+						: ctx.resolvedPluginConfig.environmentNameToWorkerMap.keys();
+				for (const environmentName of workerExportTypeEnvironmentNames) {
 					const environment = viteDevServer.environments[environmentName];
 					assert(
 						environment,


### PR DESCRIPTION
#9108 added middleware-mode support for embedded Vite servers such as Storybook. This PR fixes a later path in the same mode: the dev plugin still performed live Worker export-type inspection during `configureServer`, even when Vite was embedded by another server and therefore had no Vite-owned HTTP server.

In the external Storybook reproduction, the Worker entry is a normal default Worker export. The failure happens during Storybook startup while the Cloudflare plugin is doing live export-type inspection through the Workers runner:

```txt
Failed to build the preview
ReferenceError: __STORYBOOK_MODULE_TEST__ is not defined
  at runInRunnerObject (workers/runner-worker/index.js:107:3)
  at getWorkerEntryExportTypes (workers/runner-worker/index.js:245:29)
```

This change skips live export-type handling when Vite is running in middleware mode, detected by the absence of `viteDevServer.httpServer`. Middleware mode continues to use the config-derived Worker export types that are already available before the live inspection step. Normal Vite dev servers still perform live inspection, register the export-type HMR handler, and restart Miniflare if Worker export types change.

The regression test covers the plugin behavior directly: middleware mode does not call `getCurrentWorkerNameToExportTypesMap` or register the export-type HMR handler, while a normal Vite dev server still does both.

Local validation:

- `pnpm --filter @cloudflare/vite-plugin exec vitest run src/__tests__/dev-plugin.spec.ts`
- `pnpm --filter @cloudflare/vite-plugin exec vitest run src/__tests__/dev-plugin.spec.ts src/__tests__/hmr-events.spec.ts src/__tests__/websockets.spec.ts src/__tests__/tunnel.spec.ts`
- `pnpm --filter @cloudflare/vite-plugin check:type`
- `pnpm prettify`
- `pnpm check`

I also re-checked the external Storybook reproduction in a clean temporary install using the published `@cloudflare/vite-plugin@1.43.0` package. The clean install reproduces the error above. The earlier successful local run was caused by the repro repository's existing `node_modules` having been modified during local patched-package testing.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bug fix for middleware-mode Storybook startup behavior; no public API or docs surface changed.

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->