### PR TITLE
[wrangler] fix: report non-zero exit code when killed by a signal (e.g. OOM)

### DIFF
--- a/.changeset/fix-wrangler-signal-exit-code.md
+++ b/.changeset/fix-wrangler-signal-exit-code.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Fix `wrangler` reporting exit code 0 when its child process is killed by a signal (e.g. OOM/SIGKILL)
+
+Previously, if the underlying `wrangler` process was terminated by a signal rather than exiting normally, the CLI wrapper reported exit code 0, making CI pipelines and other automation believe the command succeeded. `wrangler` now reports a non-zero exit code and logs the signal in this case.

--- a/packages/wrangler/bin/wrangler.js
+++ b/packages/wrangler/bin/wrangler.js
@@ -5,6 +5,16 @@ const path = require("path");
 const MIN_NODE_VERSION = "22.0.0";
 let wranglerProcess;
 
+function resolveExitCode(code, signal) {
+	if (code !== null && code !== undefined) {
+		return code;
+	}
+	if (signal) {
+		console.error(`wrangler exited because it received signal ${signal}`);
+	}
+	return 1;
+}
+
 /**
  * Executes ../wrangler-dist/cli.js
  */
@@ -33,9 +43,7 @@ Consider using a Node.js version manager such as https://volta.sh/ or https://gi
 			stdio: ["inherit", "inherit", "inherit", "ipc"],
 		}
 	)
-		.on("exit", (code) =>
-			process.exit(code === undefined || code === null ? 0 : code)
-		)
+		.on("exit", (code, signal) => process.exit(resolveExitCode(code, signal)))
 		.on("message", (message) => {
 			if (process.send) {
 				process.send(message);
@@ -89,3 +97,5 @@ if (module === require.main) {
 		wranglerProcess && wranglerProcess.kill();
 	});
 }
+
+module.exports = { resolveExitCode };

--- a/packages/wrangler/src/__tests__/bin-wrangler-exit-code.test.ts
+++ b/packages/wrangler/src/__tests__/bin-wrangler-exit-code.test.ts
@@ -1,0 +1,30 @@
+import { describe, it } from "vitest";
+import { mockConsoleMethods } from "./helpers/mock-console";
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports -- bin/wrangler.js is a plain CommonJS script
+const { resolveExitCode } = require("../../bin/wrangler.js");
+
+describe("bin/wrangler.js resolveExitCode", () => {
+	const std = mockConsoleMethods();
+
+	it("passes through a normal numeric exit code", ({ expect }) => {
+		expect(resolveExitCode(0, null)).toBe(0);
+		expect(resolveExitCode(1, null)).toBe(1);
+	});
+
+	it("reports a non-zero exit code when killed by a signal", ({ expect }) => {
+		expect(resolveExitCode(null, "SIGKILL")).toBe(1);
+		expect(std.err).toContain("SIGKILL");
+	});
+
+	it("reports a non-zero exit code for SIGTERM", ({ expect }) => {
+		expect(resolveExitCode(null, "SIGTERM")).toBe(1);
+		expect(std.err).toContain("SIGTERM");
+	});
+
+	it("defaults to a non-zero exit code when code and signal are both missing", ({
+		expect,
+	}) => {
+		expect(resolveExitCode(undefined, null)).toBe(1);
+	});
+});


### PR DESCRIPTION
Fixes #14584

`bin/wrangler.js` (the actual `wrangler` executable) spawns the real CLI (`wrangler-dist/cli.js`) as a child process and forwards its exit code:

```js
.on("exit", (code) =>
	process.exit(code === undefined || code === null ? 0 : code)
)
```

Node's `exit` event fires with `code = null` and a populated `signal` when a child is killed by a signal instead of exiting normally. The handler above didn't even capture `signal`, and treated `code === null` as success — so any signal-killed `wrangler` process (OOM/SIGKILL as reported here, but also e.g. SIGTERM from an orchestrator timeout) silently reported exit code 0 to whatever invoked it, making CI pipelines believe the command succeeded. This applies to every `wrangler` command, not just `pages deploy`.

Root cause was found by the issue reporter (@QuentinFarizon) in the comments, including a proposed fix pattern.

Fix: capture `signal`, and only treat the exit as clean when a real numeric `code` came through. Otherwise log the signal to stderr and exit 1.

To make this testable without spawning the full built CLI or relying on cross-platform signal delivery (SIGKILL semantics differ on Windows, which this repo's CI matrix covers), the exit-code decision is extracted into a small exported `resolveExitCode(code, signal)` function that's unit tested directly. The file's actual CLI-spawning side effect is already guarded behind `if (module === require.main)`, so requiring it from a test doesn't trigger a spawn.

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: internal CLI robustness fix, no public API/behavior change for successful runs
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14598" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->