### PR TITLE
[wrangler] compare origins, not hrefs, when classifying dev proxy fetch errors

### DIFF
--- a/.changeset/proxyworker-origin-compare.md
+++ b/.changeset/proxyworker-origin-compare.md
@@ -2,6 +2,6 @@
 "wrangler": patch
 ---
 
-fix: correctly classify dev proxy fetch errors by comparing UserWorker origins instead of hrefs
+Correctly classify dev proxy fetch errors by comparing UserWorker origins instead of hrefs
 
 The ProxyWorker's stale-error guard compared a path-bearing URL against an origin-only URL, so it could only match for requests to `/`. Genuine network errors on any other path were misclassified as "UserWorker changed": failed GET/HEAD requests were silently parked in the retry queue (the client hangs), and non-GET requests received a misleading "Your worker restarted mid-request" 503. Errors for an unchanged UserWorker are now reported and rejected immediately.

--- a/.changeset/proxyworker-origin-compare.md
+++ b/.changeset/proxyworker-origin-compare.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+fix: correctly classify dev proxy fetch errors by comparing UserWorker origins instead of hrefs
+
+The ProxyWorker's stale-error guard compared a path-bearing URL against an origin-only URL, so it could only match for requests to `/`. Genuine network errors on any other path were misclassified as "UserWorker changed": failed GET/HEAD requests were silently parked in the retry queue (the client hangs), and non-GET requests received a misleading "Your worker restarted mid-request" 503. Errors for an unchanged UserWorker are now reported and rejected immediately.

--- a/.changeset/proxyworker-origin-compare.md
+++ b/.changeset/proxyworker-origin-compare.md
@@ -2,6 +2,6 @@
 "wrangler": patch
 ---
 
-Correctly classify dev proxy fetch errors by comparing UserWorker origins instead of hrefs
+Fix dev proxy silently hanging or returning a misleading 503 on network errors for non-root-path requests
 
-The ProxyWorker's stale-error guard compared a path-bearing URL against an origin-only URL, so it could only match for requests to `/`. Genuine network errors on any other path were misclassified as "UserWorker changed": failed GET/HEAD requests were silently parked in the retry queue (the client hangs), and non-GET requests received a misleading "Your worker restarted mid-request" 503. Errors for an unchanged UserWorker are now reported and rejected immediately.
+During `wrangler dev`, a transient network error on any request path other than `/` could be misclassified as the worker being reloaded, even when it wasn't: `GET`/`HEAD` requests would silently hang (with nothing logged) until the client timed out, and other methods would receive a misleading `Your worker restarted mid-request` 503. Such errors are now reported and surfaced immediately when the worker has not actually changed.

--- a/packages/wrangler/src/__tests__/api/startDevWorker/utils.test.ts
+++ b/packages/wrangler/src/__tests__/api/startDevWorker/utils.test.ts
@@ -3,7 +3,55 @@ import {
 	convertConfigBindingsToStartWorkerBindings,
 	convertStartDevOptionsToBindings,
 } from "../../../api/startDevWorker/binding-utils";
