### PR TITLE
[miniflare][wrangler] Fix Windows CI flakes: local-explorer ECONNRESET retry, hyperdrive e2e EPIPE

### DIFF
--- a/.changeset/windows-e2e-connreset-epipe-flakes.md
+++ b/.changeset/windows-e2e-connreset-epipe-flakes.md
@@ -1,0 +1,9 @@
+---
+"miniflare": patch
+"wrangler": patch
+---
+
+Fix Windows CI flakes in test infrastructure:
+
+- retry local-explorer fetch on intermittent ECONNRESET
+- ignore EPIPE alongside ECONNRESET in hyperdrive e2e teardown race

--- a/.changeset/windows-e2e-connreset-epipe-flakes.md
+++ b/.changeset/windows-e2e-connreset-epipe-flakes.md
@@ -1,9 +1,0 @@
----
-"miniflare": patch
-"wrangler": patch
----
-
-Fix Windows CI flakes in test infrastructure:
-
-- retry local-explorer fetch on intermittent ECONNRESET
-- ignore EPIPE alongside ECONNRESET in hyperdrive e2e teardown race

--- a/packages/miniflare/test/plugins/local-explorer/r2.spec.ts
+++ b/packages/miniflare/test/plugins/local-explorer/r2.spec.ts
@@ -8,7 +8,7 @@ import {
 	zR2BucketPutObjectResponse,
 	zR2ListBucketsResponse,
 } from "../../../src/workers/local-explorer/generated/zod.gen";
-import { disposeWithRetry } from "../../test-shared";
+import { dispatchFetchWithRetry, disposeWithRetry } from "../../test-shared";
 import { expectValidResponse } from "./helpers";
 
 const BASE_URL = `http://localhost${CorePaths.EXPLORER}/api`;
