### PR TITLE
fix(wrangler): default `dev.registry` in `unstable_startWorker` like the CLI

### DIFF
--- a/.changeset/wrangler-dev-registry-default.md
+++ b/.changeset/wrangler-dev-registry-default.md
@@ -1,0 +1,8 @@
+---
+"wrangler": minor
+"@cloudflare/workers-utils": minor
+---
+
+Default `dev.registry` in `unstable_startWorker()` like the CLI
+
+The CLI resolves the dev registry to `WRANGLER_REGISTRY_PATH` or `<global config>/registry` and passes it unless `--disable-dev-registry`, but the programmatic path used the input value raw — leaving `dev.registry` unset silently disabled cross-session service discovery, so `startWorker` workers could not resolve (or be resolved by) other local dev sessions' `script_name` bindings. `startWorker` now applies the same default; pass `dev.registry: false` to opt out (mirroring `persist: false`). The CLI's `--disable-dev-registry` and the API test harness pass `false` explicitly.

--- a/packages/workers-utils/src/types.ts
+++ b/packages/workers-utils/src/types.ts
@@ -649,8 +649,12 @@ export interface StartDevWorkerInput {
 		/** Whether to build and connect to containers during local dev. Requires Docker daemon to be running. Defaults to true. */
 		enableContainers?: boolean;
 
-		/** Path to the dev registry directory */
-		registry?: string;
+		/** Path to the dev registry directory. Defaults to the shared dev
+		 * registry (`WRANGLER_REGISTRY_PATH` or `<global config>/registry` —
+		 * the same resolution the CLI uses), so programmatic dev workers
+		 * discover and are discovered by other local dev sessions. Set
+		 * `false` to disable cross-session service discovery. */
+		registry?: string | false;
 
 		/** Path to the docker executable. Defaults to 'docker' */
 		dockerPath?: string;

--- a/packages/wrangler/src/__tests__/api/startDevWorker/ConfigController.test.ts
+++ b/packages/wrangler/src/__tests__/api/startDevWorker/ConfigController.test.ts
@@ -1,4 +1,5 @@
 import path from "node:path";
+import { getRegistryPath } from "@cloudflare/workers-utils";
 import { runInTempDir, seed } from "@cloudflare/workers-utils/test-helpers";
 import dedent from "ts-dedent";
 import { afterEach, beforeEach, describe, it, vi } from "vitest";
@@ -139,6 +140,51 @@ describe("ConfigController", () => {
 				entrypoint: path.join(process.cwd(), "src/index.ts"),
 			},
 		});