-import { rewriteUrlInHeaderValue } from "../../../api/startDevWorker/utils";
+import {
+	isSameUserWorkerOrigin,
+	rewriteUrlInHeaderValue,
+} from "../../../api/startDevWorker/utils";
+
+describe("isSameUserWorkerOrigin", () => {
+	const userWorker = { protocol: "http:", hostname: "localhost", port: "8787" };
+
+	it("matches same-origin requests regardless of path or query", () => {
+		// Regression guard for the ProxyWorker origin-vs-href fix: a request to a
+		// non-root path (or with a query string) must still resolve to the same
+		// UserWorker. An href comparison would fail all but "/" here, because
+		// urlFromParts() yields an origin-only URL.
+		assert(
+			isSameUserWorkerOrigin(new URL("http://localhost:8787/"), userWorker)
+		);
+		assert(
+			isSameUserWorkerOrigin(
+				new URL("http://localhost:8787/users/1/accessible-locks"),
+				userWorker
+			)
+		);
+		assert(
+			isSameUserWorkerOrigin(new URL("http://localhost:8787/x?a=1"), userWorker)
+		);
+	});
+
+	it("does not match when the UserWorker origin changed (e.g. new port)", () => {
+		assert(
+			!isSameUserWorkerOrigin(new URL("http://localhost:8788/"), userWorker)
+		);
+		assert(
+			!isSameUserWorkerOrigin(new URL("http://localhost:8787/some/path"), {
+				protocol: "http:",
+				hostname: "localhost",
+				port: "8788",
+			})
+		);
+	});
+
+	it("does not match when there is no proxyData (UserWorker torn down)", () => {
+		assert(
+			!isSameUserWorkerOrigin(
+				new URL("http://localhost:8787/some/path"),
+				undefined
+			)
+		);
+	});
+});
 
 describe("convertConfigBindingsToStartWorkerBindings", () => {
 	it("converts config bindings into startWorker bindings", async ({

--- a/packages/wrangler/src/__tests__/api/startDevWorker/utils.test.ts
+++ b/packages/wrangler/src/__tests__/api/startDevWorker/utils.test.ts
@@ -11,45 +11,75 @@ import {
 describe("isSameUserWorkerOrigin", () => {
 	const userWorker = { protocol: "http:", hostname: "localhost", port: "8787" };
 
-	it("matches same-origin requests regardless of path or query", () => {
+	it("matches same-origin requests regardless of path or query", ({
+		expect,
+	}) => {
 		// Regression guard for the ProxyWorker origin-vs-href fix: a request to a
 		// non-root path (or with a query string) must still resolve to the same
 		// UserWorker. An href comparison would fail all but "/" here, because
 		// urlFromParts() yields an origin-only URL.
-		assert(
+		expect(
 			isSameUserWorkerOrigin(new URL("http://localhost:8787/"), userWorker)
-		);
-		assert(
+		).toBe(true);
+		expect(
 			isSameUserWorkerOrigin(
 				new URL("http://localhost:8787/users/1/accessible-locks"),
 				userWorker
 			)
-		);
-		assert(
+		).toBe(true);
+		expect(
 			isSameUserWorkerOrigin(new URL("http://localhost:8787/x?a=1"), userWorker)
-		);
+		).toBe(true);
 	});
 
-	it("does not match when the UserWorker origin changed (e.g. new port)", () => {
-		assert(
-			!isSameUserWorkerOrigin(new URL("http://localhost:8788/"), userWorker)
-		);
-		assert(
-			!isSameUserWorkerOrigin(new URL("http://localhost:8787/some/path"), {
+	it("does not match when the port differs", ({ expect }) => {
+		expect(
+			isSameUserWorkerOrigin(new URL("http://localhost:8788/"), userWorker)
+		).toBe(false);
+		expect(
+			isSameUserWorkerOrigin(new URL("http://localhost:8787/some/path"), {
 				protocol: "http:",
 				hostname: "localhost",
 				port: "8788",
 			})
-		);
+		).toBe(false);
 	});
 
-	it("does not match when there is no proxyData (UserWorker torn down)", () => {
-		assert(
-			!isSameUserWorkerOrigin(
+	it("does not match when the hostname differs", ({ expect }) => {
+		expect(
+			isSameUserWorkerOrigin(new URL("http://127.0.0.1:8787/"), userWorker)
+		).toBe(false);
+		expect(
+			isSameUserWorkerOrigin(new URL("http://localhost:8787/some/path"), {
+				protocol: "http:",
+				hostname: "127.0.0.1",
+				port: "8787",
+			})
+		).toBe(false);
+	});
+
+	it("does not match when the protocol differs", ({ expect }) => {
+		expect(
+			isSameUserWorkerOrigin(new URL("https://localhost:8787/"), userWorker)
+		).toBe(false);
+		expect(
+			isSameUserWorkerOrigin(new URL("http://localhost:8787/some/path"), {
+				protocol: "https:",
+				hostname: "localhost",
+				port: "8787",
+			})
+		).toBe(false);
+	});
+
+	it("does not match when there is no proxyData (UserWorker torn down)", ({
+		expect,
+	}) => {
+		expect(
+			isSameUserWorkerOrigin(
 				new URL("http://localhost:8787/some/path"),
 				undefined
 			)
-		);
+		).toBe(false);
 	});
 });
 

--- a/packages/wrangler/src/api/startDevWorker/utils.ts
+++ b/packages/wrangler/src/api/startDevWorker/utils.ts
@@ -98,6 +98,24 @@ export function rewriteUrlInHeaderValue(
 	);
 }
 
+/**
+ * Whether a loopback request sent to `requestUrl` still targets the current
+ * UserWorker, described by its origin `parts` (e.g. `proxyData.userWorkerUrl`).
+ *
+ * Compares `.origin` only, NOT `.href`: `requestUrl` carries the original
+ * request's path and query, whereas `urlFromParts()` yields an origin-only URL
+ * (path "/"). An href comparison would therefore only ever match requests to
+ * "/", so a genuine network error on any other path would be misclassified as
+ * the UserWorker having been replaced.
+ */
+export function isSameUserWorkerOrigin(
+	requestUrl: URL,
+	parts: Partial<URL> | undefined
+): boolean {
+	const currentUserWorkerUrl = parts && urlFromParts(parts);
+	return requestUrl.origin === currentUserWorkerUrl?.origin;
+}
+
 type UnwrapHook<
 	T extends HookValues | Promise<HookValues>,
 	Args extends unknown[],

--- a/packages/wrangler/templates/startDevWorker/ProxyWorker.ts
+++ b/packages/wrangler/templates/startDevWorker/ProxyWorker.ts
@@ -183,11 +183,20 @@ export class ProxyWorker implements DurableObject {
 					// if proxyData.userWorkerUrl has changed, it means there is a new downstream UserWorker
 					// and that this error is stale since it was for a request to the old UserWorker
 					// so here we construct a newUserWorkerUrl so we can compare it to the (old) userWorkerUrl
+					// NOTE: compare .origin, not .href — userWorkerUrl carries the request's
+					// path+query (it is the request URL with protocol/host/port overridden)
+					// while urlFromParts() always yields origin + "/". An href comparison
+					// can therefore only match for requests to "/", misclassifying every
+					// other request's genuine network error as "UserWorker changed":
+					// failed GET/HEAD requests are silently parked in the retry queue
+					// (the client hangs) and non-GET requests receive a misleading
+					// "Your worker restarted mid-request" 503, with the underlying error
+					// never reported to the ProxyController.
 					const newUserWorkerUrl =
 						this.proxyData && urlFromParts(this.proxyData.userWorkerUrl);
 
 					// only report errors if the downstream proxy has NOT changed
-					if (userWorkerUrl.href === newUserWorkerUrl?.href) {
+					if (userWorkerUrl.origin === newUserWorkerUrl?.origin) {
 						void sendMessageToProxyController(this.env, {
 							type: "error",
 							error: {

--- a/packages/wrangler/templates/startDevWorker/ProxyWorker.ts
+++ b/packages/wrangler/templates/startDevWorker/ProxyWorker.ts
@@ -183,15 +183,9 @@ export class ProxyWorker implements DurableObject {
 					// if proxyData.userWorkerUrl has changed, it means there is a new downstream UserWorker
 					// and that this error is stale since it was for a request to the old UserWorker
 					// so here we construct a newUserWorkerUrl so we can compare it to the (old) userWorkerUrl
-					// NOTE: compare .origin, not .href — userWorkerUrl carries the request's
-					// path+query (it is the request URL with protocol/host/port overridden)
-					// while urlFromParts() always yields origin + "/". An href comparison
-					// can therefore only match for requests to "/", misclassifying every
-					// other request's genuine network error as "UserWorker changed":
-					// failed GET/HEAD requests are silently parked in the retry queue
-					// (the client hangs) and non-GET requests receive a misleading
-					// "Your worker restarted mid-request" 503, with the underlying error
-					// never reported to the ProxyController.
+					// compare .origin, not .href: userWorkerUrl carries the request's
+					// path+query while urlFromParts() is origin-only, so an href check
+					// would only match "/" and misclassify errors on other paths.
 					const newUserWorkerUrl =
 						this.proxyData && urlFromParts(this.proxyData.userWorkerUrl);
 

--- a/packages/wrangler/templates/startDevWorker/ProxyWorker.ts
+++ b/packages/wrangler/templates/startDevWorker/ProxyWorker.ts
@@ -1,6 +1,7 @@
 import {
 	createDeferred,
 	type DeferredPromise,
+	isSameUserWorkerOrigin,
 	rewriteUrlInHeaderValue,
 	urlFromParts,
 } from "../../src/api/startDevWorker/utils";
@@ -182,15 +183,13 @@ export class ProxyWorker implements DurableObject {
 					// we have crossed an async boundary, so proxyData may have changed
 					// if proxyData.userWorkerUrl has changed, it means there is a new downstream UserWorker
 					// and that this error is stale since it was for a request to the old UserWorker
-					// so here we construct a newUserWorkerUrl so we can compare it to the (old) userWorkerUrl
-					// compare .origin, not .href: userWorkerUrl carries the request's
-					// path+query while urlFromParts() is origin-only, so an href check
-					// would only match "/" and misclassify errors on other paths.
-					const newUserWorkerUrl =
-						this.proxyData && urlFromParts(this.proxyData.userWorkerUrl);
-
-					// only report errors if the downstream proxy has NOT changed
-					if (userWorkerUrl.origin === newUserWorkerUrl?.origin) {
+					// only report the error if the request still targets the current
+					// UserWorker. isSameUserWorkerOrigin compares origin (not href) so a
+					// genuine error on a non-root path isn't misread as a reload — see
+					// its docs.
+					if (
+						isSameUserWorkerOrigin(userWorkerUrl, this.proxyData?.userWorkerUrl)
+					) {
 						void sendMessageToProxyController(this.env, {
 							type: "error",
 							error: {


### PR DESCRIPTION
### What

One-line logic fix in `packages/wrangler/templates/startDevWorker/ProxyWorker.ts`:
the stale-error guard in `processQueue()`'s fetch `.catch()` now compares
`URL.origin` instead of `URL.href` when deciding whether a failed loopback fetch
belongs to a UserWorker that has since been replaced.

### Why

`userWorkerUrl` is built as `new URL(request.url)` + `Object.assign(..., proxyData.userWorkerUrl)`,
so it **carries the request's path and query**. `newUserWorkerUrl` is built via
`urlFromParts(this.proxyData.userWorkerUrl)`, whose base defaults to
`"http://localhost"` — so it is **always `origin + "/"`**.

`userWorkerUrl.href === newUserWorkerUrl?.href` can therefore only be true for
requests to `/` with no query string. For every other request, a genuine network
error from the loopback fetch to an **unchanged** UserWorker is misclassified as
"the UserWorker changed", which:

1. **Silently parks failed GET/HEAD requests** in `requestRetryQueue`. If no
   `play` message is coming (because no reload is actually in progress), the
   deferred response is never resolved — the client hangs until its own timeout,
   and nothing is logged anywhere (the error report to the ProxyController only
   happens in the href-match branch).
2. **Returns a misleading `"Your worker restarted mid-request"` 503** for
   non-GET/HEAD requests even when no restart happened.

### How we hit this

Our CI runs Newman smoke tests against `wrangler dev`. Transient loopback fetch
errors surfaced as: the same `GET /users/:id/accessible-locks` timing out after
30s, three times in a row — while interleaved requests to the same worker (and
the same Durable Object) answered in 6–45ms — plus a
`"Your worker restarted mid-request"` 503 aborting a `DELETE` later in the run.
The wrangler ProxyWorker log showed `GET … 200 OK (30080ms)` for the parked
request — it was replayed only when the client's next request pumped the retry
queue, with all worker-side processing happening in the final milliseconds. A
boot-id probe on the worker confirmed no restart occurred. Nothing appeared in
wrangler's output at any log level, because the error-report branch is
unreachable for non-root paths.

Observed on wrangler 4.54.0 and 4.105.0; the code on `main` is identical.

### Behavior after the fix

- Loopback error, UserWorker **unchanged** → error reported to ProxyController +
  request rejected immediately (the pre-existing intended behavior).
- Loopback error, UserWorker **actually replaced** (origin changed / proxy
  paused) → unchanged: GET/HEAD requeued for replay on `play`, others get the
  503.

### Notes / possible follow-up (not in this PR)

Even with correct classification, a GET parked in `requestRetryQueue` while a
reload is in progress has no deadline — if the `play` message never arrives the
client hangs forever. A bounded retry/deadline for parked requests would make
that path robust; happy to open a separate issue/PR if maintainers agree.

### Changeset

Included (`wrangler` patch bump).

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: Minor bug fix

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14593" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->