### PR TITLE
fix(wrangler): derive `nodejsCompatMode` from the effective compatibility inputs in `unstable_startWorker`

### DIFF
--- a/.changeset/wrangler-nodejs-compat-default.md
+++ b/.changeset/wrangler-nodejs-compat-default.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Derive `nodejsCompatMode` from the effective compatibility inputs in `unstable_startWorker()`
+
+The CLI computes the node-compat mode from the effective compatibility date and flags (`args.* ?? parsedConfig.*`), but the programmatic path used `input.build.nodejsCompatMode` raw — leaving it unset meant a worker's `nodejs_compat` flag (from its config file or from input-level `compatibilityFlags`) was silently ignored, so bundling failed to resolve node builtins that `wrangler dev` handles. `startWorker` now derives the mode the same way when the caller does not provide one: input-level `compatibilityDate`/`compatibilityFlags` first, then the resolved config, with no-bundle taken from the resolved `build.bundle` semantics. Passing an explicit `null` still disables it.

--- a/packages/wrangler/src/__tests__/api/startDevWorker/ConfigController.test.ts
+++ b/packages/wrangler/src/__tests__/api/startDevWorker/ConfigController.test.ts
@@ -191,6 +191,61 @@ describe("ConfigController", () => {
 		expect(config.dev?.structuredLogsHandler).toBe(structuredLogsHandler);
 	});
 
+	it("should derive nodejsCompatMode from the config like the CLI", async ({
+		expect,
+	}) => {
+		await seed({
+			"src/index.ts": dedent /* javascript */ `
+				export default {
+					fetch(request, env, ctx) {
+						return new Response("hello world")
+					}
+				} satisfies ExportedHandler
+			`,
+			"wrangler.toml": dedent /* toml */ `
+				name = "nodejs-compat-worker"
+				main = "src/index.ts"
+				compatibility_date = "2026-06-01"
+				compatibility_flags = ["nodejs_compat"]
+			`,
+		});
+
+		// Unset: derived from the resolved config's date + flags.
+		const derived = bus.waitFor("configUpdate");
+		await controller.set({ config: "./wrangler.toml" });
+		await expect(derived).resolves.toMatchObject({
+			config: { build: { nodejsCompatMode: "v2" } },
+		});
+
+		// Input-level overrides win over the config file, like the CLI's
+		// `args.* ?? parsedConfig.*`: a programmatic worker passing the
+		// flag without a config-file entry still gets the mode.
+		await seed({
+			"wrangler-no-flag.toml": dedent /* toml */ `
+				name = "nodejs-compat-worker"
+				main = "src/index.ts"
+				compatibility_date = "2026-06-01"
+			`,
+		});
+		const overridden = bus.waitFor("configUpdate");
+		await controller.set({
+			config: "./wrangler-no-flag.toml",
+			compatibilityFlags: ["nodejs_compat"],
+		});
+		await expect(overridden).resolves.toMatchObject({
+			config: { build: { nodejsCompatMode: "v2" } },
+		});
+
+		// Explicit null still disables (callers owning the mode keep it).
+		const disabled = bus.waitFor("configUpdate");
+		await controller.set({
+			config: "./wrangler.toml",
+			build: { nodejsCompatMode: null },
+		});
+		const disabledEvent = await disabled;
+		expect(disabledEvent.config.build.nodejsCompatMode).toBeNull();
+	});
+
 	it("should apply module root to parent if main is nested from base_dir", async ({
 		expect,
 	}) => {

--- a/packages/wrangler/src/api/startDevWorker/ConfigController.ts
+++ b/packages/wrangler/src/api/startDevWorker/ConfigController.ts
@@ -18,6 +18,7 @@ import { readConfig, readNewConfig } from "../../config";
 import { containersScope } from "../../containers";
 import { getNormalizedContainerOptions } from "../../containers/config";
 import { getEntry } from "../../deployment-bundle/entry";
+import { validateNodeCompatMode } from "../../deployment-bundle/node-compat";
 import { getBindings, getHostAndRoutes, getInferredHost } from "../../dev";
 import { getDurableObjectClassNameToUseSQLiteMap } from "../../dev/class-names-sqlite";
 import { getLocalPersistencePath } from "../../dev/get-local-persistence-path";
@@ -365,7 +366,21 @@ async function resolveConfig(
 		"dev"
 	);
 
-	const nodejsCompatMode = unwrapHook(input.build?.nodejsCompatMode, config);
+	// Mirror the CLI: when the caller does not provide a mode (or a hook),
+	// derive it from the same effective values the CLI feeds
+	// validateNodeCompatMode — input-level overrides first, then the
+	// resolved config (the CLI passes `args.* ?? parsedConfig.*`; the
+	// programmatic spelling of no-bundle is `build.bundle: false`).
+	// Otherwise a dev worker's own `nodejs_compat` compatibility flag is
+	// silently ignored. An explicit null still disables.
+	const nodejsCompatMode =
+		input.build?.nodejsCompatMode === undefined
+			? validateNodeCompatMode(
+					input.compatibilityDate ?? config.compatibility_date,
+					input.compatibilityFlags ?? config.compatibility_flags ?? [],
+					{ noBundle: !(input.build?.bundle ?? !config.no_bundle) }
+				)
+			: unwrapHook(input.build.nodejsCompatMode, config);
 
 	const { bindings, unsafe, printCurrentBindings } = await resolveBindings(
 		config,


### PR DESCRIPTION
Makes `unstable_startWorker()` honor a worker's `nodejs_compat` compatibility flag, the way `wrangler dev` does.

**The gap.** The CLI derives the node-compat mode from the effective compatibility values — input overrides first, then the config file (`validateNodeCompatMode(args.compatibilityDate ?? parsedConfig.compatibility_date, args.compatibilityFlags ?? parsedConfig.compatibility_flags ?? [], { noBundle: args.noBundle ?? parsedConfig.no_bundle })` in `start-dev.ts`). The programmatic path used `input.build.nodejsCompatMode` raw, so leaving it unset silently ignored the worker's `nodejs_compat` flag — whether it came from the worker's config file or from input-level `compatibilityFlags` — and bundling failed to resolve `node:*` builtins that `wrangler dev` on the same configuration handles.

**The change.** When the caller provides no `build.nodejsCompatMode`, `resolveConfig` derives it from the same effective values the rest of the resolution uses: `input.compatibilityDate ?? config.compatibility_date`, `input.compatibilityFlags ?? config.compatibility_flags ?? []`, and no-bundle from the resolved bundle semantics (`!(input.build?.bundle ?? !config.no_bundle)` — the programmatic spelling of the CLI's `--no-bundle`). An explicit value — including `null` to disable — is still unwrapped exactly as before, so callers owning the mode keep it.

**Tests:** derived `"v2"` from a config file carrying `compatibility_date` + `nodejs_compat`; derived `"v2"` from input-level `compatibilityFlags` over a config file without the flag; explicit `null` preserved.

---

- Tests
  - [x] Tests included/updated (ConfigController: derived from config file / derived from input-level flags / explicit `null` preserved)
- Public documentation
  - [x] Documentation not necessary because: bug fix aligning the programmatic dev path with the CLI's compatibility handling; no API surface change. A changeset is included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
