### PR TITLE
Fix wrangler linting (failing because of deprecated detectAgenticEnvironment usage)

### DIFF
--- a/packages/wrangler/src/__tests__/utils/detect-agent.test.ts
+++ b/packages/wrangler/src/__tests__/utils/detect-agent.test.ts
@@ -4,16 +4,19 @@ import { detectAgent } from "../../utils/detect-agent";
 
 vi.mock("am-i-vibing");
 
+// eslint-disable-next-line @typescript-eslint/no-deprecated -- the function has a deprecated overload; we only reference it here for mocking
+const mockDetectAgenticEnvironment = vi.mocked(detectAgenticEnvironment);
+
 describe("detect-agent", () => {
 	beforeEach(() => {
-		vi.mocked(detectAgenticEnvironment).mockReset();
+		mockDetectAgenticEnvironment.mockReset();
 	});
 
 	describe("detectAgent()", () => {
 		it("reports an agent (with id) when detection type is 'agent'", ({
 			expect,
 		}) => {
-			vi.mocked(detectAgenticEnvironment).mockReturnValue({
+			mockDetectAgenticEnvironment.mockReturnValue({
 				isAgentic: true,
 				id: "claude-code",
 				name: "Claude Code",
@@ -26,7 +29,7 @@ describe("detect-agent", () => {
 		it("is not an agent when type is 'hybrid', but still reports the id", ({
 			expect,
 		}) => {
-			vi.mocked(detectAgenticEnvironment).mockReturnValue({
+			mockDetectAgenticEnvironment.mockReturnValue({
 				isAgentic: true,
 				id: "warp",
 				name: "Warp",
@@ -37,7 +40,7 @@ describe("detect-agent", () => {
 		});
 
 		it("is not an agent when type is 'interactive'", ({ expect }) => {
-			vi.mocked(detectAgenticEnvironment).mockReturnValue({
+			mockDetectAgenticEnvironment.mockReturnValue({
 				isAgentic: false,
 				id: null,
 				name: null,
@@ -48,7 +51,7 @@ describe("detect-agent", () => {
 		});
 
 		it("resolves to a non-agent result when detection throws", ({ expect }) => {
-			vi.mocked(detectAgenticEnvironment).mockImplementation(() => {
+			mockDetectAgenticEnvironment.mockImplementation(() => {
 				throw new Error("boom");
 			});
 
@@ -56,7 +59,7 @@ describe("detect-agent", () => {
 		});
 
 		it("detects in a single pass", ({ expect }) => {
-			vi.mocked(detectAgenticEnvironment).mockReturnValue({
+			mockDetectAgenticEnvironment.mockReturnValue({
 				isAgentic: true,
 				id: "claude-code",
 				name: "Claude Code",
@@ -65,7 +68,7 @@ describe("detect-agent", () => {
 
 			detectAgent();
 
-			expect(detectAgenticEnvironment).toHaveBeenCalledTimes(1);
+			expect(mockDetectAgenticEnvironment).toHaveBeenCalledTimes(1);
 		});
 	});
 });

--- a/packages/wrangler/src/utils/detect-agent.ts
+++ b/packages/wrangler/src/utils/detect-agent.ts
@@ -34,10 +34,10 @@ export interface DetectedAgent {
  */
 export function detectAgent(): DetectedAgent {
 	try {
-		const detection = detectAgenticEnvironment(
-			process.env,
-			NO_PROCESS_ANCESTRY
-		);
+		const detection = detectAgenticEnvironment({
+			env: process.env,
+			processAncestry: NO_PROCESS_ANCESTRY,
+		});
 		return { isAgent: detection.type === "agent", id: detection.id };
 	} catch {
 		// Silent failure - assume we are not being run by an agent.


### PR DESCRIPTION
I just merged https://github.com/cloudflare/workers-sdk/pull/14579 but that PR was on a branch slightly out of sync with main and it broke linting because of https://github.com/cloudflare/workers-sdk/issues/14312 (note: case and point LLMs seem to be often using deprecated APIs, so I do think it's good to have linting against this 😄)

Sorry about that, this PR fixes the broken linting 🙇 

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: internal changes

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14606" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->