### PR TITLE
[wrangler] Handle queue bindings in remote dev

### DIFF
--- a/.changeset/silent-queues-jam.md
+++ b/.changeset/silent-queues-jam.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Allow `wrangler dev --remote` to start when queue producer bindings are configured
+
+Queue bindings are still unsupported in legacy remote dev mode, but Wrangler now omits them from remote preview uploads after warning. This lets unrelated routes keep working instead of returning 500 errors for the whole dev session.

--- a/packages/wrangler/src/__tests__/api/startDevWorker/ConfigController.test.ts
+++ b/packages/wrangler/src/__tests__/api/startDevWorker/ConfigController.test.ts
@@ -367,4 +367,44 @@ describe("ConfigController", () => {
 
 		expect(warningCount).toBe(1);
 	});
+
+	it("should warn when queues are configured in remote dev mode", async ({
+		expect,
+	}) => {
+		await seed({
+			"src/index.ts": dedent /* javascript */ `
+				export default {
+					fetch() {
+						return new Response("hello world")
+					}
+				}
+			`,
+			"wrangler.toml": dedent /* toml */ `
+				name = "my-worker"
+				main = "src/index.ts"
+				compatibility_date = "2024-06-01"
+
+				[[queues.producers]]
+				binding = "QUEUE"
+				queue = "test-queue"
+			`,
+		});
+
+		const event = bus.waitFor("configUpdate");
+		await controller.set({
+			config: "./wrangler.toml",
+			dev: {
+				remote: true,
+				auth: {
+					accountId: "some-account-id",
+					apiToken: { apiToken: "some-api-token" },
+				},
+			},
+		});
+		await event;
+
+		expect(std.warn).toContain(
+			"Queues are not yet supported in wrangler dev remote mode."
+		);
+	});
 });

--- a/packages/wrangler/src/__tests__/api/startDevWorker/RemoteRuntimeController.test.ts
+++ b/packages/wrangler/src/__tests__/api/startDevWorker/RemoteRuntimeController.test.ts
@@ -157,6 +157,42 @@ describe("RemoteRuntimeController", () => {
 		vi.mocked(getAccessHeaders).mockResolvedValue({});
 	});
 
+	describe("unsupported queue bindings", () => {
+		it("should omit queue producer bindings from remote preview uploads", async ({
+			expect,
+		}) => {
+			const { controller, bus } = setup();
+			const config = makeConfig({
+				bindings: {
+					QUEUE: {
+						type: "queue",
+						queue_name: "test-queue",
+					},
+					KV: {
+						type: "kv_namespace",
+						id: "test-kv-namespace",
+					},
+				},
+			});
+			const bundle = makeBundle();
+
+			controller.onBundleStart({ type: "bundleStart", config });
+			controller.onBundleComplete({ type: "bundleComplete", config, bundle });
+			await bus.waitFor("reloadComplete");
+
+			expect(createRemoteWorkerInit).toHaveBeenCalledWith(
+				expect.objectContaining({
+					bindings: {
+						KV: {
+							type: "kv_namespace",
+							id: "test-kv-namespace",
+						},
+					},
+				})
+			);
+		});
+	});
+
 	describe("stale bundle bail-out", () => {
 		it("should skip stale bundles and only reload once for rapid updates", async ({
 			expect,

--- a/packages/wrangler/src/api/startDevWorker/RemoteRuntimeController.ts
+++ b/packages/wrangler/src/api/startDevWorker/RemoteRuntimeController.ts
@@ -35,10 +35,20 @@ import type {
 	ReloadCompleteEvent,
 	ReloadStartEvent,
 } from "./events";
-import type { Bundle, StartDevWorkerOptions, Trigger } from "./types";
+import type { Binding, Bundle, StartDevWorkerOptions, Trigger } from "./types";
 import type { Route } from "@cloudflare/workers-utils";
 
 type CreateRemoteWorkerInitProps = Parameters<typeof createRemoteWorkerInit>[0];
+
+function getRemotePreviewBindings(
+	bindings: StartDevWorkerOptions["bindings"]
+): Record<string, Binding> {
+	return Object.fromEntries(
+		Object.entries(bindings ?? {}).filter(
+			([, binding]) => binding.type !== "queue"
+		)
+	);
+}
 
 export class RemoteRuntimeController extends RuntimeController {
 	#abortController = new AbortController();
@@ -154,7 +164,7 @@ export class RemoteRuntimeController extends RuntimeController {
 				assets: props.assets,
 				legacyAssetPaths: props.legacyAssetPaths,
 				format: props.format,
-				bindings: props.bindings,
+				bindings: getRemotePreviewBindings(props.bindings),
 				compatibilityDate: props.compatibilityDate,
 				compatibilityFlags: props.compatibilityFlags,
 			});


### PR DESCRIPTION
Fixes #9642.

Legacy `wrangler dev --remote` already warns that Queues are unsupported, but queue producer bindings were still included in the remote preview upload. That can make every proxied request fail even when the route does not use the queue.

This omits queue producer bindings from remote preview uploads after the existing warning, so unrelated routes can still be tested. Queue-specific code remains unsupported in this mode.

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: this preserves the existing unsupported-Queues warning and fixes remote preview behavior only.

Validation:
- `pnpm --filter wrangler... build`
- `pnpm --filter wrangler test run src/__tests__/api/startDevWorker/RemoteRuntimeController.test.ts src/__tests__/api/startDevWorker/ConfigController.test.ts`
- `pnpm --filter wrangler check:type`
- `pnpm exec oxlint --deny-warnings --type-aware packages/wrangler/src/api/startDevWorker/RemoteRuntimeController.ts packages/wrangler/src/__tests__/api/startDevWorker/RemoteRuntimeController.test.ts packages/wrangler/src/__tests__/api/startDevWorker/ConfigController.test.ts`
- `pnpm exec oxfmt --check packages/wrangler/src/api/startDevWorker/RemoteRuntimeController.ts packages/wrangler/src/__tests__/api/startDevWorker/RemoteRuntimeController.test.ts packages/wrangler/src/__tests__/api/startDevWorker/ConfigController.test.ts`