### PR TITLE
feat: surface uncaught Worker exceptions as a typed runtimeError event in local dev

### DIFF
--- a/.changeset/miniflare-handle-uncaught-error.md
+++ b/.changeset/miniflare-handle-uncaught-error.md
@@ -5,3 +5,5 @@
 Add a `handleUncaughtError` shared option that receives uncaught Worker exceptions
 
 The runtime catches handler exceptions to build the 500 response, so they never reach the inspector — the one place an uncaught exception exists as a structured value in Node is the pretty-error path, where the error report from the Worker is revived into a source-mapped `Error`. Embedders can now pass `handleUncaughtError: (error: Error) => void` to observe that revived error programmatically; logging behavior is unchanged.
+
+The hook fires only where the pretty-error path does: requests reaching the Worker through the entry socket (a browser or another HTTP client against the dev server). `dispatchFetch()` is unaffected — it always sets `MF-Disable-Pretty-Error`, and the entry worker then propagates the exception by rejecting the returned promise instead, so `dispatchFetch()` callers already receive the error directly and the hook is not invoked.

--- a/.changeset/miniflare-handle-uncaught-error.md
+++ b/.changeset/miniflare-handle-uncaught-error.md
@@ -1,0 +1,7 @@
+---
+"miniflare": minor
+---
+
+Add a `handleUncaughtError` shared option that receives uncaught Worker exceptions
+
+The runtime catches handler exceptions to build the 500 response, so they never reach the inspector — the one place an uncaught exception exists as a structured value in Node is the pretty-error path, where the error report from the Worker is revived into a source-mapped `Error`. Embedders can now pass `handleUncaughtError: (error: Error) => void` to observe that revived error programmatically; logging behavior is unchanged.

--- a/.changeset/miniflare-unmappable-frame-urls.md
+++ b/.changeset/miniflare-unmappable-frame-urls.md
@@ -1,0 +1,7 @@
+---
+"miniflare": patch
+---
+
+Keep reporting uncaught Worker errors when a stack frame's file URL has no local path
+
+`fileURLToPath` throws on `file://` URLs that cannot be represented as a local path (a non-local host; on Windows, any drive-less path — which is every `file:///...` URL reported by a POSIX-built bundle). Both the source-mapping machinery and `youch`'s error-page frame parsing convert stack-frame specifiers this way, so one such frame previously failed the whole pretty-error request: the error page was replaced by a raw Node stack, the error was not logged, and `handleUncaughtError` did not fire. Source mapping now degrades to the unmapped stack and the pretty page falls back to a plain stack response instead.

--- a/.changeset/wrangler-runtime-error-event.md
+++ b/.changeset/wrangler-runtime-error-event.md
@@ -1,0 +1,7 @@
+---
+"wrangler": minor
+---
+
+Emit a typed `runtimeError` event on the `unstable_startWorker` DevEnv for uncaught Worker exceptions
+
+Uncaught Worker exceptions were only source-mapped and printed, so programmatic consumers had to scrape terminal output to observe them. The DevEnv now re-emits a `RuntimeErrorEvent` (like `reloadComplete`) carrying the exception text and source-mapped stack — fed from Miniflare's pretty-error seam via the new `handleUncaughtError` option for exceptions the runtime catches, and from the inspector for those it does not.

--- a/packages/miniflare/src/index.ts
+++ b/packages/miniflare/src/index.ts
@@ -1567,7 +1567,8 @@ export class Miniflare {
 				response = await handlePrettyErrorRequest(
 					this.#log,
 					this.#workerSrcOpts,
-					request
+					request,
+					this.#sharedOpts.core.handleUncaughtError
 				);
 			} else if (url.pathname === "/core/log") {
 				const level = parseInt(

--- a/packages/miniflare/src/plugins/core/errors/index.ts
+++ b/packages/miniflare/src/plugins/core/errors/index.ts
@@ -182,7 +182,16 @@ function getSourceMappedStack(
 		return { map: sourceMapFile.contents, url: sourceMapFile.path };
 	}
 
-	return getSourceMapper()(retrieveSourceMap, error);
+	// Both our retriever above and the library's own fallback handlers convert
+	// frame specifiers with `fileURLToPath`, which throws on file URLs with no
+	// local-path form (a non-local host; on Windows, any drive-less path, e.g.
+	// from a POSIX-built bundle). A stack trace must never break error
+	// reporting: degrade to the unmapped stack instead.
+	try {
+		return getSourceMapper()(retrieveSourceMap, error);
+	} catch {
+		return error.stack ?? "";
+	}
 }
 
 // Due to a bug in `workerd`, if `Promise`s returned from native C++ APIs are
@@ -396,13 +405,23 @@ export async function handlePrettyErrorRequest(
 		].join("");
 	});
 
