### PR TITLE
[tools] Add emergency revert script for broken releases

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
 		"check:type": "dotenv -- turbo check:type type:tests",
 		"check:workflows": "node -r esbuild-register tools/github-workflow-helpers/validate-action-pinning.ts",
 		"dev": "dotenv -- turbo dev",
+		"emergency:revert": "node -r esbuild-register tools/deployments/emergency-revert.ts",
 		"fix": "oxlint --fix --type-aware && pnpm run prettify",
 		"prettify": "oxfmt",
 		"test": "dotenv -- turbo test",

--- a/tools/README.md
+++ b/tools/README.md
@@ -14,6 +14,8 @@ Tools for helping with CI
 - `deployments/validate-pinned-dependencies.ts` - Ensures all non-bundled dependencies of published packages (and all pnpm catalog entries) are pinned to exact versions.
   Used by the test-and-check.yml GitHub Action workflow, as part of the `check` npm script (`pnpm check:pinned-deps`).
 
+- `deployments/emergency-revert.ts` - Reverts the npm `latest` dist-tag and deprecates bad versions for wrangler and its coordinated dependents (miniflare, `@cloudflare/vite-plugin`, `@cloudflare/vitest-pool-workers`, `create-cloudflare`) during a broken-release incident. Unlike the other scripts in this directory, this is run manually (`pnpm emergency:revert -- ...`) by an authenticated npm org member — it is not invoked by any CI workflow, since OIDC Trusted Publishing does not grant `dist-tag`/`deprecate` permissions.
+
 - `dependabot/generate-dependabot-pr-changesets.ts` - Generates and commits a changeset for a Dependabot PR.
   Used by the c3-dependabot-versioning-prs.yml and miniflare-dependabot-versioning-prs.yml GitHub Action workflows.
 

