### PR TITLE
Workflows: Improve scheduled Workflows free-plan deploy error

### DIFF
--- a/.changeset/friendly-cron-workflows.md
+++ b/.changeset/friendly-cron-workflows.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Improve the deploy error for cron-triggered Workflows on free plans
+
+Wrangler now explains that Workflow schedules require a paid Workers plan instead of showing only the generic Workflows API request failure.

--- a/packages/deploy-helpers/src/deploy/helpers/error-codes.ts
+++ b/packages/deploy-helpers/src/deploy/helpers/error-codes.ts
@@ -36,3 +36,6 @@ export const INCONSISTENT_EXPORTS_ACROSS_VERSIONS_CODE = 100405;
  * `wrangler deploy` to provision and bind in one step.
  */
 export const ACTOR_BINDING_DEPENDS_ON_EXPORT_CODE = 100406;
+
+/** Workflows API code for `workflow.cron_requires_paid_plan`. */
+export const WORKFLOW_CRON_REQUIRES_PAID_PLAN_CODE = 10208;

--- a/packages/deploy-helpers/src/triggers/deploy.ts
+++ b/packages/deploy-helpers/src/triggers/deploy.ts
@@ -1,4 +1,5 @@
 import {
+	APIError,
 	formatTime,
 	getSubdomainMixedStateCheckDisabled,
 	retryOnAPIFailure,
@@ -6,6 +7,7 @@ import {
 } from "@cloudflare/workers-utils";
 import chalk from "chalk";
 import PQueue from "p-queue";
+import { WORKFLOW_CRON_REQUIRES_PAID_PLAN_CODE } from "../deploy/helpers/error-codes";
 import {
 	fetchListResult,
 	fetchResult,
@@ -296,7 +298,28 @@ export async function triggersDeploy(
 					}
 				).then(
 					() => ({ targets: [`workflow: ${workflow.name}`] }),
-					(error) => ({ targets: [], error })
+					(error) => {
+						if (
+							error instanceof APIError &&
+							error.code === WORKFLOW_CRON_REQUIRES_PAID_PLAN_CODE &&
+							workflow.schedules
+						) {
+							error.preventReport();
+							return {
+								targets: [],
+								error: new UserError(
+									`Workflow "${workflow.name}" has "schedules" configured, but scheduled Workflows require a paid Workers plan.`,
+									{
+										cause: error,
+										telemetryMessage:
+											"triggers deploy workflow cron requires paid plan",
+									}
+								),
+							};
+						}
+
+						return { targets: [], error };
+					}
 				)
 			);
 		}

--- a/packages/wrangler/src/__tests__/deploy/workflows.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/workflows.test.ts
@@ -1,5 +1,6 @@
 import * as fs from "node:fs";
 import { getInstalledPackageVersion } from "@cloudflare/autoconfig";
+import { WORKFLOW_CRON_REQUIRES_PAID_PLAN_CODE } from "@cloudflare/deploy-helpers";
 import {
 	runInTempDir,
 	writeWranglerConfig,
@@ -345,6 +346,61 @@ describe("deploy", () => {
 
 			expect(std.warn).toMatchInlineSnapshot(`""`);
 			expect(std.out).toContain("workflow: my-workflow");
+		});
+
+		it("should explain that cron-triggered workflows require a paid plan", async ({
+			expect,
+		}) => {
+			writeWranglerConfig({
+				main: "index.js",
+				workflows: [
+					{
+						binding: "WORKFLOW",
+						name: "my-workflow",
+						class_name: "MyWorkflow",
+						schedules: "0 * * * *",
+					},
+				],
+			});
+			await fs.promises.writeFile(
+				"index.js",
+				`
+                import { WorkflowEntrypoint } from 'cloudflare:workers';
+                export default {};
+                export class MyWorkflow extends WorkflowEntrypoint {};
+            `
+			);
+
+			msw.use(
+				http.put("*/accounts/:accountId/workflows/:workflowName", () => {
+					return HttpResponse.json(
+						createFetchResult(null, false, [
+							{
+								code: WORKFLOW_CRON_REQUIRES_PAID_PLAN_CODE,
+								message: "Cron-triggered workflows require a paid plan",
+							},
+						]),
+						{ status: 403 }
+					);
+				})
+			);
+			mockSubDomainRequest();
+			mockUploadWorkerRequest({
+				expectedBindings: [
+					{
+						type: "workflow",
+						name: "WORKFLOW",
+						workflow_name: "my-workflow",
+						class_name: "MyWorkflow",
+					},
+				],
+			});
+
+			await expect(runWrangler("deploy")).rejects
+				.toThrowErrorMatchingInlineSnapshot(`
+				[Error: Some triggers failed to deploy for test-name:
+				  - Workflow "my-workflow" has "schedules" configured, but scheduled Workflows require a paid Workers plan.]
+			`);
 		});
 
 		it("should deploy a workflow with schedules as an array of cron expressions", async ({


### PR DESCRIPTION
Maps the Workflows API `workflow.cron_requires_paid_plan` error to a friendlier `wrangler deploy` trigger error when a Workflow has `schedules` configured.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: This only improves CLI error text; no docs behavior or user workflow changed.

*A picture of a cute animal (not mandatory, but encouraged)*
this is dusty
<img width="2030" height="1522" alt="image" src="https://github.com/user-attachments/assets/c590ea2b-8d92-40c7-94ea-5d34de89a23a" />

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14604" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->