### PR TITLE
[chrome-devtools-patches] Update Chrome DevTools to M150 (Chrome 150)

### DIFF
--- a/.changeset/chrome-devtools-update-m150.md
+++ b/.changeset/chrome-devtools-update-m150.md
@@ -1,0 +1,7 @@
+---
+"@cloudflare/chrome-devtools-patches": patch
+---
+
+Update Chrome DevTools to Chrome 150 (M150)
+
+Updates the Chrome DevTools frontend used by `wrangler dev` and the Workers Playground to the Chrome 150 (M150) release, bringing upstream fixes and improvements while preserving the existing Workers debugging experience.

--- a/packages/chrome-devtools-patches/Makefile
+++ b/packages/chrome-devtools-patches/Makefile
@@ -1,7 +1,7 @@
 ROOT = $(realpath .)
 PATH_WITH_DEPOT = $(PATH):$(ROOT)/depot/
 # The upstream devtools commit upon which our patches are based
-HEAD = b66ecf5bef3ae6c769dbc6d904ce1c54d3771227
+HEAD = 1d67dc0dafa344bbd6ca75c124e2d6d9d53074d8
 PATCHES = $(shell ls ${PWD}/patches/*.patch)
 depot:
 	git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git depot

--- a/packages/chrome-devtools-patches/patches/0001-Expand-Browser-support-make-it-work-in-Firefox-Safar.patch
+++ b/packages/chrome-devtools-patches/patches/0001-Expand-Browser-support-make-it-work-in-Firefox-Safar.patch
@@ -1,4 +1,4 @@
-From 261ba678389218354cb8f9dce78483cf4f09716f Mon Sep 17 00:00:00 2001
+From 69fdc50c3b8828a0e7cd719e0216993dbd5f624c Mon Sep 17 00:00:00 2001
 From: Workers DevProd <workers-devprod@cloudflare.com>
 Date: Fri, 25 Oct 2024 14:15:43 +0100
 Subject: [PATCH 1/8] Expand Browser support (make it work in Firefox & Safari)
@@ -16,30 +16,17 @@ If updating the commit of devtools upon which these patches are based, make sure
 * Allows devtools to load in Safari (loading with _any_ UI is sufficent to check whether this has worked)
 * Supports viewing a list of requests in the network panel in Firefox (without the patches here this goes very obviously wrong)
 ---
- front_end/core/dom_extension/DOMExtension.ts  |  2 +-
- front_end/entrypoint_template.html            | 38 ++++++++++++++++++-
+ front_end/entrypoint_template.html            | 39 ++++++++++++++++++-
  front_end/entrypoints/js_app/js_app.ts        |  3 ++
+ front_end/ui/dom_extension/DOMExtension.ts    |  2 +-
  .../legacy/components/data_grid/DataGrid.ts   |  5 +++
- 4 files changed, 46 insertions(+), 2 deletions(-)
+ 4 files changed, 47 insertions(+), 2 deletions(-)
 
-diff --git a/front_end/core/dom_extension/DOMExtension.ts b/front_end/core/dom_extension/DOMExtension.ts
-index 202c680a30..a639437998 100644
---- a/front_end/core/dom_extension/DOMExtension.ts
-+++ b/front_end/core/dom_extension/DOMExtension.ts
-@@ -133,7 +133,7 @@ Node.prototype.getComponentSelection = function(): Selection|null {
-   while (parent && parent.nodeType !== Node.DOCUMENT_FRAGMENT_NODE) {
-     parent = parent.parentNode;
-   }
--  return parent instanceof ShadowRoot ? parent.getSelection() : this.window().getSelection();
-+  return parent instanceof ShadowRoot ? (parent?.getSelection?.() ?? this.window().getSelection()) : this.window().getSelection();
- };
- 
- Node.prototype.hasSelection = function(): boolean {
 diff --git a/front_end/entrypoint_template.html b/front_end/entrypoint_template.html
-index 64d55d4c14..07972be81f 100644
+index e778aefef2..cdf7049337 100644
 --- a/front_end/entrypoint_template.html
 +++ b/front_end/entrypoint_template.html
-@@ -13,9 +13,45 @@
+@@ -13,12 +13,49 @@
        background-color: rgb(41 42 45);
      }
    }
@@ -71,11 +58,15 @@ index 64d55d4c14..07972be81f 100644
 +  }
 +
 +  .cm-editor + .cm-editor {
-+    display: 'none',
++    display: none;
 +  }
  </style>
--<meta http-equiv="Content-Security-Policy" content="object-src 'none'; script-src 'self' https://chrome-devtools-frontend.appspot.com">
-+<meta http-equiv="Content-Security-Policy" content="object-src 'none'; script-src 'sha256-AIRkz8wOl/LgmUJduw9AsUnrb94PlBpePfk0Rowm+Vo=' 'self' https://chrome-devtools-frontend.appspot.com">
+ <meta
+   http-equiv="Content-Security-Policy"
+   content="default-src 'self' devtools: data:; style-src 'self' 'unsafe-inline' devtools:; object-src 'none'; script-src
+-  'self' https://chrome-devtools-frontend.appspot.com; img-src 'self' data: blob:; frame-src * data:; connect-src data: https://chromeuxreport.googleapis.com 'self' devtools: ws://127.0.0.1:*;">
++  'sha256-AIRkz8wOl/LgmUJduw9AsUnrb94PlBpePfk0Rowm+Vo=' 'self' https://chrome-devtools-frontend.appspot.com; img-src 'self' data: blob:; frame-src * data:; connect-src data: https://chromeuxreport.googleapis.com 'self' devtools: ws://127.0.0.1:*;">
++
  <meta name="referrer" content="no-referrer">
 +<script>
 +// Vendored from https://unpkg.com/@ungap/custom-elements@1.3.0/min.js
@@ -87,7 +78,7 @@ index 64d55d4c14..07972be81f 100644
  <link href="./application_tokens.css" rel="stylesheet">
  <link href="./design_system_tokens.css" rel="stylesheet">
 diff --git a/front_end/entrypoints/js_app/js_app.ts b/front_end/entrypoints/js_app/js_app.ts
-index a7f4827d68..2dbb4eca42 100644
+index c4b4593b3d..d5021969c1 100644
 --- a/front_end/entrypoints/js_app/js_app.ts
 +++ b/front_end/entrypoints/js_app/js_app.ts
 @@ -44,6 +44,9 @@ async function loadSourcesModule(): Promise<typeof Sources> {
@@ -100,12 +91,25 @@ index a7f4827d68..2dbb4eca42 100644
  export class JsMainImpl implements Common.Runnable.Runnable {
    static instance(opts: {forceNew: boolean|null} = {forceNew: null}): JsMainImpl {
      const {forceNew} = opts;
+diff --git a/front_end/ui/dom_extension/DOMExtension.ts b/front_end/ui/dom_extension/DOMExtension.ts
+index e3aaae75eb..1bdd11511f 100644
+--- a/front_end/ui/dom_extension/DOMExtension.ts
++++ b/front_end/ui/dom_extension/DOMExtension.ts
+@@ -134,7 +134,7 @@ Node.prototype.getComponentSelection = function(): Selection|null {
+   while (parent && parent.nodeType !== Node.DOCUMENT_FRAGMENT_NODE) {
+     parent = parent.parentNode;
+   }
+-  return parent instanceof ShadowRoot ? parent.getSelection() : this.window().getSelection();
++  return parent instanceof ShadowRoot ? (parent?.getSelection?.() ?? this.window().getSelection()) : this.window().getSelection();
+ };
+ 
+ Node.prototype.hasSelection = function(): boolean {
 diff --git a/front_end/ui/legacy/components/data_grid/DataGrid.ts b/front_end/ui/legacy/components/data_grid/DataGrid.ts
-index 70820e38a1..5c9e25c522 100644
+index 2c6baeb448..d8e9e81763 100644
 --- a/front_end/ui/legacy/components/data_grid/DataGrid.ts
 +++ b/front_end/ui/legacy/components/data_grid/DataGrid.ts
-@@ -223,6 +223,8 @@ export class DataGridImpl<T> extends Common.ObjectWrapper.ObjectWrapper<EventTyp
-     this.headerRow = this.dataTableHeadInternal.createChild('tr');
+@@ -222,6 +222,8 @@ export class DataGridImpl<T> extends Common.ObjectWrapper.ObjectWrapper<EventTyp
+     this.headerRow = this.#dataTableHead.createChild('tr');
  
      this.dataTableBody = this.dataTable.createChild('tbody');
 +    // This is required for Firefox, else Firefox will position the <tbody/> *under* the <thead/>
@@ -124,5 +128,5 @@ index 70820e38a1..5c9e25c522 100644
        return;
      }
 -- 
-2.39.5 (Apple Git-154)
+2.50.1 (Apple Git-155)
 

--- a/packages/chrome-devtools-patches/patches/0002-Setup-Cloudflare-devtools-target-type.patch
+++ b/packages/chrome-devtools-patches/patches/0002-Setup-Cloudflare-devtools-target-type.patch
@@ -1,4 +1,4 @@
-From 0b2f719ec57d77ac8837ffa62293b3c1cb97551f Mon Sep 17 00:00:00 2001
+From e203327d849387af1d35e4f239f34f9c86ba9116 Mon Sep 17 00:00:00 2001
 From: Workers DevProd <workers-devprod@cloudflare.com>
 Date: Fri, 25 Oct 2024 16:06:06 +0100
 Subject: [PATCH 2/8] Setup Cloudflare devtools target type
@@ -9,21 +9,21 @@ Subject: [PATCH 2/8] Setup Cloudflare devtools target type
  2 files changed, 6 insertions(+), 1 deletion(-)
 
 diff --git a/front_end/core/sdk/Target.ts b/front_end/core/sdk/Target.ts
-index 2437d6aac1..e9a3318268 100644
+index b36f74f402..0b0b6b51ce 100644
 --- a/front_end/core/sdk/Target.ts
 +++ b/front_end/core/sdk/Target.ts
-@@ -98,6 +98,10 @@ export class Target extends ProtocolClient.InspectorBackend.TargetBase {
+@@ -108,6 +108,10 @@ export class Target extends ProtocolClient.InspectorBackend.TargetBase {
          break;
        case Type.NODE_WORKER:
-         this.#capabilitiesMask = Capability.JS | Capability.NETWORK | Capability.TARGET;
+         this.#capabilitiesMask = Capability.JS | Capability.NETWORK | Capability.TARGET | Capability.IO;
 +        break;
 +      case Type.CLOUDFLARE:
 +        this.#capabilitiesMask = Capability.JS | Capability.NETWORK;
 +        break;
      }
-     this.#typeInternal = type;
-     this.#parentTargetInternal = parentTarget;
-@@ -298,6 +302,7 @@ export enum Type {
+     this.#type = type;
+     this.#parentTarget = parentTarget;
+@@ -297,6 +301,7 @@ export enum Type {
    AUCTION_WORKLET = 'auction-worklet',
    WORKLET = 'worklet',
    TAB = 'tab',
@@ -32,7 +32,7 @@ index 2437d6aac1..e9a3318268 100644
  }
  
 diff --git a/front_end/entrypoints/js_app/js_app.ts b/front_end/entrypoints/js_app/js_app.ts
-index 2dbb4eca42..814bc1fc70 100644
+index d5021969c1..3c0179b3ed 100644
 --- a/front_end/entrypoints/js_app/js_app.ts
 +++ b/front_end/entrypoints/js_app/js_app.ts
 @@ -61,7 +61,7 @@ export class JsMainImpl implements Common.Runnable.Runnable {
@@ -45,5 +45,5 @@ index 2dbb4eca42..814bc1fc70 100644
      }, Components.TargetDetachedDialog.TargetDetachedDialog.connectionLost);
    }
 -- 
-2.39.5 (Apple Git-154)
+2.50.1 (Apple Git-155)
 

--- a/packages/chrome-devtools-patches/patches/0003-Add-ping-to-improve-connection-stability.-Without-th.patch
+++ b/packages/chrome-devtools-patches/patches/0003-Add-ping-to-improve-connection-stability.-Without-th.patch
@@ -1,4 +1,4 @@
-From bcba740e8dd373acf74a8d7f82d93107e2bf4a08 Mon Sep 17 00:00:00 2001
+From d6566fcd0e63e5ba297ccb286e35732dde6f11db Mon Sep 17 00:00:00 2001
 From: Workers DevProd <workers-devprod@cloudflare.com>
 Date: Fri, 25 Oct 2024 15:04:17 +0100
 Subject: [PATCH 3/8] Add ping to improve connection stability. Without this,
@@ -6,40 +6,36 @@ Subject: [PATCH 3/8] Add ping to improve connection stability. Without this,
  Playground
 
 ---
- front_end/core/protocol_client/InspectorBackend.ts | 8 ++++++++
- 1 file changed, 8 insertions(+)
+ front_end/core/protocol_client/InspectorBackend.ts | 5 +++++
+ 1 file changed, 5 insertions(+)
 
 diff --git a/front_end/core/protocol_client/InspectorBackend.ts b/front_end/core/protocol_client/InspectorBackend.ts
-index 32948c2dbd..27dfa1abe3 100644
+index 8c7691a6e4..081ae4ee77 100644
 --- a/front_end/core/protocol_client/InspectorBackend.ts
 +++ b/front_end/core/protocol_client/InspectorBackend.ts
-@@ -256,6 +256,7 @@ export class SessionRouter {
-     proxyConnection: ((Connection | undefined)|null),
+@@ -187,10 +187,14 @@ export class SessionRouter implements CDPConnectionObserver {
+   readonly #sessions = new Map<string, {
+     target: TargetBase,
    }>();
-   #pendingScripts: Array<() => void> = [];
 +  #pingInterval: ReturnType<typeof setInterval>;
  
-   constructor(connection: Connection) {
-     this.#connectionInternal = connection;
-@@ -266,11 +267,18 @@ export class SessionRouter {
-     this.#connectionInternal.setOnMessage(this.onMessage.bind(this));
- 
-     this.#connectionInternal.setOnDisconnect(reason => {
-+      clearInterval(this.#pingInterval);
-       const session = this.#sessions.get('');
-       if (session) {
-         session.target.dispose(reason);
-       }
-     });
+   constructor(connection: CDPConnection) {
+     this.#connection = connection;
+     this.#connection.observe(this);
 +    this.#pingInterval = setInterval(() => {
-+      this.#connectionInternal.sendRawMessage(JSON.stringify({
-+        method: 'Runtime.getIsolateId',
-+        id: this.nextMessageId(),
-+      }));
++      void this.#connection.send('Runtime.getIsolateId', undefined, undefined);
 +    }, 10_000);
    }
  
-   registerSession(target: TargetBase, sessionId: string, proxyConnection?: Connection|null): void {
+   registerSession(target: TargetBase, sessionId: string): void {
+@@ -209,6 +213,7 @@ export class SessionRouter implements CDPConnectionObserver {
+   }
+ 
+   onDisconnect(reason: string): void {
++    clearInterval(this.#pingInterval);
+     const session = this.#sessions.get('');
+     if (session) {
+       session.target.dispose(reason);
 -- 
-2.39.5 (Apple Git-154)
+2.50.1 (Apple Git-155)
 

--- a/packages/chrome-devtools-patches/patches/0004-Support-viewing-source-files-over-the-network.-This-.patch
+++ b/packages/chrome-devtools-patches/patches/0004-Support-viewing-source-files-over-the-network.-This-.patch
@@ -1,4 +1,4 @@
-From b1f97bf51177076f6abb501cf8fe57a77640792e Mon Sep 17 00:00:00 2001
+From cd50ad3a1a9c3412390b10b65270935996f9282e Mon Sep 17 00:00:00 2001
 From: Workers DevProd <workers-devprod@cloudflare.com>
 Date: Fri, 25 Oct 2024 15:26:38 +0100
 Subject: [PATCH 4/8] Support viewing source files over the network. This
@@ -8,25 +8,24 @@ Subject: [PATCH 4/8] Support viewing source files over the network. This
 
 * Supporting a `?domain=` query param to customise the network name. Without this, the protocol is used (i.e. `file://`), which isn't super friendly (see NavigatorView.ts)
 
-* Enable JUST_MY_CODE to hide Wrangler's injected middleware (see MainImpl.ts)
+* Default the `navigator-just-my-code` setting to on, to hide Wrangler's injected middleware. Upstream graduated this from the JUST_MY_CODE experiment to a user setting, so we now flip its default rather than enabling an experiment (see sources-meta.ts)
 
-* Enable AUTHORED_DEPLOYED_GROUPING for a better grouping between source-mapped and compiled code (see MainImpl.ts)
+* Default the `navigator-group-by-authored` setting to on, for a better grouping between source-mapped and compiled code. Upstream graduated this from the AUTHORED_DEPLOYED_GROUPING experiment to a user setting, so we now flip its default rather than enabling an experiment (see sources-meta.ts)
 
 * Support the mechanism by which Wrangler provides sourcemaps, the wrangler-file:// protocol (see PageResourceLoader.ts & ParsedURL.ts)
 ---
  front_end/core/common/ParsedURL.ts        |  2 +-
- front_end/core/sdk/PageResourceLoader.ts  |  4 +++-
- front_end/entrypoints/js_app/js_app.ts    | 16 ++++++--------
- front_end/entrypoints/main/MainImpl.ts    |  2 ++
- front_end/panels/sources/NavigatorView.ts |  5 +++--
- front_end/panels/sources/sources-meta.ts  | 26 -----------------------
- 6 files changed, 15 insertions(+), 40 deletions(-)
+ front_end/core/sdk/PageResourceLoader.ts  |  4 ++-
+ front_end/entrypoints/js_app/js_app.ts    | 16 +++++-------
+ front_end/panels/sources/NavigatorView.ts |  5 ++--
+ front_end/panels/sources/sources-meta.ts  | 32 ++---------------------
+ 5 files changed, 15 insertions(+), 44 deletions(-)
 
 diff --git a/front_end/core/common/ParsedURL.ts b/front_end/core/common/ParsedURL.ts
-index d01ab1856d..e29c0eab46 100644
+index 6e4bc44156..a74d66678a 100644
 --- a/front_end/core/common/ParsedURL.ts
 +++ b/front_end/core/common/ParsedURL.ts
-@@ -365,7 +365,7 @@ export class ParsedURL {
+@@ -332,7 +332,7 @@ export class ParsedURL {
    static completeURL(baseURL: Platform.DevToolsPath.UrlString, href: string): Platform.DevToolsPath.UrlString|null {
      // Return special URLs as-is.
      if (href.startsWith('data:') || href.startsWith('blob:') || href.startsWith('javascript:') ||
@@ -36,40 +35,40 @@ index d01ab1856d..e29c0eab46 100644
      }
  
 diff --git a/front_end/core/sdk/PageResourceLoader.ts b/front_end/core/sdk/PageResourceLoader.ts
-index 722bf5f80a..cede6fbc20 100644
+index 6439842e7a..077a56184b 100644
 --- a/front_end/core/sdk/PageResourceLoader.ts
 +++ b/front_end/core/sdk/PageResourceLoader.ts
-@@ -381,7 +381,9 @@ export class PageResourceLoader extends Common.ObjectWrapper.ObjectWrapper<Event
-     const disableCache = Common.Settings.Settings.instance().moduleSetting('cache-disabled').get();
-     const resource = await networkManager.loadNetworkResource(frameId, url, {disableCache, includeCredentials: true});
+@@ -436,7 +436,9 @@ export class PageResourceLoader extends Common.ObjectWrapper.ObjectWrapper<Event
      try {
--      const content = resource.stream ? await ioModel.readToString(resource.stream) : '';
-+      // @ts-expect-error Property 'text' does not exist on type 'LoadNetworkResourcePageResult'.
-+      // Cloudflare custom extension to load network data without streams
-+      const content = resource.stream ? await ioModel.readToString(resource.stream) : (resource.text ?? '');
+       const content = resource.stream ?
+           (isBinary ? await ioModel.readToBuffer(resource.stream) : await ioModel.readToString(resource.stream)) :
+-          '';
++          // @ts-expect-error Property 'text' does not exist on type 'LoadNetworkResourcePageResult'.
++          // Cloudflare custom extension to load network data without streams
++          (resource.text ?? '');
        return {
          success: resource.success,
          content,
 diff --git a/front_end/entrypoints/js_app/js_app.ts b/front_end/entrypoints/js_app/js_app.ts
-index 814bc1fc70..893ac3533f 100644
+index 3c0179b3ed..35819cb93e 100644
 --- a/front_end/entrypoints/js_app/js_app.ts
 +++ b/front_end/entrypoints/js_app/js_app.ts
 @@ -18,17 +18,13 @@ import * as Main from '../main/main.js';
  
  const UIStrings = {
    /**
--   *@description Text that refers to the main target.
+-   * @description Text that refers to the main target.
 -   */
 -  main: 'Main',
 -  /**
--   *@description Title of the 'Scripts' tool in the Network Navigator View, which is part of the Sources tool
-+   *@description Title of the 'Cloudflare' tool in the Cloudflare Navigator View, which is part of the Sources tool
+-   * @description Title of the 'Scripts' tool in the Network Navigator View, which is part of the Sources tool
++   * @description Title of the 'Cloudflare' tool in the Cloudflare Navigator View, which is part of the Sources tool
     */
 -  networkTitle: 'Scripts',
 +  cloudflare: 'Cloudflare',
    /**
--   *@description Command for showing the 'Scripts' tool in the Network Navigator View, which is part of the Sources tool
-+   *@description Text that refers to the main target.
+-   * @description Command for showing the 'Scripts' tool in the Network Navigator View, which is part of the Sources tool
++   * @description Text that refers to the main target.
     */
 -  showNode: 'Show Scripts',
 +  main: 'Main',
@@ -87,24 +86,11 @@ index 814bc1fc70..893ac3533f 100644
    order: 2,
    persistence: UI.ViewManager.ViewPersistence.PERMANENT,
    async loadView() {
-diff --git a/front_end/entrypoints/main/MainImpl.ts b/front_end/entrypoints/main/MainImpl.ts
-index e4ac33c985..04eac3540a 100644
---- a/front_end/entrypoints/main/MainImpl.ts
-+++ b/front_end/entrypoints/main/MainImpl.ts
-@@ -359,6 +359,8 @@ export class MainImpl {
-     Root.Runtime.experiments.enableExperimentsByDefault([
-       Root.Runtime.ExperimentName.FULL_ACCESSIBILITY_TREE,
-       Root.Runtime.ExperimentName.HIGHLIGHT_ERRORS_ELEMENTS_PANEL,
-+      Root.Runtime.ExperimentName.AUTHORED_DEPLOYED_GROUPING,
-+      Root.Runtime.ExperimentName.JUST_MY_CODE,
-       ...(Root.Runtime.Runtime.queryParam('isChromeForTesting') ? ['protocol-monitor'] : []),
-     ]);
- 
 diff --git a/front_end/panels/sources/NavigatorView.ts b/front_end/panels/sources/NavigatorView.ts
-index c4f0cf6319..3c468c11a2 100644
+index af7d0ce53d..6cdd2eea0c 100644
 --- a/front_end/panels/sources/NavigatorView.ts
 +++ b/front_end/panels/sources/NavigatorView.ts
-@@ -823,8 +823,9 @@ export class NavigatorView extends UI.Widget.VBox implements SDK.TargetManager.O
+@@ -802,8 +802,9 @@ export class NavigatorView extends UI.Widget.VBox implements SDK.TargetManager.O
        return matchingContextName;
      }
  
@@ -117,10 +103,10 @@ index c4f0cf6319..3c468c11a2 100644
  
      const parsedURL = new Common.ParsedURL.ParsedURL(projectOrigin);
 diff --git a/front_end/panels/sources/sources-meta.ts b/front_end/panels/sources/sources-meta.ts
-index 966e223d5a..20ce18502a 100644
+index 9f012b5877..0d1e6cef1b 100644
 --- a/front_end/panels/sources/sources-meta.ts
 +++ b/front_end/panels/sources/sources-meta.ts
-@@ -517,32 +517,6 @@ UI.ViewManager.registerViewExtension({
+@@ -494,34 +494,6 @@ UI.ViewManager.registerViewExtension({
    },
  });
  
@@ -131,6 +117,7 @@ index 966e223d5a..20ce18502a 100644
 -  title: i18nLazyString(UIStrings.workspace),
 -  order: 3,
 -  persistence: UI.ViewManager.ViewPersistence.PERMANENT,
+-  condition: () => !Root.Runtime.Runtime.isTraceApp(),
 -  async loadView() {
 -    const Sources = await loadSourcesModule();
 -    return new Sources.SourcesNavigator.FilesNavigatorView();
@@ -144,6 +131,7 @@ index 966e223d5a..20ce18502a 100644
 -  title: i18nLazyString(UIStrings.snippets),
 -  order: 6,
 -  persistence: UI.ViewManager.ViewPersistence.PERMANENT,
+-  condition: () => !Root.Runtime.Runtime.isTraceApp(),
 -  async loadView() {
 -    const Sources = await loadSourcesModule();
 -    return new Sources.SourcesNavigator.SnippetsNavigatorView();
@@ -153,6 +141,22 @@ index 966e223d5a..20ce18502a 100644
  UI.ViewManager.registerViewExtension({
    location: UI.ViewManager.ViewLocationValues.DRAWER_VIEW,
    id: 'sources.search-sources-tab',
+@@ -1503,13 +1475,13 @@ Common.Settings.registerSettingExtension({
+ Common.Settings.registerSettingExtension({
+   settingName: 'navigator-group-by-authored',
+   settingType: Common.Settings.SettingType.BOOLEAN,
+-  defaultValue: false,
++  defaultValue: true,
+ });
+ 
+ Common.Settings.registerSettingExtension({
+   settingName: 'navigator-just-my-code',
+   settingType: Common.Settings.SettingType.BOOLEAN,
+-  defaultValue: false,
++  defaultValue: true,
+ });
+ 
+ Common.Settings.registerSettingExtension({
 -- 
-2.39.5 (Apple Git-154)
+2.50.1 (Apple Git-155)
 

--- a/packages/chrome-devtools-patches/patches/0005-Support-forcing-the-devtools-theme-via-a-query-param.patch
+++ b/packages/chrome-devtools-patches/patches/0005-Support-forcing-the-devtools-theme-via-a-query-param.patch
@@ -1,4 +1,4 @@
-From 83cc44962c8b10698abe61b74e4260a373624115 Mon Sep 17 00:00:00 2001
+From 97d32d0d4c0c4157f36c7b99553bb6fd10f4bdad Mon Sep 17 00:00:00 2001
 From: Workers DevProd <workers-devprod@cloudflare.com>
 Date: Fri, 25 Oct 2024 15:05:56 +0100
 Subject: [PATCH 5/8] Support forcing the devtools theme via a query parameter,
@@ -10,7 +10,7 @@ To test, make sure that `?theme=dark`, `?theme=default`, and `?theme=systemPrefe
  1 file changed, 8 insertions(+), 3 deletions(-)
 
 diff --git a/front_end/ui/legacy/theme_support/ThemeSupport.ts b/front_end/ui/legacy/theme_support/ThemeSupport.ts
-index 298ba78952..43ee9341ec 100644
+index 85bda316b0..93ae99ae5a 100644
 --- a/front_end/ui/legacy/theme_support/ThemeSupport.ts
 +++ b/front_end/ui/legacy/theme_support/ThemeSupport.ts
 @@ -152,14 +152,19 @@ export class ThemeSupport extends EventTarget {
@@ -25,10 +25,10 @@ index 298ba78952..43ee9341ec 100644
      const systemPreferredTheme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'default';
  
 -    const useSystemPreferred = this.setting.get() === 'systemPreferred' || isForcedColorsMode;
--    this.themeNameInternal = useSystemPreferred ? systemPreferredTheme : this.setting.get();
+-    this.#themeName = useSystemPreferred ? systemPreferredTheme : this.setting.get();
 +    const useSystemPreferred = theme === 'systemPreferred' || isForcedColorsMode;
-+    this.themeNameInternal = useSystemPreferred ? systemPreferredTheme : theme;
-     document.documentElement.classList.toggle('theme-with-dark-background', this.themeNameInternal === 'dark');
++    this.#themeName = useSystemPreferred ? systemPreferredTheme : theme;
+     document.documentElement.classList.toggle('theme-with-dark-background', this.#themeName === 'dark');
  
 -    const useChromeTheme = Common.Settings.moduleSetting('chrome-theme-colors').get();
 +    // Disable this—it adds blue headers which are out of keeping with Cloudflare styling
@@ -37,5 +37,5 @@ index 298ba78952..43ee9341ec 100644
      // Baseline is the name of Chrome's default color theme and there are two of these: default and grayscale.
      // The collective name for the rest of the color themes is dynamic.
 -- 
-2.39.5 (Apple Git-154)
+2.50.1 (Apple Git-155)
 

--- a/packages/chrome-devtools-patches/patches/0006-All-about-the-network-tab.patch
+++ b/packages/chrome-devtools-patches/patches/0006-All-about-the-network-tab.patch
@@ -1,4 +1,4 @@
-From 1729d533ea8866ee71a5e2170253f7cd6f850e0c Mon Sep 17 00:00:00 2001
+From 729ccc8510c23e6f74ccd258f450ae4978a46f5a Mon Sep 17 00:00:00 2001
 From: Workers DevProd <workers-devprod@cloudflare.com>
 Date: Fri, 25 Oct 2024 16:05:12 +0100
 Subject: [PATCH 6/8] All about the network tab!
@@ -10,23 +10,22 @@ Subject: [PATCH 6/8] All about the network tab!
 * Hide unsupported UI (cache disabling & network throttling)
 ---
  front_end/core/sdk/NetworkManager.ts     |  8 ++++++-
- front_end/entrypoints/js_app/js_app.ts   |  1 +
  front_end/panels/network/NetworkPanel.ts | 27 ------------------------
- 3 files changed, 8 insertions(+), 28 deletions(-)
+ 2 files changed, 7 insertions(+), 28 deletions(-)
 
 diff --git a/front_end/core/sdk/NetworkManager.ts b/front_end/core/sdk/NetworkManager.ts
-index 1e50c6329f..756679235b 100644
+index e4404b0bdc..7a275f02be 100644
 --- a/front_end/core/sdk/NetworkManager.ts
 +++ b/front_end/core/sdk/NetworkManager.ts
-@@ -34,6 +34,7 @@
+@@ -4,6 +4,7 @@
  
  import type * as ProtocolProxyApi from '../../generated/protocol-proxy-api.js';
  import * as Protocol from '../../generated/protocol.js';
 +import { ContentData } from '../../models/text_utils/ContentData.js';
  import * as TextUtils from '../../models/text_utils/text_utils.js';
  import * as Common from '../common/common.js';
- import type {Serializer} from '../common/Settings.js';
-@@ -846,7 +847,7 @@ export class NetworkDispatcher implements ProtocolProxyApi.NetworkDispatcher {
+ import * as i18n from '../i18n/i18n.js';
+@@ -918,7 +919,7 @@ export class NetworkDispatcher implements ProtocolProxyApi.NetworkDispatcher {
      this.updateNetworkRequest(networkRequest);
    }
  
@@ -35,7 +34,7 @@ index 1e50c6329f..756679235b 100644
      let networkRequest: NetworkRequest|null|undefined = this.#requestsById.get(requestId);
      if (!networkRequest) {
        networkRequest = this.maybeAdoptMainResourceRequest(requestId);
-@@ -855,6 +856,11 @@ export class NetworkDispatcher implements ProtocolProxyApi.NetworkDispatcher {
+@@ -927,6 +928,11 @@ export class NetworkDispatcher implements ProtocolProxyApi.NetworkDispatcher {
        return;
      }
      this.getExtraInfoBuilder(requestId).finished();
@@ -47,39 +46,27 @@ index 1e50c6329f..756679235b 100644
      this.finishNetworkRequest(networkRequest, finishTime, encodedDataLength);
      this.#manager.dispatchEventToListeners(Events.LoadingFinished, networkRequest);
    }
-diff --git a/front_end/entrypoints/js_app/js_app.ts b/front_end/entrypoints/js_app/js_app.ts
-index 893ac3533f..937e646ab5 100644
---- a/front_end/entrypoints/js_app/js_app.ts
-+++ b/front_end/entrypoints/js_app/js_app.ts
-@@ -4,6 +4,7 @@
- 
- import '../shell/shell.js';
- import '../../panels/js_timeline/js_timeline-meta.js';
-+import '../../panels/network/network-meta.js';
- import '../../panels/mobile_throttling/mobile_throttling-meta.js';
- import '../../panels/network/network-meta.js';
- 
 diff --git a/front_end/panels/network/NetworkPanel.ts b/front_end/panels/network/NetworkPanel.ts
-index f70065800e..ac1316662b 100644
+index 8ac9751bc4..6af60a62d4 100644
 --- a/front_end/panels/network/NetworkPanel.ts
 +++ b/front_end/panels/network/NetworkPanel.ts
-@@ -76,14 +76,6 @@ const UIStrings = {
-    *@description Text to preserve the log after refreshing
+@@ -79,14 +79,6 @@ const UIStrings = {
+    * @description Text to preserve the log after refreshing
     */
    preserveLog: 'Preserve log',
 -  /**
--   *@description Text to disable cache while DevTools is open
+-   * @description Text to disable cache while DevTools is open
 -   */
 -  disableCacheWhileDevtoolsIsOpen: 'Disable cache while DevTools is open',
 -  /**
--   *@description Text in Network Config View of the Network panel
+-   * @description Text in Network Config View of the Network panel
 -   */
 -  disableCache: 'Disable cache',
    /**
-    *@description Tooltip text that appears when hovering over the largeicon settings gear in show settings pane setting in network panel of the network panel
+    * @description Tooltip text that appears when hovering over the largeicon settings gear in show settings pane setting in network panel of the network panel
     */
-@@ -181,10 +173,6 @@ const UIStrings = {
-    *@description Text in Network Panel that is displayed when frames are being fetched.
+@@ -184,10 +176,6 @@ const UIStrings = {
+    * @description Text in Network Panel that is displayed when frames are being fetched.
     */
    fetchingFrames: 'Fetching frames…',
 -  /**
@@ -89,7 +76,7 @@ index f70065800e..ac1316662b 100644
  } as const;
  const str_ = i18n.i18n.registerUIStrings('panels/network/NetworkPanel.ts', UIStrings);
  const i18nString = i18n.i18n.getLocalizedString.bind(undefined, str_);
-@@ -456,21 +444,6 @@ export class NetworkPanel extends UI.Panel.Panel implements
+@@ -469,21 +457,6 @@ export class NetworkPanel extends UI.Panel.Panel implements
      this.panelToolbar.appendToolbarItem(new UI.Toolbar.ToolbarSettingCheckbox(
          this.preserveLogSetting, i18nString(UIStrings.doNotClearLogOnPageReload), i18nString(UIStrings.preserveLog)));
  
@@ -112,5 +99,5 @@ index f70065800e..ac1316662b 100644
      this.rightToolbar.appendSeparator();
      this.rightToolbar.appendToolbarItem(new UI.Toolbar.ToolbarSettingToggle(
 -- 
-2.39.5 (Apple Git-154)
+2.50.1 (Apple Git-155)
 

--- a/packages/chrome-devtools-patches/patches/0007-Limit-heap-profiling-modes-available.patch
+++ b/packages/chrome-devtools-patches/patches/0007-Limit-heap-profiling-modes-available.patch
@@ -1,31 +1,37 @@
-From c43fb074f72c73e4c7ad9dd02c061870298a4347 Mon Sep 17 00:00:00 2001
+From 18dbd30c7bd1e48999e74d1a50d780be77f77190 Mon Sep 17 00:00:00 2001
 From: Workers DevProd <workers-devprod@cloudflare.com>
 Date: Fri, 25 Oct 2024 16:07:24 +0100
 Subject: [PATCH 7/8] Limit heap profiling modes available
 
 ---
- front_end/panels/profiler/HeapProfilerPanel.ts | 8 ++------
- 1 file changed, 2 insertions(+), 6 deletions(-)
+ front_end/panels/profiler/HeapProfilerPanel.ts | 7 +++++++
+ 1 file changed, 7 insertions(+)
 
 diff --git a/front_end/panels/profiler/HeapProfilerPanel.ts b/front_end/panels/profiler/HeapProfilerPanel.ts
-index b25d9e65fc..9a19052de2 100644
+index 5a861cf740..858cd162d6 100644
 --- a/front_end/panels/profiler/HeapProfilerPanel.ts
 +++ b/front_end/panels/profiler/HeapProfilerPanel.ts
-@@ -25,12 +25,8 @@ export class HeapProfilerPanel extends ProfilesPanel implements UI.ContextMenu.P
-                                                                 UI.ActionRegistration.ActionDelegate {
-   constructor() {
-     const registry = instance;
--    const profileTypes = [
--      registry.heapSnapshotProfileType,
--      registry.trackingHeapSnapshotProfileType,
--      registry.samplingHeapProfileType,
--      registry.detachedElementProfileType,
--    ];
-+    const profileTypes =
-+        [registry.heapSnapshotProfileType];
-     super('heap-profiler', profileTypes as ProfileType[], 'profiler.heap-toggle-recording');
+@@ -7,6 +7,7 @@ import type * as SDK from '../../core/sdk/sdk.js';
+ import * as UI from '../../ui/legacy/legacy.js';
+ 
+ import type {HeapSnapshotView} from './HeapSnapshotView.js';
++import type {ProfileType} from './ProfileHeader.js';
+ import {ProfilesPanel} from './ProfilesPanel.js';
+ 
+ const UIStrings = {
+@@ -25,6 +26,12 @@ export class HeapProfilerPanel extends ProfilesPanel implements UI.ContextMenu.P
+     super('heap-profiler', 'profiler.heap-toggle-recording');
    }
  
++  override get profileTypes(): ProfileType[] {
++    // Limit heap profiling to the heap snapshot type only; the tracking,
++    // sampling and detached-element profilers are not supported in this context.
++    return [ProfilesPanel.registry.heapSnapshotProfileType];
++  }
++
+   static instance(): HeapProfilerPanel {
+     if (!heapProfilerPanelInstance) {
+       heapProfilerPanelInstance = new HeapProfilerPanel();
 -- 
-2.39.5 (Apple Git-154)
+2.50.1 (Apple Git-155)
 

--- a/packages/chrome-devtools-patches/patches/0008-Use-the-worker-name-as-the-title-for-the-Javascript-.patch
+++ b/packages/chrome-devtools-patches/patches/0008-Use-the-worker-name-as-the-title-for-the-Javascript-.patch
@@ -1,4 +1,4 @@
-From 641e6a0eb3f7cf138168185f8a51cd93b1d0db74 Mon Sep 17 00:00:00 2001
+From ad0563aa4064345778b0419b21096b484a5e493f Mon Sep 17 00:00:00 2001
 From: Workers DevProd <workers-devprod@cloudflare.com>
 Date: Fri, 25 Oct 2024 16:11:10 +0100
 Subject: [PATCH 8/8] Use the worker name as the title for the Javascript
@@ -9,7 +9,7 @@ Subject: [PATCH 8/8] Use the worker name as the title for the Javascript
  1 file changed, 5 insertions(+), 1 deletion(-)
 
 diff --git a/front_end/panels/timeline/IsolateSelector.ts b/front_end/panels/timeline/IsolateSelector.ts
-index eea81e20dd..9d19e75d79 100644
+index 39e3b367b8..fbe355acbe 100644
 --- a/front_end/panels/timeline/IsolateSelector.ts
 +++ b/front_end/panels/timeline/IsolateSelector.ts
 @@ -52,8 +52,12 @@ export class IsolateSelector extends UI.Toolbar.ToolbarItem implements SDK.Isola
@@ -27,5 +27,5 @@ index eea81e20dd..9d19e75d79 100644
      }
      itemForIsolate.removeChildren();
 -- 
-2.39.5 (Apple Git-154)
+2.50.1 (Apple Git-155)
 


### PR DESCRIPTION
Periodic rebase of our maintained Workers-specific Chrome DevTools patches onto a newer upstream release, aligned with **Chrome 150 stable** (`devtools-frontend` commit `1d67dc0dafa344bbd6ca75c124e2d6d9d53074d8`, up from `b66ecf5b`).

This is the DevTools frontend used by `wrangler dev` and the Workers Playground (see `packages/chrome-devtools-patches`). All 8 maintained patches were rebased and regenerated; applying the regenerated patch set with `git am` onto the new base reproduces the rebased tree exactly.

Notable adaptations required by upstream churn:

- **Ping keep-alive** (0003): ported to the refactored `SessionRouter` / `CDPConnectionObserver` observer model; the ping now uses the typed `connection.send("Runtime.getIsolateId", ...)` API.
- **Source viewing over the network** (0004): the `JUST_MY_CODE` and `AUTHORED_DEPLOYED_GROUPING` experiments graduated upstream into the `navigator-just-my-code` and `navigator-group-by-authored` settings. We now default those settings to on (in `sources-meta.ts`) instead of force-enabling experiments (in `MainImpl.ts`), preserving the previous behaviour.
- **Limit heap profiling modes** (0007): `ProfilesPanel` dropped its `profileTypes` constructor parameter, so we override the new virtual `get profileTypes()` getter to expose only the heap-snapshot type.
- **Browser support / CSP** (0001): re-applied our entrypoint CSP hash onto upstream's expanded `script-src`.

Verification status (this is a draft):

- Done: `git am` of the regenerated patches applies cleanly onto the new base and reproduces the rebased tree exactly.
- Pending: local build (`make devtools-frontend/out/Default/gen/front_end`).
- Pending: CI preview build (`preview:chrome-devtools-patches`) and manual smoke test (dark-mode console contrast, `?theme=` param, "Cloudflare" sources navigator, network tab with disable-cache/throttling hidden, heap profiling limited to the snapshot type).

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [x] Automated tests not possible - manual testing has been completed as follows: this fork has no automated test harness; verification is via `git am` reproducing the patched tree exactly, a local DevTools build, the CI preview build, and a manual smoke test of the patched behaviours (theme query param, "Cloudflare" sources navigator, network-tab customisations, and heap profiling limited to the snapshot type).
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: internal tooling change — a patch-rebase / version bump of the embedded Chrome DevTools fork with no user-facing API or documented-behaviour changes.

*A picture of a cute animal (not mandatory, but encouraged)*