--- a/tools/deployments/__tests__/emergency-revert.test.ts
+++ b/tools/deployments/__tests__/emergency-revert.test.ts
@@ -1,0 +1,328 @@
+import { spawnSync } from "node:child_process";
+import { afterEach, describe, it, vitest } from "vitest";
+import {
+	buildDeprecateCommand,
+	buildDistTagCommand,
+	DEFAULT_PACKAGES,
+	parseCliArgs,
+	parsePackageArg,
+	revertRelease,
+	validateSemver,
+	verifyNpmAuth,
+	verifyVersionExists,
+} from "../emergency-revert";
+import type { Mock } from "vitest";
+
+vitest.mock("node:child_process", async () => {
+	return {
+		spawnSync: vitest.fn(),
+	};
+});
+
+function mockSpawnSyncResult(status: number, stdout = "") {
+	(spawnSync as Mock).mockReturnValue({
+		status,
+		stdout: Buffer.from(stdout),
+	});
+}
+
+describe("parsePackageArg()", () => {
+	it("parses a plain package name", ({ expect }) => {
+		expect(parsePackageArg("wrangler@3.90.0:3.89.0")).toEqual({
+			name: "wrangler",
+			badVersion: "3.90.0",
+			goodVersion: "3.89.0",
+		});
+	});
+
+	it("parses a scoped package name", ({ expect }) => {
+		expect(parsePackageArg("@cloudflare/vite-plugin@1.4.0:1.3.2")).toEqual({
+			name: "@cloudflare/vite-plugin",
+			badVersion: "1.4.0",
+			goodVersion: "1.3.2",
+		});
+	});
+
+	it("throws on a missing separator", ({ expect }) => {
+		expect(() =>
+			parsePackageArg("wrangler@3.90.0")
+		).toThrowErrorMatchingInlineSnapshot(
+			`[Error: Invalid --package value "wrangler@3.90.0". Expected format: name@badVersion:goodVersion]`
+		);
+	});
+
+	it("throws on a missing version", ({ expect }) => {
+		expect(() =>
+			parsePackageArg("wrangler:3.89.0")
+		).toThrowErrorMatchingInlineSnapshot(
+			`[Error: Invalid --package value "wrangler:3.89.0". Expected format: name@badVersion:goodVersion]`
+		);
+	});
+
+	it("throws on an invalid semver version", ({ expect }) => {
+		expect(() =>
+			parsePackageArg("wrangler@abc:3.89.0")
+		).toThrowErrorMatchingInlineSnapshot(
+			`[Error: Invalid semver version "abc" for --package wrangler@abc:3.89.0 (bad version)]`
+		);
+	});
+});
+
+describe("validateSemver()", () => {
+	it("accepts a valid version", ({ expect }) => {
+		expect(() => validateSemver("3.90.0", "test")).not.toThrow();
+	});
+
+	it("rejects an invalid version", ({ expect }) => {
+		expect(() =>
+			validateSemver("abc", "test")
+		).toThrowErrorMatchingInlineSnapshot(
+			`[Error: Invalid semver version "abc" for test]`
+		);
+	});
+});
+
+describe("buildDistTagCommand()", () => {
+	it("builds the default latest tag command", ({ expect }) => {
+		expect(buildDistTagCommand("wrangler", "3.89.0", "latest")).toEqual([
+			"dist-tag",
+			"add",
+			"wrangler@3.89.0",
+			"latest",
+		]);
+	});
+
+	it("builds a command for a custom tag", ({ expect }) => {
+		expect(buildDistTagCommand("wrangler", "3.89.0", "beta")).toEqual([
+			"dist-tag",
+			"add",
+			"wrangler@3.89.0",
+			"beta",
+		]);
+	});
+});
+
+describe("buildDeprecateCommand()", () => {
+	it("builds the deprecate command", ({ expect }) => {
+		expect(buildDeprecateCommand("wrangler", "3.90.0", "bad release")).toEqual([
+			"deprecate",
+			"wrangler@3.90.0",
+			"bad release",
+		]);
+	});
+});
+
+describe("verifyVersionExists()", () => {
+	afterEach(() => {
+		(spawnSync as Mock).mockReset();
+	});
+
+	it("returns true when npm view succeeds", ({ expect }) => {
+		mockSpawnSyncResult(0, "3.89.0\n");
+		expect(verifyVersionExists("wrangler", "3.89.0")).toBe(true);
+		expect(spawnSync).toHaveBeenCalledWith(
+			"npm",
+			["view", "wrangler@3.89.0", "version"],
+			expect.any(Object)
+		);
+	});
+
+	it("returns false when npm view fails", ({ expect }) => {
+		mockSpawnSyncResult(1);
+		expect(verifyVersionExists("wrangler", "999.0.0")).toBe(false);
+	});
+});
+
+describe("verifyNpmAuth()", () => {
+	afterEach(() => {
+		(spawnSync as Mock).mockReset();
+	});
+
+	it("returns true when whoami succeeds", ({ expect }) => {
+		mockSpawnSyncResult(0, "some-user\n");
+		expect(verifyNpmAuth()).toBe(true);
+		expect(spawnSync).toHaveBeenCalledWith(
+			"npm",
+			["whoami"],
+			expect.any(Object)
+		);
+	});
+
+	it("returns false when whoami fails", ({ expect }) => {
+		mockSpawnSyncResult(1);
+		expect(verifyNpmAuth()).toBe(false);
+	});
+});
+
+describe("revertRelease()", () => {
+	afterEach(() => {
+		(spawnSync as Mock).mockReset();
+		vitest.restoreAllMocks();
+	});
+
+	it("exits with an error when given an empty spec list", ({ expect }) => {
+		vitest.spyOn(console, "error").mockImplementation(() => {});
+		vitest.spyOn(process, "exit").mockImplementation(() => undefined as never);
+
+		revertRelease([], { dryRun: true, tag: "latest" });
+
+		expect(process.exit).toHaveBeenCalledWith(1);
+		expect(spawnSync).not.toHaveBeenCalled();
+	});
+
+	it("in dry-run mode never calls dist-tag or deprecate", ({ expect }) => {
+		mockSpawnSyncResult(0, "1.0.0\n");
+		vitest.spyOn(console, "log").mockImplementation(() => {});
+
+		revertRelease(
+			[{ name: "wrangler", badVersion: "3.90.0", goodVersion: "3.89.0" }],
+			{ dryRun: true, tag: "latest" }
+		);
+
+		const calledArgs = (spawnSync as Mock).mock.calls.map((call) => call[1]);
+		expect(calledArgs.some((args) => args[0] === "dist-tag")).toBe(false);
+		expect(calledArgs.some((args) => args[0] === "deprecate")).toBe(false);
+		expect(calledArgs.some((args) => args[0] === "whoami")).toBe(false);
+	});
+
+	it("in execute mode calls dist-tag and deprecate for each package", ({
+		expect,
+	}) => {
+		mockSpawnSyncResult(0, "1.0.0\n");
+		vitest.spyOn(console, "log").mockImplementation(() => {});
+
+		revertRelease(
+			[{ name: "wrangler", badVersion: "3.90.0", goodVersion: "3.89.0" }],
+			{ dryRun: false, tag: "latest" }
+		);
+
+		const calledArgs = (spawnSync as Mock).mock.calls.map((call) => call[1]);
+		expect(calledArgs).toContainEqual([
+			"dist-tag",
+			"add",
+			"wrangler@3.89.0",
+			"latest",
+		]);
+		expect(
+			calledArgs.some(
+				(args) => args[0] === "deprecate" && args[1] === "wrangler@3.90.0"
+			)
+		).toBe(true);
+	});
+
+	it("aborts entirely when one package fails the registry preflight", ({
+		expect,
+	}) => {
+		(spawnSync as Mock).mockImplementation((_cmd, args: string[]) => {
+			if (args[1] === "wrangler@999.0.0") {
+				return { status: 1, stdout: Buffer.from("") };
+			}
+			return { status: 0, stdout: Buffer.from("1.0.0\n") };
+		});
+		vitest.spyOn(console, "log").mockImplementation(() => {});
+		vitest.spyOn(console, "error").mockImplementation(() => {});
+		vitest.spyOn(process, "exit").mockImplementation(() => undefined as never);
+
+		revertRelease(
+			[
+				{ name: "wrangler", badVersion: "999.0.0", goodVersion: "3.89.0" },
+				{ name: "miniflare", badVersion: "4.0.0", goodVersion: "3.99.0" },
+			],
+			{ dryRun: false, tag: "latest" }
+		);
+
+		expect(process.exit).toHaveBeenCalledWith(1);
+		const calledArgs = (spawnSync as Mock).mock.calls.map((call) => call[1]);
+		expect(calledArgs.some((args) => args[0] === "dist-tag")).toBe(false);
+		expect(calledArgs.some((args) => args[0] === "deprecate")).toBe(false);
+	});
+
+	it("blocks execution when npm auth fails", ({ expect }) => {
+		(spawnSync as Mock).mockImplementation((_cmd, args: string[]) => {
+			if (args[0] === "whoami") {
+				return { status: 1, stdout: Buffer.from("") };
+			}
+			return { status: 0, stdout: Buffer.from("1.0.0\n") };
+		});
+		vitest.spyOn(console, "log").mockImplementation(() => {});
+		vitest.spyOn(console, "error").mockImplementation(() => {});
+		vitest.spyOn(process, "exit").mockImplementation(() => undefined as never);
+
+		revertRelease(
+			[{ name: "wrangler", badVersion: "3.90.0", goodVersion: "3.89.0" }],
+			{ dryRun: false, tag: "latest" }
+		);
+
+		expect(process.exit).toHaveBeenCalledWith(1);
+		const calledArgs = (spawnSync as Mock).mock.calls.map((call) => call[1]);
+		expect(calledArgs.some((args) => args[0] === "dist-tag")).toBe(false);
+		expect(calledArgs.some((args) => args[0] === "deprecate")).toBe(false);
+	});
+});
+
+describe("parseCliArgs()", () => {
+	afterEach(() => {
+		vitest.restoreAllMocks();
+	});
+
+	it("exits with an error when no --package flag is given", ({ expect }) => {
+		vitest.spyOn(console, "error").mockImplementation(() => {});
+		vitest.spyOn(console, "log").mockImplementation(() => {});
+		vitest.spyOn(process, "exit").mockImplementation(() => undefined as never);
+
+		parseCliArgs([]);
+
+		expect(process.exit).toHaveBeenCalledWith(1);
+	});
+
+	it("exits when a package isn't in the known set", ({ expect }) => {
+		vitest.spyOn(console, "error").mockImplementation(() => {});
+		vitest.spyOn(process, "exit").mockImplementation(() => undefined as never);
+
+		parseCliArgs(["--package", "not-a-known-package@1.0.0:0.9.0"]);
+
+		expect(process.exit).toHaveBeenCalledWith(1);
+	});
+
+	it("succeeds when an unknown package is paired with --allow-package", ({
+		expect,
+	}) => {
+		const result = parseCliArgs([
+			"--allow-package",
+			"@cloudflare/pages-shared",
+			"--package",
+			"@cloudflare/pages-shared@1.0.0:0.9.0",
+		]);
+
+		expect(result.specs).toEqual([
+			{
+				name: "@cloudflare/pages-shared",
+				badVersion: "1.0.0",
+				goodVersion: "0.9.0",
+			},
+		]);
+	});
+
+	it("defaults to dry-run and the latest tag", ({ expect }) => {
+		const result = parseCliArgs([
+			"--package",
+			`${DEFAULT_PACKAGES[0]}@1.0.0:0.9.0`,
+		]);
+
+		expect(result.dryRun).toBe(true);
+		expect(result.tag).toBe("latest");
+	});
+
+	it("honors --execute and a custom --tag", ({ expect }) => {
+		const result = parseCliArgs([
+			"--package",
+			`${DEFAULT_PACKAGES[0]}@1.0.0:0.9.0`,
+			"--execute",
+			"--tag",
+			"beta",
+		]);
+
+		expect(result.dryRun).toBe(false);
+		expect(result.tag).toBe("beta");
+	});
+});

