### PR TITLE
fix(wrangler): emit an error event for watch-mode rebuild failures

### DIFF
--- a/.changeset/watch-rebuild-error-event.md
+++ b/.changeset/watch-rebuild-error-event.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Emit an error event for watch-mode rebuild failures in `unstable_startWorker`
+
+Initial build failures already dispatch an error event (surfaced as `buildFailed` on the DevEnv bus), but watch-mode rebuild failures were only logged from inside the esbuild plugin, so programmatic consumers had no way to observe them while dev kept serving the previous bundle. Rebuild failures now route through the same error path as initial-build failures: terminal output is unchanged and `buildFailed` fires symmetrically.

--- a/packages/wrangler/src/__tests__/api/startDevWorker/BundleController.test.ts
+++ b/packages/wrangler/src/__tests__/api/startDevWorker/BundleController.test.ts
@@ -133,6 +133,66 @@ describe("BundleController", { retry: 5, timeout: 10_000 }, () => {
 				`);
 		});
 
+		test("a watch-mode rebuild failure emits an error event and recovers", async ({
+			expect,
+		}) => {
+			await seed({
+				"src/index.ts": dedent /* javascript */ `
+				export default {
+					fetch(request, env, ctx) {
+						return new Response("ok")
+					}
+				} satisfies ExportedHandler
+			`,
+			});
+			const config = configDefaults({
+				entrypoint: path.resolve("src/index.ts"),
+				projectRoot: path.resolve("src"),
+			});
+			const first = bus.waitFor("bundleComplete");
+			controller.onConfigUpdate({ type: "configUpdate", config });
+			await first;
+
+			// Break the source: the rebuild failure must surface as an error
+			// event (routed like initial-build failures, so DevEnv can emit
+			// `buildFailed`), not just terminal text.
+			const errorEvent = bus.waitFor(
+				"error",
+				(e) =>
+					e.source === "BundlerController" &&
+					e.reason === "Failed to rebuild the Worker"
+			);
+			await seed({
+				"src/index.ts": dedent /* javascript */ `
+				export default {
+					fetch(request, env, ctx) {
+			`,
+			});
+			const errored = await errorEvent;
+			expect(errored.cause).toMatchObject({
+				errors: expect.arrayContaining([
+					expect.objectContaining({
+						location: expect.objectContaining({ file: "index.ts" }),
+					}),
+				]),
+			});
+
+			// Fixing the source recovers the watch loop with a fresh bundle.
+			const recovered = bus.waitFor("bundleComplete");
+			await seed({
+				"src/index.ts": dedent /* javascript */ `
+				export default {
+					fetch(request, env, ctx) {
+						return new Response("fixed")
+					}
+				} satisfies ExportedHandler
+			`,
+			});
+			expect(
+				findSourceFile((await recovered).bundle.entrypointSource, "index.ts")
+			).toContain("fixed");
+		});
+
 		test("multiple ts source files", async ({ expect }) => {
 			await seed({
 				"src/index.ts": dedent /* javascript */ `

--- a/packages/wrangler/src/api/startDevWorker/BundlerController.ts
+++ b/packages/wrangler/src/api/startDevWorker/BundlerController.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { extractBindingsOfType } from "@cloudflare/deploy-helpers";
 import { getWranglerTmpDir } from "@cloudflare/workers-utils";
 import { watch } from "chokidar";
+import { BuildFailure } from "../../deployment-bundle/build-failures";
 import { bundleWorker, shouldCheckFetch } from "../../deployment-bundle/bundle";
 import { getBundleType } from "../../deployment-bundle/bundle-type";
 import {
@@ -302,9 +303,10 @@ export class BundlerController extends Controller {
 						this.emitErrorEvent({
 							type: "error",
 							reason: "Failed to rebuild the Worker",
-							cause: Object.assign(
-								new Error(`Build failed with ${errors.length} error(s)`),
-								{ errors, warnings }
+							cause: new BuildFailure(
+								`Build failed with ${errors.length} error(s)`,
+								errors,
+								warnings
 							),
 							source: "BundlerController",
 							data: undefined,

--- a/packages/wrangler/src/api/startDevWorker/BundlerController.ts
+++ b/packages/wrangler/src/api/startDevWorker/BundlerController.ts
@@ -294,6 +294,23 @@ export class BundlerController extends Controller {
 				onStart: () => {
 					this.emitBundleStartEvent(config);
 				},
+				onRebuildError: (errors, warnings) => {
+					if (!buildAborter.signal.aborted) {
+						// Watch-mode rebuild failures route through the same error
+						// path as initial-build failures, so DevEnv logs them
+						// (logBuildFailure) and emits `buildFailed` symmetrically.
+						this.emitErrorEvent({
+							type: "error",
+							reason: "Failed to rebuild the Worker",
+							cause: Object.assign(
+								new Error(`Build failed with ${errors.length} error(s)`),
+								{ errors, warnings }
+							),
+							source: "BundlerController",
+							data: undefined,
+						});
+					}
+				},
 				checkFetch: shouldCheckFetch(
 					config.compatibilityDate,
 					config.compatibilityFlags

--- a/packages/wrangler/src/deployment-bundle/build-failures.ts
+++ b/packages/wrangler/src/deployment-bundle/build-failures.ts
@@ -3,6 +3,19 @@ import type * as esbuild from "esbuild";
 import type { NodeJSCompatMode } from "miniflare";
 
 /**
+ * Matches esbuild's BuildFailure shape for errors we construct ourselves.
+ */
+export class BuildFailure extends Error {
+	constructor(
+		message: string,
+		readonly errors: esbuild.Message[],
+		readonly warnings: esbuild.Message[]
+	) {
+		super(message);
+	}
+}
+
+/**
  * RegExp matching against esbuild's error text when it is unable to resolve
  * a Node built-in module. If we detect this when node_compat is disabled,
  * we'll rewrite the error to suggest enabling it.
@@ -84,7 +97,9 @@ export function rewriteUnresolvedModuleBuildFailure(errors: esbuild.Message[]) {
 }
 
 /**
- * Returns true if the passed value looks like an esbuild BuildFailure object
+ * Returns true if the passed value looks like an esbuild BuildFailure object.
+ * Keep this structural so it handles both esbuild failures and locally-created
+ * BuildFailure instances.
  */
 export function isBuildFailure(err: unknown): err is esbuild.BuildFailure {
 	return (

--- a/packages/wrangler/src/deployment-bundle/bundle.ts
+++ b/packages/wrangler/src/deployment-bundle/bundle.ts
@@ -12,6 +12,7 @@ import { getFlag } from "../experimental-flags";
 import { getBasePath } from "../paths";
 import { applyMiddlewareLoaderFacade } from "./apply-middleware";
 import {
+	BuildFailure,
 	isBuildFailure,
 	rewriteNodeCompatBuildFailure,
 	rewriteUnresolvedModuleBuildFailure,
@@ -563,16 +564,6 @@ export async function bundleWorker(
 			entryDirectory: entry.projectRoot,
 		},
 	};
-}
-
-class BuildFailure extends Error {
-	constructor(
-		message: string,
-		readonly errors: esbuild.Message[],
-		readonly warnings: esbuild.Message[]
-	) {
-		super(message);
-	}
 }
 
 /**

--- a/packages/wrangler/src/deployment-bundle/esbuild-plugins/log-build-output.ts
+++ b/packages/wrangler/src/deployment-bundle/esbuild-plugins/log-build-output.ts
@@ -1,14 +1,19 @@
 import { logBuildFailure, logBuildWarnings } from "../../logger";
-import type { Plugin } from "esbuild";
+import type { Message, Plugin } from "esbuild";
 import type { NodeJSCompatMode } from "miniflare";
 
 /**
  * Log esbuild warnings and errors
+ *
+ * When `onRebuildError` is provided, watch-mode rebuild failures are
+ * delegated to it instead of being logged here, so the caller can route
+ * them through its own error handling (which owns the logging).
  */
 export function logBuildOutput(
 	nodejsCompatMode: NodeJSCompatMode | undefined,
 	onStart?: () => void,
-	updateBundle?: () => void
+	updateBundle?: () => void,
+	onRebuildError?: (errors: Message[], warnings: Message[]) => void
 ): Plugin {
 	let bundled = false;
 
@@ -29,7 +34,11 @@ export function logBuildOutput(
 					}
 				} else {
 					if (errors.length > 0) {
-						logBuildFailure(errors, warnings);
+						if (onRebuildError) {
+							onRebuildError(errors, warnings);
+						} else {
+							logBuildFailure(errors, warnings);
+						}
 						return;
 					}
 

--- a/packages/wrangler/src/dev/use-esbuild.ts
+++ b/packages/wrangler/src/dev/use-esbuild.ts
@@ -20,7 +20,7 @@ import type {
 	Config,
 	Entry,
 } from "@cloudflare/workers-utils";
-import type { Metafile } from "esbuild";
+import type { Metafile, Message } from "esbuild";
 import type { NodeJSCompatMode } from "miniflare";
 
 export type EsbuildBundle = {
@@ -62,6 +62,7 @@ export function runBuild(
 		watch,
 		projectRoot,
 		onStart,
+		onRebuildError,
 		defineNavigatorUserAgent,
 		checkFetch,
 		pythonModulesExcludes,
@@ -91,6 +92,7 @@ export function runBuild(
 		watch: boolean;
 		projectRoot: string | undefined;
 		onStart: () => void;
+		onRebuildError?: (errors: Message[], warnings: Message[]) => void;
 		defineNavigatorUserAgent: boolean;
 		checkFetch: boolean;
 		pythonModulesExcludes?: string[];
@@ -189,7 +191,14 @@ export function runBuild(
 						define,
 						targetConsumer,
 						testScheduled,
-						plugins: [logBuildOutput(nodejsCompatMode, onStart, updateBundle)],
+						plugins: [
+							logBuildOutput(
+								nodejsCompatMode,
+								onStart,
+								updateBundle,
+								onRebuildError
+							),
+						],
 						local,
 						projectRoot,
 						defineNavigatorUserAgent,


### PR DESCRIPTION
When `unstable_startWorker` runs in watch mode and a rebuild fails, the `logBuildOutput` esbuild plugin logs the failure and swallows it — no error event is dispatched, so programmatic consumers cannot observe that dev is now serving the previous bundle. Initial build failures, by contrast, route through the error path and surface as `buildFailed` on the DevEnv.

This threads an optional `onRebuildError(errors, warnings)` callback through `logBuildOutput`/`runBuild`; `BundlerController` provides it and routes rebuild failures through the same error path as initial-build failures, attaching the esbuild messages as the error `cause`. Terminal output is unchanged (the error path still logs via `logBuildFailure`), `buildFailed` now fires symmetrically, and recovery is unaffected (the next successful rebuild emits `reloadComplete` as before).

---

- Tests
  - [x] Tests included/updated (BundleController: rebuild failure emits the event; next good build recovers)
- Public documentation
  - [x] Documentation not necessary because: `unstable_startWorker` is an experimental API; a changeset is included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14561" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->