### PR TITLE
Suggest similar commands when a typo is detected

### DIFF
--- a/.changeset/suggest-similar-commands-on-typo.md
+++ b/.changeset/suggest-similar-commands-on-typo.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Suggest similar commands when a typo is detected
+
+When an unknown command or subcommand is entered, wrangler now suggests the closest matching command if one exists within a reasonable edit distance. For example, running `wrangler whoamio` will display `Did you mean "wrangler whoami"?`, and running `wrangler kv namespase` will display `Did you mean "wrangler kv namespace"?`.

--- a/packages/wrangler/src/__tests__/index.test.ts
+++ b/packages/wrangler/src/__tests__/index.test.ts
@@ -234,6 +234,141 @@ describe("wrangler", () => {
 		});
 	});
 
+	describe("command typo suggestions", () => {
+		it("should suggest 'whoami' when user types 'whoamio'", async ({
+			expect,
+		}) => {
+			await expect(
+				runWrangler("whoamio")
+			).rejects.toThrowErrorMatchingInlineSnapshot(
+				`[Error: Unknown argument: whoamio]`
+			);
+
+			expect(std.err).toContain("Unknown argument: whoamio");
+			expect(std.info).toContain('Did you mean "wrangler whoami"?');
+		});
+
+		it("should suggest 'deploy' when user types 'delpoy'", async ({
+			expect,
+		}) => {
+			await expect(
+				runWrangler("delpoy")
+			).rejects.toThrowErrorMatchingInlineSnapshot(
+				`[Error: Unknown argument: delpoy]`
+			);
+
+			expect(std.err).toContain("Unknown argument: delpoy");
+			expect(std.info).toContain('Did you mean "wrangler deploy"?');
+		});
+
+		it("should not suggest anything for a completely unrelated command", async ({
+			expect,
+		}) => {
+			await expect(
+				runWrangler("xyzzy")
+			).rejects.toThrowErrorMatchingInlineSnapshot(
+				`[Error: Unknown argument: xyzzy]`
+			);
+
+			expect(std.err).toContain("Unknown argument: xyzzy");
+			expect(std.info).not.toContain("Did you mean");
+		});
+
+		it("should suggest a command even with --help flag", async ({ expect }) => {
+			await expect(
+				runWrangler("whoamio --help")
+			).rejects.toThrowErrorMatchingInlineSnapshot(
+				`[Error: Unknown argument: whoamio]`
+			);
+
+			expect(std.err).toContain("Unknown argument: whoamio");
+			expect(std.info).toContain('Did you mean "wrangler whoami"?');
+
+			// The suggestion should appear exactly once (not duplicated between
+			// the --help path in index.ts and the error handler)
+			expect(std.info.match(/Did you mean/g)).toHaveLength(1);
+		});
+
+		it("should suggest a subcommand for 'kv namespase'", async ({ expect }) => {
+			await expect(runWrangler("kv namespase")).rejects.toThrow(
+				/Unknown argument/
+			);
+
+			expect(std.info).toContain('Did you mean "wrangler kv namespace"?');
+		});
+
+		it("should suggest a nested subcommand for 'kv namespace craete'", async ({
+			expect,
+		}) => {
+			await expect(runWrangler("kv namespace craete")).rejects.toThrow(
+				/Unknown argument/
+			);
+
+			expect(std.info).toContain(
+				'Did you mean "wrangler kv namespace create"?'
+			);
+		});
+
+		it("should preserve trailing args in suggestion for 'kv namespase create'", async ({
+			expect,
+		}) => {
+			await expect(runWrangler("kv namespase create")).rejects.toThrow(
+				/Unknown argument/
+			);
+
+			expect(std.info).toContain(
+				'Did you mean "wrangler kv namespace create"?'
+			);
+		});
+
+		it("should not suggest a subcommand for a completely unrelated subcommand", async ({
+			expect,
+		}) => {
+			await expect(runWrangler("kv xyzzy")).rejects.toThrow(/Unknown argument/);
+
+			expect(std.info).not.toContain("Did you mean");
+		});
+
+		it("should suggest 'whoami' when user types 'who-am-i'", async ({
+			expect,
+		}) => {
+			await expect(
+				runWrangler("who-am-i")
+			).rejects.toThrowErrorMatchingInlineSnapshot(
+				`[Error: Unknown argument: who-am-i]`
+			);
+
+			expect(std.err).toContain("Unknown argument: who-am-i");
+			expect(std.info).toContain('Did you mean "wrangler whoami"?');
+		});
+
+		it("should suggest 'login' when user types 'log-in'", async ({
+			expect,
+		}) => {
+			await expect(
+				runWrangler("log-in")
+			).rejects.toThrowErrorMatchingInlineSnapshot(
+				`[Error: Unknown argument: log-in]`
+			);
+
+			expect(std.err).toContain("Unknown argument: log-in");
+			expect(std.info).toContain('Did you mean "wrangler login"?');
+		});
+
+		it("should suggest 'logout' when user types 'log-out'", async ({
+			expect,
+		}) => {
+			await expect(
+				runWrangler("log-out")
+			).rejects.toThrowErrorMatchingInlineSnapshot(
+				`[Error: Unknown argument: log-out]`
+			);
+
+			expect(std.err).toContain("Unknown argument: log-out");
+			expect(std.info).toContain('Did you mean "wrangler logout"?');
+		});
+	});
+
 	describe("invalid flag on valid command", () => {
 		it("should display command-specific help for unknown flag", async ({
 			expect,

--- a/packages/wrangler/src/__tests__/utils/did-you-mean.test.ts
+++ b/packages/wrangler/src/__tests__/utils/did-you-mean.test.ts
@@ -1,0 +1,102 @@
+import { describe, it } from "vitest";
+import { getSuggestion, logDidYouMean } from "../../utils/did-you-mean";
+import { mockConsoleMethods } from "../helpers/mock-console";
+
+describe("getSuggestion", () => {
+	const commands = ["whoami", "deploy", "dev", "init", "pages", "kv", "r2"];
+
+	it("should suggest the closest match for a typo", ({ expect }) => {
+		expect(getSuggestion("whoamio", commands)).toBe("whoami");
+	});
+
+	it("should suggest 'deploy' for 'delpoy'", ({ expect }) => {
+		expect(getSuggestion("delpoy", commands)).toBe("deploy");
+	});
+
+	it("should suggest 'dev' for 'dve'", ({ expect }) => {
+		expect(getSuggestion("dve", commands)).toBe("dev");
+	});
+
+	it("should return undefined for a completely unrelated input", ({
+		expect,
+	}) => {
+		expect(getSuggestion("xyzzy", commands)).toBeUndefined();
+	});
+
+	it("should be case-insensitive", ({ expect }) => {
+		expect(getSuggestion("WHOAMIO", commands)).toBe("whoami");
+	});
+
+	it("should return undefined when candidates list is empty", ({ expect }) => {
+		expect(getSuggestion("whoami", [])).toBeUndefined();
+	});
+
+	it("should return exact match when input matches a candidate", ({
+		expect,
+	}) => {
+		expect(getSuggestion("deploy", commands)).toBe("deploy");
+	});
+
+	it("should respect custom maxDistance", ({ expect }) => {
+		// "delpoy" is distance 2 from "deploy"
+		expect(getSuggestion("delpoy", commands, 1)).toBeUndefined();
+		expect(getSuggestion("delpoy", commands, 2)).toBe("deploy");
+	});
+
+	it("should work with Set input", ({ expect }) => {
+		const commandSet = new Set(commands);
+		expect(getSuggestion("whoamio", commandSet)).toBe("whoami");
+	});
+
+	it("should not suggest short commands for unrelated short inputs", ({
+		expect,
+	}) => {
+		// "cat" -> "ai" (distance 2) should be rejected for 2-char candidates
+		expect(getSuggestion("cat", commands)).toBeUndefined();
+		// "foo" -> "d1" (distance 3) should be rejected
+		expect(getSuggestion("foo", commands)).toBeUndefined();
+	});
+
+	it("should still suggest longer commands for short inputs when close enough", ({
+		expect,
+	}) => {
+		// "git" -> "init" (distance 2) is a sensible suggestion because "init"
+		// is a 4-char candidate — the scaled threshold allows it
+		expect(getSuggestion("git", commands)).toBe("init");
+	});
+});
+
+describe("logDidYouMean", () => {
+	const std = mockConsoleMethods();
+	const commands = ["whoami", "deploy", "dev", "init", "pages", "kv", "r2"];
+
+	it("should log a suggestion in a box when a close match exists", ({
+		expect,
+	}) => {
+		logDidYouMean("whoamio", commands, "wrangler");
+
+		expect(std.info).toContain('Did you mean "wrangler whoami"?');
+		expect(std.info).toContain("╭");
+		expect(std.info).toContain("╰");
+	});
+
+	it("should not log anything when no close match exists", ({ expect }) => {
+		logDidYouMean("xyzzy", commands, "wrangler");
+
+		expect(std.info).not.toContain("Did you mean");
+	});
+
+	it("should include the full command prefix for subcommands", ({ expect }) => {
+		const subcommands = ["namespace", "key", "bulk"];
+		logDidYouMean("namespase", subcommands, "wrangler kv");
+
+		expect(std.info).toContain('Did you mean "wrangler kv namespace"?');
+	});
+
+	it("should preserve trailing args after the typo", ({ expect }) => {
+		const subcommands = ["namespace", "key", "bulk"];
+		logDidYouMean("namespase", subcommands, "wrangler kv", ["create"]);
+
+		expect(std.info).toContain('Did you mean "wrangler kv namespace create"?');
+	});
+});

--- a/packages/wrangler/src/__tests__/utils/levenshtein.test.ts
+++ b/packages/wrangler/src/__tests__/utils/levenshtein.test.ts
@@ -1,0 +1,57 @@
+import { describe, it } from "vitest";
+import { levenshteinDistance } from "../../utils/levenshtein";
+
+describe("levenshteinDistance", () => {
+	it("should return 0 for identical strings", ({ expect }) => {
+		expect(levenshteinDistance("hello", "hello")).toBe(0);
+	});
+
+	it("should return the length of the other string when one is empty", ({
+		expect,
+	}) => {
+		expect(levenshteinDistance("", "hello")).toBe(5);
+		expect(levenshteinDistance("hello", "")).toBe(5);
+	});
+
+	it("should return 0 for two empty strings", ({ expect }) => {
+		expect(levenshteinDistance("", "")).toBe(0);
+	});
+
+	it("should handle single character insertions", ({ expect }) => {
+		expect(levenshteinDistance("whoami", "whoamio")).toBe(1);
+	});
+
+	it("should handle single character deletions", ({ expect }) => {
+		expect(levenshteinDistance("deploy", "deplo")).toBe(1);
+	});
+
+	it("should handle single character substitutions", ({ expect }) => {
+		expect(levenshteinDistance("deploy", "deplox")).toBe(1);
+	});
+
+	it("should handle transpositions as two edits", ({ expect }) => {
+		// Standard Levenshtein treats transpositions as 2 edits (delete + insert)
+		expect(levenshteinDistance("deploy", "delpoy")).toBe(2);
+	});
+
+	it("should handle completely different strings", ({ expect }) => {
+		expect(levenshteinDistance("abc", "xyz")).toBe(3);
+	});
+
+	it("should be symmetric", ({ expect }) => {
+		expect(levenshteinDistance("kitten", "sitting")).toBe(
+			levenshteinDistance("sitting", "kitten")
+		);
+	});
+
+	it("should handle single character strings", ({ expect }) => {
+		expect(levenshteinDistance("a", "b")).toBe(1);
+		expect(levenshteinDistance("a", "a")).toBe(0);
+		expect(levenshteinDistance("a", "")).toBe(1);
+	});
+
+	it("should compute correct distance for longer strings", ({ expect }) => {
+		// "kitten" -> "sitting": k->s, e->i, +g = 3 edits
+		expect(levenshteinDistance("kitten", "sitting")).toBe(3);
+	});
+});

--- a/packages/wrangler/src/core/CommandRegistry.ts
+++ b/packages/wrangler/src/core/CommandRegistry.ts
@@ -155,6 +155,37 @@ export class CommandRegistry {
 	}
 
 	/**
+	 * Get the set of valid subcommand names at a given command path.
+	 *
+	 * Walks the definition tree along the given path segments, then returns
+	 * the keys of the subtree at that node. Returns `undefined` if the path
+	 * does not exist in the tree or has no subcommands.
+	 *
+	 * @param pathSegments - The command path segments to walk (e.g., `["kv"]`
+	 *   returns `namespace`, `key`, `bulk`; `["kv", "namespace"]` returns
+	 *   `create`, `list`, `delete`, etc.)
+	 * @returns A set of valid subcommand names, or `undefined` if the path is
+	 *   invalid or has no subcommands
+	 */
+	getSubcommands(pathSegments: string[]): Set<string> | undefined {
+		let currentTree = this.#tree;
+
+		for (const segment of pathSegments) {
+			const node = currentTree.get(segment);
+			if (!node) {
+				return undefined;
+			}
+			currentTree = node.subtree;
+		}
+
+		if (currentTree.size === 0) {
+			return undefined;
+		}
+
+		return new Set(currentTree.keys());
+	}
+
+	/**
 	 * Returns the map of categories to command segments, ordered according to
 	 * the category order. Commands within each category are sorted alphabetically.
 	 * Used for grouping commands in the help output.

--- a/packages/wrangler/src/core/handle-errors.ts
+++ b/packages/wrangler/src/core/handle-errors.ts
@@ -22,6 +22,7 @@ import { logBuildFailure, logger } from "../logger";
 import { captureGlobalException } from "../sentry";
 import { getAuthFromEnv } from "../user";
 import { whoami } from "../user/whoami";
+import { logDidYouMean } from "../utils/did-you-mean";
 import { logPossibleBugMessage } from "../utils/logPossibleBugMessage";
 import type { ReadConfigCommandArgs } from "../config";
 import type { ComplianceConfig } from "@cloudflare/workers-utils";
@@ -314,7 +315,8 @@ export function getErrorType(e: unknown): string | undefined {
 export async function handleError(
 	e: unknown,
 	args: ReadConfigCommandArgs,
-	subCommandParts: string[]
+	subCommandParts: string[],
+	commandResolver?: (path: string[]) => Set<string> | undefined
 ): Promise<void> {
 	let mayReport = true;
 	let loggableException = e;
@@ -511,8 +513,31 @@ export async function handleError(
 		]);
 
 		if (isRootLevelError) {
+			if (commandResolver && unknownArgs.length > 0) {
+				const knownCommands = commandResolver([]);
+				if (knownCommands) {
+					logDidYouMean(unknownArgs[0], knownCommands, "wrangler");
+				}
+			}
 			await showHelpWithCategories();
 			return;
+		}
+
+		// For non-root-level errors, check if the unknown arg is a subcommand typo.
+		// e.g. "wrangler kv namespase" -> unknownArgs=["namespase"], nonFlagArgs=["kv","namespase"]
+		// The parent path is the valid command segments before the typo.
+		if (isUnknownArgOrCommand && commandResolver && unknownArgs.length > 0) {
+			const unknownArg = unknownArgs[0];
+			const typoIndex = nonFlagArgs.indexOf(unknownArg);
+			if (typoIndex > 0) {
+				const parentPath = nonFlagArgs.slice(0, typoIndex);
+				const trailingArgs = nonFlagArgs.slice(typoIndex + 1);
+				const knownSubcommands = commandResolver(parentPath);
+				if (knownSubcommands) {
+					const prefix = ["wrangler", ...parentPath].join(" ");
+					logDidYouMean(unknownArg, knownSubcommands, prefix, trailingArgs);
+				}
+			}
 		}
 
 		await wrangler.parse();

--- a/packages/wrangler/src/index.ts
+++ b/packages/wrangler/src/index.ts
@@ -493,6 +493,7 @@ import {
 	authListCommand,
 } from "./user/profiles";
 import { noProxy, proxy } from "./utils/constants";
+import { logDidYouMean } from "./utils/did-you-mean";
 import { debugLogFilepath } from "./utils/log-file";
 import { vectorizeCreateCommand } from "./vectorize/create";
 import { vectorizeCreateMetadataIndexCommand } from "./vectorize/createMetadataIndex";
@@ -2629,13 +2630,16 @@ export async function main(argv: string[]): Promise<void> {
 		return;
 	}
 
-	// Check for unknown command with a `--help` flag
+	// Check for unknown command with a `--help` flag.
+	// This throw happens before the try-catch that calls handleError(), so
+	// we log the error and suggestion here (handleError is never reached).
 	const [subCommand] = nonFlagArgs;
 	if (hasHelpFlag && subCommand) {
 		const knownCommands = registry.topLevelCommands;
 		if (!knownCommands.has(subCommand)) {
 			logger.info("");
 			logger.error(`Unknown argument: ${subCommand}`);
+			logDidYouMean(subCommand, knownCommands, "wrangler");
 			await showHelpWithCategories();
 			throw new CommandLineArgsError(`Unknown argument: ${subCommand}`, {
 				telemetryMessage: "cli help unknown argument",
@@ -2692,7 +2696,11 @@ export async function main(argv: string[]): Promise<void> {
 				dispatchGenericCommandErrorEvent(dispatcher, startTime, e);
 			}
 			try {
-				await handleError(e, configArgs, argv);
+				await handleError(e, configArgs, argv, (path) =>
+					path.length === 0
+						? registry.topLevelCommands
+						: registry.getSubcommands(path)
+				);
 			} catch (handleErrorErr) {
 				// handleError itself threw before it could log the error.
 				// Fall back to raw stderr so the user always sees something.

--- a/packages/wrangler/src/utils/did-you-mean.ts
+++ b/packages/wrangler/src/utils/did-you-mean.ts
@@ -1,0 +1,76 @@
+import { logger } from "../logger";
+import { drawBox } from "./box";
+import { levenshteinDistance } from "./levenshtein";
+
+/**
+ * Given an unknown input string and a list of valid candidates, returns the
+ * closest candidate whose Levenshtein distance is within the given threshold.
+ * Comparison is case-insensitive. If multiple candidates share the same
+ * distance, the first one encountered (in iteration order) is returned.
+ *
+ * The effective threshold for each candidate is scaled down based on the
+ * shorter of the input and candidate lengths, so that short candidates (e.g.
+ * "d1", "ai") require a proportionally closer match and don't produce
+ * nonsensical suggestions.
+ *
+ * @param input - The unknown input string to find a suggestion for
+ * @param candidates - An iterable of valid candidate strings to compare against
+ * @param maxDistance - The upper-bound Levenshtein distance for a candidate to
+ *   be considered a match. Defaults to 3. The actual threshold per candidate
+ *   is `min(maxDistance, floor(min(inputLen, candidateLen) * 2 / 3))`.
+ * @returns The closest matching candidate, or `undefined` if no candidate is
+ *   within the threshold
+ */
+export function getSuggestion(
+	input: string,
+	candidates: Iterable<string>,
+	maxDistance: number = 3
+): string | undefined {
+	const lowerInput = input.toLowerCase();
+	let bestMatch: string | undefined;
+	let bestDistance = maxDistance + 1;
+
+	for (const candidate of candidates) {
+		const distance = levenshteinDistance(lowerInput, candidate.toLowerCase());
+		// Scale the threshold down for short candidates so we don't match
+		// e.g. "cat" -> "ai" or "foo" -> "d1" just because they're within 3 edits.
+		const effectiveMax = Math.min(
+			maxDistance,
+			bestDistance,
+			Math.floor((Math.min(lowerInput.length, candidate.length) * 2) / 3)
+		);
+		if (distance <= effectiveMax) {
+			bestDistance = distance;
+			bestMatch = candidate;
+		}
+	}
+
+	return bestMatch;
+}
+
+/**
+ * Finds the closest matching command for an unknown input and logs a "Did you
+ * mean ...?" suggestion to the user if a match is found.
+ *
+ * @param unknownCommand - The unrecognized command or subcommand entered by
+ *   the user
+ * @param candidates - An iterable of valid command names to compare against
+ * @param commandPrefix - The prefix to display before the suggestion (e.g.,
+ *   `"wrangler"` or `"wrangler kv"`)
+ * @param trailingArgs - Additional arguments that appeared after the typo and
+ *   should be preserved in the suggestion (e.g., `["create"]` so that
+ *   `wrangler kv namespacess create` suggests `wrangler kv namespace create`)
+ */
+export function logDidYouMean(
+	unknownCommand: string,
+	candidates: Iterable<string>,
+	commandPrefix: string,
+	trailingArgs: string[] = []
+): void {
+	const suggestion = getSuggestion(unknownCommand, candidates);
+	if (suggestion) {
+		const parts = [commandPrefix, suggestion, ...trailingArgs];
+		const box = drawBox([`Did you mean "${parts.join(" ")}"?`]);
+		logger.info(`\n${box}\n`);
+	}
+}

--- a/packages/wrangler/src/utils/levenshtein.ts
+++ b/packages/wrangler/src/utils/levenshtein.ts
@@ -1,42 +1,40 @@
 /**
- * Computes the Levenshtein distance between two strings using an iterative
- * dynamic programming approach. The Levenshtein distance is the minimum number
+ * Computes the Levenshtein distance between two strings using a recursive
+ * approach with memoization. The Levenshtein distance is the minimum number
  * of single-character edits (insertions, deletions, or substitutions) required
  * to transform one string into the other.
  *
- * Uses O(min(n, m)) space by only keeping two rows of the DP matrix.
- *
  * @param a - The first string
  * @param b - The second string
+ * @param cache - Internal memoization cache; callers should not pass this
  * @returns The Levenshtein distance between the two strings
  */
-export function levenshteinDistance(a: string, b: string): number {
-	// Ensure `a` is the shorter string so we use less memory
-	if (a.length > b.length) {
-		[a, b] = [b, a];
+export function levenshteinDistance(
+	a: string,
+	b: string,
+	cache = new Map<string, number>()
+): number {
+	const key = `${a}|${b}`;
+	const cacheValue = cache.get(key);
+	if (cacheValue !== undefined) {
+		return cacheValue;
 	}
-
-	const aLen = a.length;
-	const bLen = b.length;
-
-	// previous and current row of distances
-	let prev = Array.from({ length: aLen + 1 }, (_, i) => i);
-	let curr = new Array<number>(aLen + 1);
-
-	for (let j = 1; j <= bLen; j++) {
-		curr[0] = j;
-
-		for (let i = 1; i <= aLen; i++) {
-			const cost = a[i - 1] === b[j - 1] ? 0 : 1;
-			curr[i] = Math.min(
-				prev[i] + 1, // deletion
-				curr[i - 1] + 1, // insertion
-				prev[i - 1] + cost // substitution
+	let result;
+	if (b == "") {
+		result = a.length;
+	} else if (a == "") {
+		result = b.length;
+	} else if (a[0] === b[0]) {
+		result = levenshteinDistance(a.slice(1), b.slice(1), cache);
+	} else {
+		result =
+			1 +
+			Math.min(
+				levenshteinDistance(a.slice(1), b, cache),
+				levenshteinDistance(a, b.slice(1), cache),
+				levenshteinDistance(a.slice(1), b.slice(1), cache)
 			);
-		}
-
-		[prev, curr] = [curr, prev];
 	}
-
-	return prev[aLen];
+	cache.set(key, result);
+	return result;
 }

--- a/packages/wrangler/src/utils/levenshtein.ts
+++ b/packages/wrangler/src/utils/levenshtein.ts
@@ -1,0 +1,42 @@
+/**
+ * Computes the Levenshtein distance between two strings using an iterative
+ * dynamic programming approach. The Levenshtein distance is the minimum number
+ * of single-character edits (insertions, deletions, or substitutions) required
+ * to transform one string into the other.
+ *
+ * Uses O(min(n, m)) space by only keeping two rows of the DP matrix.
+ *
+ * @param a - The first string
+ * @param b - The second string
+ * @returns The Levenshtein distance between the two strings
+ */
+export function levenshteinDistance(a: string, b: string): number {
+	// Ensure `a` is the shorter string so we use less memory
+	if (a.length > b.length) {
+		[a, b] = [b, a];
+	}
+
+	const aLen = a.length;
+	const bLen = b.length;
+
+	// previous and current row of distances
+	let prev = Array.from({ length: aLen + 1 }, (_, i) => i);
+	let curr = new Array<number>(aLen + 1);
+
+	for (let j = 1; j <= bLen; j++) {
+		curr[0] = j;
+
+		for (let i = 1; i <= aLen; i++) {
+			const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+			curr[i] = Math.min(
+				prev[i] + 1, // deletion
+				curr[i - 1] + 1, // insertion
+				prev[i - 1] + cost // substitution
+			);
+		}
+
+		[prev, curr] = [curr, prev];
+	}
+
+	return prev[aLen];
+}

--- a/packages/wrangler/src/zones.ts
+++ b/packages/wrangler/src/zones.ts
@@ -1,6 +1,7 @@
 import { getZoneForRoute, getZoneIdFromHost } from "@cloudflare/deploy-helpers";
 import { configFileName, UserError } from "@cloudflare/workers-utils";
 import { fetchListResult } from "./cfetch";
+import { levenshteinDistance } from "./utils/levenshtein";
 import type { ZoneIdCache } from "@cloudflare/deploy-helpers";
 import type { ComplianceConfig, Route } from "@cloudflare/workers-utils";
 
@@ -69,33 +70,6 @@ async function getRoutesForZone(
 }
 
 /**
- * Given two strings, return the levenshtein distance between them as a simple text match heuristic
- */
-function distanceBetween(a: string, b: string, cache = new Map()): number {
-	if (cache.has(`${a}|${b}`)) {
-		return cache.get(`${a}|${b}`);
-	}
-	let result;
-	if (b == "") {
-		result = a.length;
-	} else if (a == "") {
-		result = b.length;
-	} else if (a[0] === b[0]) {
-		result = distanceBetween(a.slice(1), b.slice(1), cache);
-	} else {
-		result =
-			1 +
-			Math.min(
-				distanceBetween(a.slice(1), b, cache),
-				distanceBetween(a, b.slice(1), cache),
-				distanceBetween(a.slice(1), b.slice(1), cache)
-			);
-	}
-	cache.set(`${a}|${b}`, result);
-	return result;
-}
-
-/**
  * Given an invalid route, sort the valid routes by closeness to the invalid route (levenstein distance)
  */
 function findClosestRoute(
@@ -103,8 +77,8 @@ function findClosestRoute(
 	assignedRoutes: WorkerRoute[]
 ): WorkerRoute[] {
 	return assignedRoutes.sort((a, b) => {
-		const distanceA = distanceBetween(providedRoute, a.pattern);
-		const distanceB = distanceBetween(providedRoute, b.pattern);
+		const distanceA = levenshteinDistance(providedRoute, a.pattern);
+		const distanceB = levenshteinDistance(providedRoute, b.pattern);
 		return distanceA - distanceB;
 	});
 }


### PR DESCRIPTION
This PR updates Wrangler to suggest the likely correct command when a user mistypes a command.

I'm not sure how valuable this is (I do think this improves UX somewhat) it was just a quick idea I had 🙂

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: improved UX

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