--- a/tools/deployments/emergency-revert.ts
+++ b/tools/deployments/emergency-revert.ts
@@ -1,0 +1,284 @@
+import { spawnSync } from "node:child_process";
+import { valid } from "semver";
+import type { SpawnSyncReturns } from "node:child_process";
+
+/**
+ * Emergency revert tool for when a Wrangler release is broken.
+ *
+ * Unlike its siblings in this directory, this script is never invoked by
+ * CI. Normal releases (changesets.yml) and hotfix releases
+ * (hotfix-release.yml) both publish via npm OIDC Trusted Publishing, which
+ * only covers `npm publish` — it does not grant `npm dist-tag` or
+ * `npm deprecate` permissions. Run this locally with an authenticated npm
+ * session (`npm login`, or `NODE_AUTH_TOKEN` set to a token with
+ * publish/admin rights on these packages).
+ *
+ * Usage:
+ *   pnpm emergency:revert -- --package wrangler@3.90.0:3.89.0 --package miniflare@4.20250709.0:4.20250708.0 --execute
+ *
+ * Omit `--execute` to preview the exact commands that would run without
+ * doing anything (default).
+ */
+
+export const DEFAULT_PACKAGES: string[] = [
+	"wrangler",
+	"miniflare",
+	"@cloudflare/vite-plugin",
+	"@cloudflare/vitest-pool-workers",
+	"create-cloudflare",
+];
+
+export interface PackageRevertSpec {
+	name: string;
+	badVersion: string;
+	goodVersion: string;
+}
+
+export interface RevertOptions {
+	dryRun: boolean;
+	tag: string;
+	deprecateMessage?: string;
+}
+
+export function defaultDeprecateMessage(goodVersion: string): string {
+	return `This version was published as part of a broken release and has been deprecated. Please upgrade to ${goodVersion} or later.`;
+}
+
+/**
+ * Parses "name@badVersion:goodVersion", including scoped package names
+ * (e.g. "@cloudflare/vite-plugin@1.4.0:1.3.2").
+ */
+export function parsePackageArg(arg: string): PackageRevertSpec {
+	const match = /^(@?[^@]+(?:\/[^@]+)?)@([^:]+):(.+)$/.exec(arg);
+	if (!match) {
+		throw new Error(
+			`Invalid --package value "${arg}". Expected format: name@badVersion:goodVersion`
+		);
+	}
+	const [, name, badVersion, goodVersion] = match;
+	validateSemver(badVersion, `--package ${arg} (bad version)`);
+	validateSemver(goodVersion, `--package ${arg} (good version)`);
+	return { name, badVersion, goodVersion };
+}
+
+export function validateSemver(version: string, context: string): void {
+	if (valid(version) === null) {
+		throw new Error(`Invalid semver version "${version}" for ${context}`);
+	}
+}
+
+export function buildDistTagCommand(
+	pkgName: string,
+	version: string,
+	tag: string
+): string[] {
+	return ["dist-tag", "add", `${pkgName}@${version}`, tag];
+}
+
+export function buildDeprecateCommand(
+	pkgName: string,
+	version: string,
+	message: string
+): string[] {
+	return ["deprecate", `${pkgName}@${version}`, message];
+}
+
+export function runNpmCommand(args: string[]): SpawnSyncReturns<Buffer> {
+	return spawnSync("npm", args, { env: process.env });
+}
+
+export function verifyVersionExists(pkgName: string, version: string): boolean {
+	const result = runNpmCommand(["view", `${pkgName}@${version}`, "version"]);
+	return result.status === 0 && result.stdout.toString().trim().length > 0;
+}
+
+export function verifyNpmAuth(): boolean {
+	const result = runNpmCommand(["whoami"]);
+	return result.status === 0;
+}
+
+export function revertPackage(
+	spec: PackageRevertSpec,
+	options: RevertOptions
+): string | undefined {
+	const message =
+		options.deprecateMessage ?? defaultDeprecateMessage(spec.goodVersion);
+	const distTagArgs = buildDistTagCommand(
+		spec.name,
+		spec.goodVersion,
+		options.tag
+	);
+	const deprecateArgs = buildDeprecateCommand(
+		spec.name,
+		spec.badVersion,
+		message
+	);
+
+	if (options.dryRun) {
+		console.log(`[${spec.name}] Would run: npm ${distTagArgs.join(" ")}`);
+		console.log(`[${spec.name}] Would run: npm ${deprecateArgs.join(" ")}`);
+		return undefined;
+	}
+
+	console.log(`[${spec.name}] Running: npm ${distTagArgs.join(" ")}`);
+	const distTagResult = runNpmCommand(distTagArgs);
+	if (distTagResult.status !== 0) {
+		return `[${spec.name}] Failed to move "${options.tag}" tag to ${spec.goodVersion}`;
+	}
+
+	console.log(`[${spec.name}] Running: npm ${deprecateArgs.join(" ")}`);
+	const deprecateResult = runNpmCommand(deprecateArgs);
+	if (deprecateResult.status !== 0) {
+		return `[${spec.name}] Failed to deprecate ${spec.badVersion}`;
+	}
+
+	return undefined;
+}
+
+export function revertRelease(
+	specs: PackageRevertSpec[],
+	options: RevertOptions
+): void {
+	if (specs.length === 0) {
+		console.error("Error: at least one --package must be given.");
+		process.exit(1);
+		return;
+	}
+
+	console.log("Verifying all versions exist on the registry...");
+	const preflightFailures: string[] = [];
+	for (const spec of specs) {
+		if (!verifyVersionExists(spec.name, spec.badVersion)) {
+			preflightFailures.push(
+				`${spec.name}@${spec.badVersion} not found on npm`
+			);
+		}
+		if (!verifyVersionExists(spec.name, spec.goodVersion)) {
+			preflightFailures.push(
+				`${spec.name}@${spec.goodVersion} not found on npm`
+			);
+		}
+	}
+	if (preflightFailures.length > 0) {
+		console.error("Error: one or more versions could not be verified:");
+		for (const failure of preflightFailures) {
+			console.error(`  - ${failure}`);
+		}
+		console.error("Nothing was changed.");
+		process.exit(1);
+		return;
+	}
+
+	console.log("All versions verified.");
+
+	if (options.dryRun) {
+		console.log("\nDry run (pass --execute to actually run these commands):\n");
+		for (const spec of specs) {
+			revertPackage(spec, options);
+		}
+		return;
+	}
+
+	if (!verifyNpmAuth()) {
+		console.error(
+			"Error: not logged in to npm. Run `npm login` before using --execute."
+		);
+		process.exit(1);
+		return;
+	}
+
+	const failures: string[] = [];
+	for (const spec of specs) {
+		const failure = revertPackage(spec, options);
+		if (failure) {
+			failures.push(failure);
+		}
+	}
+
+	if (failures.length > 0) {
+		console.error("\nSome packages failed to revert:");
+		for (const failure of failures) {
+			console.error(`  - ${failure}`);
+		}
+		process.exit(1);
+		return;
+	}
+
+	console.log("\nDone.");
+}
+
+function printUsage(): void {
+	console.log(`
+Usage:
+  pnpm emergency:revert -- --package <name>@<badVersion>:<goodVersion> [--package ...] [--execute] [--tag <tag>] [--message "<text>"] [--allow-package <name>]
+
+Example:
+  pnpm emergency:revert -- --package wrangler@3.90.0:3.89.0 --package miniflare@4.20250709.0:4.20250708.0 --execute
+
+Known coordinated packages: ${DEFAULT_PACKAGES.join(", ")}
+Use --allow-package to revert a package outside this list.
+
+Omit --execute to preview the commands that would run without changing anything (default).
+`);
+}
+
+export function parseCliArgs(argv: string[]): {
+	specs: PackageRevertSpec[];
+	dryRun: boolean;
+	tag: string;
+	deprecateMessage?: string;
+} {
+	const allowedPackages = new Set(DEFAULT_PACKAGES);
+	const specs: PackageRevertSpec[] = [];
+	let dryRun = true;
+	let tag = "latest";
+	let deprecateMessage: string | undefined;
+
+	// --allow-package can appear anywhere in argv relative to --package, so
+	// collect it in a first pass before validating package names.
+	for (let i = 0; i < argv.length; i++) {
+		if (argv[i] === "--allow-package") {
+			allowedPackages.add(argv[++i]);
+		}
+	}
+
+	for (let i = 0; i < argv.length; i++) {
+		const arg = argv[i];
+		if (arg === "-h" || arg === "--help") {
+			printUsage();
+			process.exit(0);
+		} else if (arg === "--package") {
+			const spec = parsePackageArg(argv[++i]);
+			if (!allowedPackages.has(spec.name)) {
+				console.error(
+					`Error: "${spec.name}" is not a known coordinated package; pass --allow-package ${spec.name} if this is intentional.`
+				);
+				process.exit(1);
+			}
+			specs.push(spec);
+		} else if (arg === "--execute") {
+			dryRun = false;
+		} else if (arg === "--tag") {
+			tag = argv[++i];
+		} else if (arg === "--message") {
+			deprecateMessage = argv[++i];
+		} else if (arg === "--allow-package") {
+			i++; // already handled above
+		}
+	}
+
+	if (specs.length === 0) {
+		console.error("Error: at least one --package must be given.\n");
+		printUsage();
+		process.exit(1);
+	}
+
+	return { specs, dryRun, tag, deprecateMessage };
+}
+
+if (require.main === module) {
+	const { specs, dryRun, tag, deprecateMessage } = parseCliArgs(
+		process.argv.slice(2)
+	);
+	revertRelease(specs, { dryRun, tag, deprecateMessage });
+}

