### PR TITLE
[wrangler] Upgrade signal-exit to v4 for ESM compatibility

### DIFF
--- a/.changeset/signal-exit-esm.md
+++ b/.changeset/signal-exit-esm.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Upgrade `signal-exit` from v3 to v4
+
+The bundled `signal-exit` dependency was CJS-only. Upgrading to v4 (which ships a dual ESM/CJS build) unblocks ESM output. Exit-cleanup behaviour is unchanged, though v4 no longer registers handlers for a few signals that are no longer supported by the OS (`SIGUNUSED` on Linux; `SIGABRT`/`SIGALRM` on Windows).

--- a/.changeset/signal-exit-esm.md
+++ b/.changeset/signal-exit-esm.md
@@ -1,5 +1,6 @@
 ---
 "wrangler": patch
+"@cloudflare/workers-utils": patch
 ---
 
 Upgrade `signal-exit` from v3 to v4

--- a/packages/workers-utils/package.json
+++ b/packages/workers-utils/package.json
@@ -58,7 +58,6 @@
 		"@cloudflare/workflows-shared": "workspace:*",
 		"@types/command-exists": "^1.2.0",
 		"@types/node": "catalog:default",
-		"@types/signal-exit": "^3.0.1",
 		"@vitest/ui": "catalog:default",
 		"cloudflare": "^5.2.0",
 		"command-exists": "catalog:default",

--- a/packages/workers-utils/src/wrangler-tmp-dir.ts
+++ b/packages/workers-utils/src/wrangler-tmp-dir.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
-import onExit from "signal-exit";
+import { onExit } from "signal-exit";
 import { removeDirSync } from "./fs-helpers";
 
 /**

--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -119,7 +119,6 @@
 		"@types/prompts": "^2.0.14",
 		"@types/resolve": "^1.20.6",
 		"@types/shell-quote": "^1.7.2",
-		"@types/signal-exit": "^3.0.1",
 		"@types/supports-color": "^8.1.1",
 		"@types/ws": "^8.5.7",
 		"@types/yargs": "^17.0.22",

--- a/packages/wrangler/src/pages/deployment-tails.ts
+++ b/packages/wrangler/src/pages/deployment-tails.ts
@@ -4,7 +4,7 @@ import {
 	FatalError,
 	UserError,
 } from "@cloudflare/workers-utils";
-import onExit from "signal-exit";
+import { onExit } from "signal-exit";
 import { fetchResult } from "../cfetch";
 import { readConfig } from "../config";
 import { getConfigCache } from "../config-cache";
@@ -280,7 +280,7 @@ export const pagesDeploymentTailCommand = createCommand({
 			};
 		})();
 
-		onExit(onCloseTail);
+		onExit(() => void onCloseTail());
 
 		tail.on("message", (data) => {
 			if (format === "pretty") {

--- a/packages/wrangler/src/utils/log-file.ts
+++ b/packages/wrangler/src/utils/log-file.ts
@@ -7,7 +7,7 @@ import {
 	getGlobalConfigPath,
 } from "@cloudflare/workers-utils";
 import { Mutex } from "miniflare";
-import onExit from "signal-exit";
+import { onExit } from "signal-exit";
 import { logger } from "../logger";
 import { ensureDirectoryExists } from "./filesystem";
 import type { LoggerLevel } from "../logger";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,8 +61,8 @@ catalogs:
       specifier: 1.60.0
       version: 1.60.0
     signal-exit:
-      specifier: 3.0.7
-      version: 3.0.7
+      specifier: 4.1.0
+      version: 4.1.0
     smol-toml:
       specifier: 1.5.2
       version: 1.5.2
@@ -4182,9 +4182,6 @@ importers:
       '@types/node':
         specifier: 22.15.17
         version: 22.15.17
-      '@types/signal-exit':
-        specifier: ^3.0.1
-        version: 3.0.1
       '@vitest/ui':
         specifier: catalog:default
         version: 4.1.0(vitest@4.1.0)
@@ -4205,7 +4202,7 @@ importers:
         version: 3.2.0
       signal-exit:
         specifier: catalog:default
-        version: 3.0.7
+        version: 4.1.0
       smol-toml:
         specifier: catalog:default
         version: 1.5.2
@@ -4391,9 +4388,6 @@ importers:
       '@types/shell-quote':
         specifier: ^1.7.2
         version: 1.7.2
-      '@types/signal-exit':
-        specifier: ^3.0.1
-        version: 3.0.1
       '@types/supports-color':
         specifier: ^8.1.1
         version: 8.1.1
@@ -4531,7 +4525,7 @@ importers:
         version: 1.8.1
       signal-exit:
         specifier: catalog:default
-        version: 3.0.7
+        version: 4.1.0
       smol-toml:
         specifier: catalog:default
         version: 1.5.2
@@ -9381,9 +9375,6 @@ packages:
 
   '@types/shell-quote@1.7.2':
     resolution: {integrity: sha512-p3SZxGp6LXB6RPdMpJmquKjaxQlN/ijyBLTKGPg9IJK6J2g2sJsMmtXP9kNR+Axxi6MDKN2e/76HCOUmvkIpcw==}
-
-  '@types/signal-exit@3.0.1':
-    resolution: {integrity: sha512-OSitN9PP9E/c4tlt1Qdj3CAz5uHD9Da5rhUqlaKyQRCX1T7Zdpbk6YdeZbR2eiE2ce+NMBgVnMxGqpaPSNQDUQ==}
 
   '@types/stack-utils@2.0.3':
     resolution: {integrity: sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==}
@@ -20407,8 +20398,6 @@ snapshots:
       '@types/send': 0.17.4
 
   '@types/shell-quote@1.7.2': {}
-
-  '@types/signal-exit@3.0.1': {}
 
   '@types/stack-utils@2.0.3': {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -130,7 +130,7 @@ catalog:
   "capnweb": "0.5.0"
   "ci-info": "4.4.0"
   "open": "11.0.0"
-  "signal-exit": "3.0.7"
+  "signal-exit": "4.1.0"
   # CAUTION: Most usage of @cloudflare/vitest-pool-workers in this monorepo should use workspace:* instead of this catalog version
   # However, some packages (pages-shared, workers-shared, etc...) need to be tested using vitest-pool-workers but are themselves
   # ultimately included in vitest-pool-workers (through Wrangler), causing a circular dependency.


### PR DESCRIPTION
Upgrades the bundled `signal-exit` dependency from v3 to v4.

`signal-exit@3.0.7` is CJS-only, which blocks ESM output. `signal-exit@4.1.0` ships a dual ESM/CJS build. The v4 API replaces the default export with a named `onExit` export, so the three import sites (`packages/wrangler/src/utils/log-file.ts`, `packages/wrangler/src/pages/deployment-tails.ts`, `packages/workers-utils/src/wrangler-tmp-dir.ts`) are updated accordingly. `@types/signal-exit` is dropped since v4 bundles its own types.

The v4 `Handler` type is stricter (`true | void`, not a Promise), so the `pages deployment tail` cleanup handler is wrapped to explicitly void its promise. Exit-cleanup behaviour is otherwise unchanged, though v4 no longer registers handlers for a few signals that are no longer supported by the OS (`SIGUNUSED` on Linux; `SIGABRT`/`SIGALRM` on Windows).

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: this is a drop-in dependency upgrade with an identical public API surface, covered by existing type-checking and the existing test suites for the affected modules.
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: internal dependency change with no user-facing behaviour change.
