### PR TITLE
[wrangler] Warn when Images binding is configured without Workers Cache enabled

### DIFF
--- a/.changeset/images-cache-warning.md
+++ b/.changeset/images-cache-warning.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Warn when an Images binding is configured without Workers Cache enabled
+
+`wrangler deploy` and `wrangler versions upload` now print a warning if your Worker has an `images` binding but `cache.enabled` is not set. Enabling Workers Cache lets Cloudflare cache transformed images at the edge, reducing Images usage.

--- a/packages/deploy-helpers/src/deploy/helpers/validate-worker-props.ts
+++ b/packages/deploy-helpers/src/deploy/helpers/validate-worker-props.ts
@@ -98,6 +98,13 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 		);
 	}
 
+	if (config.images && !config.cache?.enabled) {
+		const warnFn = logger.once?.warn ?? logger.warn;
+		warnFn(
+			"Your Worker has an Images binding configured, but Workers Cache is not enabled. Enabling `cache.enabled` lets Cloudflare cache transformed images at the edge and reduce Images usage. Read more: https://developers.cloudflare.com/workers/cache/configuration/"
+		);
+	}
+
 	if (props.command === "deploy") {
 		validateRoutes(props.routes, props.assetsOptions);
 		assert(

--- a/packages/wrangler/src/__tests__/deploy/bindings.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/bindings.test.ts
@@ -2061,6 +2061,45 @@ describe("deploy", () => {
 			});
 		});
 
+		describe("[images]", () => {
+			it("should warn when an images binding is configured without cache enabled", async ({
+				expect,
+			}) => {
+				writeWranglerConfig({
+					images: { binding: "IMAGES" },
+				});
+				writeWorkerSource();
+				mockSubDomainRequest();
+				mockUploadWorkerRequest({
+					expectedBindings: [{ name: "IMAGES", type: "images" }],
+				});
+
+				await runWrangler("deploy index.js");
+
+				expect(std.warn).toContain(
+					"Your Worker has an Images binding configured, but Workers Cache is not enabled."
+				);
+			});
+
+			it("should not warn when an images binding is configured with cache enabled", async ({
+				expect,
+			}) => {
+				writeWranglerConfig({
+					images: { binding: "IMAGES" },
+					cache: { enabled: true },
+				});
+				writeWorkerSource();
+				mockSubDomainRequest();
+				mockUploadWorkerRequest({
+					expectedBindings: [{ name: "IMAGES", type: "images" }],
+				});
+
+				await runWrangler("deploy index.js");
+
+				expect(std.warn).toMatchInlineSnapshot(`""`);
+			});
+		});
+
 		describe("[dispatch_namespaces]", () => {
 			it("should support bindings to a dispatch namespace", async ({
 				expect,


### PR DESCRIPTION
Fixes [IMAGES-2405](https://jira.cfdata.org/browse/IMAGES-2405)

Prints a one-time warning during `wrangler deploy` and `wrangler versions upload` if a Worker has an `images` binding but `cache.enabled` is not set, since enabling Workers Cache is the easiest way to cache transformed images at the edge and reduce Images usage.


---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because:

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