--- a/tools/deployments/emergency-revert.ts
+++ b/tools/deployments/emergency-revert.ts
@@ -254,6 +254,7 @@ export function parseCliArgs(argv: string[]): {
 					`Error: "${spec.name}" is not a known coordinated package; pass --allow-package ${spec.name} if this is intentional.`
 				);
 				process.exit(1);
+				continue;
 			}
 			specs.push(spec);
 		} else if (arg === "--execute") {

--- a/tools/deployments/emergency-revert.ts
+++ b/tools/deployments/emergency-revert.ts
@@ -83,8 +83,20 @@ export function buildDeprecateCommand(
 	return ["deprecate", `${pkgName}@${version}`, message];
 }
 
-export function runNpmCommand(args: string[]): SpawnSyncReturns<Buffer> {
-	return spawnSync("npm", args, { env: process.env });
+/**
+ * Runs an npm command. Read-only checks (view/whoami) keep piped stdio so
+ * their output can be inspected programmatically. Mutating commands
+ * (dist-tag add, deprecate) use inherited stdio so npm can prompt for an
+ * OTP (2FA) and its own output/errors are visible during an incident.
+ */
+export function runNpmCommand(
+	args: string[],
+	{ inherit = false }: { inherit?: boolean } = {}
+): SpawnSyncReturns<Buffer> {
+	return spawnSync("npm", args, {
+		env: process.env,
+		stdio: inherit ? "inherit" : "pipe",
+	});
 }
 
 export function verifyVersionExists(pkgName: string, version: string): boolean {
@@ -121,13 +133,13 @@ export function revertPackage(
 	}
 
 	console.log(`[${spec.name}] Running: npm ${distTagArgs.join(" ")}`);
-	const distTagResult = runNpmCommand(distTagArgs);
+	const distTagResult = runNpmCommand(distTagArgs, { inherit: true });
 	if (distTagResult.status !== 0) {
 		return `[${spec.name}] Failed to move "${options.tag}" tag to ${spec.goodVersion}`;
 	}
 
 	console.log(`[${spec.name}] Running: npm ${deprecateArgs.join(" ")}`);
-	const deprecateResult = runNpmCommand(deprecateArgs);
+	const deprecateResult = runNpmCommand(deprecateArgs, { inherit: true });
 	if (deprecateResult.status !== 0) {
 		return `[${spec.name}] Failed to deprecate ${spec.badVersion}`;
 	}
@@ -238,7 +250,14 @@ export function parseCliArgs(argv: string[]): {
 	// collect it in a first pass before validating package names.
 	for (let i = 0; i < argv.length; i++) {
 		if (argv[i] === "--allow-package") {
-			allowedPackages.add(argv[++i]);
+			const value = argv[i + 1];
+			if (!value) {
+				console.error('Error: missing value for "--allow-package".');
+				process.exit(1);
+				return { specs: [], dryRun, tag, deprecateMessage };
+			}
+			allowedPackages.add(value);
+			i++;
 		}
 	}
 
@@ -250,8 +269,9 @@ export function parseCliArgs(argv: string[]): {
 		} else if (arg === "--package") {
 			const value = argv[i + 1];
 			if (!value) {
-				console.error("Error: missing value for \"--package\".");
+				console.error('Error: missing value for "--package".');
 				process.exit(1);
+				continue;
 			}
 			i++;
 			const spec = parsePackageArg(value);
@@ -268,16 +288,18 @@ export function parseCliArgs(argv: string[]): {
 		} else if (arg === "--tag") {
 			const value = argv[i + 1];
 			if (!value) {
-				console.error("Error: missing value for \"--tag\".");
+				console.error('Error: missing value for "--tag".');
 				process.exit(1);
+				continue;
 			}
 			tag = value;
 			i++;
 		} else if (arg === "--message") {
 			const value = argv[i + 1];
 			if (!value) {
-				console.error("Error: missing value for \"--message\".");
+				console.error('Error: missing value for "--message".');
 				process.exit(1);
+				continue;
 			}
 			deprecateMessage = value;
 			i++;
@@ -290,6 +312,7 @@ export function parseCliArgs(argv: string[]): {
 		console.error("Error: at least one --package must be given.\n");
 		printUsage();
 		process.exit(1);
+		return { specs: [], dryRun, tag, deprecateMessage };
 	}
 
 	return { specs, dryRun, tag, deprecateMessage };

--- a/tools/deployments/emergency-revert.ts
+++ b/tools/deployments/emergency-revert.ts
@@ -248,7 +248,13 @@ export function parseCliArgs(argv: string[]): {
 			printUsage();
 			process.exit(0);
 		} else if (arg === "--package") {
-			const spec = parsePackageArg(argv[++i]);
+			const value = argv[i + 1];
+			if (!value) {
+				console.error("Error: missing value for \"--package\".");
+				process.exit(1);
+			}
+			i++;
+			const spec = parsePackageArg(value);
 			if (!allowedPackages.has(spec.name)) {
 				console.error(
 					`Error: "${spec.name}" is not a known coordinated package; pass --allow-package ${spec.name} if this is intentional.`
@@ -260,9 +266,21 @@ export function parseCliArgs(argv: string[]): {
 		} else if (arg === "--execute") {
 			dryRun = false;
 		} else if (arg === "--tag") {
-			tag = argv[++i];
+			const value = argv[i + 1];
+			if (!value) {
+				console.error("Error: missing value for \"--tag\".");
+				process.exit(1);
+			}
+			tag = value;
+			i++;
 		} else if (arg === "--message") {
-			deprecateMessage = argv[++i];
+			const value = argv[i + 1];
+			if (!value) {
+				console.error("Error: missing value for \"--message\".");
+				process.exit(1);
+			}
+			deprecateMessage = value;
+			i++;
 		} else if (arg === "--allow-package") {
 			i++; // already handled above
 		}


### PR DESCRIPTION
Fixes #14219

Adds `tools/deployments/emergency-revert.ts`, automating the two manual steps described in the issue for when a Wrangler release is broken:
1. move the npm `latest` dist-tag back to a known-good version
2. mark the bad version as deprecated

## Design

- Covers the coordinated package set with a real `dependency`/`peerDependency` relationship to wrangler/miniflare: `wrangler`, `miniflare`, `@cloudflare/vite-plugin`, `@cloudflare/vitest-pool-workers`, `create-cloudflare` (matches `hotfix-release.yml`'s existing `--filter wrangler --filter miniflare --filter create-cloudflare` grouping, extended to also include vite-plugin and vitest-pool-workers per the actual dependency graph). `--allow-package` is an escape hatch for anything outside that default set.
- Per-package `--package name@badVersion:goodVersion` flags (repeatable), not a single global version pair or a manifest file — `.changeset/config.json` has `linked: []`, so every package versions independently, and one shell invocation is faster/harder to fumble than editing a file mid-incident.
- **Dry-run by default** — `--execute` is required to actually mutate anything. An all-or-nothing registry-existence preflight (`npm view <pkg>@<version>`) runs across *every* package before anything is touched, so a bad version string for one package can't leave the others half-reverted. An `npm whoami` auth check runs before any mutation too, failing with a clear "run `npm login`" message instead of a mid-run 401.
- Unknown package names are rejected immediately (not silently no-op'd) unless paired with `--allow-package` — the highest-value guardrail against a typo under incident pressure.

## Why this is a plain script, not a new CI workflow

Normal releases (`changesets.yml`) and hotfix releases (`hotfix-release.yml`) both publish via npm OIDC Trusted Publishing (`id-token: write`, no npm token secret) — but OIDC Trusted Publishing only covers `npm publish`, not `npm dist-tag`/`npm deprecate`. Those need a real authenticated npm session. So this is necessarily a manually-run local CLI tool for an authenticated npm-org member during an incident, not something that can piggyback on existing CI auth. Wrapping it in a team-gated `workflow_dispatch` workflow (mirroring `hotfix-release.yml`'s team check) would need a new long-lived npm token/secret — new security surface beyond what the issue asks for ("a script"). Left as a possible follow-up for a maintainer to decide on.

Also noted but left out of scope: `hotfix-release.yml`'s `--filter` list is missing `@cloudflare/vite-plugin` and `@cloudflare/vitest-pool-workers` relative to the actual dependency graph — a real, unrelated gap in a different workflow (normal hotfix publish, not emergency dist-tag/deprecate). Happy to file that separately if useful.

---

- Tests
  - [x] Tests included/updated
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: internal release-engineering tooling, no user-facing API or documented behavior
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14576" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->