-	const html = await youch.toHTML(error, {
-		request: {
-			url: `${request.cf?.prettyErrorOriginalUrl ?? request.url}`,
-			method: request.method,
-			headers: getHeaders(request),
-		},
-	});
+	// `youch`'s frame parsing converts `file://` frame specifiers with
+	// `fileURLToPath`, which throws on URLs with no local-path form (a
+	// non-local host; on Windows, any drive-less path). The pretty page is
+	// best-effort: fall back to the plain stack response rather than failing
+	// the request.
+	let html: string;
+	try {
+		html = await youch.toHTML(error, {
+			request: {
+				url: `${request.cf?.prettyErrorOriginalUrl ?? request.url}`,
+				method: request.method,
+				headers: getHeaders(request),
+			},
+		});
+	} catch {
+		return new Response(error.stack, { status: 500 });
+	}
 
 	return new Response(html, {
 		status: 500,

--- a/packages/miniflare/src/plugins/core/errors/index.ts
+++ b/packages/miniflare/src/plugins/core/errors/index.ts
@@ -273,7 +273,8 @@ export function reviveError(
 export async function handlePrettyErrorRequest(
 	log: Log,
 	workerSrcOpts: NameSourceOptions[],
-	request: Request
+	request: Request,
+	handleUncaughtError?: (error: Error) => void
 ): Promise<Response> {
 	// Parse and validate the error we've been given from user code
 	const caught = JsonErrorSchema.parse(await request.json());
@@ -303,6 +304,12 @@ export async function handlePrettyErrorRequest(
 
 	// Log source-mapped error to console if logging enabled
 	log.error(error);
+
+	// Hand the revived, source-mapped error to the embedder — the one place
+	// an uncaught Worker exception exists as a structured value in Node
+	// (workerd catches handler exceptions to build the 500, so it never
+	// reaches the inspector's Runtime.exceptionThrown).
+	handleUncaughtError?.(error);
 
 	// Only return a pretty-error HTML page if the client accepts it. Specifically
 	// don't return a HTML page to cURL, as HTML with minified scripts is hard to

--- a/packages/miniflare/src/plugins/core/errors/index.ts
+++ b/packages/miniflare/src/plugins/core/errors/index.ts
@@ -308,8 +308,18 @@ export async function handlePrettyErrorRequest(
 	// Hand the revived, source-mapped error to the embedder — the one place
 	// an uncaught Worker exception exists as a structured value in Node
 	// (workerd catches handler exceptions to build the 500, so it never
-	// reaches the inspector's Runtime.exceptionThrown).
-	handleUncaughtError?.(error);
+	// reaches the inspector's Runtime.exceptionThrown). The callback observes
+	// the error response, so it must not be able to break it: contain a
+	// throwing callback and keep building the page.
+	try {
+		handleUncaughtError?.(error);
+	} catch (callbackError) {
+		log.error(
+			callbackError instanceof Error
+				? callbackError
+				: new Error(String(callbackError))
+		);
+	}
 
 	// Only return a pretty-error HTML page if the client accepts it. Specifically
 	// don't return a HTML page to cURL, as HTML with minified scripts is hard to

--- a/packages/miniflare/src/plugins/core/errors/index.ts
+++ b/packages/miniflare/src/plugins/core/errors/index.ts
@@ -307,23 +307,23 @@ export async function handlePrettyErrorRequest(
 
 	// Hand the revived, source-mapped error to the embedder — the one place
 	// an uncaught Worker exception exists as a structured value in Node
-	// (workerd catches handler exceptions to build the 500, so it never
-	// reaches the inspector's Runtime.exceptionThrown). The callback observes
-	// the error response, so it must not be able to break it: contain a
-	// throwing callback — and absorb a rejecting async one, which is
-	// type-assignable to the void contract — and keep building the page.
-	const logCallbackError = (callbackError: unknown) =>
-		log.error(
-			callbackError instanceof Error
-				? callbackError
-				: new Error(String(callbackError))
-		);
-	try {
-		const result: unknown = handleUncaughtError?.(error);
-		if (result instanceof Promise) result.catch(logCallbackError);
-	} catch (callbackError) {
-		logCallbackError(callbackError);
-	}
+	// (workerd catches handler exceptions to build the 500 response, so they
+	// never reach the inspector's `Runtime.exceptionThrown`).
+	//
+	// The callback only observes the error, so a misbehaving callback must
+	// not break the error response we are building here. It can fail in two
+	// ways: throw synchronously, or — since an async function is assignable
+	// to the `void`-returning signature — return a promise that later
+	// rejects. The async wrapper funnels both into a single rejection, which
+	// we log instead of propagating.
+	void (async () => handleUncaughtError?.(error))().catch(
+		(callbackError: unknown) =>
+			log.error(
+				callbackError instanceof Error
+					? callbackError
+					: new Error(String(callbackError))
+			)
+	);
 
 	// Only return a pretty-error HTML page if the client accepts it. Specifically
 	// don't return a HTML page to cURL, as HTML with minified scripts is hard to

--- a/packages/miniflare/src/plugins/core/errors/index.ts
+++ b/packages/miniflare/src/plugins/core/errors/index.ts
@@ -310,15 +310,19 @@ export async function handlePrettyErrorRequest(
 	// (workerd catches handler exceptions to build the 500, so it never
 	// reaches the inspector's Runtime.exceptionThrown). The callback observes
 	// the error response, so it must not be able to break it: contain a
-	// throwing callback and keep building the page.
-	try {
-		handleUncaughtError?.(error);
-	} catch (callbackError) {
+	// throwing callback — and absorb a rejecting async one, which is
+	// type-assignable to the void contract — and keep building the page.
+	const logCallbackError = (callbackError: unknown) =>
 		log.error(
 			callbackError instanceof Error
 				? callbackError
 				: new Error(String(callbackError))
 		);
+	try {
+		const result: unknown = handleUncaughtError?.(error);
+		if (result instanceof Promise) result.catch(logCallbackError);
+	} catch (callbackError) {
+		logCallbackError(callbackError);
 	}
 
 	// Only return a pretty-error HTML page if the client accepts it. Specifically

--- a/packages/miniflare/src/plugins/core/index.ts
+++ b/packages/miniflare/src/plugins/core/index.ts
@@ -289,9 +289,12 @@ export const CoreSharedOptionsSchema = z
 			.returns(z.void())
 			.optional(),
 
+		// Deliberately not z.function(): its call-time wrapper rejects an
+		// async callback's returned promise as an invalid return type and
+		// drops it un-awaited, turning a type-legal callback into an
+		// unhandled rejection. The invocation site owns containment instead.
 		handleUncaughtError: z
-			.function(z.tuple([z.instanceof(Error)]))
-			.returns(z.void())
+			.custom<(error: Error) => void>((value) => typeof value === "function")
 			.optional(),
 
 		upstream: z.string().optional(),

--- a/packages/miniflare/src/plugins/core/index.ts
+++ b/packages/miniflare/src/plugins/core/index.ts
@@ -289,10 +289,15 @@ export const CoreSharedOptionsSchema = z
 			.returns(z.void())
 			.optional(),
 
-		// Deliberately not z.function(): its call-time wrapper rejects an
-		// async callback's returned promise as an invalid return type and
-		// drops it un-awaited, turning a type-legal callback into an
-		// unhandled rejection. The invocation site owns containment instead.
+		// Deliberately not `z.function()`: parsing that schema replaces the
+		// callback with a validating wrapper. When the callback is `async`
+		// (assignable to a `void` return), the wrapper calls it, rejects the
+		// returned promise as an invalid `void` return value, and drops that
+		// promise un-awaited — so if the callback later rejects, no caller
+		// holds the promise and the rejection crashes the process as an
+		// unhandled rejection. `z.custom()` passes the function through
+		// unwrapped; the call site in `handlePrettyErrorRequest` contains
+		// both throwing and rejecting callbacks.
 		handleUncaughtError: z
 			.custom<(error: Error) => void>((value) => typeof value === "function")
 			.optional(),

--- a/packages/miniflare/src/plugins/core/index.ts
+++ b/packages/miniflare/src/plugins/core/index.ts
@@ -289,6 +289,11 @@ export const CoreSharedOptionsSchema = z
 			.returns(z.void())
 			.optional(),
 
+		handleUncaughtError: z
+			.function(z.tuple([z.instanceof(Error)]))
+			.returns(z.void())
+			.optional(),
+
 		upstream: z.string().optional(),
 		// TODO: add back validation of cf object
 		cf: z.union([z.boolean(), z.string(), z.record(z.any())]).optional(),

--- a/packages/miniflare/test/plugins/core/errors/index.spec.ts
+++ b/packages/miniflare/test/plugins/core/errors/index.spec.ts
@@ -554,3 +554,31 @@ test("keeps building the error response when handleUncaughtError throws", async 
 	expect(errorLogs[0]).toMatch(/Unusual oops!/);
 	expect(errorLogs[1]).toMatch(/Callback oops!/);
 });
+
+test("absorbs a rejecting async handleUncaughtError callback", async ({
+	expect,
+}) => {
+	const log = new CustomLog();
+	const mf = new Miniflare({
+		log,
+		modules: true,
+		// An async callback is type-assignable to the void contract; its
+		// rejection must be absorbed, not left to crash the process
+		async handleUncaughtError() {
+			throw new Error("Async callback oops!");
+		},
+		script: JSON_ERROR_SCRIPT,
+	});
+	useDispose(mf);
+
+	const res = await fetch(await mf.ready);
+	expect(res.status).toBe(500);
+	expect(await res.text()).toMatch(/Unusual oops!/);
+
+	// The rejection is absorbed into the log, not left unhandled (an
+	// unhandled rejection would also fail the test file under vitest)
+	await new Promise((resolve) => setTimeout(resolve, 10));
+	const errorLogs = log.getLogs(LogLevel.ERROR);
+	expect(errorLogs[0]).toMatch(/Unusual oops!/);
+	expect(errorLogs[1]).toMatch(/Async callback oops!/);
+});

--- a/packages/miniflare/test/plugins/core/errors/index.spec.ts
+++ b/packages/miniflare/test/plugins/core/errors/index.spec.ts
@@ -527,6 +527,57 @@ test("invokes handleUncaughtError with the revived error", async ({
 	expect(errors[0].stack).toMatch(/Object\.fetch/);
 });
 
+// A stack frame may name a `file://` URL that `fileURLToPath` cannot convert
+// to a local path. No single URL is invalid everywhere — a drive-less
+// `file:///...` (every frame a POSIX-built bundle reports) throws on Windows
+// but is fine on POSIX, while a non-local-host URL throws on POSIX but is a
+// valid UNC path on Windows — so the stack carries one of each, and every
+// platform's runner exercises the degradation through its own rejection.
+const UNMAPPABLE_STACK_SCRIPT = `
+export default {
+	async fetch() {
+		return Response.json(
+			{
+				name: "Error",
+				message: "Unmappable oops!",
+				stack: "Error: Unmappable oops!\\n    at fetch (file:///virtual/index.mjs:2:3)\\n    at reroute (file://not-local/index.mjs:1:1)",
+			},
+			{
+				status: 500,
+				headers: { "MF-Experimental-Error-Stack": "true" },
+			}
+		);
+	},
+}`;
+
+test("still reports the error when a stack frame's file URL has no local path", async ({
+	expect,
+}) => {
+	const log = new CustomLog();
+	const errors: Error[] = [];
+	const mf = new Miniflare({
+		log,
+		modules: true,
+		handleUncaughtError(error) {
+			errors.push(error);
+		},
+		script: UNMAPPABLE_STACK_SCRIPT,
+	});
+	useDispose(mf);
+
+	const res = await fetch(await mf.ready);
+	expect(res.status).toBe(500);
+	// The error response is still built from the revived error...
+	expect(await res.text()).toMatch(/Unmappable oops!/);
+	// ...the error is still logged...
+	expect(log.getLogs(LogLevel.ERROR)[0]).toMatch(/Unmappable oops!/);
+	// ...and the callback still fires, with both frames preserved un-mapped.
+	expect(errors.length).toBe(1);
+	expect(errors[0].message).toBe("Unmappable oops!");
+	expect(errors[0].stack).toContain("file:///virtual/index.mjs");
+	expect(errors[0].stack).toContain("file://not-local/index.mjs");
+});
+
 test("keeps building the error response when handleUncaughtError throws", async ({
 	expect,
 }) => {

--- a/packages/miniflare/test/plugins/core/errors/index.spec.ts
+++ b/packages/miniflare/test/plugins/core/errors/index.spec.ts
@@ -479,3 +479,78 @@ Caused by: TypeError: The value cannot be converted because it is not an integer
 	// Check `dispatchFetch()` propagates exception
 	await expect(mf.dispatchFetch(url)).rejects.toThrow("Unusual oops!");
 });
+
+// This emulates a Worker bundled with the Wrangler json-error middleware
+// See packages/wrangler/templates/middleware/middleware-miniflare3-json-error.ts
+const JSON_ERROR_SCRIPT = `
+function reduceError(e) {
+	return {
+		name: e?.name,
+		message: e?.message ?? String(e),
+		stack: e?.stack,
+		cause: e?.cause === undefined ? undefined : reduceError(e.cause),
+	};
+}
+export default {
+	async fetch() {
+		try {
+			throw new Error("Unusual oops!");
+		} catch (e) {
+			return Response.json(reduceError(e), {
+				status: 500,
+				headers: { "MF-Experimental-Error-Stack": "true" },
+			});
+		}
+	},
+}`;
+
+test("invokes handleUncaughtError with the revived error", async ({
+	expect,
+}) => {
+	const log = new CustomLog();
+	const errors: Error[] = [];
+	const mf = new Miniflare({
+		log,
+		modules: true,
+		handleUncaughtError(error) {
+			errors.push(error);
+		},
+		script: JSON_ERROR_SCRIPT,
+	});
+	useDispose(mf);
+
+	const res = await fetch(await mf.ready);
+	expect(res.status).toBe(500);
+	expect(errors.length).toBe(1);
+	expect(errors[0]).toBeInstanceOf(Error);
+	expect(errors[0].message).toBe("Unusual oops!");
+	expect(errors[0].stack).toMatch(/Object\.fetch/);
+});
+
+test("keeps building the error response when handleUncaughtError throws", async ({
+	expect,
+}) => {
+	const log = new CustomLog();
+	const mf = new Miniflare({
+		log,
+		modules: true,
+		handleUncaughtError() {
+			throw new Error("Callback oops!");
+		},
+		script: JSON_ERROR_SCRIPT,
+	});
+	useDispose(mf);
+
+	// The pretty-error page is still returned...
+	const res = await fetch(await mf.ready, {
+		headers: { Accept: "text/html" },
+	});
+	expect(res.status).toBe(500);
+	expect(res.headers.get("Content-Type") ?? "").toMatch(/^text\/html/);
+	expect(await res.text()).toMatch(/Unusual oops!/);
+
+	// ...and the callback's own error is logged after the Worker error
+	const errorLogs = log.getLogs(LogLevel.ERROR);
+	expect(errorLogs[0]).toMatch(/Unusual oops!/);
+	expect(errorLogs[1]).toMatch(/Callback oops!/);
+});

--- a/packages/wrangler/src/__tests__/api/startDevWorker/LocalRuntimeController.test.ts
+++ b/packages/wrangler/src/__tests__/api/startDevWorker/LocalRuntimeController.test.ts
@@ -182,6 +182,78 @@ describe("LocalRuntimeController", () => {
 	});
 
 	describe("Core", () => {
+		it("dispatches a typed runtimeError for an uncaught Worker exception", async ({
+			expect,
+		}) => {
+			const bus = new FakeBus();
+			const controller = new LocalRuntimeController(bus);
+			teardown(() => controller.teardown());
+
+			const config = {
+				name: "worker",
+				entrypoint: "NOT_REAL",
+				compatibilityDate: "2023-10-01",
+			};
+			// This virtual bundle bypasses the real bundler, so it speaks the
+			// json-error middleware's documented contract directly (a 500 JSON
+			// error with the MF-Experimental-Error-Stack header) — exactly what
+			// wrangler's injected middleware produces for an uncaught throw.
+			const bundle: Bundle = {
+				type: "esm",
+				modules: [],
+				id: 0,
+				path: "/virtual/esm/index.mjs",
+				entrypointSource: dedent /*javascript*/ `
+					export default {
+						fetch(request, env, ctx) {
+							return Response.json(
+								{
+									name: "Error",
+									message: "uncaught boom",
+									stack: "Error: uncaught boom\\n    at fetch (file:///virtual/esm/index.mjs:3:9)",
+								},
+								{
+									status: 500,
+									headers: { "MF-Experimental-Error-Stack": "true" },
+								}
+							);
+						}
+					}
+				`,
+				entry: {
+					file: "esm/index.mjs",
+					projectRoot: "/virtual/",
+					configPath: undefined,
+					format: "modules",
+					moduleRoot: "/virtual",
+					name: undefined,
+					exports: [],
+				},
+				dependencies: {},
+				sourceMapPath: undefined,
+				sourceMapMetadata: undefined,
+			};
+			controller.onBundleStart({
+				type: "bundleStart",
+				config: configDefaults(config),
+			});
+			controller.onBundleComplete({
+				type: "bundleComplete",
+				config: configDefaults(config),
+				bundle,
+			});
+			const reload = await bus.waitFor("reloadComplete");
+			const url = urlFromParts(reload.proxyData.userWorkerUrl);
+
+			const errorEvent = bus.waitFor("runtimeError");
+			const res = await fetch(url);
+			expect(res.status).toBe(500);
+			const event = await errorEvent;
+			expect(event.source).toBe("LocalRuntimeController");
+			expect(event.text).toContain("uncaught boom");
+			expect(event.stack).toContain("uncaught boom");
+		});
+
 		it("should start Miniflare with module worker", async ({ expect }) => {
 			const bus = new FakeBus();
 			const controller = new LocalRuntimeController(bus);

--- a/packages/wrangler/src/__tests__/api/startDevWorker/LocalRuntimeController.test.ts
+++ b/packages/wrangler/src/__tests__/api/startDevWorker/LocalRuntimeController.test.ts
@@ -15,6 +15,7 @@ import {
 	getUserWorkerInnerUrlOverrides,
 	LocalRuntimeController,
 } from "../../../api/startDevWorker/LocalRuntimeController";
+import { MultiworkerRuntimeController } from "../../../api/startDevWorker/MultiworkerRuntimeController";
 import { urlFromParts } from "../../../api/startDevWorker/utils";
 import { RuleTypeToModuleType } from "../../../deployment-bundle/module-collection";
 import { usingLocalSecretsStoreSecretAPI } from "../../../secrets-store/commands";
@@ -1681,6 +1682,134 @@ describe("LocalRuntimeController", () => {
 		it.todo("exposes Analytics Engine bindings");
 		it.todo("exposes dispatch namespace bindings");
 		it.todo("exposes mTLS bindings");
+	});
+});
+
+describe("MultiworkerRuntimeController", () => {
+	mockConsoleMethods();
+	runInTempDir();
+	// Make sure teardown is declared after runInTempDir so it runs before we delete the temp directory
+	const teardown = useTeardown();
+
+	// The multiworker controller builds its Miniflare options through its own
+	// code path, so the runtimeError wiring must be pinned separately from the
+	// single-worker test above.
+	it("dispatches a typed runtimeError for an uncaught Worker exception", async ({
+		expect,
+	}) => {
+		const bus = new FakeBus();
+		const controller = new MultiworkerRuntimeController(bus, 2);
+		teardown(() => controller.teardown());
+
+		const primaryConfig = configDefaults({
+			name: "primary-worker",
+			dev: {
+				persist: "./persist",
+				remote: false,
+				multiworkerPrimary: true,
+			},
+		});
+		const secondaryConfig = configDefaults({
+			name: "secondary-worker",
+			dev: {
+				persist: "./persist",
+				remote: false,
+				multiworkerPrimary: false,
+			},
+		});
+
+		// Same virtual-bundle shape as the single-worker runtimeError test:
+		// speaks the json-error middleware's documented contract directly.
+		const throwingBundle: Bundle = {
+			type: "esm",
+			modules: [],
+			id: 0,
+			path: "/virtual/esm/primary.mjs",
+			entrypointSource: dedent /*javascript*/ `
+				export default {
+					fetch(request, env, ctx) {
+						return Response.json(
+							{
+								name: "Error",
+								message: "uncaught boom",
+								stack: "Error: uncaught boom\\n    at fetch (file:///virtual/esm/primary.mjs:3:9)",
+							},
+							{
+								status: 500,
+								headers: { "MF-Experimental-Error-Stack": "true" },
+							}
+						);
+					}
+				}
+			`,
+			entry: {
+				file: "esm/primary.mjs",
+				projectRoot: "/virtual/",
+				configPath: undefined,
+				format: "modules",
+				moduleRoot: "/virtual",
+				name: undefined,
+				exports: [],
+			},
+			dependencies: {},
+			sourceMapPath: undefined,
+			sourceMapMetadata: undefined,
+		};
+		const quietBundle: Bundle = {
+			type: "esm",
+			modules: [],
+			id: 0,
+			path: "/virtual/esm/secondary.mjs",
+			entrypointSource: dedent /*javascript*/ `
+				export default {
+					fetch(request, env, ctx) {
+						return new Response("ok");
+					}
+				}
+			`,
+			entry: {
+				file: "esm/secondary.mjs",
+				projectRoot: "/virtual/",
+				configPath: undefined,
+				format: "modules",
+				moduleRoot: "/virtual",
+				name: undefined,
+				exports: [],
+			},
+			dependencies: {},
+			sourceMapPath: undefined,
+			sourceMapMetadata: undefined,
+		};
+
+		controller.onBundleStart({
+			type: "bundleStart",
+			config: primaryConfig,
+		});
+		controller.onBundleComplete({
+			type: "bundleComplete",
+			config: primaryConfig,
+			bundle: throwingBundle,
+		});
+		controller.onBundleStart({
+			type: "bundleStart",
+			config: secondaryConfig,
+		});
+		controller.onBundleComplete({
+			type: "bundleComplete",
+			config: secondaryConfig,
+			bundle: quietBundle,
+		});
+
+		const reload = await bus.waitFor("reloadComplete");
+		const url = urlFromParts(reload.proxyData.userWorkerUrl);
+
+		const errorEvent = bus.waitFor("runtimeError");
+		const res = await fetch(url);
+		expect(res.status).toBe(500);
+		const event = await errorEvent;
+		expect(event.source).toBe("LocalRuntimeController");
+		expect(event.text).toContain("uncaught boom");
+		expect(event.stack).toContain("uncaught boom");
 	});
 });
 

--- a/packages/wrangler/src/__tests__/api/startDevWorker/ProxyController.test.ts
+++ b/packages/wrangler/src/__tests__/api/startDevWorker/ProxyController.test.ts
@@ -1,0 +1,38 @@
+import { describe, test } from "vitest";
+import { ProxyController } from "../../../api/startDevWorker/ProxyController";
+import { FakeBus } from "../../helpers/fake-bus";
+import { mockConsoleMethods } from "../../helpers/mock-console";
+
+describe("ProxyController", () => {
+	mockConsoleMethods();
+
+	test("Runtime.exceptionThrown dispatches a typed runtimeError event", async ({
+		expect,
+	}) => {
+		const bus = new FakeBus();
+		const controller = new ProxyController(bus);
+		const waited = bus.waitFor("runtimeError");
+		controller.onInspectorProxyWorkerMessage({
+			method: "Runtime.exceptionThrown",
+			params: {
+				timestamp: 0,
+				exceptionDetails: {
+					exceptionId: 1,
+					text: "Uncaught Error: boom",
+					lineNumber: 0,
+					columnNumber: 0,
+					exception: {
+						type: "object",
+						subtype: "error",
+						description: "Error: boom\n    at fetch (index.js:1:1)",
+					},
+				},
+			},
+		});
+		const event = await waited;
+		expect(event.source).toBe("ProxyController");
+		expect(event.text).toBe("Uncaught Error: boom");
+		expect(event.stack).toContain("Error: boom");
+		expect(event.exceptionDetails.exceptionId).toBe(1);
+	});
+});

--- a/packages/wrangler/src/__tests__/api/startDevWorker/ProxyController.test.ts
+++ b/packages/wrangler/src/__tests__/api/startDevWorker/ProxyController.test.ts
@@ -33,6 +33,6 @@ describe("ProxyController", () => {
 		expect(event.source).toBe("ProxyController");
 		expect(event.text).toBe("Uncaught Error: boom");
 		expect(event.stack).toContain("Error: boom");
-		expect(event.exceptionDetails.exceptionId).toBe(1);
+		expect(event.exceptionDetails?.exceptionId).toBe(1);
 	});
 });

--- a/packages/wrangler/src/api/index.ts
+++ b/packages/wrangler/src/api/index.ts
@@ -48,6 +48,7 @@ export type {
 	ReloadStartEvent,
 	ReloadCompleteEvent,
 	DevRegistryUpdateEvent,
+	RuntimeErrorEvent,
 	PreviewTokenExpiredEvent,
 	ReadyEvent,
 	ProxyWorkerIncomingRequestBody,

--- a/packages/wrangler/src/api/startDevWorker/BaseController.ts
+++ b/packages/wrangler/src/api/startDevWorker/BaseController.ts
@@ -6,6 +6,7 @@ import type {
 	DevRegistryUpdateEvent,
 	ErrorEvent,
 	PreviewTokenExpiredEvent,
+	RuntimeErrorEvent,
 	ReloadCompleteEvent,
 	ReloadStartEvent,
 } from "./events";
@@ -19,6 +20,7 @@ export type ControllerEvent =
 	| ReloadStartEvent
 	| ReloadCompleteEvent
 	| DevRegistryUpdateEvent
+	| RuntimeErrorEvent
 	| PreviewTokenExpiredEvent;
 
 export interface ControllerBus {

--- a/packages/wrangler/src/api/startDevWorker/DevEnv.ts
+++ b/packages/wrangler/src/api/startDevWorker/DevEnv.ts
@@ -145,6 +145,12 @@ export class DevEnv extends EventEmitter implements ControllerBus {
 				this.emit("reloadComplete", event);
 				break;
 
+			case "runtimeError":
+				// Re-emitted as an external EventEmitter event (like
+				// `reloadComplete`) so callers can observe runtime errors.
+				this.emit("runtimeError", event);
+				break;
+
 			case "devRegistryUpdate":
 				this.config.onDevRegistryUpdate(event);
 				break;

--- a/packages/wrangler/src/api/startDevWorker/LocalRuntimeController.ts
+++ b/packages/wrangler/src/api/startDevWorker/LocalRuntimeController.ts
@@ -277,6 +277,23 @@ export class LocalRuntimeController extends RuntimeController {
 		process.on("exit", this.cleanupContainers);
 	}
 
+	/**
+	 * Surfaces uncaught Worker exceptions as typed `runtimeError` events
+	 * (workerd catches handler exceptions to build the 500 response, so they
+	 * never reach the inspector — Miniflare's pretty-error path is where the
+	 * revived, source-mapped Error exists). Installed as Miniflare's
+	 * `handleUncaughtError` by every code path that builds Miniflare options:
+	 * this controller's and `MultiworkerRuntimeController`'s.
+	 */
+	protected dispatchRuntimeError = (error: Error): void => {
+		this.bus.dispatch({
+			type: "runtimeError",
+			source: "LocalRuntimeController",
+			text: `${error.name ?? "Error"}: ${error.message}`,
+			stack: error.stack ?? "",
+		});
+	};
+
 	async #onBundleComplete(data: BundleCompleteEvent, id: number) {
 		try {
 			// A newer bundle has already been queued — skip this stale one
@@ -391,18 +408,7 @@ export class LocalRuntimeController extends RuntimeController {
 				}
 			);
 			options.liveReload = false; // TODO: set in buildMiniflareOptions once old code path is removed
-			// Surface uncaught Worker exceptions as typed events (workerd
-			// catches handler exceptions to build the 500 response, so they
-			// never reach the inspector — Miniflare's pretty-error path is
-			// where the revived, source-mapped Error exists).
-			options.handleUncaughtError = (error) => {
-				this.bus.dispatch({
-					type: "runtimeError",
-					source: "LocalRuntimeController",
-					text: `${error.name ?? "Error"}: ${error.message}`,
-					stack: error.stack ?? "",
-				});
-			};
+			options.handleUncaughtError = this.dispatchRuntimeError;
 
 			// Bail out if a newer bundle arrived while we were building
 			// miniflare options — avoid a redundant local server reload.

--- a/packages/wrangler/src/api/startDevWorker/LocalRuntimeController.ts
+++ b/packages/wrangler/src/api/startDevWorker/LocalRuntimeController.ts
@@ -391,6 +391,18 @@ export class LocalRuntimeController extends RuntimeController {
 				}
 			);
 			options.liveReload = false; // TODO: set in buildMiniflareOptions once old code path is removed
+			// Surface uncaught Worker exceptions as typed events (workerd
+			// catches handler exceptions to build the 500 response, so they
+			// never reach the inspector — Miniflare's pretty-error path is
+			// where the revived, source-mapped Error exists).
+			options.handleUncaughtError = (error) => {
+				this.bus.dispatch({
+					type: "runtimeError",
+					source: "LocalRuntimeController",
+					text: `${error.name ?? "Error"}: ${error.message}`,
+					stack: error.stack ?? "",
+				});
+			};
 
 			// Bail out if a newer bundle arrived while we were building
 			// miniflare options — avoid a redundant local server reload.

--- a/packages/wrangler/src/api/startDevWorker/MultiworkerRuntimeController.ts
+++ b/packages/wrangler/src/api/startDevWorker/MultiworkerRuntimeController.ts
@@ -232,6 +232,12 @@ export class MultiworkerRuntimeController extends LocalRuntimeController {
 				}
 			);
 
+			// `handleUncaughtError` is a shared Miniflare option, and the
+			// merged options spread the primary worker's shared options —
+			// install the hook on every worker's options rather than assuming
+			// which one is primary.
+			options.handleUncaughtError = this.dispatchRuntimeError;
+
 			this.#options.set(data.config.name, {
 				options,
 				primary: Boolean(data.config.dev.multiworkerPrimary),

--- a/packages/wrangler/src/api/startDevWorker/ProxyController.ts
+++ b/packages/wrangler/src/api/startDevWorker/ProxyController.ts
@@ -514,6 +514,17 @@ export class ProxyController extends Controller {
 
 				const stack = getSourceMappedStack(message.params.exceptionDetails);
 				logger.error(message.params.exceptionDetails.text, stack);
+				// Also surface the exception as a typed event so programmatic
+				// startWorker consumers can observe runtime errors without
+				// scraping logs (re-emitted externally by DevEnv, like
+				// `reloadComplete`).
+				this.bus.dispatch({
+					type: "runtimeError",
+					source: "ProxyController",
+					text: message.params.exceptionDetails.text,
+					stack,
+					exceptionDetails: message.params.exceptionDetails,
+				});
 				break;
 			}
 			default: {

--- a/packages/wrangler/src/api/startDevWorker/events.ts
+++ b/packages/wrangler/src/api/startDevWorker/events.ts
@@ -1,5 +1,6 @@
 import type { DevToolsEvent } from "./devtools";
 import type { Bundle, StartDevWorkerOptions } from "./types";
+import type Protocol from "devtools-protocol";
 import type { Miniflare, WorkerRegistry } from "miniflare";
 
 export type ErrorEvent =
@@ -80,6 +81,17 @@ export type DevRegistryUpdateEvent = {
 };
 
 // ProxyController
+export type RuntimeErrorEvent = {
+	type: "runtimeError";
+	source: "ProxyController";
+
+	/** The exception summary line (`exceptionDetails.text`). */
+	text: string;
+	/** The source-mapped stack. */
+	stack: string;
+	/** The raw Chrome DevTools Protocol exception details. */
+	exceptionDetails: Protocol.Runtime.ExceptionDetails;
+};
 export type PreviewTokenExpiredEvent = {
 	type: "previewTokenExpired";
 

--- a/packages/wrangler/src/api/startDevWorker/events.ts
+++ b/packages/wrangler/src/api/startDevWorker/events.ts
@@ -82,8 +82,11 @@ export type DevRegistryUpdateEvent = {
 
 // LocalRuntimeController (uncaught Worker exceptions, revived and
 // source-mapped by Miniflare's pretty-error path) and ProxyController
-// (inspector-relayed Runtime.exceptionThrown, for exceptions the runtime
-// did not catch).
+// (inspector-relayed Runtime.exceptionThrown). The two sources are disjoint
+// for a given exception: the pretty-error path only sees exceptions the
+// runtime caught to build a 500 response — which therefore never reach the
+// inspector — while the inspector only reports exceptions the runtime did
+// not catch. `source` distinguishes them should that invariant ever change.
 export type RuntimeErrorEvent = {
 	type: "runtimeError";
 	source: "LocalRuntimeController" | "ProxyController";

--- a/packages/wrangler/src/api/startDevWorker/events.ts
+++ b/packages/wrangler/src/api/startDevWorker/events.ts
@@ -80,17 +80,21 @@ export type DevRegistryUpdateEvent = {
 	registry: WorkerRegistry;
 };
 
-// ProxyController
+// LocalRuntimeController (uncaught Worker exceptions, revived and
+// source-mapped by Miniflare's pretty-error path) and ProxyController
+// (inspector-relayed Runtime.exceptionThrown, for exceptions the runtime
+// did not catch).
 export type RuntimeErrorEvent = {
 	type: "runtimeError";
-	source: "ProxyController";
+	source: "LocalRuntimeController" | "ProxyController";
 
-	/** The exception summary line (`exceptionDetails.text`). */
+	/** The exception summary line. */
 	text: string;
 	/** The source-mapped stack. */
 	stack: string;
-	/** The raw Chrome DevTools Protocol exception details. */
-	exceptionDetails: Protocol.Runtime.ExceptionDetails;
+	/** The raw Chrome DevTools Protocol exception details, when the event
+	 * came over the inspector. */
+	exceptionDetails?: Protocol.Runtime.ExceptionDetails;
 };
 export type PreviewTokenExpiredEvent = {
 	type: "previewTokenExpired";


### PR DESCRIPTION
During local dev, an uncaught exception in a Worker handler is source-mapped and printed, but never surfaced programmatically — `unstable_startWorker` consumers and Miniflare embedders have to scrape terminal output.

The inspector cannot close this gap: workerd catches handler exceptions to build the 500 response, so `Runtime.exceptionThrown` never fires for them (verified against a live inspector session — `Runtime.enable` acks, then silence after a throwing `fetch`). The one place such an exception exists as a structured value in Node is Miniflare's pretty-error path: the bundler-injected json-error middleware reports the error (500 + `MF-Experimental-Error-Stack`), the core entry worker forwards it to the loopback, and `handlePrettyErrorRequest` revives a source-mapped `Error` — which today dead-ends at `log.error`.

Prior art within this repo points the same way. `@cloudflare/vite-plugin` speaks the same json-error contract from its runner worker (`maybeCaptureError` copies `reduceError` from the wrangler middleware template), so its errors flow into this exact seam — and equally dead-end at `log.error`. `@cloudflare/vitest-pool-workers` already integrates through the sibling embedder hooks — `handleStructuredLogs` in its shared Miniflare options — where the only error signal available is level plus message text, which it has to filter by substring-matching a hardcoded ignore-list. `handleUncaughtError` completes that hook family with the one error that already exists as a structured, source-mapped value.

Changes:

- **miniflare**: new optional shared option `handleUncaughtError?: (error: Error) => void` (following the `handleRuntimeStdio`/`handleStructuredLogs` pattern), invoked in `handlePrettyErrorRequest` with the revived, source-mapped error alongside the existing `log.error`. No behavior change for non-consumers.
- **wrangler**: new `RuntimeErrorEvent` dispatched on the controller bus and re-emitted externally by `DevEnv` (like `reloadComplete`). `LocalRuntimeController` feeds it from the new Miniflare option; `ProxyController` also dispatches it from its existing `Runtime.exceptionThrown` handler (exceptions the runtime does *not* catch), with `exceptionDetails` attached and a `source` discriminator.

---

- Tests
  - [x] Tests included/updated (ProxyController unit test for the inspector path; LocalRuntimeController test against real workerd with a bundle speaking the json-error middleware contract)
- Public documentation
  - [x] Documentation not necessary because: experimental/programmatic APIs; changesets for both packages are included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14562" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->