### PR TITLE
Enable `@typescript-eslint/no-deprecated` linting rule for `wrangler`

### DIFF
--- a/.oxlintrc.jsonc
+++ b/.oxlintrc.jsonc
@@ -209,7 +209,6 @@
 				"packages/local-explorer-ui/**",
 				"packages/vite-plugin-cloudflare/**",
 				"packages/workflows-shared/**",
-				"packages/wrangler/**",
 			],
 			"rules": {
 				"@typescript-eslint/no-deprecated": "off",

--- a/packages/wrangler/e2e/unenv-preset/worker/index.ts
+++ b/packages/wrangler/e2e/unenv-preset/worker/index.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-deprecated -- this e2e test intentionally exercises deprecated Node.js util methods and cluster APIs to verify unenv polyfill behavior */
 import assert from "node:assert";
 
 export default {

--- a/packages/wrangler/src/__tests__/agents-skills-install.test.ts
+++ b/packages/wrangler/src/__tests__/agents-skills-install.test.ts
@@ -25,6 +25,9 @@ vi.unmock("../agents-skills-install");
 
 vi.mock("am-i-vibing");
 
+// eslint-disable-next-line @typescript-eslint/no-deprecated -- the function has a deprecated overload; we only reference it here for mocking
+const mockDetectAgenticEnvironment = vi.mocked(detectAgenticEnvironment);
+
 // Mock rosie-skills to avoid real network/WASM calls.
 // vi.hoisted() is required because vi.mock() factories are hoisted above normal
 // variable declarations, so plain `const` variables would still be in the TDZ.
@@ -1071,7 +1074,7 @@ describe("telemetryCurrentAgentSkillsInstalled", () => {
 
 	beforeEach(() => {
 		// Default: no agent detected
-		vi.mocked(detectAgenticEnvironment).mockReturnValue({
+		mockDetectAgenticEnvironment.mockReturnValue({
 			isAgentic: false,
 			id: null,
 			name: null,
@@ -1090,7 +1093,7 @@ describe("telemetryCurrentAgentSkillsInstalled", () => {
 	test("resolves to null when detectAgenticEnvironment throws", async ({
 		expect,
 	}) => {
-		vi.mocked(detectAgenticEnvironment).mockImplementation(() => {
+		mockDetectAgenticEnvironment.mockImplementation(() => {
 			throw new Error("Detection failed");
 		});
 		const telemetryCurrentAgentSkillsInstalled = await freshTelemetryImport();
@@ -1103,7 +1106,7 @@ describe("telemetryCurrentAgentSkillsInstalled", () => {
 	test("resolves to null when agent is detected but not in telemetryAgentMappings", async ({
 		expect,
 	}) => {
-		vi.mocked(detectAgenticEnvironment).mockReturnValue({
+		mockDetectAgenticEnvironment.mockReturnValue({
 			isAgentic: true,
 			id: "jules",
 			name: "Jules",
@@ -1119,7 +1122,7 @@ describe("telemetryCurrentAgentSkillsInstalled", () => {
 	test("resolves to false when GitHub API fetch fails and no cache exists", async ({
 		expect,
 	}) => {
-		vi.mocked(detectAgenticEnvironment).mockReturnValue({
+		mockDetectAgenticEnvironment.mockReturnValue({
 			isAgentic: true,
 			id: "claude-code",
 			name: "Claude Code",
@@ -1137,7 +1140,7 @@ describe("telemetryCurrentAgentSkillsInstalled", () => {
 	test("resolves to false when no skills are present in agent's globalSkillsPath", async ({
 		expect,
 	}) => {
-		vi.mocked(detectAgenticEnvironment).mockReturnValue({
+		mockDetectAgenticEnvironment.mockReturnValue({
 			isAgentic: true,
 			id: "claude-code",
 			name: "Claude Code",
@@ -1155,7 +1158,7 @@ describe("telemetryCurrentAgentSkillsInstalled", () => {
 	test("resolves to 'manual' when some skills exist but no metadata file", async ({
 		expect,
 	}) => {
-		vi.mocked(detectAgenticEnvironment).mockReturnValue({
+		mockDetectAgenticEnvironment.mockReturnValue({
 			isAgentic: true,
 			id: "claude-code",
 			name: "Claude Code",
@@ -1175,7 +1178,7 @@ describe("telemetryCurrentAgentSkillsInstalled", () => {
 	test("resolves to 'automatic' when skills exist and metadata confirms successful install", async ({
 		expect,
 	}) => {
-		vi.mocked(detectAgenticEnvironment).mockReturnValue({
+		mockDetectAgenticEnvironment.mockReturnValue({
 			isAgentic: true,
 			id: "claude-code",
 			name: "Claude Code",
@@ -1208,7 +1211,7 @@ describe("telemetryCurrentAgentSkillsInstalled", () => {
 	test("resolves to 'manual' when metadata says install failed entirely (installFailed: true)", async ({
 		expect,
 	}) => {
-		vi.mocked(detectAgenticEnvironment).mockReturnValue({
+		mockDetectAgenticEnvironment.mockReturnValue({
 			isAgentic: true,
 			id: "claude-code",
 			name: "Claude Code",
@@ -1241,7 +1244,7 @@ describe("telemetryCurrentAgentSkillsInstalled", () => {
 	test("resolves to 'manual' when metadata says install failed for this agent (installFailed: string[])", async ({
 		expect,
 	}) => {
-		vi.mocked(detectAgenticEnvironment).mockReturnValue({
+		mockDetectAgenticEnvironment.mockReturnValue({
 			isAgentic: true,
 			id: "claude-code",
 			name: "Claude Code",
@@ -1274,7 +1277,7 @@ describe("telemetryCurrentAgentSkillsInstalled", () => {
 	test("resolves to 'manual' when agent is not in detectedAgents", async ({
 		expect,
 	}) => {
-		vi.mocked(detectAgenticEnvironment).mockReturnValue({
+		mockDetectAgenticEnvironment.mockReturnValue({
 			isAgentic: true,
 			id: "claude-code",
 			name: "Claude Code",
@@ -1301,7 +1304,7 @@ describe("telemetryCurrentAgentSkillsInstalled", () => {
 	test("resolves to 'manual' when metadata has accepted='unanswered' (user interrupted prompt)", async ({
 		expect,
 	}) => {
-		vi.mocked(detectAgenticEnvironment).mockReturnValue({
+		mockDetectAgenticEnvironment.mockReturnValue({
 			isAgentic: true,
 			id: "claude-code",
 			name: "Claude Code",
@@ -1333,7 +1336,7 @@ describe("telemetryCurrentAgentSkillsInstalled", () => {
 	});
 
 	test("uses cached GitHub API response within TTL", async ({ expect }) => {
-		vi.mocked(detectAgenticEnvironment).mockReturnValue({
+		mockDetectAgenticEnvironment.mockReturnValue({
 			isAgentic: true,
 			id: "claude-code",
 			name: "Claude Code",
@@ -1382,7 +1385,7 @@ describe("telemetryCurrentAgentSkillsInstalled", () => {
 	test("falls back to stale cache when GitHub API returns an error", async ({
 		expect,
 	}) => {
-		vi.mocked(detectAgenticEnvironment).mockReturnValue({
+		mockDetectAgenticEnvironment.mockReturnValue({
 			isAgentic: true,
 			id: "claude-code",
 			name: "Claude Code",
@@ -1428,7 +1431,7 @@ describe("telemetryCurrentAgentSkillsInstalled", () => {
 	});
 
 	test("works with cursor-agent amIVibingId mapping", async ({ expect }) => {
-		vi.mocked(detectAgenticEnvironment).mockReturnValue({
+		mockDetectAgenticEnvironment.mockReturnValue({
 			isAgentic: true,
 			id: "cursor-agent",
 			name: "Cursor Agent",
@@ -1461,7 +1464,7 @@ describe("telemetryCurrentAgentSkillsInstalled", () => {
 	test("resolves to 'manual' when skills exist at an alternativeGlobalPath but no metadata", async ({
 		expect,
 	}) => {
-		vi.mocked(detectAgenticEnvironment).mockReturnValue({
+		mockDetectAgenticEnvironment.mockReturnValue({
 			isAgentic: true,
 			id: "opencode",
 			name: "OpenCode",
@@ -1483,7 +1486,7 @@ describe("telemetryCurrentAgentSkillsInstalled", () => {
 	test("resolves to 'automatic' when skills at alternativeGlobalPath were installed for another agent", async ({
 		expect,
 	}) => {
-		vi.mocked(detectAgenticEnvironment).mockReturnValue({
+		mockDetectAgenticEnvironment.mockReturnValue({
 			isAgentic: true,
 			id: "opencode",
 			name: "OpenCode",
@@ -1517,7 +1520,7 @@ describe("telemetryCurrentAgentSkillsInstalled", () => {
 	test("resolves to 'manual' when skills at alternativeGlobalPath were installed for another agent but failed", async ({
 		expect,
 	}) => {
-		vi.mocked(detectAgenticEnvironment).mockReturnValue({
+		mockDetectAgenticEnvironment.mockReturnValue({
 			isAgentic: true,
 			id: "opencode",
 			name: "OpenCode",
@@ -1549,7 +1552,7 @@ describe("telemetryCurrentAgentSkillsInstalled", () => {
 	test("resolves to false when skills are not at primary or any alternativeGlobalPath", async ({
 		expect,
 	}) => {
-		vi.mocked(detectAgenticEnvironment).mockReturnValue({
+		mockDetectAgenticEnvironment.mockReturnValue({
 			isAgentic: true,
 			id: "opencode",
 			name: "OpenCode",
@@ -1572,7 +1575,7 @@ describe("telemetryCurrentAgentSkillsInstalled", () => {
 		test("resolves to 'automatic' when metadata uses the legacy flat AgentInfo schema", async ({
 			expect,
 		}) => {
-			vi.mocked(detectAgenticEnvironment).mockReturnValue({
+			mockDetectAgenticEnvironment.mockReturnValue({
 				isAgentic: true,
 				id: "claude-code",
 				name: "Claude Code",
@@ -1605,7 +1608,7 @@ describe("telemetryCurrentAgentSkillsInstalled", () => {
 		test("migrates legacy metadata to version 1 on disk when read", async ({
 			expect,
 		}) => {
-			vi.mocked(detectAgenticEnvironment).mockReturnValue({
+			mockDetectAgenticEnvironment.mockReturnValue({
 				isAgentic: true,
 				id: "claude-code",
 				name: "Claude Code",
@@ -1652,7 +1655,7 @@ describe("telemetryCurrentAgentSkillsInstalled", () => {
 		test("resolves to 'manual' when legacy metadata says install failed", async ({
 			expect,
 		}) => {
-			vi.mocked(detectAgenticEnvironment).mockReturnValue({
+			mockDetectAgenticEnvironment.mockReturnValue({
 				isAgentic: true,
 				id: "claude-code",
 				name: "Claude Code",
@@ -1684,7 +1687,7 @@ describe("telemetryCurrentAgentSkillsInstalled", () => {
 	});
 
 	test("memoises the result across multiple calls", async ({ expect }) => {
-		vi.mocked(detectAgenticEnvironment).mockReturnValue({
+		mockDetectAgenticEnvironment.mockReturnValue({
 			isAgentic: false,
 			id: null,
 			name: null,

--- a/packages/wrangler/src/__tests__/ai-search.test.ts
+++ b/packages/wrangler/src/__tests__/ai-search.test.ts
@@ -724,7 +724,7 @@ describe("ai-search commands", () => {
 				runWrangler(
 					"ai-search create my-instance --namespace default --type builtin --source-jurisdiction eu"
 				)
-			).rejects.toThrowError(
+			).rejects.toThrow(
 				/--source-jurisdiction is only supported with --type r2/
 			);
 		});
@@ -737,7 +737,7 @@ describe("ai-search commands", () => {
 				runWrangler(
 					"ai-search create my-instance --namespace default --type web-crawler --source https://example.com --source-jurisdiction eu"
 				)
-			).rejects.toThrowError(
+			).rejects.toThrow(
 				/--source-jurisdiction is only supported with --type r2/
 			);
 		});

--- a/packages/wrangler/src/__tests__/deploy/config-args-merging.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/config-args-merging.test.ts
@@ -154,6 +154,7 @@ function mockUploadVersion(has_preview = false) {
 
 /** Parse WorkerMetadata from a captured upload request */
 async function getMetadata(request: Request): Promise<WorkerMetadata> {
+	// eslint-disable-next-line @typescript-eslint/no-deprecated -- formData() is the standard Web API; only deprecated on undici's server-side types
 	const formBody = await request.clone().formData();
 	return JSON.parse(await toString(formBody.get("metadata"))) as WorkerMetadata;
 }

--- a/packages/wrangler/src/__tests__/deploy/helpers.ts
+++ b/packages/wrangler/src/__tests__/deploy/helpers.ts
@@ -727,6 +727,7 @@ export const mockAssetUploadRequest = async (
 				uploadUrls?.push(request.url);
 				uploadContentTypeHeaders.push(request.headers.get("Content-Type"));
 				uploadAuthHeaders.push(request.headers.get("Authorization"));
+				// eslint-disable-next-line @typescript-eslint/no-deprecated -- formData() is the standard Web API; only deprecated on undici's server-side types
 				const formData = await request.formData();
 				bodies.push(formData);
 				if (bodies.length === numberOfBuckets) {

--- a/packages/wrangler/src/__tests__/flagship.test.ts
+++ b/packages/wrangler/src/__tests__/flagship.test.ts
@@ -369,14 +369,12 @@ describe("flagship", () => {
 				runWrangler(
 					`flagship flags create app-1 f --variation on=true --variation off=false --default-variation off --rule "serve=on; when="`
 				)
-			).rejects.toThrowError(/Condition expression is empty/);
+			).rejects.toThrow(/Condition expression is empty/);
 			await expect(
 				runWrangler(
 					`flagship flags create app-1 f --variation on=true --variation off=false --default-variation off --rule "serve=on; when=plan equals pro OR"`
 				)
-			).rejects.toThrowError(
-				/Logical operators must appear between conditions/
-			);
+			).rejects.toThrow(/Logical operators must appear between conditions/);
 		});
 
 		it("rejects malformed rule JSON", async ({ expect }) => {
@@ -384,7 +382,7 @@ describe("flagship", () => {
 				runWrangler(
 					`flagship flags create app-1 f --variation on=true --variation off=false --default-variation off --rule-json '{"conditions":[]}'`
 				)
-			).rejects.toThrowError(/serve_variation/);
+			).rejects.toThrow(/serve_variation/);
 		});
 
 		it("defaults new flags to boolean on/off variations", async ({
@@ -639,13 +637,13 @@ describe("flagship", () => {
 		it("requires an app id and at least one flag key", async ({ expect }) => {
 			await expect(
 				runWrangler("flagship flags delete app-1 --force")
-			).rejects.toThrowError(/Not enough non-option arguments/);
+			).rejects.toThrow(/Not enough non-option arguments/);
 		});
 
 		it("requires --force to delete with --json", async ({ expect }) => {
 			await expect(
 				runWrangler("flagship flags delete app-1 new-ui --json")
-			).rejects.toThrowError(/Pass --force/);
+			).rejects.toThrow(/Pass --force/);
 			expect(JSON.parse(std.out)).toEqual({
 				error:
 					"Pass --force to skip the confirmation prompt when using --json.",
@@ -676,7 +674,7 @@ describe("flagship", () => {
 			);
 			await expect(
 				runWrangler("flagship flags delete app-1 alpha beta gamma --force")
-			).rejects.toThrowError(/Failed to process 1 of the requested items/);
+			).rejects.toThrow(/Failed to process 1 of the requested items/);
 			expect(deleted).toEqual(["alpha", "gamma"]);
 			expect(std.out).toContain("Deleted flag 'alpha'");
 			expect(std.out).toContain("Deleted flag 'gamma'");
@@ -706,7 +704,7 @@ describe("flagship", () => {
 				runWrangler(
 					"flagship flags delete app-1 alpha beta gamma --force --json"
 				)
-			).rejects.toThrowError(/Failed to process 1 of the requested items/);
+			).rejects.toThrow(/Failed to process 1 of the requested items/);
 			expect(JSON.parse(std.out)).toMatchObject({
 				results: [{ key: "alpha" }, { key: "gamma" }],
 				failures: [{ target: "beta" }],
@@ -831,7 +829,7 @@ describe("flagship", () => {
 			);
 			await expect(
 				runWrangler("flagship flags disable app-1 alpha missing")
-			).rejects.toThrowError(/Failed to process 1 of the requested items/);
+			).rejects.toThrow(/Failed to process 1 of the requested items/);
 			expect(std.out).toContain("Disabled flag");
 		});
 
@@ -948,7 +946,7 @@ describe("flagship", () => {
 				runWrangler(
 					"flagship flags rollout app-1 new-ui --to on --percentage NaN"
 				)
-			).rejects.toThrowError(/--percentage must be between 0 and 100/);
+			).rejects.toThrow(/--percentage must be between 0 and 100/);
 		});
 
 		it("removes the rollout without changing the default when percentage is 0", async ({
@@ -1057,7 +1055,7 @@ describe("flagship", () => {
 				runWrangler(
 					"flagship flags rollout app-1 new-ui --to on --percentage 25 --json"
 				)
-			).rejects.toThrowError(/Pass --force to confirm/);
+			).rejects.toThrow(/Pass --force to confirm/);
 		});
 
 		it("asks for confirmation before a split replaces targeting rules with conditions", async ({
@@ -1184,7 +1182,7 @@ describe("flagship", () => {
 				runWrangler(
 					`flagship flags create app-1 f -V on=true -V off=false --default off --rule "priority=1; serve=on; when=plan equals pro" --rule "priority=1; serve=off; when=plan equals free"`
 				)
-			).rejects.toThrowError(/Duplicate rule priority 1/);
+			).rejects.toThrow(/Duplicate rule priority 1/);
 		});
 
 		it("rejects a default variation that is not defined", async ({
@@ -1194,7 +1192,7 @@ describe("flagship", () => {
 				runWrangler(
 					"flagship flags create app-1 f -V on=true -V off=false --default nope"
 				)
-			).rejects.toThrowError(/Default variation "nope" is not one of/);
+			).rejects.toThrow(/Default variation "nope" is not one of/);
 		});
 
 		it("rejects a rule that serves an unknown variation", async ({
@@ -1204,7 +1202,7 @@ describe("flagship", () => {
 				runWrangler(
 					`flagship flags create app-1 f -V on=true -V off=false --default off --rule "serve=maybe; when=plan equals pro"`
 				)
-			).rejects.toThrowError(/serves unknown variation "maybe"/);
+			).rejects.toThrow(/serves unknown variation "maybe"/);
 		});
 
 		it("treats lowercase and/or inside a value literally", async ({
@@ -1302,7 +1300,7 @@ describe("flagship", () => {
 				runWrangler(
 					`flagship flags create app-1 f -V on=true -V off=false --default off --rule 'serve=on; when=title equals "oops'`
 				)
-			).rejects.toThrowError(/Unterminated double quote/);
+			).rejects.toThrow(/Unterminated double quote/);
 		});
 
 		it("rejects a malformed bracketed list", async ({ expect }) => {
@@ -1310,7 +1308,7 @@ describe("flagship", () => {
 				runWrangler(
 					`flagship flags create app-1 f -V on=true -V off=false --default off --rule "serve=on; when=country in [US,CA"`
 				)
-			).rejects.toThrowError(/Unterminated "\["/);
+			).rejects.toThrow(/Unterminated "\["/);
 		});
 
 		it("rejects an empty list item", async ({ expect }) => {
@@ -1318,7 +1316,7 @@ describe("flagship", () => {
 				runWrangler(
 					`flagship flags create app-1 f -V on=true -V off=false --default off --rule "serve=on; when=country in [US,,CA]"`
 				)
-			).rejects.toThrowError(/List items must not be empty/);
+			).rejects.toThrow(/List items must not be empty/);
 		});
 
 		it("rejects a condition with no value", async ({ expect }) => {
@@ -1326,7 +1324,7 @@ describe("flagship", () => {
 				runWrangler(
 					`flagship flags create app-1 f -V on=true -V off=false --default off --rule "serve=on; when=plan equals"`
 				)
-			).rejects.toThrowError(/Could not find a valid operator|missing a value/);
+			).rejects.toThrow(/Could not find a valid operator|missing a value/);
 		});
 
 		it("rejects a rollout with multiple @ separators", async ({ expect }) => {
@@ -1334,7 +1332,7 @@ describe("flagship", () => {
 				runWrangler(
 					`flagship flags create app-1 f -V on=true -V off=false --default off --rule "serve=on; rollout=30%@user@id"`
 				)
-			).rejects.toThrowError(/single non-empty attribute/);
+			).rejects.toThrow(/single non-empty attribute/);
 		});
 
 		it("rejects a rollout with an empty percentage", async ({ expect }) => {
@@ -1342,7 +1340,7 @@ describe("flagship", () => {
 				runWrangler(
 					`flagship flags create app-1 f -V on=true -V off=false --default off --rule "serve=on; rollout=@user_id"`
 				)
-			).rejects.toThrowError(/Expected a percentage between 0 and 100/);
+			).rejects.toThrow(/Expected a percentage between 0 and 100/);
 		});
 
 		it("rejects duplicate variation names", async ({ expect }) => {
@@ -1350,7 +1348,7 @@ describe("flagship", () => {
 				runWrangler(
 					"flagship flags create app-1 f -V on=true -V on=false --default on"
 				)
-			).rejects.toThrowError(/Duplicate variation "on"/);
+			).rejects.toThrow(/Duplicate variation "on"/);
 		});
 
 		it("rejects a non-finite number variation", async ({ expect }) => {
@@ -1358,7 +1356,7 @@ describe("flagship", () => {
 				runWrangler(
 					"flagship flags create app-1 f --type number -V big=Infinity --default big"
 				)
-			).rejects.toThrowError(/not a valid finite number/);
+			).rejects.toThrow(/not a valid finite number/);
 		});
 
 		it("rejects variations with inconsistent inferred types", async ({
@@ -1368,9 +1366,7 @@ describe("flagship", () => {
 				runWrangler(
 					"flagship flags create app-1 f -V a=true -V b=5 --default a"
 				)
-			).rejects.toThrowError(
-				/Variation "b" is number but variation "a" is boolean/
-			);
+			).rejects.toThrow(/Variation "b" is number but variation "a" is boolean/);
 		});
 
 		it("rejects --set-variation introducing an inconsistent type", async ({
@@ -1385,7 +1381,7 @@ describe("flagship", () => {
 			});
 			await expect(
 				runWrangler("flagship flags update app-1 f --set-variation extra=5")
-			).rejects.toThrowError(
+			).rejects.toThrow(
 				/Variation "extra" is number but variation "on" is boolean/
 			);
 		});
@@ -1395,7 +1391,7 @@ describe("flagship", () => {
 				runWrangler(
 					`flagship flags create app-1 f -V on=true -V off=false --default off --rule-json '{"serve_variation":"on","conditions":[],"bogus":1}'`
 				)
-			).rejects.toThrowError(/Unexpected field "bogus"/);
+			).rejects.toThrow(/Unexpected field "bogus"/);
 		});
 
 		it("rejects a --rule-json condition mixing logical and base fields", async ({
@@ -1405,7 +1401,7 @@ describe("flagship", () => {
 				runWrangler(
 					`flagship flags create app-1 f -V on=true -V off=false --default off --rule-json '{"serve_variation":"on","conditions":[{"logical_operator":"AND","clauses":[],"attribute":"x"}]}'`
 				)
-			).rejects.toThrowError(/Unexpected field "attribute"/);
+			).rejects.toThrow(/Unexpected field "attribute"/);
 		});
 	});
 
@@ -1420,7 +1416,7 @@ describe("flagship", () => {
 			});
 			await expect(
 				runWrangler("flagship flags split app-1 model -w a=10 -w a=90")
-			).rejects.toThrowError(/Duplicate weight for variation "a"/);
+			).rejects.toThrow(/Duplicate weight for variation "a"/);
 		});
 
 		it("rejects a non-finite split weight", async ({ expect }) => {
@@ -1433,7 +1429,7 @@ describe("flagship", () => {
 			});
 			await expect(
 				runWrangler("flagship flags split app-1 model -w a=Infinity -w b=10")
-			).rejects.toThrowError(/non-negative finite number/);
+			).rejects.toThrow(/non-negative finite number/);
 		});
 	});
 
@@ -1482,7 +1478,7 @@ describe("flagship", () => {
 				runWrangler(
 					`flagship flags update app-1 new-ui --rule "serve=on; when=plan equals pro" --add-rule "serve=off; when=plan equals free"`
 				)
-			).rejects.toThrowError(/Cannot replace rules .* and append rules/);
+			).rejects.toThrow(/Cannot replace rules .* and append rules/);
 		});
 
 		it("lists rules for a flag", async ({ expect }) => {
@@ -1630,7 +1626,7 @@ describe("flagship", () => {
 			});
 			await expect(
 				runWrangler("flagship flags rules reorder app-1 new-ui --order 1,wat,2")
-			).rejects.toThrowError(/Invalid --order/);
+			).rejects.toThrow(/Invalid --order/);
 		});
 
 		it("rejects duplicate and extra reorder priorities", async ({ expect }) => {
@@ -1647,12 +1643,12 @@ describe("flagship", () => {
 			mockGet("apps/app-1/flags/new-ui", flag);
 			await expect(
 				runWrangler("flagship flags rules reorder app-1 new-ui --order 1,2,1")
-			).rejects.toThrowError(/must contain each existing rule priority/);
+			).rejects.toThrow(/must contain each existing rule priority/);
 
 			mockGet("apps/app-1/flags/new-ui", flag);
 			await expect(
 				runWrangler("flagship flags rules reorder app-1 new-ui --order 1,2,3")
-			).rejects.toThrowError(/must contain each existing rule priority/);
+			).rejects.toThrow(/must contain each existing rule priority/);
 		});
 	});
 
@@ -1678,16 +1674,16 @@ describe("flagship", () => {
 		it("rejects --all with explicit pagination options", async ({ expect }) => {
 			await expect(
 				runWrangler("flagship flags changelog app-1 new-ui --all --limit 3")
-			).rejects.toThrowError(/Cannot use --all together with --limit/);
+			).rejects.toThrow(/Cannot use --all together with --limit/);
 		});
 
 		it("rejects invalid pagination limits", async ({ expect }) => {
 			await expect(
 				runWrangler("flagship flags list app-1 --limit 0")
-			).rejects.toThrowError(/Invalid --limit/);
+			).rejects.toThrow(/Invalid --limit/);
 			await expect(
 				runWrangler("flagship flags changelog app-1 new-ui --limit 201")
-			).rejects.toThrowError(/Invalid --limit/);
+			).rejects.toThrow(/Invalid --limit/);
 		});
 
 		it("follows the cursor with --all when listing flags", async ({
@@ -1747,13 +1743,13 @@ describe("flagship", () => {
 
 	describe("app id is required", () => {
 		it("requires an app id for flags list", async ({ expect }) => {
-			await expect(runWrangler("flagship flags list")).rejects.toThrowError(
+			await expect(runWrangler("flagship flags list")).rejects.toThrow(
 				"Not enough non-option arguments: got 0, need at least 1"
 			);
 		});
 
 		it("requires an app id for apps get", async ({ expect }) => {
-			await expect(runWrangler("flagship apps get")).rejects.toThrowError(
+			await expect(runWrangler("flagship apps get")).rejects.toThrow(
 				"Not enough non-option arguments: got 0, need at least 1"
 			);
 		});

--- a/packages/wrangler/src/__tests__/helpers/mock-upload-worker.ts
+++ b/packages/wrangler/src/__tests__/helpers/mock-upload-worker.ts
@@ -96,6 +96,7 @@ export function mockUploadWorkerRequest(
 			expect(params.dispatchNamespace).toEqual(expectedDispatchNamespace);
 		}
 
+		// eslint-disable-next-line @typescript-eslint/no-deprecated -- formData() is the standard Web API; only deprecated on undici's server-side types
 		const formBody = await request.formData();
 		if (typeof expectedEntry === "string" || expectedEntry instanceof RegExp) {
 			expect(await serialize(formBody.get("index.js"))).toMatch(expectedEntry);

--- a/packages/wrangler/src/__tests__/metrics.test.ts
+++ b/packages/wrangler/src/__tests__/metrics.test.ts
@@ -33,6 +33,8 @@ import { runWrangler } from "./helpers/run-wrangler";
 import type { ExpectStatic } from "vitest";
 
 vi.mock("am-i-vibing");
+// eslint-disable-next-line @typescript-eslint/no-deprecated -- the function has a deprecated overload; we only reference it here for mocking
+const mockDetectAgenticEnvironment = vi.mocked(detectAgenticEnvironment);
 vi.mock("../metrics/helpers");
 vi.mock("../metrics/send-event");
 vi.mock("../package-manager");
@@ -90,7 +92,7 @@ describe("metrics", () => {
 		describe("sendAdhocEvent()", () => {
 			beforeEach(() => {
 				// Default: no agent detected
-				vi.mocked(detectAgenticEnvironment).mockReturnValue({
+				mockDetectAgenticEnvironment.mockReturnValue({
 					isAgentic: false,
 					id: null,
 					name: null,
@@ -196,7 +198,7 @@ describe("metrics", () => {
 			});
 
 			it("should include agent ID when detected", async ({ expect }) => {
-				vi.mocked(detectAgenticEnvironment).mockReturnValue({
+				mockDetectAgenticEnvironment.mockReturnValue({
 					isAgentic: true,
 					id: "claude-code",
 					name: "Claude Code",
@@ -215,7 +217,7 @@ describe("metrics", () => {
 			});
 
 			it("should set agent to null if detection throws", async ({ expect }) => {
-				vi.mocked(detectAgenticEnvironment).mockImplementation(() => {
+				mockDetectAgenticEnvironment.mockImplementation(() => {
 					throw new Error("Detection failed");
 				});
 
@@ -257,7 +259,7 @@ describe("metrics", () => {
 			};
 			beforeEach(() => {
 				// Default: no agent detected
-				vi.mocked(detectAgenticEnvironment).mockReturnValue({
+				mockDetectAgenticEnvironment.mockReturnValue({
 					isAgentic: false,
 					id: null,
 					name: null,
@@ -530,7 +532,7 @@ describe("metrics", () => {
 			it("should include agent ID in command events when detected", async ({
 				expect,
 			}) => {
-				vi.mocked(detectAgenticEnvironment).mockReturnValue({
+				mockDetectAgenticEnvironment.mockReturnValue({
 					isAgentic: true,
 					id: "cursor-agent",
 					name: "Cursor Agent",

--- a/packages/wrangler/src/__tests__/pages/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/pages/deploy.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-deprecated -- formData() is the standard Web API for parsing multipart bodies; only deprecated on undici's server-side types */
 import { mkdirSync, writeFileSync } from "node:fs";
 import { chdir } from "node:process";
 import {

--- a/packages/wrangler/src/__tests__/vectorize/vectorize.upsert.test.ts
+++ b/packages/wrangler/src/__tests__/vectorize/vectorize.upsert.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-deprecated -- formData() is the standard Web API for parsing multipart bodies; only deprecated on undici's server-side types */
 import crypto from "node:crypto";
 import { writeFileSync } from "node:fs";
 import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";

--- a/packages/wrangler/src/__tests__/versions/secrets.test.ts
+++ b/packages/wrangler/src/__tests__/versions/secrets.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-deprecated -- formData() is the standard Web API for parsing multipart bodies; only deprecated on undici's server-side types */
 import { writeFileSync } from "node:fs";
 import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";

--- a/packages/wrangler/src/__tests__/versions/secrets/utils.ts
+++ b/packages/wrangler/src/__tests__/versions/secrets/utils.ts
@@ -149,6 +149,7 @@ export function mockPostVersion(
 				expect(params.accountId).toEqual("some-account-id");
 				expect(params.scriptName).toMatch(/script-name(-test)?/);
 
+				// eslint-disable-next-line @typescript-eslint/no-deprecated -- formData() is the standard Web API; only deprecated on undici's server-side types
 				const formData = await request.formData();
 				const metadata = JSON.parse(
 					formData.get("metadata") as string

--- a/packages/wrangler/src/__tests__/versions/versions.upload.test.ts
+++ b/packages/wrangler/src/__tests__/versions/versions.upload.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-deprecated -- formData() is the standard Web API for parsing multipart bodies; only deprecated on undici's server-side types */
 import assert from "node:assert";
 import * as fs from "node:fs";
 import {

--- a/packages/wrangler/src/agents-skills-install.ts
+++ b/packages/wrangler/src/agents-skills-install.ts
@@ -683,7 +683,7 @@ function directoryContainsAnySkill(
 async function computeTelemetryCurrentAgentSkillsInstalled(): Promise<AgentSkillsInstallStatus> {
 	let agentId: string | null = null;
 	try {
-		const detection = detectAgenticEnvironment(process.env, []);
+		const detection = detectAgenticEnvironment();
 		agentId = detection.id;
 	} catch {
 		return null;

--- a/packages/wrangler/src/api/index.ts
+++ b/packages/wrangler/src/api/index.ts
@@ -75,6 +75,7 @@ export {
 	unstable_getVarsForDev,
 	unstable_readConfig,
 	unstable_getDurableObjectClassNameToUseSQLiteMap,
+	// eslint-disable-next-line @typescript-eslint/no-deprecated -- re-exporting deprecated public API for backward compatibility
 	unstable_getDevCompatibilityDate,
 	getPlatformProxy,
 	unstable_getMiniflareWorkerOptions,

--- a/packages/wrangler/src/cfetch/internal.ts
+++ b/packages/wrangler/src/cfetch/internal.ts
@@ -332,10 +332,12 @@ export async function fetchWorkerDefinitionFromDash(
 
 	if (usesModules) {
 		// For testing purposes only, sorry not sorry -- msw doesn't implement Response#formData
+		// eslint-disable-next-line @typescript-eslint/no-deprecated -- formData() is the standard Web API; only deprecated on undici's server-side types
 		if (!response.formData) {
 			response = new Response(await response.text(), response);
 		}
 
+		// eslint-disable-next-line @typescript-eslint/no-deprecated -- formData() is the standard Web API; only deprecated on undici's server-side types
 		const form = await response.formData();
 		const files = Array.from(form.entries()).map(([filename, contents]) =>
 			contents instanceof File ? contents : new File([contents], filename)

--- a/packages/wrangler/src/check/commands.ts
+++ b/packages/wrangler/src/check/commands.ts
@@ -199,11 +199,13 @@ async function parseFormDataFromFile(file: string): Promise<FormData> {
 	const boundary = Uint8Array.prototype.slice
 		.call(bundle, 2, firstLine)
 		.toString();
-	return await new Response(bundle, {
+	const response = new Response(bundle, {
 		headers: {
 			"Content-Type": "multipart/form-data; boundary=" + boundary,
 		},
-	}).formData();
+	});
+	// eslint-disable-next-line @typescript-eslint/no-deprecated -- formData() is the standard Web API; only deprecated on undici's server-side types
+	return await response.formData();
 }
 
 export async function analyseBundle(

--- a/packages/wrangler/src/cli.ts
+++ b/packages/wrangler/src/cli.ts
@@ -75,6 +75,7 @@ export {
 	unstable_readConfig,
 	experimental_generateTypes,
 	unstable_getDurableObjectClassNameToUseSQLiteMap,
+	// eslint-disable-next-line @typescript-eslint/no-deprecated -- re-exporting deprecated public API for backward compatibility
 	unstable_getDevCompatibilityDate,
 	getPlatformProxy,
 	unstable_getMiniflareWorkerOptions,

--- a/packages/wrangler/src/cloudchamber/apply.ts
+++ b/packages/wrangler/src/cloudchamber/apply.ts
@@ -195,6 +195,7 @@ function observabilityToConfiguration(
 function containerAppToInstanceType(
 	containerApp: ContainerApp
 ): Partial<UserDeploymentConfiguration> {
+	// eslint-disable-next-line @typescript-eslint/no-deprecated -- kept for backward compatibility, reads deprecated `configuration` from API response
 	let configuration = (containerApp.configuration ??
 		{}) as Partial<UserDeploymentConfiguration>;
 
@@ -259,6 +260,7 @@ function containerAppToCreateApplication(
 	);
 	const instanceType = containerAppToInstanceType(containerApp);
 	const configuration: UserDeploymentConfiguration = {
+		// eslint-disable-next-line @typescript-eslint/no-deprecated -- kept for backward compatibility, reads deprecated `configuration` from API response
 		...(containerApp.configuration as UserDeploymentConfiguration),
 		...instanceType,
 		observability: observabilityConfiguration,
@@ -280,6 +282,7 @@ function containerAppToCreateApplication(
 			// De-sugar image name
 			image: resolveImageName(accountId, configuration.image),
 		},
+		// eslint-disable-next-line @typescript-eslint/no-deprecated -- kept for backward compatibility, `instances` is deprecated in favor of `max_instances`
 		instances: containerApp.instances ?? 0,
 		scheduling_policy:
 			(containerApp.scheduling_policy as SchedulingPolicy) ??
@@ -372,7 +375,9 @@ export async function apply(
 	log(dim("Container application changes\n"));
 
 	for (const appConfigNoDefaults of config.containers) {
+		// eslint-disable-next-line @typescript-eslint/no-deprecated -- kept for backward compatibility, populates deprecated `configuration` for API compatibility
 		appConfigNoDefaults.configuration ??= {};
+		// eslint-disable-next-line @typescript-eslint/no-deprecated -- kept for backward compatibility, populates deprecated `configuration` for API compatibility
 		appConfigNoDefaults.configuration.image = appConfigNoDefaults.image;
 		const application =
 			applicationByNames[
@@ -405,8 +410,10 @@ export async function apply(
 
 			if (
 				prevApp.durable_objects !== undefined &&
+				// eslint-disable-next-line @typescript-eslint/no-deprecated -- kept for backward compatibility, reads deprecated `durable_objects` from config
 				appConfigNoDefaults.durable_objects !== undefined &&
 				prevApp.durable_objects.namespace_id !==
+					// eslint-disable-next-line @typescript-eslint/no-deprecated -- kept for backward compatibility, reads deprecated `durable_objects` from config
 					appConfigNoDefaults.durable_objects.namespace_id
 			) {
 				throw new UserError(
@@ -438,6 +445,7 @@ export async function apply(
 				config.configPath
 			);
 
+			// eslint-disable-next-line @typescript-eslint/no-deprecated -- Diff is used here for formatted config string diffing, not JSON objects
 			const diff = new Diff(prev, now);
 			if (diff.changes === 0) {
 				updateStatus(`no changes ${brandColor(application.name)}`);

--- a/packages/wrangler/src/cloudchamber/create.ts
+++ b/packages/wrangler/src/cloudchamber/create.ts
@@ -340,6 +340,7 @@ async function handleInteractiveCloudchamberCreateCommand(
 		resolveMemory(args, config.cloudchamber) ??
 		account.defaults.memory_mib ??
 		Math.round(
+			// eslint-disable-next-line @typescript-eslint/no-deprecated -- kept for backward compatibility, falls back to deprecated `memory` when `memory_mib` is not set
 			parseByteSize(account.defaults.memory ?? "2000MiB", 1024) / (1024 * 1024)
 		);
 	const vcpu = args.vcpu ?? config.cloudchamber.vcpu ?? account.defaults.vcpus;

--- a/packages/wrangler/src/cloudchamber/instance-type/instance-type.ts
+++ b/packages/wrangler/src/cloudchamber/instance-type/instance-type.ts
@@ -191,6 +191,7 @@ export function cleanForInstanceType(
 	}
 
 	delete app.configuration.disk;
+	// eslint-disable-next-line @typescript-eslint/no-deprecated -- intentionally cleaning up deprecated `memory` field
 	delete app.configuration.memory;
 	delete app.configuration.memory_mib;
 	delete app.configuration.vcpu;

--- a/packages/wrangler/src/containers/config.ts
+++ b/packages/wrangler/src/containers/config.ts
@@ -99,9 +99,12 @@ export const getNormalizedContainerOptions = async (
 		let tiers: number[] | undefined;
 		if (container.constraints?.tiers) {
 			tiers = container.constraints.tiers;
+			// eslint-disable-next-line @typescript-eslint/no-deprecated -- kept for backward compatibility, falls back to deprecated `tier` when `tiers` is not set
 		} else if (container.constraints?.tier === -1) {
 			tiers = undefined;
+			// eslint-disable-next-line @typescript-eslint/no-deprecated -- kept for backward compatibility, falls back to deprecated `tier` when `tiers` is not set
 		} else if (container.constraints?.tier) {
+			// eslint-disable-next-line @typescript-eslint/no-deprecated -- kept for backward compatibility, falls back to deprecated `tier` when `tiers` is not set
 			tiers = [container.constraints.tier];
 		} else {
 			tiers = [1, 2];
@@ -139,6 +142,7 @@ export const getNormalizedContainerOptions = async (
 					config.observability?.logs?.enabled ??
 					config.observability?.enabled === true,
 			},
+			// eslint-disable-next-line @typescript-eslint/no-deprecated -- kept for backward compatibility, falls back to deprecated `wrangler_ssh` when `ssh` is not set
 			wrangler_ssh: container.ssh ?? container.wrangler_ssh,
 			authorized_keys: container.authorized_keys,
 			trusted_user_ca_keys: container.trusted_user_ca_keys,
@@ -147,15 +151,21 @@ export const getNormalizedContainerOptions = async (
 		let instanceTypeOrLimits: InstanceTypeOrLimits;
 		const MB = 1000 * 1000;
 		if (
+			// eslint-disable-next-line @typescript-eslint/no-deprecated -- kept for backward compatibility, deprecated `configuration` path for custom instance types
 			container.configuration?.disk !== undefined ||
+			// eslint-disable-next-line @typescript-eslint/no-deprecated -- kept for backward compatibility, deprecated `configuration` path for custom instance types
 			container.configuration?.vcpu !== undefined ||
+			// eslint-disable-next-line @typescript-eslint/no-deprecated -- kept for backward compatibility, deprecated `configuration` path for custom instance types
 			container.configuration?.memory_mib !== undefined
 		) {
 			// deprecated path to set a custom instance type
 			// if an individual limit is not set, default to the dev instance type values
 			instanceTypeOrLimits = {
+				// eslint-disable-next-line @typescript-eslint/no-deprecated -- kept for backward compatibility, deprecated `configuration` path for custom instance types
 				disk_bytes: (container.configuration?.disk?.size_mb ?? 2000) * MB, // defaults to 2GB in bytes
+				// eslint-disable-next-line @typescript-eslint/no-deprecated -- kept for backward compatibility, deprecated `configuration` path for custom instance types
 				vcpu: container.configuration?.vcpu ?? 0.0625,
+				// eslint-disable-next-line @typescript-eslint/no-deprecated -- kept for backward compatibility, deprecated `configuration` path for custom instance types
 				memory_mib: container.configuration?.memory_mib ?? 256,
 			};
 		} else if (

--- a/packages/wrangler/src/containers/deploy.ts
+++ b/packages/wrangler/src/containers/deploy.ts
@@ -478,6 +478,7 @@ export async function apply(
 			nowContainer,
 			config.configPath
 		);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated -- Diff is used here for formatted config string diffing, not JSON objects
 		const diff = new Diff(prev, now);
 
 		if (diff.changes === 0) {
@@ -742,6 +743,7 @@ export function cleanApplicationFromAPI(
 		cleanedPreviousApp.configuration.instance_type = instance_type;
 
 		delete cleanedPreviousApp.configuration.disk;
+		// eslint-disable-next-line @typescript-eslint/no-deprecated -- intentionally cleaning up deprecated `memory` field
 		delete cleanedPreviousApp.configuration.memory;
 		delete cleanedPreviousApp.configuration.memory_mib;
 		delete cleanedPreviousApp.configuration.vcpu;

--- a/packages/wrangler/src/metrics/metrics-dispatcher.ts
+++ b/packages/wrangler/src/metrics/metrics-dispatcher.ts
@@ -52,14 +52,14 @@ export function getMetricsDispatcher(options: MetricsConfigOptions) {
 	const amplitude_session_id = Date.now();
 	let amplitude_event_id = 0;
 
-	// Detect agent environment once when dispatcher is created
-	// Pass empty array for processAncestry to skip process tree checks entirely.
-	// Process tree traversal uses execSync('ps ...') which is slow and can cause
-	// timeouts, especially in CI environments. Environment variable detection
-	// is sufficient for identifying most agentic environments.
+	// Detect agent environment once when dispatcher is created.
+	// Environment variable detection is sufficient for identifying most agentic
+	// environments — process tree traversal (checkProcesses) is disabled by
+	// default since it uses execSync('ps ...') which is slow and can cause
+	// timeouts, especially in CI environments.
 	let agent: string | null = null;
 	try {
-		const agentDetection = detectAgenticEnvironment(process.env, []);
+		const agentDetection = detectAgenticEnvironment();
 		agent = agentDetection.id;
 	} catch {
 		// Silent failure - agent remains null

--- a/packages/wrangler/src/pages/dev.ts
+++ b/packages/wrangler/src/pages/dev.ts
@@ -1401,6 +1401,7 @@ function getBindingsFromArgs(args: typeof pagesDevCommand.args): Partial<
 			})
 			.filter(Boolean) as NonNullable<AdditionalDevProps["services"]>;
 
+		// eslint-disable-next-line @typescript-eslint/no-deprecated -- intentionally checking deprecated `environment` field to warn users
 		if (services.find(({ environment }) => !!environment)) {
 			// We haven't yet properly defined how environments of service bindings should
 			// work, so if the user is using an environment for any of their service

--- a/packages/wrangler/src/pipelines/cli/legacy-helpers.ts
+++ b/packages/wrangler/src/pipelines/cli/legacy-helpers.ts
@@ -38,6 +38,7 @@ export async function getLegacyPipeline(
 	name: string,
 	format: "pretty" | "json"
 ): Promise<void> {
+	// eslint-disable-next-line @typescript-eslint/no-deprecated -- legacy pipelines use validateName (allows hyphens); validateEntityName uses different regex
 	validateName("pipeline name", name);
 
 	const pipeline = await getPipeline(config, accountId, name);

--- a/packages/wrangler/src/preview/shared.ts
+++ b/packages/wrangler/src/preview/shared.ts
@@ -261,6 +261,7 @@ export function extractConfigBindings(config: Config): EnvBindings {
 		};
 	}
 
+	// eslint-disable-next-line @typescript-eslint/no-deprecated -- kept for backward compatibility, forwards deprecated `pipeline` field alongside `stream`
 	for (const { binding, stream, pipeline } of previews?.pipelines ?? []) {
 		env[binding] = {
 			type: "pipelines",

--- a/packages/wrangler/src/type-generation/index.ts
+++ b/packages/wrangler/src/type-generation/index.ts
@@ -2907,6 +2907,7 @@ function collectAllPipelines(
 				});
 			}
 
+			// eslint-disable-next-line @typescript-eslint/no-deprecated -- kept for backward compatibility, falls back to deprecated `pipeline` when `stream` is not set
 			if (!pipeline.stream && !pipeline.pipeline) {
 				throwMissingBindingError({
 					binding: pipeline,
@@ -2925,6 +2926,7 @@ function collectAllPipelines(
 			pipelinesMap.set(pipeline.binding, {
 				binding: pipeline.binding,
 				stream: pipeline.stream,
+				// eslint-disable-next-line @typescript-eslint/no-deprecated -- kept for backward compatibility, falls back to deprecated `pipeline` when `stream` is not set
 				pipeline: pipeline.pipeline,
 			});
 		}
@@ -4124,9 +4126,11 @@ function collectPipelinesPerEnvironment(
 					binding: pipeline.binding,
 					stream: pipeline.stream,
 				});
+				// eslint-disable-next-line @typescript-eslint/no-deprecated -- kept for backward compatibility, falls back to deprecated `pipeline` when `stream` is not set
 			} else if (pipeline.pipeline) {
 				pipelines.push({
 					binding: pipeline.binding,
+					// eslint-disable-next-line @typescript-eslint/no-deprecated -- kept for backward compatibility, falls back to deprecated `pipeline` when `stream` is not set
 					pipeline: pipeline.pipeline,
 				});
 			} else {

--- a/packages/wrangler/src/utils/add-created-resource-config.ts
+++ b/packages/wrangler/src/utils/add-created-resource-config.ts
@@ -83,8 +83,10 @@ export async function createdResourceConfig<K extends ValidKeys>(
 	}
 ) {
 	const envString = env ? ` in the "${env}" environment` : "";
+	// eslint-disable-next-line @typescript-eslint/no-deprecated -- friendlyBindingNames is keyed by config field name; getBindingTypeFriendlyName uses a different key space
+	const resourceName = friendlyBindingNames[resource];
 	logger.log(
-		`To access your new ${friendlyBindingNames[resource]} in your Worker, add the following snippet to your configuration file${envString}:`
+		`To access your new ${resourceName} in your Worker, add the following snippet to your configuration file${envString}:`
 	);
 
 	logger.log(

--- a/packages/wrangler/src/versions/secrets/index.ts
+++ b/packages/wrangler/src/versions/secrets/index.ts
@@ -244,6 +244,7 @@ async function parseModules(
 	if (
 		contentRes.headers.get("content-type")?.startsWith("multipart/form-data")
 	) {
+		// eslint-disable-next-line @typescript-eslint/no-deprecated -- formData() is the standard Web API; only deprecated on undici's server-side types
 		const formData = await contentRes.formData();
 
 		// Workers Sites is not supported


### PR DESCRIPTION
This PR enabled the `@typescript-eslint/no-deprecated` linting rule for the `wrangler` package

Followup for https://github.com/cloudflare/workers-sdk/pull/14472, https://github.com/cloudflare/workers-sdk/pull/14491, https://github.com/cloudflare/workers-sdk/pull/14509, and https://github.com/cloudflare/workers-sdk/pull/14522

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: internal refactoring
