### PR TITLE
fix: pass auth profiles to vite

### DIFF
--- a/.changeset/fix-auth-profiles-vite-plugin.md
+++ b/.changeset/fix-auth-profiles-vite-plugin.md
@@ -7,4 +7,4 @@ fix: Respect auth profiles when using remote bindings in the Vite plugin
 
 Auth profiles (configured via `wrangler auth create` and `wrangler auth activate`) were previously being ignored when using remote bindings with the Vite plugin. This is now fixed.
 
-Note that the profile directory is resolved based on the current working directory, or the the config file location of the primary worker.
+Note that the profile directory is resolved based on your the [`root`](https://vite.dev/config/shared-options.html#root) value of your Vite config.

--- a/.changeset/fix-auth-profiles-vite-plugin.md
+++ b/.changeset/fix-auth-profiles-vite-plugin.md
@@ -7,4 +7,4 @@ fix: Respect auth profiles when using remote bindings in the Vite plugin
 
 Auth profiles (configured via `wrangler auth create` and `wrangler auth activate`) were previously being ignored when using remote bindings with the Vite plugin. This is now fixed.
 
-Note that the profile directory is resolved based on your the [`root`](https://vite.dev/config/shared-options.html#root) value of your Vite config.
+Note that the profile directory is resolved based on the [Vite project root](https://vite.dev/config/shared-options.html#root).

--- a/.changeset/fix-auth-profiles-vite-plugin.md
+++ b/.changeset/fix-auth-profiles-vite-plugin.md
@@ -6,3 +6,5 @@
 fix: Respect auth profiles when using remote bindings in the Vite plugin
 
 Auth profiles (configured via `wrangler auth create` and `wrangler auth activate`) were previously being ignored when using remote bindings with the Vite plugin. This is now fixed.
+
+Note that the profile directory is resolved based on the current working directory, or the the config file location of the primary worker.

--- a/.changeset/fix-auth-profiles-vite-plugin.md
+++ b/.changeset/fix-auth-profiles-vite-plugin.md
@@ -1,0 +1,8 @@
+---
+"wrangler": patch
+"@cloudflare/vite-plugin": patch
+---
+
+fix: Respect auth profiles when using remote bindings in the Vite plugin
+
+Auth profiles (configured via `wrangler auth create` and `wrangler auth activate`) were previously being ignored when using remote bindings with the Vite plugin. This is now fixed.

--- a/packages/vite-plugin-cloudflare/e2e/remote-bindings.test.ts
+++ b/packages/vite-plugin-cloudflare/e2e/remote-bindings.test.ts
@@ -1,4 +1,6 @@
+import { mkdirSync, writeFileSync } from "node:fs";
 import { readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
 import { setTimeout } from "node:timers/promises";
 import { assert, beforeAll, describe, test, vi } from "vitest";
 import {
@@ -192,6 +194,60 @@ if (isWindows) {
 		});
 	});
 }
+
+describe.skipIf(isWindows)(
+	"remote bindings resolve auth profile from vite config root",
+	() => {
+		const projectPath = seed("remote-bindings-config-account-id", {
+			pm: "pnpm",
+		});
+
+		test("uses directory-bound auth profile instead of triggering oauth", async ({
+			expect,
+		}) => {
+			// Set up a fake HOME with a .wrangler global config directory containing:
+			//  - a named profile with a dummy oauth token
+			//  - a directory binding mapping the project path to that profile
+			const fakeHome = path.join(projectPath, ".fake-home");
+			const wranglerDir = path.join(fakeHome, ".wrangler");
+
+			mkdirSync(path.join(wranglerDir, "config"), { recursive: true });
+			writeFileSync(
+				path.join(wranglerDir, "config", "e2e-test-profile.toml"),
+				[
+					'oauth_token = "fake-oauth-token-for-e2e-test"',
+					'refresh_token = "fake-refresh-token"',
+					`expiration_time = "2099-01-01T00:00:00+00:00"`,
+				].join("\n")
+			);
+
+			mkdirSync(path.join(wranglerDir, "profiles"), { recursive: true });
+			writeFileSync(
+				path.join(wranglerDir, "profiles", "directory-bindings.json"),
+				JSON.stringify({ [projectPath]: "e2e-test-profile" })
+			);
+
+			const proc = await runLongLived("pnpm", "dev", projectPath, {
+				HOME: fakeHome,
+				CLOUDFLARE_API_TOKEN: undefined,
+				CLOUDFLARE_API_KEY: undefined,
+				CLOUDFLARE_EMAIL: undefined,
+			});
+
+			// as opposed to hitting the OAuth path, which would indicate that the profile did not register
+			await vi.waitFor(
+				async () => {
+					expect(proc.stderr).toMatch(
+						/A request to the Cloudflare API \(\/accounts\/not-a-valid-account-id-abc\/.*?\) failed/
+					);
+				},
+				{
+					timeout: 10_000,
+				}
+			);
+		});
+	}
+);
 
 describe.skipIf(isWindows)("remote bindings disabled", () => {
 	const projectPath = seed("remote-bindings-disabled", { pm: "pnpm" });

--- a/packages/vite-plugin-cloudflare/src/miniflare-options.ts
+++ b/packages/vite-plugin-cloudflare/src/miniflare-options.ts
@@ -252,6 +252,10 @@ export async function getDevMiniflareOptions(
 
 	const containerTagToOptionsMap: ContainerTagToOptionsMap = new Map();
 
+	const profileDir = entryWorkerConfig?.configPath
+		? path.dirname(entryWorkerConfig.configPath)
+		: process.cwd();
+
 	const workersFromConfig =
 		resolvedPluginConfig.type === "workers"
 			? await Promise.all(
@@ -275,9 +279,7 @@ export async function getDevMiniflareOptions(
 												name: worker.config.name,
 												bindings: bindings ?? {},
 												account_id: worker.config.account_id,
-												profileDir: worker.config.configPath
-													? path.dirname(worker.config.configPath)
-													: undefined, // will fallback to cwd
+												profileDir,
 											},
 											preExistingRemoteProxySession ?? null
 										);
@@ -647,6 +649,12 @@ export async function getPreviewMiniflareOptions(
 	const { resolvedPluginConfig, resolvedViteConfig } = ctx;
 	const containerTagToOptionsMap: ContainerTagToOptionsMap = new Map();
 
+	const firstWorkerConfigPath =
+		resolvedPluginConfig.workers[0]?.config.configPath;
+	const previewProfileDir = firstWorkerConfigPath
+		? path.dirname(firstWorkerConfigPath)
+		: undefined;
+
 	const workers: Array<WorkerOptions> = (
 		await Promise.all(
 			resolvedPluginConfig.workers.map(async (previewWorker) => {
@@ -668,9 +676,7 @@ export async function getPreviewMiniflareOptions(
 								name: workerConfig.name,
 								bindings: bindings ?? {},
 								account_id: workerConfig.account_id,
-								profileDir: workerConfig.configPath
-									? path.dirname(workerConfig.configPath)
-									: undefined,
+								profileDir: previewProfileDir,
 							},
 							preExistingRemoteProxySessionData ?? null
 						);

--- a/packages/vite-plugin-cloudflare/src/miniflare-options.ts
+++ b/packages/vite-plugin-cloudflare/src/miniflare-options.ts
@@ -252,10 +252,6 @@ export async function getDevMiniflareOptions(
 
 	const containerTagToOptionsMap: ContainerTagToOptionsMap = new Map();
 
-	const profileDir = entryWorkerConfig?.configPath
-		? path.dirname(entryWorkerConfig.configPath)
-		: process.cwd();
-
 	const workersFromConfig =
 		resolvedPluginConfig.type === "workers"
 			? await Promise.all(
@@ -279,7 +275,7 @@ export async function getDevMiniflareOptions(
 												name: worker.config.name,
 												bindings: bindings ?? {},
 												account_id: worker.config.account_id,
-												profileDir,
+												profileDir: resolvedViteConfig.root,
 											},
 											preExistingRemoteProxySession ?? null
 										);
@@ -649,12 +645,6 @@ export async function getPreviewMiniflareOptions(
 	const { resolvedPluginConfig, resolvedViteConfig } = ctx;
 	const containerTagToOptionsMap: ContainerTagToOptionsMap = new Map();
 
-	const firstWorkerConfigPath =
-		resolvedPluginConfig.workers[0]?.config.configPath;
-	const previewProfileDir = firstWorkerConfigPath
-		? path.dirname(firstWorkerConfigPath)
-		: undefined;
-
 	const workers: Array<WorkerOptions> = (
 		await Promise.all(
 			resolvedPluginConfig.workers.map(async (previewWorker) => {
@@ -676,7 +666,7 @@ export async function getPreviewMiniflareOptions(
 								name: workerConfig.name,
 								bindings: bindings ?? {},
 								account_id: workerConfig.account_id,
-								profileDir: previewProfileDir,
+								profileDir: resolvedViteConfig.root,
 							},
 							preExistingRemoteProxySessionData ?? null
 						);

--- a/packages/vite-plugin-cloudflare/src/miniflare-options.ts
+++ b/packages/vite-plugin-cloudflare/src/miniflare-options.ts
@@ -275,6 +275,9 @@ export async function getDevMiniflareOptions(
 												name: worker.config.name,
 												bindings: bindings ?? {},
 												account_id: worker.config.account_id,
+												profileDir: worker.config.configPath
+													? path.dirname(worker.config.configPath)
+													: undefined, // will fallback to cwd
 											},
 											preExistingRemoteProxySession ?? null
 										);
@@ -665,6 +668,9 @@ export async function getPreviewMiniflareOptions(
 								name: workerConfig.name,
 								bindings: bindings ?? {},
 								account_id: workerConfig.account_id,
+								profileDir: workerConfig.configPath
+									? path.dirname(workerConfig.configPath)
+									: undefined,
 							},
 							preExistingRemoteProxySessionData ?? null
 						);

--- a/packages/wrangler/src/api/remoteBindings/index.ts
+++ b/packages/wrangler/src/api/remoteBindings/index.ts
@@ -4,7 +4,8 @@ import {
 	getCloudflareComplianceRegion,
 } from "@cloudflare/workers-utils";
 import { readConfig } from "../../config";
-import { requireApiToken, requireAuth } from "../../user";
+import { requireApiToken, requireAuth, setProfile } from "../../user";
+import { createWranglerProfileStore } from "../../user/profile-store";
 import { convertConfigBindingsToStartWorkerBindings } from "../startDevWorker";
 import { startRemoteProxySession } from "./start-remote-proxy-session";
 import type { CfAccount } from "../../dev/create-worker-preview";
@@ -50,6 +51,11 @@ type WorkerConfigObject = {
 	complianceRegion?: Config["compliance_region"];
 	/** Id of the account owning the worker */
 	account_id?: Config["account_id"];
+	/**
+	 * directory used to resolve the auth profile from directory bindings.
+	 * Falls back to `process.cwd()` when not provided.
+	 */
+	profileDir?: string;
 };
 
 /**
@@ -118,7 +124,8 @@ export async function maybeStartOrUpdateRemoteProxySession(
 					? {
 							account_id: workerConfigObject.account_id,
 						}
-					: config
+					: config,
+				workerConfigObject.profileDir
 			),
 		});
 	} else {
@@ -142,7 +149,8 @@ export async function maybeStartOrUpdateRemoteProxySession(
 								? {
 										account_id: workerConfigObject.account_id,
 									}
-								: config
+								: config,
+							workerConfigObject.profileDir
 						),
 					});
 				}
@@ -173,12 +181,19 @@ export async function maybeStartOrUpdateRemoteProxySession(
  *
  * @param auth the auth hook provided by the user if any
  * @param config the user's wrangler config if any
+ * @param profileDir working directory used to resolve the auth profile from directory bindings,
+ *            falls back to `process.cwd()` when not provided
  * @returns the auth hook to pass to the startRemoteProxy session function if any
  */
 function getAuthHook(
 	auth: AsyncHook<CfAccount> | undefined,
-	config: Pick<Config, "account_id"> | undefined
+	config: Pick<Config, "account_id"> | undefined,
+	profileDir: string | undefined
 ): AsyncHook<CfAccount> | undefined {
+	const profile = createWranglerProfileStore().resolve({
+		cwd: profileDir ?? process.cwd(),
+	});
+	setProfile(profile);
 	if (auth) {
 		return auth;
 	}


### PR DESCRIPTION
Fixes #14580 

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [x] Automated tests not possible - manual testing has been completed as follows: ran `wrangler logout; wrangler auth profile create/activate 'test'; vite dev` in a directory with remote bindings. no oauth flow triggered, remote bindings used the 'test' profile. then deleted profile, and it required re-authing.
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bugfix

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
