### PR TITLE
chore: use catalog for `workerd` dependency

### DIFF
--- a/packages/miniflare/package.json
+++ b/packages/miniflare/package.json
@@ -52,7 +52,7 @@
 		"@cspotcode/source-map-support": "0.8.1",
 		"sharp": "0.34.5",
 		"undici": "catalog:default",
-		"workerd": "1.20260708.1",
+		"workerd": "catalog:default",
 		"ws": "catalog:default",
 		"youch": "4.1.0-beta.10"
 	},

--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -84,7 +84,7 @@
 		"miniflare": "workspace:*",
 		"path-to-regexp": "6.3.0",
 		"unenv": "2.0.0-rc.24",
-		"workerd": "1.20260708.1"
+		"workerd": "catalog:default"
 	},
 	"devDependencies": {
 		"@aws-sdk/client-s3": "^3.721.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,6 +84,9 @@ catalogs:
     vitest:
       specifier: 4.1.0
       version: 4.1.0
+    workerd:
+      specifier: 1.20260708.1
+      version: 1.20260708.1
     ws:
       specifier: 8.21.0
       version: 8.21.0
@@ -2264,7 +2267,7 @@ importers:
         specifier: catalog:default
         version: 7.28.0
       workerd:
-        specifier: 1.20260708.1
+        specifier: catalog:default
         version: 1.20260708.1
       ws:
         specifier: catalog:default
@@ -4289,7 +4292,7 @@ importers:
         specifier: 2.0.0-rc.24
         version: 2.0.0-rc.24
       workerd:
-        specifier: 1.20260708.1
+        specifier: catalog:default
         version: 1.20260708.1
     devDependencies:
       '@aws-sdk/client-s3':


### PR DESCRIPTION
Fixes N/A

Updates direct `workerd` dependency declarations in `miniflare` and `wrangler` to use the workspace catalog version instead of duplicating the pinned version in each `package.json`.

This keeps `workerd` version management centralized in `pnpm-workspace.yaml`, matching the existing pattern used for `@cloudflare/workers-types`.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: Internal monorepo structure change
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: Internal monorepo structure change

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

🦦