### PR TITLE
[miniflare] fix: preserve metadata for present-but-falsy KV values in bulk getWithMetadata

### DIFF
--- a/.changeset/fix-kv-bulk-metadata-falsy-values.md
+++ b/.changeset/fix-kv-bulk-metadata-falsy-values.md
@@ -1,0 +1,5 @@
+---
+"miniflare": patch
+---
+
+Fix bulk `getWithMetadata` dropping metadata for present keys whose value is falsy (`0`, `false`, empty string). The bulk-get handler gated on the decoded value's truthiness instead of the key's presence, so falsy-but-present values were returned unwrapped instead of as `{ value, metadata }`.

--- a/.changeset/fix-kv-bulk-metadata-falsy-values.md
+++ b/.changeset/fix-kv-bulk-metadata-falsy-values.md
@@ -2,4 +2,4 @@
 "miniflare": patch
 ---
 
-Fix bulk `getWithMetadata` dropping metadata for present keys whose value is falsy (`0`, `false`, empty string). The bulk-get handler gated on the decoded value's truthiness instead of the key's presence, so falsy-but-present values were returned unwrapped instead of as `{ value, metadata }`.
+Fix bulk `getWithMetadata` dropping metadata for present keys whose value is falsy (`0`, `false`, empty string). Previously, calling `getWithMetadata` on such keys would return the raw value without its `{ value, metadata }` wrapper.

--- a/packages/miniflare/src/workers/kv/namespace.worker.ts
+++ b/packages/miniflare/src/workers/kv/namespace.worker.ts
@@ -102,7 +102,7 @@ async function processKeyValue(
 			`At least one of the requested keys corresponds to a non-${type} value`
 		);
 	}
-	if (val && withMetadata) {
+	if (obj !== null && withMetadata) {
 		return [
 			{
 				value: val,

--- a/packages/miniflare/test/plugins/kv/index.spec.ts
+++ b/packages/miniflare/test/plugins/kv/index.spec.ts
@@ -253,6 +253,28 @@ test("bulk get: check metadata as string", async ({ expect }) => {
 	expect(result).toEqual(expectedResult);
 });
 
+test("bulk get: check metadata for present-but-falsy values", async ({
+	expect,
+}) => {
+	const { kv } = ctx;
+	await kv.put("key1", "0", { metadata: { testing: "zero" } });
+	await kv.put("key2", "false", { metadata: { testing: "false" } });
+	await kv.put("key3", "", { metadata: { testing: "empty" } });
+
+	const result: any = await kv.getWithMetadata(["key1", "key2"], "json");
+	const expectedResult: any = new Map([
+		["key1", { value: 0, metadata: { testing: "zero" } }],
+		["key2", { value: false, metadata: { testing: "false" } }],
+	]);
+	expect(result.get("key1")).toEqual(expectedResult.get("key1"));
+	expect(result.get("key2")).toEqual(expectedResult.get("key2"));
+
+	const textResult: any = await kv.getWithMetadata(["key3"]);
+	expect(textResult).toEqual(
+		new Map([["key3", { value: "", metadata: { testing: "empty" } }]])
+	);
+});
+
 test("bulk get: get with metadata for 404", async ({ expect }) => {
 	const { kv } = ctx;
 


### PR DESCRIPTION
Fixes #14594

`processKeyValue()` in `packages/miniflare/src/workers/kv/namespace.worker.ts` gated the bulk `getWithMetadata` response shape on the *decoded value's* truthiness (`val && withMetadata`) instead of the *key's presence* (`obj !== null`). As a result, present keys whose value happened to be JSON `0`, JSON `false`, or an empty string were returned as bare unwrapped values instead of `{ value, metadata }`, silently dropping their metadata.

Fix: check entry presence (`obj !== null`) instead of value truthiness — the same distinction already used a few lines below for the single-key `GET` 404 check. Missing-key behavior (bare `null`) is unchanged.

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: internal bug fix restoring documented/tested contract, no user-facing API change
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14597" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->