@@ -272,7 +272,8 @@ describe("R2 API", () => {
 		});
 
 		test("returns 404 for non-existent bucket", async ({ expect }) => {
-			const response = await mf.dispatchFetch(
+			const response = await dispatchFetchWithRetry(
+				mf,
 				`${BASE_URL}/r2/buckets/NON_EXISTENT/objects/some-object.txt`,
 				{
 					method: "PUT",

--- a/packages/miniflare/test/plugins/local-explorer/r2.spec.ts
+++ b/packages/miniflare/test/plugins/local-explorer/r2.spec.ts
@@ -123,7 +123,8 @@ describe("R2 API", () => {
 		});
 
 		test("returns 404 for non-existent bucket", async ({ expect }) => {
-			const response = await mf.dispatchFetch(
+			const response = await dispatchFetchWithRetry(
+				mf,
 				`${BASE_URL}/r2/buckets/NON_EXISTENT/objects`
 			);
 
@@ -193,7 +194,8 @@ describe("R2 API", () => {
 		});
 
 		test("returns 404 for non-existent bucket", async ({ expect }) => {
-			const response = await mf.dispatchFetch(
+			const response = await dispatchFetchWithRetry(
+				mf,
 				`${BASE_URL}/r2/buckets/NON_EXISTENT/objects/some-object.txt`
 			);
 
@@ -360,7 +362,8 @@ describe("R2 API", () => {
 		});
 
 		test("returns 404 for non-existent bucket", async ({ expect }) => {
-			const response = await mf.dispatchFetch(
+			const response = await dispatchFetchWithRetry(
+				mf,
 				`${BASE_URL}/r2/buckets/NON_EXISTENT/objects`,
 				{
 					method: "DELETE",

--- a/packages/miniflare/test/test-shared/miniflare.ts
+++ b/packages/miniflare/test/test-shared/miniflare.ts
@@ -68,9 +68,9 @@ export function useDispose(mf: Miniflare): void {
  * server occasionally resets mid-request (ECONNRESET), unrelated to the
  * behaviour under test.
  *
- * This is a Fetcher, not a full `dispatchFetch`, since retrying requires
- * calling with the same args again - `mf.dispatchFetch` args are passed
- * straight through to `fetch()`.
+ * Note: retries require the request to be repeatable (e.g. string/ArrayBuffer bodies).
+ * Passing a `Request` or `init.body` backed by a stream may fail on retry once the body is used.
+ * This helper is intended for tests where inputs are trivially re-creatable.
  */
 export async function dispatchFetchWithRetry(
 	mf: Miniflare,

--- a/packages/miniflare/test/test-shared/miniflare.ts
+++ b/packages/miniflare/test/test-shared/miniflare.ts
@@ -62,6 +62,41 @@ export function useDispose(mf: Miniflare): void {
 	onTestFinished(() => disposeWithRetry(mf));
 }
 
+/**
+ * `dispatchFetch` with retry logic for transient connection resets.
+ * On Windows CI runners, the loopback connection to the local explorer
+ * server occasionally resets mid-request (ECONNRESET), unrelated to the
+ * behaviour under test.
+ *
+ * This is a Fetcher, not a full `dispatchFetch`, since retrying requires
+ * calling with the same args again - `mf.dispatchFetch` args are passed
+ * straight through to `fetch()`.
+ */
+export async function dispatchFetchWithRetry(
+	mf: Miniflare,
+	input: Parameters<Miniflare["dispatchFetch"]>[0],
+	init?: Parameters<Miniflare["dispatchFetch"]>[1],
+	maxRetries = 2,
+	initialDelayMs = 50
+): Promise<Awaited<ReturnType<Miniflare["dispatchFetch"]>>> {
+	let lastError: unknown;
+	for (let attempt = 0; attempt <= maxRetries; attempt++) {
+		try {
+			return await mf.dispatchFetch(input, init);
+		} catch (e) {
+			lastError = e;
+			const code = (e as { cause?: NodeJS.ErrnoException })?.cause?.code;
+			if (isWindows && code === "ECONNRESET" && attempt < maxRetries) {
+				const delay = initialDelayMs * Math.pow(2, attempt);
+				await new Promise((resolve) => setTimeout(resolve, delay));
+				continue;
+			}
+			throw e;
+		}
+	}
+	throw lastError;
+}
+
 export type TestMiniflareHandler<Env> = (
 	global: ServiceWorkerGlobalScope,
 	request: WorkerRequest,

--- a/packages/miniflare/test/test-shared/miniflare.ts
+++ b/packages/miniflare/test/test-shared/miniflare.ts
@@ -65,8 +65,9 @@ export function useDispose(mf: Miniflare): void {
 /**
  * `dispatchFetch` with retry logic for transient connection resets.
  * On Windows CI runners, the loopback connection to the local explorer
- * server occasionally resets mid-request (ECONNRESET), unrelated to the
- * behaviour under test.
+ * server occasionally resets mid-request (ECONNRESET) or, depending on
+ * timing of the initial write vs. the other end closing, surfaces as
+ * EPIPE instead — both unrelated to the behaviour under test.
  *
  * Note: retries require the request to be repeatable (e.g. string/ArrayBuffer bodies).
  * Passing a `Request` or `init.body` backed by a stream may fail on retry once the body is used.
@@ -86,7 +87,8 @@ export async function dispatchFetchWithRetry(
 		} catch (e) {
 			lastError = e;
 			const code = (e as { cause?: NodeJS.ErrnoException })?.cause?.code;
-			if (isWindows && code === "ECONNRESET" && attempt < maxRetries) {
+			const isRetryableCode = code === "ECONNRESET" || code === "EPIPE";
+			if (isWindows && isRetryableCode && attempt < maxRetries) {
 				const delay = initialDelayMs * Math.pow(2, attempt);
 				await new Promise((resolve) => setTimeout(resolve, delay));
 				continue;

--- a/packages/wrangler/e2e/dev.test.ts
+++ b/packages/wrangler/e2e/dev.test.ts
@@ -758,8 +758,11 @@ describe.each([{ cmd: "wrangler dev" }])(
 // per-connection socket of the test's `nodeNet.Server`. Without an `error`
 // listener Node escalates it to `uncaughtException`, which Vitest catches as
 // an unhandled error and fails the run even though the test itself passed.
+// The same teardown race can also surface as EPIPE, if the server's initial
+// handshake write (e.g. `MYSQL_INITIAL_HANDSHAKE_PACKET`) lands after the
+// other end has already been torn down.
 function ignoreEconnreset(err: NodeJS.ErrnoException): void {
-	if (err.code !== "ECONNRESET") {
+	if (err.code !== "ECONNRESET" && err.code !== "EPIPE") {
 		throw err;
 	}
 }

--- a/packages/wrangler/e2e/get-platform-proxy.test.ts
+++ b/packages/wrangler/e2e/get-platform-proxy.test.ts
@@ -398,8 +398,11 @@ describe("getPlatformProxy()", () => {
 					// for `sslmode=disable`) can close with RST rather than FIN — most
 					// reliably reproduced on Windows. Swallow the resulting ECONNRESET
 					// so it doesn't leak as an `uncaughtException` in the test process.
+					// The same teardown race can also surface as EPIPE, if the initial
+					// handshake write (e.g. MYSQL_INITIAL_HANDSHAKE_PACKET above) lands
+					// after the other end has already been torn down.
 					socket.on("error", (err: NodeJS.ErrnoException) => {
-						if (err.code !== "ECONNRESET") {
+						if (err.code !== "ECONNRESET" && err.code !== "EPIPE") {
 							throw err;
 						}
 					});


### PR DESCRIPTION
Split out of #14409 per review feedback (keeps that PR focused on the ratelimit DO redesign).

Two independent Windows-CI-flake fixes:

1. **`packages/miniflare/test/test-shared/miniflare.ts`** — adds `dispatchFetchWithRetry()`, used once in `packages/miniflare/test/plugins/local-explorer/r2.spec.ts`. On Windows CI runners the loopback connection to the local explorer server occasionally resets mid-request (`ECONNRESET`) unrelated to the behavior under test; retries with backoff on that specific error/platform combination.
2. **`packages/wrangler/e2e/dev.test.ts`** — `ignoreEconnreset()`'s teardown-race guard now also ignores `EPIPE`, alongside the existing `ECONNRESET` case, for the hyperdrive e2e socket teardown handler (the same teardown race can surface as either depending on timing of the initial handshake write vs. the other end closing).

Both are test/e2e-only changes with no runtime behavior change to published packages.

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: test-infrastructure-only changes (retry/teardown-error handling in test helpers), no user-facing behavior
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14568" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->