+	});
+
+	it("should default dev.registry like the CLI, with a `false` opt-out", async ({
+		expect,
+	}) => {
+		await seed({
+			"src/index.ts": dedent /* javascript */ `
+				export default {
+					fetch(request, env, ctx) {
+						return new Response("hello world")
+					}
+				} satisfies ExportedHandler
+			`,
+		});
+
+		// Unset: the CLI's shared-registry default applies, so programmatic
+		// dev workers discover (and are discovered by) other dev sessions.
+		const defaulted = bus.waitFor("configUpdate");
+		await controller.set({ entrypoint: "src/index.ts" });
+		await expect(defaulted).resolves.toMatchObject({
+			type: "configUpdate",
+			config: { dev: { registry: getRegistryPath() } },
+		});
+
+		// Explicit path: preserved verbatim.
+		const explicit = bus.waitFor("configUpdate");
+		await controller.set({
+			entrypoint: "src/index.ts",
+			dev: { registry: path.join(process.cwd(), "custom-registry") },
+		});
+		await expect(explicit).resolves.toMatchObject({
+			config: {
+				dev: { registry: path.join(process.cwd(), "custom-registry") },
+			},
+		});
+
+		// `false`: discovery disabled — resolves to undefined, mirroring
+		// `persist: false`.
+		const disabled = bus.waitFor("configUpdate");
+		await controller.set({
+			entrypoint: "src/index.ts",
+			dev: { registry: false },
+		});
+		const disabledEvent = await disabled;
+		expect(disabledEvent.config.dev.registry).toBeUndefined();
 	});
 
 	it("should apply module root to parent if main is nested from base_dir", async ({

--- a/packages/wrangler/src/api/startDevWorker/ConfigController.ts
+++ b/packages/wrangler/src/api/startDevWorker/ConfigController.ts
@@ -8,6 +8,7 @@ import {
 	getTodaysCompatDate,
 	getDisableConfigWatching,
 	getDockerPath,
+	getRegistryPath,
 	UserError,
 } from "@cloudflare/workers-utils";
 import { watch } from "chokidar";
@@ -110,6 +111,14 @@ async function resolveDevConfig(
 		config
 	);
 
+	// Mirror `persist`: apply the CLI's default so programmatic dev workers
+	// join the shared dev registry (cross-session service discovery) unless
+	// the caller passes an explicit path or opts out with `false`.
+	const devRegistryPath =
+		input.dev?.registry === false
+			? undefined
+			: (input.dev?.registry ?? getRegistryPath());
+
 	const { host, routes } = await getHostAndRoutes(
 		{
 			host: input.dev?.origin?.hostname,
@@ -171,7 +180,7 @@ async function resolveDevConfig(
 		structuredLogsHandler: input.dev?.structuredLogsHandler,
 		// absolute resolved path
 		persist: localPersistencePath,
-		registry: input.dev?.registry,
+		registry: devRegistryPath,
 		multiworkerPrimary: input.dev?.multiworkerPrimary,
 		inferOriginFromRoutes: input.dev?.inferOriginFromRoutes ?? true,
 		routeRequestsByRoutes: input.dev?.routeRequestsByRoutes ?? false,
@@ -272,7 +281,11 @@ async function resolveBindings(
 		);
 	};
 
-	// Print the initial bindings table
+	// Print the initial bindings table. Deliberately keyed on the EXPLICIT
+	// input, not the resolved default: printing is cosmetic and reading the
+	// defaulted registry here would change output for every caller that
+	// never opted in (the CLI always passes an explicit path, so its print
+	// behavior is unchanged).
 	printCurrentBindings(
 		input.dev?.registry ? getWorkerRegistry(input.dev.registry) : null
 	);

--- a/packages/wrangler/src/api/startDevWorker/types.ts
+++ b/packages/wrangler/src/api/startDevWorker/types.ts
@@ -77,6 +77,9 @@ export type StartDevWorkerOptions = Omit<
 	};
 	dev: StartDevWorkerInput["dev"] & {
 		persist: string | false;
+		/** Resolved: the default registry path is applied and `false`
+		 * (discovery disabled) resolves to undefined. */
+		registry?: string;
 		auth?: AsyncHook<CfAccount>; // redefine without config.account_id hook param (can only be provided by ConfigController with access to the Wrangler configuration file, not by other controllers eg RemoteRuntimeContoller)
 		/** Handles structured runtime logs. */
 		structuredLogsHandler?: (log: WorkerdStructuredLog) => void;

--- a/packages/wrangler/src/api/test-harness.ts
+++ b/packages/wrangler/src/api/test-harness.ts
@@ -443,7 +443,10 @@ export function createTestHarness(options?: TestHarnessOptions): TestHarness {
 					watch: false,
 					persist: false,
 					inspector: false,
-					registry: undefined,
+					// `false`, not `undefined`: harness workers must stay
+					// invisible to the shared dev registry (undefined now
+					// means "apply the CLI default", mirroring `persist`).
+					registry: false,
 					structuredLogsHandler: (log: WorkerdStructuredLog) =>
 						captureStructuredLog(log),
 					outboundService: (request) => {

--- a/packages/wrangler/src/dev/start-dev.ts
+++ b/packages/wrangler/src/dev/start-dev.ts
@@ -263,7 +263,7 @@ async function setupDevEnv(
 				liveReload: args.liveReload,
 				testScheduled: args.testScheduled,
 				logLevel: args.logLevel,
-				registry: args.disableDevRegistry ? undefined : getRegistryPath(),
+				registry: args.disableDevRegistry ? false : getRegistryPath(),
 				multiworkerPrimary: args.multiworkerPrimary,
 				enableContainers: args.enableContainers,
 				dockerPath: args.dockerPath,


### PR DESCRIPTION
Makes `unstable_startWorker()` join the shared local dev registry by default, the way `wrangler dev` does.

**The gap.** The CLI resolves the dev registry to `WRANGLER_REGISTRY_PATH` or `<global config>/registry` (`getRegistryPath()`) and passes it unless `--disable-dev-registry`. The programmatic path used `input.dev.registry` raw, so leaving it unset silently disabled cross-session service discovery: a `startWorker` worker could not resolve — or be resolved by — other local dev sessions' `script_name` bindings. The `@cloudflare/vite-plugin` dev path already defaults to the same registry directory (via miniflare's `getDefaultDevRegistryPath()`, whose env override is `MINIFLARE_REGISTRY_PATH` rather than `WRANGLER_REGISTRY_PATH`, but whose default location is the same `<global config>/registry`), which left `startWorker` as the odd one out among the dev hosts.

**The change.** `resolveDevConfig` mirrors the existing `persist` shape: unset applies the CLI's default, an explicit path is preserved verbatim, and `dev.registry: false` opts out (the input type widens to `string | false`; the resolved `StartDevWorkerOptions` field stays `string | undefined`). The CLI's `--disable-dev-registry` now passes `false` explicitly, and `createTestHarness` pins `false` so harness workers stay invisible to the shared registry — both previously relied on `undefined` meaning "disabled". The initial bindings-table print stays keyed on the explicit input, so CLI output is unchanged.

**Behavior change (the point of the PR):** programmatic callers that left `dev.registry` unset now join the shared dev registry, like `wrangler dev` sessions do. Callers needing isolation pass `false` — the old unset behavior. That includes this repo's own direct `startWorker()` consumers in fixtures and e2e tests, which now participate in the shared registry the same way the CLI-driven test runs always have; `createTestHarness` is the one consumer deliberately pinned to `false` (harness workers must stay invisible). If specific fixtures should stay isolated instead, pinning `false` there is a one-liner — happy to do that in this PR if preferred. Minor bump on `wrangler` and `@cloudflare/workers-utils` for the widened input type.

**Tests:** the ConfigController suite pins all three cases — unset resolves to `getRegistryPath()`, an explicit path is preserved verbatim, `false` resolves to `undefined`.

---

- Tests
  - [x] Tests included (ConfigController: default / explicit path / `false` opt-out)
- Public documentation
  - [x] Documentation not necessary because: the `StartDevWorkerInput` doc comment documents the new default and the opt-out; `unstable_startWorker` is an unstable API. A changeset is included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14615" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->