### PR TITLE
Enable `@typescript-eslint/no-deprecated` linting rule for `local-explorer-ui`

### DIFF
--- a/.oxlintrc.jsonc
+++ b/.oxlintrc.jsonc
@@ -206,7 +206,6 @@
 		// TODO: Remove the following overrides, one package at a time.
 		{
 			"files": [
-				"packages/local-explorer-ui/**",
 				"packages/vite-plugin-cloudflare/**",
 				"packages/workflows-shared/**",
 			],

--- a/packages/local-explorer-ui/src/components/AddKVForm.tsx
+++ b/packages/local-explorer-ui/src/components/AddKVForm.tsx
@@ -27,7 +27,7 @@ export function AddKVForm({ onAdd, clearSignal = 0 }: AddKVFormProps) {
 		setKeyError(newValue.trim() ? validateKey(newValue) : null);
 	};
 
-	const handleSubmit = async (e: React.FormEvent) => {
+	const handleSubmit = async (e: React.SyntheticEvent<HTMLFormElement>) => {
 		e.preventDefault();
 
 		const validationError = validateKey(key);

--- a/packages/local-explorer-ui/src/components/AddKVForm.tsx
+++ b/packages/local-explorer-ui/src/components/AddKVForm.tsx
@@ -1,5 +1,10 @@
 import { Button, cn } from "@cloudflare/kumo";
-import { useEffect, useState } from "react";
+import {
+	useEffect,
+	useState,
+	type ChangeEvent,
+	type SyntheticEvent,
+} from "react";
 import { validateKey } from "../utils/kv-validation";
 
 interface AddKVFormProps {
@@ -21,13 +26,13 @@ export function AddKVForm({ onAdd, clearSignal = 0 }: AddKVFormProps) {
 		}
 	}, [clearSignal]);
 
-	const handleKeyChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+	const handleKeyChange = (e: ChangeEvent<HTMLInputElement>) => {
 		const newValue = e.target.value;
 		setKey(newValue);
 		setKeyError(newValue.trim() ? validateKey(newValue) : null);
 	};
 
-	const handleSubmit = async (e: React.SyntheticEvent<HTMLFormElement>) => {
+	const handleSubmit = async (e: SyntheticEvent<HTMLFormElement>) => {
 		e.preventDefault();
 
 		const validationError = validateKey(key);

--- a/packages/local-explorer-ui/src/components/Breadcrumbs.tsx
+++ b/packages/local-explorer-ui/src/components/Breadcrumbs.tsx
@@ -1,7 +1,6 @@
 import { Breadcrumbs as KumoBreadcrumbs } from "@cloudflare/kumo";
 import { Fragment } from "react";
-import type React from "react";
-import type { FC, PropsWithChildren, ReactNode } from "react";
+import type { FC, JSX, PropsWithChildren, ReactNode } from "react";
 
 interface BreadcrumbsProps extends PropsWithChildren {
 	icon: FC<{ className?: string }>;
@@ -14,7 +13,7 @@ export function Breadcrumbs({
 	icon: Icon,
 	items,
 	title,
-}: BreadcrumbsProps): React.JSX.Element {
+}: BreadcrumbsProps): JSX.Element {
 	return (
 		<div className="box-border flex min-h-14.5 shrink-0 items-center gap-2 border-b border-kumo-fill bg-kumo-elevated px-6 text-sm">
 			<KumoBreadcrumbs>

--- a/packages/local-explorer-ui/src/components/Breadcrumbs.tsx
+++ b/packages/local-explorer-ui/src/components/Breadcrumbs.tsx
@@ -1,5 +1,6 @@
 import { Breadcrumbs as KumoBreadcrumbs } from "@cloudflare/kumo";
 import { Fragment } from "react";
+import type React from "react";
 import type { FC, PropsWithChildren, ReactNode } from "react";
 
 interface BreadcrumbsProps extends PropsWithChildren {
@@ -13,7 +14,7 @@ export function Breadcrumbs({
 	icon: Icon,
 	items,
 	title,
-}: BreadcrumbsProps): JSX.Element {
+}: BreadcrumbsProps): React.JSX.Element {
 	return (
 		<div className="box-border flex min-h-14.5 shrink-0 items-center gap-2 border-b border-kumo-fill bg-kumo-elevated px-6 text-sm">
 			<KumoBreadcrumbs>

--- a/packages/local-explorer-ui/src/components/NotFound.tsx
+++ b/packages/local-explorer-ui/src/components/NotFound.tsx
@@ -1,7 +1,8 @@
 import { Button } from "@cloudflare/kumo";
 import { Link, type NotFoundRouteProps } from "@tanstack/react-router";
+import type { JSX } from "react";
 
-export function NotFound(_props: NotFoundRouteProps): React.JSX.Element {
+export function NotFound(_props: NotFoundRouteProps): JSX.Element {
 	return (
 		<div className="text-text-secondary flex flex-1 flex-col items-center justify-center space-y-4 p-12 text-center">
 			<h2 className="text-text text-3xl font-bold">Page not found</h2>

--- a/packages/local-explorer-ui/src/components/NotFound.tsx
+++ b/packages/local-explorer-ui/src/components/NotFound.tsx
@@ -1,7 +1,7 @@
 import { Button } from "@cloudflare/kumo";
 import { Link, type NotFoundRouteProps } from "@tanstack/react-router";
 
-export function NotFound(_props: NotFoundRouteProps): JSX.Element {
+export function NotFound(_props: NotFoundRouteProps): React.JSX.Element {
 	return (
 		<div className="text-text-secondary flex flex-1 flex-col items-center justify-center space-y-4 p-12 text-center">
 			<h2 className="text-text text-3xl font-bold">Page not found</h2>

--- a/packages/local-explorer-ui/src/components/R2ObjectTable.tsx
+++ b/packages/local-explorer-ui/src/components/R2ObjectTable.tsx
@@ -7,7 +7,7 @@ import {
 	TrashIcon,
 } from "@phosphor-icons/react";
 import { Link } from "@tanstack/react-router";
-import { useRef } from "react";
+import { useRef, type JSX } from "react";
 import { formatDate, formatSize } from "../utils/format";
 import type { R2Object } from "../api";
 
@@ -45,7 +45,7 @@ function ActionMenu({
 	isDirectory,
 	onDelete,
 	onDownload,
-}: ActionMenuProps): React.JSX.Element {
+}: ActionMenuProps): JSX.Element {
 	return (
 		<DropdownMenu>
 			<DropdownMenu.Trigger
@@ -101,7 +101,7 @@ function BulkActionMenu({
 	onDownload,
 	selectedFileCount,
 	selectedTotalCount,
-}: BulkActionMenuProps): React.JSX.Element {
+}: BulkActionMenuProps): JSX.Element {
 	return (
 		<DropdownMenu>
 			<DropdownMenu.Trigger
@@ -159,7 +159,7 @@ export function R2ObjectTable({
 	onNavigateToPrefix,
 	onSelectionChange,
 	selectedKeys,
-}: R2ObjectTableProps): React.JSX.Element | null {
+}: R2ObjectTableProps): JSX.Element | null {
 	// Combine directories and files for display
 	const items: Array<
 		| {

--- a/packages/local-explorer-ui/src/components/R2ObjectTable.tsx
+++ b/packages/local-explorer-ui/src/components/R2ObjectTable.tsx
@@ -45,7 +45,7 @@ function ActionMenu({
 	isDirectory,
 	onDelete,
 	onDownload,
-}: ActionMenuProps): JSX.Element {
+}: ActionMenuProps): React.JSX.Element {
 	return (
 		<DropdownMenu>
 			<DropdownMenu.Trigger
@@ -101,7 +101,7 @@ function BulkActionMenu({
 	onDownload,
 	selectedFileCount,
 	selectedTotalCount,
-}: BulkActionMenuProps): JSX.Element {
+}: BulkActionMenuProps): React.JSX.Element {
 	return (
 		<DropdownMenu>
 			<DropdownMenu.Trigger
@@ -159,7 +159,7 @@ export function R2ObjectTable({
 	onNavigateToPrefix,
 	onSelectionChange,
 	selectedKeys,
-}: R2ObjectTableProps): JSX.Element | null {
+}: R2ObjectTableProps): React.JSX.Element | null {
 	// Combine directories and files for display
 	const items: Array<
 		| {

--- a/packages/local-explorer-ui/src/components/R2UploadDialog.tsx
+++ b/packages/local-explorer-ui/src/components/R2UploadDialog.tsx
@@ -1,6 +1,12 @@
 import { Button, Dialog } from "@cloudflare/kumo";
 import { PlusIcon, TrashIcon, UploadIcon } from "@phosphor-icons/react";
-import { useCallback, useState } from "react";
+import {
+	useCallback,
+	useState,
+	type ChangeEvent,
+	type DragEvent,
+	type JSX,
+} from "react";
 import { r2BucketPutObject } from "../api";
 
 interface R2UploadDialogProps {
@@ -52,7 +58,7 @@ export function R2UploadDialog({
 	onOpenChange,
 	onUploadComplete,
 	open,
-}: R2UploadDialogProps): React.JSX.Element {
+}: R2UploadDialogProps): JSX.Element {
 	const [contentType, setContentType] = useState<string>("");
 	const [customMetadata, setCustomMetadata] = useState<MetadataEntry[]>([]);
 	const [dragOver, setDragOver] = useState<boolean>(false);
@@ -75,7 +81,7 @@ export function R2UploadDialog({
 		setContentType(getMimeType(selectedFile));
 	}
 
-	function handleFileChange(e: React.ChangeEvent<HTMLInputElement>): void {
+	function handleFileChange(e: ChangeEvent<HTMLInputElement>): void {
 		const [selectedFile] = e.target.files ?? [];
 		if (!selectedFile) {
 			return;
@@ -84,7 +90,7 @@ export function R2UploadDialog({
 		handleFileSelect(selectedFile);
 	}
 
-	function handleDrop(e: React.DragEvent<HTMLDivElement>): void {
+	function handleDrop(e: DragEvent<HTMLDivElement>): void {
 		e.preventDefault();
 		setDragOver(false);
 
@@ -96,12 +102,12 @@ export function R2UploadDialog({
 		handleFileSelect(droppedFile);
 	}
 
-	function handleDragOver(e: React.DragEvent<HTMLDivElement>): void {
+	function handleDragOver(e: DragEvent<HTMLDivElement>): void {
 		e.preventDefault();
 		setDragOver(true);
 	}
 
-	function handleDragLeave(e: React.DragEvent<HTMLDivElement>): void {
+	function handleDragLeave(e: DragEvent<HTMLDivElement>): void {
 		e.preventDefault();
 		setDragOver(false);
 	}

--- a/packages/local-explorer-ui/src/components/R2UploadDialog.tsx
+++ b/packages/local-explorer-ui/src/components/R2UploadDialog.tsx
@@ -52,7 +52,7 @@ export function R2UploadDialog({
 	onOpenChange,
 	onUploadComplete,
 	open,
-}: R2UploadDialogProps): JSX.Element {
+}: R2UploadDialogProps): React.JSX.Element {
 	const [contentType, setContentType] = useState<string>("");
 	const [customMetadata, setCustomMetadata] = useState<MetadataEntry[]>([]);
 	const [dragOver, setDragOver] = useState<boolean>(false);

--- a/packages/local-explorer-ui/src/components/ResourceError.tsx
+++ b/packages/local-explorer-ui/src/components/ResourceError.tsx
@@ -2,15 +2,14 @@ import { Button } from "@cloudflare/kumo";
 import { WarningIcon } from "@phosphor-icons/react";
 import { Link, type ErrorComponentProps } from "@tanstack/react-router";
 import type { WorkersApiResponseCommonFailure } from "../api";
+import type { JSX } from "react";
 
 const DEFAULT_ERROR_DESCRIPTION =
 	"An unknown error occurred. Please report this issue to Cloudflare.";
 
 export function ResourceError({
 	error,
-}: ErrorComponentProps<
-	Error | WorkersApiResponseCommonFailure
->): React.JSX.Element {
+}: ErrorComponentProps<Error | WorkersApiResponseCommonFailure>): JSX.Element {
 	const details =
 		("errors" in error ? error.errors?.[0]?.message : error.message) ??
 		DEFAULT_ERROR_DESCRIPTION;

--- a/packages/local-explorer-ui/src/components/ResourceError.tsx
+++ b/packages/local-explorer-ui/src/components/ResourceError.tsx
@@ -8,7 +8,9 @@ const DEFAULT_ERROR_DESCRIPTION =
 
 export function ResourceError({
 	error,
-}: ErrorComponentProps<Error | WorkersApiResponseCommonFailure>): JSX.Element {
+}: ErrorComponentProps<
+	Error | WorkersApiResponseCommonFailure
+>): React.JSX.Element {
 	const details =
 		("errors" in error ? error.errors?.[0]?.message : error.message) ??
 		DEFAULT_ERROR_DESCRIPTION;

--- a/packages/local-explorer-ui/src/components/SidebarGroupPopup.tsx
+++ b/packages/local-explorer-ui/src/components/SidebarGroupPopup.tsx
@@ -26,7 +26,7 @@ export function SidebarGroupPopup({
 	icon,
 	items,
 	title,
-}: SidebarGroupPopupProps): JSX.Element {
+}: SidebarGroupPopupProps): React.JSX.Element {
 	const hasActiveItem = items.some((item) => item.isActive);
 
 	return (

--- a/packages/local-explorer-ui/src/components/SidebarGroupPopup.tsx
+++ b/packages/local-explorer-ui/src/components/SidebarGroupPopup.tsx
@@ -2,6 +2,7 @@ import { Sidebar, type SidebarMenuButtonProps } from "@cloudflare/kumo";
 import { Popover } from "@cloudflare/kumo/primitives/popover";
 import { Link } from "@tanstack/react-router";
 import type { FileRouteTypes } from "../routeTree.gen";
+import type { JSX } from "react";
 
 interface SidebarGroupItem {
 	id: string;
@@ -26,7 +27,7 @@ export function SidebarGroupPopup({
 	icon,
 	items,
 	title,
-}: SidebarGroupPopupProps): React.JSX.Element {
+}: SidebarGroupPopupProps): JSX.Element {
 	const hasActiveItem = items.some((item) => item.isActive);
 
 	return (

--- a/packages/local-explorer-ui/src/components/TableSelect.tsx
+++ b/packages/local-explorer-ui/src/components/TableSelect.tsx
@@ -8,7 +8,7 @@ import {
 import { useNavigate } from "@tanstack/react-router";
 import { useCallback } from "react";
 import type { StudioRef } from "./studio";
-import type { RefObject } from "react";
+import type { JSX, RefObject } from "react";
 
 interface TableSelectProps {
 	studioRef: RefObject<StudioRef | null>;
@@ -20,7 +20,7 @@ export function TableSelect({
 	studioRef,
 	tables,
 	selectedTable,
-}: TableSelectProps): React.JSX.Element {
+}: TableSelectProps): JSX.Element {
 	const navigate = useNavigate();
 
 	const handleTableChange = useCallback(

--- a/packages/local-explorer-ui/src/components/TableSelect.tsx
+++ b/packages/local-explorer-ui/src/components/TableSelect.tsx
@@ -20,7 +20,7 @@ export function TableSelect({
 	studioRef,
 	tables,
 	selectedTable,
-}: TableSelectProps): JSX.Element {
+}: TableSelectProps): React.JSX.Element {
 	const navigate = useNavigate();
 
 	const handleTableChange = useCallback(

--- a/packages/local-explorer-ui/src/components/WorkerSelector.tsx
+++ b/packages/local-explorer-ui/src/components/WorkerSelector.tsx
@@ -5,7 +5,7 @@ import {
 	CheckIcon,
 	TerminalIcon,
 } from "@phosphor-icons/react";
-import { useState } from "react";
+import { useState, type JSX } from "react";
 import type { LocalExplorerWorker } from "../api";
 
 // Re-export the type for convenience
@@ -63,7 +63,7 @@ export function WorkerSelector({
 	workers,
 	selectedWorker,
 	onWorkerChange,
-}: WorkerSelectorProps): React.JSX.Element {
+}: WorkerSelectorProps): JSX.Element {
 	const sidebar = useSidebar();
 
 	const [open, setOpen] = useState(false);

--- a/packages/local-explorer-ui/src/components/WorkerSelector.tsx
+++ b/packages/local-explorer-ui/src/components/WorkerSelector.tsx
@@ -63,7 +63,7 @@ export function WorkerSelector({
 	workers,
 	selectedWorker,
 	onWorkerChange,
-}: WorkerSelectorProps): JSX.Element {
+}: WorkerSelectorProps): React.JSX.Element {
 	const sidebar = useSidebar();
 
 	const [open, setOpen] = useState(false);

--- a/packages/local-explorer-ui/src/components/studio/Code/Block.tsx
+++ b/packages/local-explorer-ui/src/components/studio/Code/Block.tsx
@@ -8,7 +8,7 @@ export function CodeBlock({
 	code,
 	language,
 	maxHeight,
-}: CodeBlockProps): JSX.Element {
+}: CodeBlockProps): React.JSX.Element {
 	return (
 		<pre
 			className="overflow-auto rounded bg-kumo-elevated p-3 font-mono text-sm"

--- a/packages/local-explorer-ui/src/components/studio/Code/Block.tsx
+++ b/packages/local-explorer-ui/src/components/studio/Code/Block.tsx
@@ -1,3 +1,5 @@
+import type { JSX } from "react";
+
 interface CodeBlockProps {
 	code: string;
 	language?: string;
@@ -8,7 +10,7 @@ export function CodeBlock({
 	code,
 	language,
 	maxHeight,
-}: CodeBlockProps): React.JSX.Element {
+}: CodeBlockProps): JSX.Element {
 	return (
 		<pre
 			className="overflow-auto rounded bg-kumo-elevated p-3 font-mono text-sm"

--- a/packages/local-explorer-ui/src/components/studio/ContextMenu.tsx
+++ b/packages/local-explorer-ui/src/components/studio/ContextMenu.tsx
@@ -9,7 +9,7 @@ import {
 } from "react";
 import type { VirtualElement } from "@floating-ui/react";
 import type { Icon } from "@phosphor-icons/react";
-import type { PropsWithChildren, ReactNode } from "react";
+import type { JSX, MouseEvent, PropsWithChildren, ReactNode } from "react";
 
 interface DropdownButtonItem {
 	destructiveAction?: boolean;
@@ -31,7 +31,7 @@ export type DropdownItemBuilderProps = DropdownButtonItem | DropdownDividerItem;
 type OnOpenChangeHandler = (open: boolean) => void;
 
 type OpenContextMenuHandler = (
-	mouseEvent: React.MouseEvent<Element, MouseEvent>,
+	mouseEvent: MouseEvent<Element, MouseEvent>,
 	menuItems: DropdownItemBuilderProps[],
 	onOpenChange?: OnOpenChangeHandler
 ) => void;
@@ -64,7 +64,7 @@ interface DropdownMenuItemsBuilderProps {
 
 function DropdownMenuItemsBuilder({
 	items,
-}: DropdownMenuItemsBuilderProps): React.JSX.Element {
+}: DropdownMenuItemsBuilderProps): JSX.Element {
 	return (
 		<>
 			{items.map((item, index) => {
@@ -117,7 +117,7 @@ export function StudioContextMenuProvider({
 
 	const openContextMenu = useCallback(
 		(
-			mouseEvent: React.MouseEvent<Element, MouseEvent>,
+			mouseEvent: MouseEvent<Element, MouseEvent>,
 			items: DropdownItemBuilderProps[],
 			_onOpenChange?: OnOpenChangeHandler
 		) => {

--- a/packages/local-explorer-ui/src/components/studio/ContextMenu.tsx
+++ b/packages/local-explorer-ui/src/components/studio/ContextMenu.tsx
@@ -64,7 +64,7 @@ interface DropdownMenuItemsBuilderProps {
 
 function DropdownMenuItemsBuilder({
 	items,
-}: DropdownMenuItemsBuilderProps): JSX.Element {
+}: DropdownMenuItemsBuilderProps): React.JSX.Element {
 	return (
 		<>
 			{items.map((item, index) => {

--- a/packages/local-explorer-ui/src/components/studio/ContextMenu.tsx
+++ b/packages/local-explorer-ui/src/components/studio/ContextMenu.tsx
@@ -9,7 +9,7 @@ import {
 } from "react";
 import type { VirtualElement } from "@floating-ui/react";
 import type { Icon } from "@phosphor-icons/react";
-import type { JSX, MouseEvent, PropsWithChildren, ReactNode } from "react";
+import type { JSX, PropsWithChildren, ReactNode } from "react";
 
 interface DropdownButtonItem {
 	destructiveAction?: boolean;
@@ -31,7 +31,7 @@ export type DropdownItemBuilderProps = DropdownButtonItem | DropdownDividerItem;
 type OnOpenChangeHandler = (open: boolean) => void;
 
 type OpenContextMenuHandler = (
-	mouseEvent: MouseEvent<Element, MouseEvent>,
+	mouseEvent: React.MouseEvent<Element, MouseEvent>,
 	menuItems: DropdownItemBuilderProps[],
 	onOpenChange?: OnOpenChangeHandler
 ) => void;
@@ -117,7 +117,7 @@ export function StudioContextMenuProvider({
 
 	const openContextMenu = useCallback(
 		(
-			mouseEvent: MouseEvent<Element, MouseEvent>,
+			mouseEvent: React.MouseEvent<Element, MouseEvent>,
 			items: DropdownItemBuilderProps[],
 			_onOpenChange?: OnOpenChangeHandler
 		) => {

--- a/packages/local-explorer-ui/src/components/studio/Explain/SQLiteExplainTab.tsx
+++ b/packages/local-explorer-ui/src/components/studio/Explain/SQLiteExplainTab.tsx
@@ -2,7 +2,7 @@ import { cn, Tooltip } from "@cloudflare/kumo";
 import { TableIcon } from "@phosphor-icons/react";
 import { Fragment } from "react";
 import type { StudioResultSet } from "../../../types/studio";
-import type { ReactNode } from "react";
+import type { JSX, ReactNode } from "react";
 
 interface StudioSQLiteExplainProps {
 	data: StudioResultSet;
@@ -20,7 +20,7 @@ interface StudioSQLiteExplainTree extends StudioSQLiteExplainRow {
 
 export function StudioSQLiteExplainTab({
 	data,
-}: StudioSQLiteExplainProps): React.JSX.Element {
+}: StudioSQLiteExplainProps): JSX.Element {
 	const rows = data.rows as unknown as StudioSQLiteExplainRow[];
 
 	let tree = rows.map(
@@ -60,7 +60,7 @@ interface ExplainNodesProps {
 	data: StudioSQLiteExplainTree[];
 }
 
-function ExplainNodes({ data }: ExplainNodesProps): React.JSX.Element {
+function ExplainNodes({ data }: ExplainNodesProps): JSX.Element {
 	return (
 		<>
 			{data.map((row) => {

--- a/packages/local-explorer-ui/src/components/studio/Explain/SQLiteExplainTab.tsx
+++ b/packages/local-explorer-ui/src/components/studio/Explain/SQLiteExplainTab.tsx
@@ -20,7 +20,7 @@ interface StudioSQLiteExplainTree extends StudioSQLiteExplainRow {
 
 export function StudioSQLiteExplainTab({
 	data,
-}: StudioSQLiteExplainProps): JSX.Element {
+}: StudioSQLiteExplainProps): React.JSX.Element {
 	const rows = data.rows as unknown as StudioSQLiteExplainRow[];
 
 	let tree = rows.map(
@@ -60,7 +60,7 @@ interface ExplainNodesProps {
 	data: StudioSQLiteExplainTree[];
 }
 
-function ExplainNodes({ data }: ExplainNodesProps): JSX.Element {
+function ExplainNodes({ data }: ExplainNodesProps): React.JSX.Element {
 	return (
 		<>
 			{data.map((row) => {

--- a/packages/local-explorer-ui/src/components/studio/Modal.tsx
+++ b/packages/local-explorer-ui/src/components/studio/Modal.tsx
@@ -1,5 +1,5 @@
 import { createContext, useCallback, useContext, useState } from "react";
-import type { ComponentType, PropsWithChildren } from "react";
+import type { ComponentType, JSX, PropsWithChildren } from "react";
 
 interface ModalInjectedProps {
 	closeModal: () => void;
@@ -39,9 +39,7 @@ export function useModal(): ModalContextValue {
 /**
  * Simple modal provider for the portable Studio component
  */
-export function ModalProvider({
-	children,
-}: PropsWithChildren): React.JSX.Element {
+export function ModalProvider({ children }: PropsWithChildren): JSX.Element {
 	const [modals, setModals] = useState<Array<IModalEntry>>([]);
 
 	const handleOpenModal = useCallback(

--- a/packages/local-explorer-ui/src/components/studio/Modal.tsx
+++ b/packages/local-explorer-ui/src/components/studio/Modal.tsx
@@ -39,7 +39,9 @@ export function useModal(): ModalContextValue {
 /**
  * Simple modal provider for the portable Studio component
  */
-export function ModalProvider({ children }: PropsWithChildren): JSX.Element {
+export function ModalProvider({
+	children,
+}: PropsWithChildren): React.JSX.Element {
 	const [modals, setModals] = useState<Array<IModalEntry>>([]);
 
 	const handleOpenModal = useCallback(

--- a/packages/local-explorer-ui/src/components/studio/Modal/DropTableConfirmation.tsx
+++ b/packages/local-explorer-ui/src/components/studio/Modal/DropTableConfirmation.tsx
@@ -19,7 +19,7 @@ export function DropTableConfirmationModal({
 	onSuccess,
 	schemaName,
 	tableName,
-}: DropTableConfirmationModalProps): JSX.Element {
+}: DropTableConfirmationModalProps): React.JSX.Element {
 	const [challengeInput, setChallengeInput] = useState<string>("");
 	const [error, setError] = useState<string | null>(null);
 	const [isDeleting, setIsDeleting] = useState<boolean>(false);

--- a/packages/local-explorer-ui/src/components/studio/Modal/DropTableConfirmation.tsx
+++ b/packages/local-explorer-ui/src/components/studio/Modal/DropTableConfirmation.tsx
@@ -1,7 +1,7 @@
 import { Button, Dialog, Text } from "@cloudflare/kumo";
 import { useState } from "react";
 import type { IStudioDriver } from "../../../types/studio";
-import type { SubmitEvent } from "react";
+import type { JSX, SubmitEvent } from "react";
 
 interface DropTableConfirmationModalProps {
 	closeModal: () => void;
@@ -19,7 +19,7 @@ export function DropTableConfirmationModal({
 	onSuccess,
 	schemaName,
 	tableName,
-}: DropTableConfirmationModalProps): React.JSX.Element {
+}: DropTableConfirmationModalProps): JSX.Element {
 	const [challengeInput, setChallengeInput] = useState<string>("");
 	const [error, setError] = useState<string | null>(null);
 	const [isDeleting, setIsDeleting] = useState<boolean>(false);

--- a/packages/local-explorer-ui/src/components/studio/Modal/Export/OptionsEditor.tsx
+++ b/packages/local-explorer-ui/src/components/studio/Modal/Export/OptionsEditor.tsx
@@ -15,7 +15,7 @@ interface StudioExportOptionProps {
 export function StudioExportOptionEditor({
 	onChange,
 	value,
-}: StudioExportOptionProps): JSX.Element {
+}: StudioExportOptionProps): React.JSX.Element {
 	return (
 		<>
 			<SettingItem>
@@ -75,7 +75,7 @@ interface SQLExportEditorProps {
 function SQLExportEditor({
 	onChange,
 	value,
-}: SQLExportEditorProps): JSX.Element {
+}: SQLExportEditorProps): React.JSX.Element {
 	return (
 		<>
 			<SettingItem>
@@ -159,7 +159,7 @@ interface CSVExportEditorProps {
 function CSVExportEditor({
 	onChange,
 	value,
-}: CSVExportEditorProps): JSX.Element {
+}: CSVExportEditorProps): React.JSX.Element {
 	return (
 		<>
 			<SettingItem>
@@ -243,7 +243,10 @@ interface SettingItemProps extends PropsWithChildren {
 	lastItem?: boolean;
 }
 
-function SettingItem({ children, lastItem }: SettingItemProps): JSX.Element {
+function SettingItem({
+	children,
+	lastItem,
+}: SettingItemProps): React.JSX.Element {
 	return (
 		<div
 			className={cn(
@@ -256,11 +259,11 @@ function SettingItem({ children, lastItem }: SettingItemProps): JSX.Element {
 	);
 }
 
-function SettingLabel({ children }: PropsWithChildren): JSX.Element {
+function SettingLabel({ children }: PropsWithChildren): React.JSX.Element {
 	return <div className="py-2 font-medium">{children}</div>;
 }
 
-function SettingOption({ children }: PropsWithChildren): JSX.Element {
+function SettingOption({ children }: PropsWithChildren): React.JSX.Element {
 	return <div>{children}</div>;
 }
 
@@ -274,7 +277,7 @@ function SettingOptionDropdown({
 	items,
 	onChange,
 	value,
-}: SettingOptionDropdownProps): JSX.Element {
+}: SettingOptionDropdownProps): React.JSX.Element {
 	return (
 		<select
 			className="cursor-pointer rounded-md border border-kumo-fill bg-transparent px-3 py-2 text-sm"

--- a/packages/local-explorer-ui/src/components/studio/Modal/Export/OptionsEditor.tsx
+++ b/packages/local-explorer-ui/src/components/studio/Modal/Export/OptionsEditor.tsx
@@ -3,6 +3,7 @@ import type { StudioExportOption } from "../../../../types/studio";
 import type {
 	ChangeEvent,
 	Dispatch,
+	JSX,
 	PropsWithChildren,
 	SetStateAction,
 } from "react";
@@ -15,7 +16,7 @@ interface StudioExportOptionProps {
 export function StudioExportOptionEditor({
 	onChange,
 	value,
-}: StudioExportOptionProps): React.JSX.Element {
+}: StudioExportOptionProps): JSX.Element {
 	return (
 		<>
 			<SettingItem>
@@ -75,7 +76,7 @@ interface SQLExportEditorProps {
 function SQLExportEditor({
 	onChange,
 	value,
-}: SQLExportEditorProps): React.JSX.Element {
+}: SQLExportEditorProps): JSX.Element {
 	return (
 		<>
 			<SettingItem>
@@ -159,7 +160,7 @@ interface CSVExportEditorProps {
 function CSVExportEditor({
 	onChange,
 	value,
-}: CSVExportEditorProps): React.JSX.Element {
+}: CSVExportEditorProps): JSX.Element {
 	return (
 		<>
 			<SettingItem>
@@ -243,10 +244,7 @@ interface SettingItemProps extends PropsWithChildren {
 	lastItem?: boolean;
 }
 
-function SettingItem({
-	children,
-	lastItem,
-}: SettingItemProps): React.JSX.Element {
+function SettingItem({ children, lastItem }: SettingItemProps): JSX.Element {
 	return (
 		<div
 			className={cn(
@@ -259,11 +257,11 @@ function SettingItem({
 	);
 }
 
-function SettingLabel({ children }: PropsWithChildren): React.JSX.Element {
+function SettingLabel({ children }: PropsWithChildren): JSX.Element {
 	return <div className="py-2 font-medium">{children}</div>;
 }
 
-function SettingOption({ children }: PropsWithChildren): React.JSX.Element {
+function SettingOption({ children }: PropsWithChildren): JSX.Element {
 	return <div>{children}</div>;
 }
 
@@ -277,7 +275,7 @@ function SettingOptionDropdown({
 	items,
 	onChange,
 	value,
-}: SettingOptionDropdownProps): React.JSX.Element {
+}: SettingOptionDropdownProps): JSX.Element {
 	return (
 		<select
 			className="cursor-pointer rounded-md border border-kumo-fill bg-transparent px-3 py-2 text-sm"

--- a/packages/local-explorer-ui/src/components/studio/Modal/Export/index.tsx
+++ b/packages/local-explorer-ui/src/components/studio/Modal/Export/index.tsx
@@ -1,5 +1,5 @@
 import { Button, Dialog } from "@cloudflare/kumo";
-import { useState } from "react";
+import { useState, type JSX } from "react";
 import {
 	exportCSVFromStudioResult,
 	exportSQLFromStudioResult,
@@ -21,7 +21,7 @@ export function StudioExportModal({
 	closeModal,
 	isOpen,
 	result,
-}: StudioExportModalProps): React.JSX.Element {
+}: StudioExportModalProps): JSX.Element {
 	const { driver } = useStudioContext();
 
 	const [error, setError] = useState<string | null>(null);

--- a/packages/local-explorer-ui/src/components/studio/Modal/Export/index.tsx
+++ b/packages/local-explorer-ui/src/components/studio/Modal/Export/index.tsx
@@ -21,7 +21,7 @@ export function StudioExportModal({
 	closeModal,
 	isOpen,
 	result,
-}: StudioExportModalProps): JSX.Element {
+}: StudioExportModalProps): React.JSX.Element {
 	const { driver } = useStudioContext();
 
 	const [error, setError] = useState<string | null>(null);

--- a/packages/local-explorer-ui/src/components/studio/QueryResult/Stats.tsx
+++ b/packages/local-explorer-ui/src/components/studio/QueryResult/Stats.tsx
@@ -2,7 +2,7 @@ import { Tooltip } from "@cloudflare/kumo";
 import { QuestionIcon } from "@phosphor-icons/react";
 import { useMemo } from "react";
 import type { StudioResultStat } from "../../../types/studio";
-import type { ReactElement } from "react";
+import type { JSX, ReactElement } from "react";
 
 function formatDuration(duration: number): string {
 	if (duration < 1000) {
@@ -22,7 +22,7 @@ interface StudioQueryResultStatsProps {
 
 export function StudioQueryResultStats({
 	stats,
-}: StudioQueryResultStatsProps): React.JSX.Element {
+}: StudioQueryResultStatsProps): JSX.Element {
 	const statsComponents = useMemo((): ReactElement[] => {
 		const content = new Array<ReactElement>();
 

--- a/packages/local-explorer-ui/src/components/studio/QueryResult/Stats.tsx
+++ b/packages/local-explorer-ui/src/components/studio/QueryResult/Stats.tsx
@@ -22,7 +22,7 @@ interface StudioQueryResultStatsProps {
 
 export function StudioQueryResultStats({
 	stats,
-}: StudioQueryResultStatsProps): JSX.Element {
+}: StudioQueryResultStatsProps): React.JSX.Element {
 	const statsComponents = useMemo((): ReactElement[] => {
 		const content = new Array<ReactElement>();
 

--- a/packages/local-explorer-ui/src/components/studio/QueryResult/Summary.tsx
+++ b/packages/local-explorer-ui/src/components/studio/QueryResult/Summary.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, type JSX } from "react";
 import { CodeBlock } from "../Code/Block";
 import { StudioQueryResultStats } from "./Stats";
 import type {
@@ -12,7 +12,7 @@ interface StudioQueryResultSummaryProps {
 
 export function StudioQueryResultSummary({
 	progress,
-}: StudioQueryResultSummaryProps): React.JSX.Element {
+}: StudioQueryResultSummaryProps): JSX.Element {
 	const [currentTime, setCurrentTime] = useState(() => Date.now());
 
 	useEffect(() => {

--- a/packages/local-explorer-ui/src/components/studio/QueryResult/Summary.tsx
+++ b/packages/local-explorer-ui/src/components/studio/QueryResult/Summary.tsx
@@ -12,7 +12,7 @@ interface StudioQueryResultSummaryProps {
 
 export function StudioQueryResultSummary({
 	progress,
-}: StudioQueryResultSummaryProps): JSX.Element {
+}: StudioQueryResultSummaryProps): React.JSX.Element {
 	const [currentTime, setCurrentTime] = useState(() => Date.now());
 
 	useEffect(() => {

--- a/packages/local-explorer-ui/src/components/studio/QueryResult/Tab.tsx
+++ b/packages/local-explorer-ui/src/components/studio/QueryResult/Tab.tsx
@@ -1,6 +1,6 @@
 import { Button } from "@cloudflare/kumo";
 import { ExportIcon } from "@phosphor-icons/react";
-import { useMemo, useState } from "react";
+import { useMemo, useState, type JSX } from "react";
 import { StudioExportModal } from "../Modal/Export";
 import { StudioResultTable } from "../Table/Result";
 import { createStudioTableStateFromResult } from "../Table/State/Helpers";
@@ -15,7 +15,7 @@ interface StudioQueryResultTabProps {
 
 export function StudioQueryResultTab({
 	result,
-}: StudioQueryResultTabProps): React.JSX.Element {
+}: StudioQueryResultTabProps): JSX.Element {
 	const [isExportModalOpen, setIsExportModalOpen] = useState<boolean>(false);
 
 	const state = useMemo(

--- a/packages/local-explorer-ui/src/components/studio/QueryResult/Tab.tsx
+++ b/packages/local-explorer-ui/src/components/studio/QueryResult/Tab.tsx
@@ -15,7 +15,7 @@ interface StudioQueryResultTabProps {
 
 export function StudioQueryResultTab({
 	result,
-}: StudioQueryResultTabProps): JSX.Element {
+}: StudioQueryResultTabProps): React.JSX.Element {
 	const [isExportModalOpen, setIsExportModalOpen] = useState<boolean>(false);
 
 	const state = useMemo(

--- a/packages/local-explorer-ui/src/components/studio/Table/ActionsDropdown.tsx
+++ b/packages/local-explorer-ui/src/components/studio/Table/ActionsDropdown.tsx
@@ -1,6 +1,6 @@
 import { Button, DropdownMenu } from "@cloudflare/kumo";
 import { CopyIcon, TableIcon, TextTIcon } from "@phosphor-icons/react";
-import { useCallback } from "react";
+import { useCallback, type JSX } from "react";
 import type { IStudioDriver } from "../../../types/studio";
 
 export interface TableTarget {
@@ -31,7 +31,7 @@ export function StudioTableActionsDropdown({
 	currentTable,
 	driver,
 	schemaName = "main",
-}: TableActionsDropdownProps): React.JSX.Element {
+}: TableActionsDropdownProps): JSX.Element {
 	const handleCopyTableName = useCallback(async (): Promise<void> => {
 		if (!currentTable) {
 			return;

--- a/packages/local-explorer-ui/src/components/studio/Table/ActionsDropdown.tsx
+++ b/packages/local-explorer-ui/src/components/studio/Table/ActionsDropdown.tsx
@@ -31,7 +31,7 @@ export function StudioTableActionsDropdown({
 	currentTable,
 	driver,
 	schemaName = "main",
-}: TableActionsDropdownProps): JSX.Element {
+}: TableActionsDropdownProps): React.JSX.Element {
 	const handleCopyTableName = useCallback(async (): Promise<void> => {
 		if (!currentTable) {
 			return;

--- a/packages/local-explorer-ui/src/components/studio/Table/BaseTable.tsx
+++ b/packages/local-explorer-ui/src/components/studio/Table/BaseTable.tsx
@@ -8,7 +8,13 @@ import {
 import { StudioTableHeaderList } from "./HeaderList";
 import { useStudioTableVisibility } from "./useVisibilityCalculation";
 import type { StudioTableHeaderInput, StudioTableState } from "./State";
-import type { ReactElement } from "react";
+import type {
+	CSSProperties,
+	JSX,
+	KeyboardEvent,
+	MouseEvent,
+	ReactElement,
+} from "react";
 
 /**
  * A flexible and efficient table component designed for handling large datasets.
@@ -163,21 +169,18 @@ export interface StudioTableCellRendererProps<MetadataType = unknown> {
 }
 
 interface TableCellListCommonProps<MetadataType = unknown> {
-	onCellMouseDown?: (
-		event: React.MouseEvent,
-		data: { x: number; y: number }
-	) => void;
+	onCellMouseDown?: (event: MouseEvent, data: { x: number; y: number }) => void;
 	onContextMenu?: (props: {
 		state: StudioTableState<MetadataType>;
-		event: React.MouseEvent;
+		event: MouseEvent;
 	}) => void;
-	onGutterClick?: (event: React.MouseEvent, rowNumber: number) => void;
+	onGutterClick?: (event: MouseEvent, rowNumber: number) => void;
 	onHeaderContextMenu?: (
-		e: React.MouseEvent,
+		e: MouseEvent,
 		header: StudioTableHeaderProps<MetadataType>
 	) => void;
-	onKeyDown?: (event: React.KeyboardEvent) => void;
-	onKeyUp?: (event: React.KeyboardEvent) => void;
+	onKeyDown?: (event: KeyboardEvent) => void;
+	onKeyUp?: (event: KeyboardEvent) => void;
 	renderCell: (
 		props: StudioTableCellRendererProps<MetadataType>
 	) => ReactElement;
@@ -199,7 +202,7 @@ interface RenderCellListProps<
 > extends TableCellListCommonProps<HeaderMetadata> {
 	colEnd: number;
 	colStart: number;
-	customStyles?: React.CSSProperties;
+	customStyles?: CSSProperties;
 	hasSticky: boolean;
 	headers: StudioTableHeaderProps<HeaderMetadata>[];
 	onHeaderResize: (idx: number, newWidth: number) => void;
@@ -223,7 +226,7 @@ function renderCellList<HeaderMetadata = unknown>({
 	rowHeight,
 	rowStart,
 	state,
-}: RenderCellListProps<HeaderMetadata>): React.JSX.Element {
+}: RenderCellListProps<HeaderMetadata>): JSX.Element {
 	const headerSizes = state.getHeaderWidth();
 
 	const templateSizes =

--- a/packages/local-explorer-ui/src/components/studio/Table/BaseTable.tsx
+++ b/packages/local-explorer-ui/src/components/studio/Table/BaseTable.tsx
@@ -223,7 +223,7 @@ function renderCellList<HeaderMetadata = unknown>({
 	rowHeight,
 	rowStart,
 	state,
-}: RenderCellListProps<HeaderMetadata>): JSX.Element {
+}: RenderCellListProps<HeaderMetadata>): React.JSX.Element {
 	const headerSizes = state.getHeaderWidth();
 
 	const templateSizes =

--- a/packages/local-explorer-ui/src/components/studio/Table/FakePadding.tsx
+++ b/packages/local-explorer-ui/src/components/studio/Table/FakePadding.tsx
@@ -1,4 +1,4 @@
-import type { PropsWithChildren } from "react";
+import type { JSX, PropsWithChildren } from "react";
 
 type StudioTableFakeBodyPaddingProps = PropsWithChildren<{
 	colCount: number;
@@ -42,7 +42,7 @@ export function StudioTableFakeBodyPadding({
 	rowEnd,
 	rowHeight,
 	rowStart,
-}: StudioTableFakeBodyPaddingProps): React.JSX.Element {
+}: StudioTableFakeBodyPaddingProps): JSX.Element {
 	const paddingTop = rowStart * rowHeight;
 	const paddingBottom = (rowCount - rowEnd) * rowHeight;
 

--- a/packages/local-explorer-ui/src/components/studio/Table/FakePadding.tsx
+++ b/packages/local-explorer-ui/src/components/studio/Table/FakePadding.tsx
@@ -42,7 +42,7 @@ export function StudioTableFakeBodyPadding({
 	rowEnd,
 	rowHeight,
 	rowStart,
-}: StudioTableFakeBodyPaddingProps): JSX.Element {
+}: StudioTableFakeBodyPaddingProps): React.JSX.Element {
 	const paddingTop = rowStart * rowHeight;
 	const paddingBottom = (rowCount - rowEnd) * rowHeight;
 

--- a/packages/local-explorer-ui/src/components/studio/Table/HeaderList.tsx
+++ b/packages/local-explorer-ui/src/components/studio/Table/HeaderList.tsx
@@ -2,7 +2,7 @@ import { cn } from "@cloudflare/kumo";
 import { StudioTableHeaderResizer } from "./HeaderResizer";
 import type { StudioTableHeaderProps } from "./BaseTable";
 import type { StudioTableState } from "./State";
-import type { ReactElement } from "react";
+import type { JSX, MouseEventHandler, ReactElement } from "react";
 
 interface StudioTableHeaderListProps<HeaderMetadata> {
 	headers: StudioTableHeaderProps<HeaderMetadata>[];
@@ -18,7 +18,7 @@ export function StudioTableHeaderList<HeaderMetadata = unknown>({
 	renderHeader,
 	state,
 	sticky,
-}: StudioTableHeaderListProps<HeaderMetadata>): React.JSX.Element {
+}: StudioTableHeaderListProps<HeaderMetadata>): JSX.Element {
 	return (
 		<thead className="contents">
 			<tr className="contents">
@@ -55,12 +55,12 @@ function StudioTableHeader<HeaderMetadata = unknown>({
 }: {
 	header: StudioTableHeaderProps<HeaderMetadata>;
 	idx: number;
-	onContextMenu?: React.MouseEventHandler;
+	onContextMenu?: MouseEventHandler;
 	onHeaderResize: (idx: number, newWidth: number) => void;
 	renderHeader: (props: StudioTableHeaderProps<HeaderMetadata>) => ReactElement;
 	state: StudioTableState<HeaderMetadata>;
 	sticky: boolean;
-}): React.JSX.Element {
+}): JSX.Element {
 	return (
 		<th
 			className={cn(

--- a/packages/local-explorer-ui/src/components/studio/Table/HeaderList.tsx
+++ b/packages/local-explorer-ui/src/components/studio/Table/HeaderList.tsx
@@ -18,7 +18,7 @@ export function StudioTableHeaderList<HeaderMetadata = unknown>({
 	renderHeader,
 	state,
 	sticky,
-}: StudioTableHeaderListProps<HeaderMetadata>): JSX.Element {
+}: StudioTableHeaderListProps<HeaderMetadata>): React.JSX.Element {
 	return (
 		<thead className="contents">
 			<tr className="contents">
@@ -60,7 +60,7 @@ function StudioTableHeader<HeaderMetadata = unknown>({
 	renderHeader: (props: StudioTableHeaderProps<HeaderMetadata>) => ReactElement;
 	state: StudioTableState<HeaderMetadata>;
 	sticky: boolean;
-}): JSX.Element {
+}): React.JSX.Element {
 	return (
 		<th
 			className={cn(

--- a/packages/local-explorer-ui/src/components/studio/Table/HeaderResizer.tsx
+++ b/packages/local-explorer-ui/src/components/studio/Table/HeaderResizer.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState, type JSX } from "react";
 
 interface StudioTableHeaderResizerProps {
 	idx: number;
@@ -8,7 +8,7 @@ interface StudioTableHeaderResizerProps {
 export function StudioTableHeaderResizer({
 	idx,
 	onResize,
-}: StudioTableHeaderResizerProps): React.JSX.Element {
+}: StudioTableHeaderResizerProps): JSX.Element {
 	const handlerRef = useRef<HTMLDivElement>(null);
 
 	const [resizing, setResizing] = useState<boolean>(false);

--- a/packages/local-explorer-ui/src/components/studio/Table/HeaderResizer.tsx
+++ b/packages/local-explorer-ui/src/components/studio/Table/HeaderResizer.tsx
@@ -8,7 +8,7 @@ interface StudioTableHeaderResizerProps {
 export function StudioTableHeaderResizer({
 	idx,
 	onResize,
-}: StudioTableHeaderResizerProps): JSX.Element {
+}: StudioTableHeaderResizerProps): React.JSX.Element {
 	const handlerRef = useRef<HTMLDivElement>(null);
 
 	const [resizing, setResizing] = useState<boolean>(false);

--- a/packages/local-explorer-ui/src/components/studio/Table/Result/DisplayCell.tsx
+++ b/packages/local-explorer-ui/src/components/studio/Table/Result/DisplayCell.tsx
@@ -48,7 +48,10 @@ interface BlobCellValueProps {
 	vector?: boolean;
 }
 
-function BlobCellValue({ value, vector }: BlobCellValueProps): JSX.Element {
+function BlobCellValue({
+	value,
+	vector,
+}: BlobCellValueProps): React.JSX.Element {
 	if (vector) {
 		const floatArray = new Float32Array(new Uint8Array(value).buffer);
 		const floatArrayText = floatArray.join(", ");

--- a/packages/local-explorer-ui/src/components/studio/Table/Result/DisplayCell.tsx
+++ b/packages/local-explorer-ui/src/components/studio/Table/Result/DisplayCell.tsx
@@ -1,5 +1,5 @@
 import { cn } from "@cloudflare/kumo";
-import { forwardRef, useMemo } from "react";
+import { forwardRef, useMemo, type JSX } from "react";
 import { createStudioEditableCell } from "./EditableCell";
 import type { StudioTableHeaderProps } from "../BaseTable";
 import type { StudioResultHeaderMetadata } from "../State/Helpers";
@@ -48,10 +48,7 @@ interface BlobCellValueProps {
 	vector?: boolean;
 }
 
-function BlobCellValue({
-	value,
-	vector,
-}: BlobCellValueProps): React.JSX.Element {
+function BlobCellValue({ value, vector }: BlobCellValueProps): JSX.Element {
 	if (vector) {
 		const floatArray = new Float32Array(new Uint8Array(value).buffer);
 		const floatArrayText = floatArray.join(", ");

--- a/packages/local-explorer-ui/src/components/studio/Table/Result/EditableCell.tsx
+++ b/packages/local-explorer-ui/src/components/studio/Table/Result/EditableCell.tsx
@@ -18,7 +18,7 @@ import type { StudioTableHeaderProps } from "../BaseTable";
 import type { StudioTableState } from "../State";
 import type { StudioResultHeaderMetadata } from "../State/Helpers";
 import type { Extension } from "@codemirror/state";
-import type { ReactNode } from "react";
+import type { CSSProperties, FC, JSX, ReactNode } from "react";
 
 export type StudioTableCellEditorType = "input" | "json" | "text";
 
@@ -64,7 +64,7 @@ function InputCellEditor({
 	readOnly,
 	state,
 	value,
-}: Readonly<InputCellEditorProps>): React.JSX.Element {
+}: Readonly<InputCellEditorProps>): JSX.Element {
 	const inputRef = useRef<HTMLInputElement>(null);
 	const shouldExit = useRef<boolean>(true);
 
@@ -97,7 +97,7 @@ function InputCellEditor({
 						className="fixed flex flex-col rounded border border-kumo-fill bg-kumo-base shadow"
 						ref={refs.setFloating}
 						style={{
-							...(floatingStyles as React.CSSProperties),
+							...(floatingStyles as CSSProperties),
 							width: POPOVER_WIDTH,
 							height: POPOVER_HEIGHT,
 						}}
@@ -185,7 +185,7 @@ function PopoverEditor({
 	defaultValue,
 	onApply,
 	readOnly,
-}: PopoverEditorProps): React.JSX.Element {
+}: PopoverEditorProps): JSX.Element {
 	const editorRef = useRef<StudioCodeMirrorReference>(null);
 
 	const extensions = useMemo(
@@ -224,7 +224,7 @@ export function createStudioEditableCell<T = unknown>({
 	align,
 	toString,
 	toValue,
-}: TabeEditableCellProps<T>): React.FC<TableEditableCell<T>> {
+}: TabeEditableCellProps<T>): FC<TableEditableCell<T>> {
 	return function GenericEditableCell({
 		editMode,
 		editor,

--- a/packages/local-explorer-ui/src/components/studio/Table/Result/EditableCell.tsx
+++ b/packages/local-explorer-ui/src/components/studio/Table/Result/EditableCell.tsx
@@ -64,7 +64,7 @@ function InputCellEditor({
 	readOnly,
 	state,
 	value,
-}: Readonly<InputCellEditorProps>): JSX.Element {
+}: Readonly<InputCellEditorProps>): React.JSX.Element {
 	const inputRef = useRef<HTMLInputElement>(null);
 	const shouldExit = useRef<boolean>(true);
 
@@ -185,7 +185,7 @@ function PopoverEditor({
 	defaultValue,
 	onApply,
 	readOnly,
-}: PopoverEditorProps): JSX.Element {
+}: PopoverEditorProps): React.JSX.Element {
 	const editorRef = useRef<StudioCodeMirrorReference>(null);
 
 	const extensions = useMemo(

--- a/packages/local-explorer-ui/src/components/studio/Table/Result/index.tsx
+++ b/packages/local-explorer-ui/src/components/studio/Table/Result/index.tsx
@@ -26,7 +26,7 @@ import type {
 } from "../BaseTable";
 import type { StudioTableState } from "../State";
 import type { StudioResultHeaderMetadata } from "../State/Helpers";
-import type { PropsWithChildren, ReactNode } from "react";
+import type { JSX, KeyboardEvent, PropsWithChildren, ReactNode } from "react";
 
 interface StudioResultTableProps {
 	arrangeHeaderIndex: number[];
@@ -51,14 +51,14 @@ export function StudioResultTable({
 	orderByColumn,
 	orderByDirection,
 	state,
-}: StudioResultTableProps): React.JSX.Element {
+}: StudioResultTableProps): JSX.Element {
 	const { copyCallback, onContextMenu, pasteCallback } =
 		useStudioResultTableContextMenu(state);
 
 	const renderCell = useCallback(
 		(
 			props: StudioTableCellRendererProps<StudioResultHeaderMetadata>
-		): React.JSX.Element => {
+		): JSX.Element => {
 			const { header, isFocus, x, y } = props;
 
 			const align = header.metadata?.typeHint === "NUMBER" ? "right" : "left";
@@ -120,7 +120,7 @@ export function StudioResultTable({
 	const renderHeader = useCallback(
 		(
 			header: StudioTableHeaderProps<StudioResultHeaderMetadata>
-		): React.JSX.Element => {
+		): JSX.Element => {
 			const hasColumnInfo =
 				(header.metadata.indexes && header.metadata.indexes.length > 0) ||
 				header.metadata.isPrimaryKey ||
@@ -236,7 +236,7 @@ export function StudioResultTable({
 	);
 
 	const onKeyDown = useCallback(
-		(e: React.KeyboardEvent): void => {
+		(e: KeyboardEvent): void => {
 			// Detect the "modifier" key: Command (⌘) on macOS, Control (Ctrl) on Windows/Linux
 			const isModifierPressed = e.metaKey || e.ctrlKey;
 
@@ -282,7 +282,7 @@ function HeaderDropdownMenu({
 	header,
 	orderByColumn,
 	orderByDirection,
-}: HeaderDropdownMenuProps): React.JSX.Element {
+}: HeaderDropdownMenuProps): JSX.Element {
 	const [open, setOpen] = useState<boolean>(false);
 
 	const orderIconPart =

--- a/packages/local-explorer-ui/src/components/studio/Table/Result/index.tsx
+++ b/packages/local-explorer-ui/src/components/studio/Table/Result/index.tsx
@@ -51,14 +51,14 @@ export function StudioResultTable({
 	orderByColumn,
 	orderByDirection,
 	state,
-}: StudioResultTableProps): JSX.Element {
+}: StudioResultTableProps): React.JSX.Element {
 	const { copyCallback, onContextMenu, pasteCallback } =
 		useStudioResultTableContextMenu(state);
 
 	const renderCell = useCallback(
 		(
 			props: StudioTableCellRendererProps<StudioResultHeaderMetadata>
-		): JSX.Element => {
+		): React.JSX.Element => {
 			const { header, isFocus, x, y } = props;
 
 			const align = header.metadata?.typeHint === "NUMBER" ? "right" : "left";
@@ -120,7 +120,7 @@ export function StudioResultTable({
 	const renderHeader = useCallback(
 		(
 			header: StudioTableHeaderProps<StudioResultHeaderMetadata>
-		): JSX.Element => {
+		): React.JSX.Element => {
 			const hasColumnInfo =
 				(header.metadata.indexes && header.metadata.indexes.length > 0) ||
 				header.metadata.isPrimaryKey ||
@@ -282,7 +282,7 @@ function HeaderDropdownMenu({
 	header,
 	orderByColumn,
 	orderByDirection,
-}: HeaderDropdownMenuProps): JSX.Element {
+}: HeaderDropdownMenuProps): React.JSX.Element {
 	const [open, setOpen] = useState<boolean>(false);
 
 	const orderIconPart =

--- a/packages/local-explorer-ui/src/components/studio/Table/SchemaEditor/Column.tsx
+++ b/packages/local-explorer-ui/src/components/studio/Table/SchemaEditor/Column.tsx
@@ -24,7 +24,7 @@ import type {
 	StudioTableSchemaChange,
 } from "../../../../types/studio";
 import type { Icon } from "@phosphor-icons/react";
-import type { Dispatch, PropsWithChildren, SetStateAction } from "react";
+import type { Dispatch, JSX, PropsWithChildren, SetStateAction } from "react";
 
 interface StudioColumnSchemaEditorProps {
 	columnIndex: number;
@@ -51,7 +51,7 @@ export function StudioColumnSchemaEditor({
 	onChange,
 	readOnlyExistingColumns,
 	value,
-}: StudioColumnSchemaEditorProps): React.JSX.Element | null {
+}: StudioColumnSchemaEditorProps): JSX.Element | null {
 	const { openModal } = useModal();
 	const column = value.columns[columnIndex];
 
@@ -301,7 +301,7 @@ interface ColumnConstraintDescriptionProps {
 function ColumnConstraintDescription({
 	column,
 	constraints,
-}: ColumnConstraintDescriptionProps): React.JSX.Element {
+}: ColumnConstraintDescriptionProps): JSX.Element {
 	// Check if it contains foreign key
 	let referenceTableName = column.constraint?.foreignKey?.foreignTableName;
 	let referenceColumnName = column.constraint?.foreignKey?.foreignColumns?.[0];
@@ -360,7 +360,7 @@ function ColumnConstraintBadge({
 	children,
 	icon: IconComponent,
 	name,
-}: ColumnConstraintBadgeProps): React.JSX.Element {
+}: ColumnConstraintBadgeProps): JSX.Element {
 	return (
 		<div className="inline-flex items-center gap-1 overflow-hidden rounded border border-kumo-fill">
 			<div className="flex items-center border-r border-kumo-fill bg-kumo-overlay p-1">
@@ -386,7 +386,7 @@ export function StudioColumnEditorModal({
 	isOpen,
 	onConfirm,
 	schemaChanges,
-}: StudioColumnEditiorDrawerProps): React.JSX.Element {
+}: StudioColumnEditiorDrawerProps): JSX.Element {
 	const [value, setValue] = useState<StudioTableColumn>(() =>
 		defaultValue
 			? structuredClone(defaultValue)

--- a/packages/local-explorer-ui/src/components/studio/Table/SchemaEditor/Column.tsx
+++ b/packages/local-explorer-ui/src/components/studio/Table/SchemaEditor/Column.tsx
@@ -51,7 +51,7 @@ export function StudioColumnSchemaEditor({
 	onChange,
 	readOnlyExistingColumns,
 	value,
-}: StudioColumnSchemaEditorProps): JSX.Element | null {
+}: StudioColumnSchemaEditorProps): React.JSX.Element | null {
 	const { openModal } = useModal();
 	const column = value.columns[columnIndex];
 
@@ -301,7 +301,7 @@ interface ColumnConstraintDescriptionProps {
 function ColumnConstraintDescription({
 	column,
 	constraints,
-}: ColumnConstraintDescriptionProps): JSX.Element {
+}: ColumnConstraintDescriptionProps): React.JSX.Element {
 	// Check if it contains foreign key
 	let referenceTableName = column.constraint?.foreignKey?.foreignTableName;
 	let referenceColumnName = column.constraint?.foreignKey?.foreignColumns?.[0];
@@ -360,7 +360,7 @@ function ColumnConstraintBadge({
 	children,
 	icon: IconComponent,
 	name,
-}: ColumnConstraintBadgeProps): JSX.Element {
+}: ColumnConstraintBadgeProps): React.JSX.Element {
 	return (
 		<div className="inline-flex items-center gap-1 overflow-hidden rounded border border-kumo-fill">
 			<div className="flex items-center border-r border-kumo-fill bg-kumo-overlay p-1">
@@ -386,7 +386,7 @@ export function StudioColumnEditorModal({
 	isOpen,
 	onConfirm,
 	schemaChanges,
-}: StudioColumnEditiorDrawerProps): JSX.Element {
+}: StudioColumnEditiorDrawerProps): React.JSX.Element {
 	const [value, setValue] = useState<StudioTableColumn>(() =>
 		defaultValue
 			? structuredClone(defaultValue)

--- a/packages/local-explorer-ui/src/components/studio/Table/SchemaEditor/ConstraintListEditor.tsx
+++ b/packages/local-explorer-ui/src/components/studio/Table/SchemaEditor/ConstraintListEditor.tsx
@@ -11,7 +11,7 @@ import { produce } from "immer";
 import { useCallback } from "react";
 import type { StudioTableSchemaChange } from "../../../../types/studio";
 import type { DragEndEvent } from "@dnd-kit/core";
-import type { Dispatch, SetStateAction } from "react";
+import type { Dispatch, JSX, SetStateAction } from "react";
 
 interface StudioConstraintListEditorProps {
 	onChange: Dispatch<SetStateAction<StudioTableSchemaChange>>;
@@ -142,7 +142,7 @@ function SortableColumnList({
 	disabledRearrange,
 	onChange,
 	value,
-}: SortableColumnListProps): React.JSX.Element {
+}: SortableColumnListProps): JSX.Element {
 	const handleDragEnd = useCallback(
 		(event: DragEndEvent): void => {
 			const { active, over } = event;
@@ -181,9 +181,7 @@ interface SortableColumnItemProps {
 	id: string;
 }
 
-function SortableColumnItem({
-	id,
-}: SortableColumnItemProps): React.JSX.Element {
+function SortableColumnItem({ id }: SortableColumnItemProps): JSX.Element {
 	const { attributes, listeners, setNodeRef, transform, transition } =
 		useSortable({ id });
 

--- a/packages/local-explorer-ui/src/components/studio/Table/SchemaEditor/ConstraintListEditor.tsx
+++ b/packages/local-explorer-ui/src/components/studio/Table/SchemaEditor/ConstraintListEditor.tsx
@@ -142,7 +142,7 @@ function SortableColumnList({
 	disabledRearrange,
 	onChange,
 	value,
-}: SortableColumnListProps): JSX.Element {
+}: SortableColumnListProps): React.JSX.Element {
 	const handleDragEnd = useCallback(
 		(event: DragEndEvent): void => {
 			const { active, over } = event;
@@ -181,7 +181,9 @@ interface SortableColumnItemProps {
 	id: string;
 }
 
-function SortableColumnItem({ id }: SortableColumnItemProps): JSX.Element {
+function SortableColumnItem({
+	id,
+}: SortableColumnItemProps): React.JSX.Element {
 	const { attributes, listeners, setNodeRef, transform, transition } =
 		useSortable({ id });
 

--- a/packages/local-explorer-ui/src/components/studio/Table/SchemaEditor/index.tsx
+++ b/packages/local-explorer-ui/src/components/studio/Table/SchemaEditor/index.tsx
@@ -16,7 +16,7 @@ import type {
 	StudioTableSchemaChange,
 } from "../../../../types/studio";
 import type { StudioCodeMirrorReference } from "../../Code/Mirror";
-import type { Dispatch, SetStateAction } from "react";
+import type { Dispatch, JSX, SetStateAction } from "react";
 
 interface StudioTableSchemaEditorProps {
 	disabledAddColumn?: boolean;
@@ -36,7 +36,7 @@ export function StudioTableSchemaEditor({
 	onSaveChange,
 	readOnlyExistingColumns,
 	value,
-}: StudioTableSchemaEditorProps): React.JSX.Element {
+}: StudioTableSchemaEditorProps): JSX.Element {
 	const { openModal } = useModal();
 
 	const editorRef = useRef<StudioCodeMirrorReference>(null);
@@ -231,7 +231,7 @@ interface IndexListProps {
 	indexList: StudioTableIndex[];
 }
 
-function IndexList({ indexList }: IndexListProps): React.JSX.Element | null {
+function IndexList({ indexList }: IndexListProps): JSX.Element | null {
 	if (indexList.length === 0) {
 		return null;
 	}

--- a/packages/local-explorer-ui/src/components/studio/Table/SchemaEditor/index.tsx
+++ b/packages/local-explorer-ui/src/components/studio/Table/SchemaEditor/index.tsx
@@ -36,7 +36,7 @@ export function StudioTableSchemaEditor({
 	onSaveChange,
 	readOnlyExistingColumns,
 	value,
-}: StudioTableSchemaEditorProps): JSX.Element {
+}: StudioTableSchemaEditorProps): React.JSX.Element {
 	const { openModal } = useModal();
 
 	const editorRef = useRef<StudioCodeMirrorReference>(null);
@@ -231,7 +231,7 @@ interface IndexListProps {
 	indexList: StudioTableIndex[];
 }
 
-function IndexList({ indexList }: IndexListProps): JSX.Element | null {
+function IndexList({ indexList }: IndexListProps): React.JSX.Element | null {
 	if (indexList.length === 0) {
 		return null;
 	}

--- a/packages/local-explorer-ui/src/components/studio/Table/index.tsx
+++ b/packages/local-explorer-ui/src/components/studio/Table/index.tsx
@@ -4,7 +4,7 @@ import type { StudioTableProps } from "./BaseTable";
 
 export function StudioTable<T = unknown>(
 	props: StudioTableProps<T>
-): JSX.Element {
+): React.JSX.Element {
 	const {
 		onKeyDown: customKeyDownHandler,
 		onKeyUp: customKeyUpHandler,

--- a/packages/local-explorer-ui/src/components/studio/Table/index.tsx
+++ b/packages/local-explorer-ui/src/components/studio/Table/index.tsx
@@ -1,10 +1,16 @@
-import { useCallback, useRef } from "react";
+import {
+	useCallback,
+	useRef,
+	type JSX,
+	type KeyboardEvent,
+	type MouseEvent,
+} from "react";
 import { StudioBaseTable } from "./BaseTable";
 import type { StudioTableProps } from "./BaseTable";
 
 export function StudioTable<T = unknown>(
 	props: StudioTableProps<T>
-): React.JSX.Element {
+): JSX.Element {
 	const {
 		onKeyDown: customKeyDownHandler,
 		onKeyUp: customKeyUpHandler,
@@ -14,7 +20,7 @@ export function StudioTable<T = unknown>(
 	const shiftSelectionPosition = useRef<{ x: number; y: number } | null>(null);
 
 	const onShiftKeyDownCallBack = useCallback(
-		(e: React.KeyboardEvent): void => {
+		(e: KeyboardEvent): void => {
 			const focus = state.getFocus();
 
 			if (e.shiftKey && focus) {
@@ -73,7 +79,7 @@ export function StudioTable<T = unknown>(
 
 	// Provide key navigation
 	const onKeyDown = useCallback(
-		(e: React.KeyboardEvent): void => {
+		(e: KeyboardEvent): void => {
 			if (state.isInEditMode()) {
 				return;
 			}
@@ -161,7 +167,7 @@ export function StudioTable<T = unknown>(
 	);
 
 	const onKeyUp = useCallback(
-		(e: React.KeyboardEvent): void => {
+		(e: KeyboardEvent): void => {
 			if (state.isInEditMode()) {
 				return;
 			}
@@ -178,7 +184,7 @@ export function StudioTable<T = unknown>(
 	);
 
 	const onGutterClick = useCallback(
-		(e: React.MouseEvent, rowNumber: number): void => {
+		(e: MouseEvent, rowNumber: number): void => {
 			const focusCell = state.getFocus();
 			if (e.shiftKey && focusCell) {
 				state.selectRowRange(focusCell.y, rowNumber);
@@ -194,7 +200,7 @@ export function StudioTable<T = unknown>(
 	);
 
 	const onCellMouseDown = useCallback(
-		(e: React.MouseEvent, { x, y }: { x: number; y: number }): void => {
+		(e: MouseEvent, { x, y }: { x: number; y: number }): void => {
 			const shiftKey = e.shiftKey;
 			const focusedCell = state.getFocus();
 

--- a/packages/local-explorer-ui/src/components/studio/Tabs/CreateUpdateTable.tsx
+++ b/packages/local-explorer-ui/src/components/studio/Tabs/CreateUpdateTable.tsx
@@ -8,6 +8,7 @@ import type {
 	StudioTableSchema,
 	StudioTableSchemaChange,
 } from "../../../types/studio";
+import type { JSX } from "react";
 
 interface StudioEditTableTabProps {
 	schemaName?: string;
@@ -19,7 +20,7 @@ const LAYOUT_CLASSES = "overflow-auto w-full h-full bg-kumo-base";
 export function StudioCreateUpdateTableTab({
 	schemaName,
 	tableName,
-}: StudioEditTableTabProps): React.JSX.Element {
+}: StudioEditTableTabProps): JSX.Element {
 	const { driver, refreshSchema, replaceStudioTab } = useStudioContext();
 	const {
 		identifier: tabIdentifier,

--- a/packages/local-explorer-ui/src/components/studio/Tabs/CreateUpdateTable.tsx
+++ b/packages/local-explorer-ui/src/components/studio/Tabs/CreateUpdateTable.tsx
@@ -19,7 +19,7 @@ const LAYOUT_CLASSES = "overflow-auto w-full h-full bg-kumo-base";
 export function StudioCreateUpdateTableTab({
 	schemaName,
 	tableName,
-}: StudioEditTableTabProps): JSX.Element {
+}: StudioEditTableTabProps): React.JSX.Element {
 	const { driver, refreshSchema, replaceStudioTab } = useStudioContext();
 	const {
 		identifier: tabIdentifier,

--- a/packages/local-explorer-ui/src/components/studio/Tabs/Query.tsx
+++ b/packages/local-explorer-ui/src/components/studio/Tabs/Query.tsx
@@ -1,7 +1,14 @@
 import { Button, DropdownMenu } from "@cloudflare/kumo";
 import { SplitPane } from "@cloudflare/workers-editor-shared";
 import { BinocularsIcon, CaretDownIcon, PlayIcon } from "@phosphor-icons/react";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+	useCallback,
+	useEffect,
+	useMemo,
+	useRef,
+	useState,
+	type JSX,
+} from "react";
 import { runStudioMultipleSQLStatements } from "../../../utils/studio";
 import { beautifySQLQuery } from "../../../utils/studio/formatter";
 import { useStudioContext } from "../Context";
@@ -24,9 +31,7 @@ interface StudioQueryTabProps {
 	query?: string;
 }
 
-export function StudioQueryTab({
-	query,
-}: StudioQueryTabProps): React.JSX.Element {
+export function StudioQueryTab({ query }: StudioQueryTabProps): JSX.Element {
 	const { driver, schemas, refreshSchema } = useStudioContext();
 
 	const editorRef = useRef<StudioCodeMirrorReference>(null);

--- a/packages/local-explorer-ui/src/components/studio/Tabs/Query.tsx
+++ b/packages/local-explorer-ui/src/components/studio/Tabs/Query.tsx
@@ -24,7 +24,9 @@ interface StudioQueryTabProps {
 	query?: string;
 }
 
-export function StudioQueryTab({ query }: StudioQueryTabProps): JSX.Element {
+export function StudioQueryTab({
+	query,
+}: StudioQueryTabProps): React.JSX.Element {
 	const { driver, schemas, refreshSchema } = useStudioContext();
 
 	const editorRef = useRef<StudioCodeMirrorReference>(null);

--- a/packages/local-explorer-ui/src/components/studio/Tabs/TableExplorer.tsx
+++ b/packages/local-explorer-ui/src/components/studio/Tabs/TableExplorer.tsx
@@ -41,7 +41,7 @@ const DEFAULT_PAGE_SIZE = 50;
 export function StudioTableExplorerTab({
 	schemaName,
 	tableName,
-}: StudioTableExplorerTabProps): JSX.Element {
+}: StudioTableExplorerTabProps): React.JSX.Element {
 	const { closeStudioTab, driver, schemas } = useStudioContext();
 
 	const [changeNumber, setChangeNumber] = useState<number>(0);

--- a/packages/local-explorer-ui/src/components/studio/Tabs/TableExplorer.tsx
+++ b/packages/local-explorer-ui/src/components/studio/Tabs/TableExplorer.tsx
@@ -8,7 +8,14 @@ import {
 	SpinnerIcon,
 	TrashIcon,
 } from "@phosphor-icons/react";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+	useCallback,
+	useEffect,
+	useMemo,
+	useState,
+	type FocusEvent,
+	type JSX,
+} from "react";
 import {
 	buildStudioMutationPlans,
 	commitStudioTableChanges,
@@ -41,7 +48,7 @@ const DEFAULT_PAGE_SIZE = 50;
 export function StudioTableExplorerTab({
 	schemaName,
 	tableName,
-}: StudioTableExplorerTabProps): React.JSX.Element {
+}: StudioTableExplorerTabProps): JSX.Element {
 	const { closeStudioTab, driver, schemas } = useStudioContext();
 
 	const [changeNumber, setChangeNumber] = useState<number>(0);
@@ -245,7 +252,7 @@ export function StudioTableExplorerTab({
 	);
 
 	const onOffsetBlur = useCallback(
-		(e: React.FocusEvent<HTMLInputElement>): void => {
+		(e: FocusEvent<HTMLInputElement>): void => {
 			const raw = e.currentTarget.value.trim();
 			const offsetValue = Number(raw);
 			const clampedOffset = Math.max(
@@ -271,7 +278,7 @@ export function StudioTableExplorerTab({
 	);
 
 	const onLimitBlur = useCallback(
-		(e: React.FocusEvent<HTMLInputElement>): void => {
+		(e: FocusEvent<HTMLInputElement>): void => {
 			const raw = e.currentTarget.value.trim();
 			const limitValue = Number(raw);
 			const clampedLimit = Math.max(

--- a/packages/local-explorer-ui/src/components/studio/WhereFilterInput.tsx
+++ b/packages/local-explorer-ui/src/components/studio/WhereFilterInput.tsx
@@ -37,7 +37,7 @@ export function StudioWhereFilterInput({
 	loading,
 	onApply,
 	value,
-}: StudioWhereFilterInputProps): JSX.Element {
+}: StudioWhereFilterInputProps): React.JSX.Element {
 	const editorRef = useRef<StudioCodeMirrorReference>(null);
 
 	const [currentValue, setCurrentValue] = useState<string>("");
@@ -104,36 +104,37 @@ export function StudioWhereFilterInput({
 		}
 	}, [editorRef]);
 
-	const applyButtonContent = useMemo<JSX.Element>((): JSX.Element => {
-		if (loading) {
-			return (
-				<>
-					<SpinnerIcon className="animate-spin" />
-					<span>Applying</span>
-				</>
-			);
-		}
+	const applyButtonContent =
+		useMemo<React.JSX.Element>((): React.JSX.Element => {
+			if (loading) {
+				return (
+					<>
+						<SpinnerIcon className="animate-spin" />
+						<span>Applying</span>
+					</>
+				);
+			}
 
-		if (parsingError) {
+			if (parsingError) {
+				return (
+					<>
+						<span className="text-red-500">●</span>
+						<span>Apply</span>
+					</>
+				);
+			}
+
+			if (currentValue === value) {
+				return <span>Applied</span>;
+			}
+
 			return (
 				<>
-					<span className="text-red-500">●</span>
+					<span className="text-kumo-subtle">●</span>
 					<span>Apply</span>
 				</>
 			);
-		}
-
-		if (currentValue === value) {
-			return <span>Applied</span>;
-		}
-
-		return (
-			<>
-				<span className="text-kumo-subtle">●</span>
-				<span>Apply</span>
-			</>
-		);
-	}, [loading, currentValue, value, parsingError]);
+		}, [loading, currentValue, value, parsingError]);
 
 	return (
 		<div className="flex items-center rounded border border-kumo-fill bg-kumo-elevated">

--- a/packages/local-explorer-ui/src/components/studio/WhereFilterInput.tsx
+++ b/packages/local-explorer-ui/src/components/studio/WhereFilterInput.tsx
@@ -1,6 +1,13 @@
 import { Button, Tooltip } from "@cloudflare/kumo";
 import { SpinnerIcon } from "@phosphor-icons/react";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+	useCallback,
+	useEffect,
+	useMemo,
+	useRef,
+	useState,
+	type JSX,
+} from "react";
 import { tokenizeSQL } from "../../utils/studio/sql";
 import { StudioWhereParser } from "../../utils/studio/where-parser";
 import { StudioSQLWhereEditor } from "./SQLWhereEditor";
@@ -37,7 +44,7 @@ export function StudioWhereFilterInput({
 	loading,
 	onApply,
 	value,
-}: StudioWhereFilterInputProps): React.JSX.Element {
+}: StudioWhereFilterInputProps): JSX.Element {
 	const editorRef = useRef<StudioCodeMirrorReference>(null);
 
 	const [currentValue, setCurrentValue] = useState<string>("");
@@ -104,37 +111,36 @@ export function StudioWhereFilterInput({
 		}
 	}, [editorRef]);
 
-	const applyButtonContent =
-		useMemo<React.JSX.Element>((): React.JSX.Element => {
-			if (loading) {
-				return (
-					<>
-						<SpinnerIcon className="animate-spin" />
-						<span>Applying</span>
-					</>
-				);
-			}
-
-			if (parsingError) {
-				return (
-					<>
-						<span className="text-red-500">●</span>
-						<span>Apply</span>
-					</>
-				);
-			}
-
-			if (currentValue === value) {
-				return <span>Applied</span>;
-			}
-
+	const applyButtonContent = useMemo<JSX.Element>((): JSX.Element => {
+		if (loading) {
 			return (
 				<>
-					<span className="text-kumo-subtle">●</span>
+					<SpinnerIcon className="animate-spin" />
+					<span>Applying</span>
+				</>
+			);
+		}
+
+		if (parsingError) {
+			return (
+				<>
+					<span className="text-red-500">●</span>
 					<span>Apply</span>
 				</>
 			);
-		}, [loading, currentValue, value, parsingError]);
+		}
+
+		if (currentValue === value) {
+			return <span>Applied</span>;
+		}
+
+		return (
+			<>
+				<span className="text-kumo-subtle">●</span>
+				<span>Apply</span>
+			</>
+		);
+	}, [loading, currentValue, value, parsingError]);
 
 	return (
 		<div className="flex items-center rounded border border-kumo-fill bg-kumo-elevated">

--- a/packages/local-explorer-ui/src/components/studio/WindowTab/ContentWrapper.tsx
+++ b/packages/local-explorer-ui/src/components/studio/WindowTab/ContentWrapper.tsx
@@ -1,13 +1,17 @@
 import { cn } from "@cloudflare/kumo";
-import { useCallback } from "react";
+import {
+	useCallback,
+	type Dispatch,
+	type JSX,
+	type RefObject,
+	type SetStateAction,
+} from "react";
 import { StudioCurrentWindowTabContext } from "./Context";
 import type { BeforeTabClosingHandler, StudioWindowTabItem } from "./types";
 
 interface StudioTabContentWrapperProps {
-	beforeClosingHandlersRef: React.RefObject<
-		Map<string, BeforeTabClosingHandler>
-	>;
-	onTabsChange?: React.Dispatch<React.SetStateAction<StudioWindowTabItem[]>>;
+	beforeClosingHandlersRef: RefObject<Map<string, BeforeTabClosingHandler>>;
+	onTabsChange?: Dispatch<SetStateAction<StudioWindowTabItem[]>>;
 	selectedTabKey?: string;
 	tab: StudioWindowTabItem;
 }
@@ -19,7 +23,7 @@ export function StudioTabContentWrapper({
 	onTabsChange,
 	selectedTabKey,
 	tab,
-}: StudioTabContentWrapperProps): React.JSX.Element {
+}: StudioTabContentWrapperProps): JSX.Element {
 	const tabKey = tab.key;
 
 	/**

--- a/packages/local-explorer-ui/src/components/studio/WindowTab/ContentWrapper.tsx
+++ b/packages/local-explorer-ui/src/components/studio/WindowTab/ContentWrapper.tsx
@@ -19,7 +19,7 @@ export function StudioTabContentWrapper({
 	onTabsChange,
 	selectedTabKey,
 	tab,
-}: StudioTabContentWrapperProps): JSX.Element {
+}: StudioTabContentWrapperProps): React.JSX.Element {
 	const tabKey = tab.key;
 
 	/**

--- a/packages/local-explorer-ui/src/components/studio/WindowTab/ItemRenderer.tsx
+++ b/packages/local-explorer-ui/src/components/studio/WindowTab/ItemRenderer.tsx
@@ -1,6 +1,6 @@
 import { cn } from "@cloudflare/kumo";
 import { CircleIcon, XIcon } from "@phosphor-icons/react";
-import { useState } from "react";
+import { useState, type JSX } from "react";
 import type { StudioWindowTabItem } from "./types";
 
 interface StudioWindowTabItemRendererProps {
@@ -18,7 +18,7 @@ export function StudioWindowTabItemRenderer({
 	onDoubleClick,
 	selected,
 	tab,
-}: StudioWindowTabItemRendererProps): React.JSX.Element {
+}: StudioWindowTabItemRendererProps): JSX.Element {
 	const isDirty = tab.isDirty;
 	const isTemp = tab.isTemp;
 

--- a/packages/local-explorer-ui/src/components/studio/WindowTab/ItemRenderer.tsx
+++ b/packages/local-explorer-ui/src/components/studio/WindowTab/ItemRenderer.tsx
@@ -18,7 +18,7 @@ export function StudioWindowTabItemRenderer({
 	onDoubleClick,
 	selected,
 	tab,
-}: StudioWindowTabItemRendererProps): JSX.Element {
+}: StudioWindowTabItemRendererProps): React.JSX.Element {
 	const isDirty = tab.isDirty;
 	const isTemp = tab.isTemp;
 

--- a/packages/local-explorer-ui/src/components/studio/WindowTab/MenuProps.tsx
+++ b/packages/local-explorer-ui/src/components/studio/WindowTab/MenuProps.tsx
@@ -6,7 +6,7 @@ interface StudioWindowTabMenuProps {
 
 export function StudioWindowTabMenu({
 	onClick,
-}: StudioWindowTabMenuProps): JSX.Element {
+}: StudioWindowTabMenuProps): React.JSX.Element {
 	return (
 		<button
 			className="sticky right-0 flex h-10 cursor-pointer items-center gap-2 border-b border-kumo-fill px-4 py-3 text-xs font-semibold tracking-wide text-kumo-subtle hover:bg-kumo-fill disabled:cursor-not-allowed"

--- a/packages/local-explorer-ui/src/components/studio/WindowTab/MenuProps.tsx
+++ b/packages/local-explorer-ui/src/components/studio/WindowTab/MenuProps.tsx
@@ -1,4 +1,5 @@
 import { PlusIcon } from "@phosphor-icons/react";
+import type { JSX } from "react";
 
 interface StudioWindowTabMenuProps {
 	onClick: () => void;
@@ -6,7 +7,7 @@ interface StudioWindowTabMenuProps {
 
 export function StudioWindowTabMenu({
 	onClick,
-}: StudioWindowTabMenuProps): React.JSX.Element {
+}: StudioWindowTabMenuProps): JSX.Element {
 	return (
 		<button
 			className="sticky right-0 flex h-10 cursor-pointer items-center gap-2 border-b border-kumo-fill px-4 py-3 text-xs font-semibold tracking-wide text-kumo-subtle hover:bg-kumo-fill disabled:cursor-not-allowed"

--- a/packages/local-explorer-ui/src/components/studio/WindowTab/Pane.tsx
+++ b/packages/local-explorer-ui/src/components/studio/WindowTab/Pane.tsx
@@ -3,7 +3,7 @@ import { useStudioContext } from "../Context";
 import { StudioWindowTab } from ".";
 import type { StudioWindowTabItem } from "./types";
 
-export function StudioWindowTabPane(): JSX.Element {
+export function StudioWindowTabPane(): React.JSX.Element {
 	const {
 		openStudioTab,
 		selectedTabKey,

--- a/packages/local-explorer-ui/src/components/studio/WindowTab/Pane.tsx
+++ b/packages/local-explorer-ui/src/components/studio/WindowTab/Pane.tsx
@@ -1,9 +1,9 @@
-import { useCallback } from "react";
+import { useCallback, type JSX } from "react";
 import { useStudioContext } from "../Context";
 import { StudioWindowTab } from ".";
 import type { StudioWindowTabItem } from "./types";
 
-export function StudioWindowTabPane(): React.JSX.Element {
+export function StudioWindowTabPane(): JSX.Element {
 	const {
 		openStudioTab,
 		selectedTabKey,

--- a/packages/local-explorer-ui/src/components/studio/WindowTab/index.tsx
+++ b/packages/local-explorer-ui/src/components/studio/WindowTab/index.tsx
@@ -1,4 +1,4 @@
-import { useRef } from "react";
+import { useRef, type Dispatch, type JSX, type SetStateAction } from "react";
 import { StudioTabContentWrapper } from "./ContentWrapper";
 import { StudioWindowTabItemRenderer } from "./ItemRenderer";
 import { StudioWindowTabMenu } from "./MenuProps";
@@ -14,7 +14,7 @@ export interface StudioWindowTabProps {
 	/**
 	 * Called when the tab list changes — either due to closing a tab or reordering tabs via drag-and-drop.
 	 */
-	onTabsChange?: React.Dispatch<React.SetStateAction<StudioWindowTabItem[]>>;
+	onTabsChange?: Dispatch<SetStateAction<StudioWindowTabItem[]>>;
 	/**
 	 * The key of the currently selected (active) tab.
 	 */
@@ -33,7 +33,7 @@ export function StudioWindowTab({
 	onTabsChange,
 	selectedTabKey,
 	tabs,
-}: StudioWindowTabProps): React.JSX.Element {
+}: StudioWindowTabProps): JSX.Element {
 	const beforeClosingHandlersRef = useRef(
 		new Map<string, BeforeTabClosingHandler>()
 	);

--- a/packages/local-explorer-ui/src/components/studio/WindowTab/index.tsx
+++ b/packages/local-explorer-ui/src/components/studio/WindowTab/index.tsx
@@ -33,7 +33,7 @@ export function StudioWindowTab({
 	onTabsChange,
 	selectedTabKey,
 	tabs,
-}: StudioWindowTabProps): JSX.Element {
+}: StudioWindowTabProps): React.JSX.Element {
 	const beforeClosingHandlersRef = useRef(
 		new Map<string, BeforeTabClosingHandler>()
 	);

--- a/packages/local-explorer-ui/src/components/studio/WindowTab/types.ts
+++ b/packages/local-explorer-ui/src/components/studio/WindowTab/types.ts
@@ -1,13 +1,14 @@
 import type { Icon } from "@phosphor-icons/react";
+import type { JSX, ReactNode } from "react";
 
 export interface StudioWindowTabItem {
-	component: React.JSX.Element;
+	component: JSX.Element;
 	icon: Icon;
 	identifier: string;
 	isDirty?: boolean;
 	isTemp?: boolean;
 	key: string;
-	title: React.ReactNode;
+	title: ReactNode;
 	type?: string;
 }
 

--- a/packages/local-explorer-ui/src/components/studio/WindowTab/types.ts
+++ b/packages/local-explorer-ui/src/components/studio/WindowTab/types.ts
@@ -1,7 +1,7 @@
 import type { Icon } from "@phosphor-icons/react";
 
 export interface StudioWindowTabItem {
-	component: JSX.Element;
+	component: React.JSX.Element;
 	icon: Icon;
 	identifier: string;
 	isDirty?: boolean;

--- a/packages/local-explorer-ui/src/components/workflows/CopyButton.tsx
+++ b/packages/local-explorer-ui/src/components/workflows/CopyButton.tsx
@@ -1,5 +1,5 @@
 import { CheckIcon, CopyIcon } from "@phosphor-icons/react";
-import { useState } from "react";
+import { useState, type JSX } from "react";
 
 export function CopyButton({
 	text,
@@ -7,7 +7,7 @@ export function CopyButton({
 }: {
 	text: string;
 	label?: string;
-}): React.JSX.Element {
+}): JSX.Element {
 	const [copied, setCopied] = useState(false);
 
 	function handleCopy(): void {

--- a/packages/local-explorer-ui/src/components/workflows/CopyButton.tsx
+++ b/packages/local-explorer-ui/src/components/workflows/CopyButton.tsx
@@ -7,7 +7,7 @@ export function CopyButton({
 }: {
 	text: string;
 	label?: string;
-}): JSX.Element {
+}): React.JSX.Element {
 	const [copied, setCopied] = useState(false);
 
 	function handleCopy(): void {

--- a/packages/local-explorer-ui/src/components/workflows/CreateInstanceDialog.tsx
+++ b/packages/local-explorer-ui/src/components/workflows/CreateInstanceDialog.tsx
@@ -1,5 +1,5 @@
 import { Button, Dialog } from "@cloudflare/kumo";
-import { useCallback, useState } from "react";
+import { useCallback, useState, type JSX } from "react";
 import { workflowsCreateInstance } from "../../api";
 
 interface CreateWorkflowInstanceDialogProps {
@@ -14,7 +14,7 @@ export function CreateWorkflowInstanceDialog({
 	onOpenChange,
 	open,
 	workflowName,
-}: CreateWorkflowInstanceDialogProps): React.JSX.Element {
+}: CreateWorkflowInstanceDialogProps): JSX.Element {
 	const [creating, setCreating] = useState<boolean>(false);
 	const [error, setError] = useState<string | null>(null);
 	const [instanceId, setInstanceId] = useState<string>("");

--- a/packages/local-explorer-ui/src/components/workflows/CreateInstanceDialog.tsx
+++ b/packages/local-explorer-ui/src/components/workflows/CreateInstanceDialog.tsx
@@ -14,7 +14,7 @@ export function CreateWorkflowInstanceDialog({
 	onOpenChange,
 	open,
 	workflowName,
-}: CreateWorkflowInstanceDialogProps): JSX.Element {
+}: CreateWorkflowInstanceDialogProps): React.JSX.Element {
 	const [creating, setCreating] = useState<boolean>(false);
 	const [error, setError] = useState<string | null>(null);
 	const [instanceId, setInstanceId] = useState<string>("");

--- a/packages/local-explorer-ui/src/components/workflows/ScrollableCodeBlock.tsx
+++ b/packages/local-explorer-ui/src/components/workflows/ScrollableCodeBlock.tsx
@@ -2,7 +2,7 @@ export function ScrollableCodeBlock({
 	content,
 }: {
 	content: string;
-}): JSX.Element {
+}): React.JSX.Element {
 	return (
 		<pre className="max-h-64 overflow-y-auto px-4 py-3 font-mono text-xs wrap-break-word whitespace-pre-wrap text-kumo-default">
 			{content}

--- a/packages/local-explorer-ui/src/components/workflows/ScrollableCodeBlock.tsx
+++ b/packages/local-explorer-ui/src/components/workflows/ScrollableCodeBlock.tsx
@@ -1,8 +1,10 @@
+import type { JSX } from "react";
+
 export function ScrollableCodeBlock({
 	content,
 }: {
 	content: string;
-}): React.JSX.Element {
+}): JSX.Element {
 	return (
 		<pre className="max-h-64 overflow-y-auto px-4 py-3 font-mono text-xs wrap-break-word whitespace-pre-wrap text-kumo-default">
 			{content}

--- a/packages/local-explorer-ui/src/components/workflows/StatusBadge.tsx
+++ b/packages/local-explorer-ui/src/components/workflows/StatusBadge.tsx
@@ -33,7 +33,7 @@ interface WorkflowStatusBadgeProps {
 
 export function WorkflowStatusBadge({
 	status,
-}: WorkflowStatusBadgeProps): JSX.Element {
+}: WorkflowStatusBadgeProps): React.JSX.Element {
 	const resolvedStatus = (
 		status && status in statusStyles ? status : "unknown"
 	) as WorkflowStatus;

--- a/packages/local-explorer-ui/src/components/workflows/StatusBadge.tsx
+++ b/packages/local-explorer-ui/src/components/workflows/StatusBadge.tsx
@@ -1,5 +1,6 @@
 import { cn } from "@cloudflare/kumo";
 import type { WorkflowsInstance } from "../../api";
+import type { JSX } from "react";
 
 type WorkflowStatus = NonNullable<WorkflowsInstance["status"]>;
 
@@ -33,7 +34,7 @@ interface WorkflowStatusBadgeProps {
 
 export function WorkflowStatusBadge({
 	status,
-}: WorkflowStatusBadgeProps): React.JSX.Element {
+}: WorkflowStatusBadgeProps): JSX.Element {
 	const resolvedStatus = (
 		status && status in statusStyles ? status : "unknown"
 	) as WorkflowStatus;

--- a/packages/local-explorer-ui/src/components/workflows/StatusIcon.tsx
+++ b/packages/local-explorer-ui/src/components/workflows/StatusIcon.tsx
@@ -7,8 +7,9 @@ import {
 	StopIcon,
 	WarningCircleIcon,
 } from "@phosphor-icons/react";
+import type { JSX } from "react";
 
-export function StatusIcon({ status }: { status: string }): React.JSX.Element {
+export function StatusIcon({ status }: { status: string }): JSX.Element {
 	switch (status) {
 		case "complete":
 			return (

--- a/packages/local-explorer-ui/src/components/workflows/StatusIcon.tsx
+++ b/packages/local-explorer-ui/src/components/workflows/StatusIcon.tsx
@@ -8,7 +8,7 @@ import {
 	WarningCircleIcon,
 } from "@phosphor-icons/react";
 
-export function StatusIcon({ status }: { status: string }): JSX.Element {
+export function StatusIcon({ status }: { status: string }): React.JSX.Element {
 	switch (status) {
 		case "complete":
 			return (

--- a/packages/local-explorer-ui/src/components/workflows/StepRow.tsx
+++ b/packages/local-explorer-ui/src/components/workflows/StepRow.tsx
@@ -1,6 +1,6 @@
 import { Loader, Tooltip } from "@cloudflare/kumo";
 import { ArrowClockwiseIcon, CheckIcon, PlusIcon } from "@phosphor-icons/react";
-import { memo } from "react";
+import { memo, type JSX } from "react";
 import { CopyButton } from "./CopyButton";
 import { formatDuration, formatJson } from "./helpers";
 import { ScrollableCodeBlock } from "./ScrollableCodeBlock";
@@ -17,7 +17,7 @@ function StepStatusIcon({
 	finished?: boolean;
 	hasError?: boolean;
 	subtle?: boolean;
-}): React.JSX.Element {
+}): JSX.Element {
 	if (success === false || hasError) {
 		if (subtle) {
 			return (
@@ -78,7 +78,7 @@ export const StepRow = memo(function StepRow({
 	isExpanded: boolean;
 	onToggleExpanded: () => void;
 	onRestartFromStep?: (step: StepData) => void;
-}): React.JSX.Element {
+}): JSX.Element {
 	const hasDetails =
 		step.type === "step" ||
 		(step.type === "waitForEvent" &&
@@ -168,7 +168,7 @@ function StepCodeCard({
 }: {
 	label: string;
 	content: string;
-}): React.JSX.Element {
+}): JSX.Element {
 	return (
 		<div>
 			<h5 className="mb-2 text-sm font-medium text-kumo-default">{label}</h5>
@@ -182,7 +182,7 @@ function StepCodeCard({
 	);
 }
 
-function StepDoDetails({ step }: { step: StepData }): React.JSX.Element {
+function StepDoDetails({ step }: { step: StepData }): JSX.Element {
 	// Get error text from last failed attempt
 	const failedAttempt =
 		step.success === false && step.attempts
@@ -289,7 +289,7 @@ function StepDoDetails({ step }: { step: StepData }): React.JSX.Element {
 	);
 }
 
-function WaitForEventDetails({ step }: { step: StepData }): React.JSX.Element {
+function WaitForEventDetails({ step }: { step: StepData }): JSX.Element {
 	const hasPayload = step.finished && !step.error;
 	const hasError = !!step.error;
 

--- a/packages/local-explorer-ui/src/components/workflows/StepRow.tsx
+++ b/packages/local-explorer-ui/src/components/workflows/StepRow.tsx
@@ -17,7 +17,7 @@ function StepStatusIcon({
 	finished?: boolean;
 	hasError?: boolean;
 	subtle?: boolean;
-}): JSX.Element {
+}): React.JSX.Element {
 	if (success === false || hasError) {
 		if (subtle) {
 			return (
@@ -78,7 +78,7 @@ export const StepRow = memo(function StepRow({
 	isExpanded: boolean;
 	onToggleExpanded: () => void;
 	onRestartFromStep?: (step: StepData) => void;
-}): JSX.Element {
+}): React.JSX.Element {
 	const hasDetails =
 		step.type === "step" ||
 		(step.type === "waitForEvent" &&
@@ -168,7 +168,7 @@ function StepCodeCard({
 }: {
 	label: string;
 	content: string;
-}): JSX.Element {
+}): React.JSX.Element {
 	return (
 		<div>
 			<h5 className="mb-2 text-sm font-medium text-kumo-default">{label}</h5>
@@ -182,7 +182,7 @@ function StepCodeCard({
 	);
 }
 
-function StepDoDetails({ step }: { step: StepData }): JSX.Element {
+function StepDoDetails({ step }: { step: StepData }): React.JSX.Element {
 	// Get error text from last failed attempt
 	const failedAttempt =
 		step.success === false && step.attempts
@@ -289,7 +289,7 @@ function StepDoDetails({ step }: { step: StepData }): JSX.Element {
 	);
 }
 
-function WaitForEventDetails({ step }: { step: StepData }): JSX.Element {
+function WaitForEventDetails({ step }: { step: StepData }): React.JSX.Element {
 	const hasPayload = step.finished && !step.error;
 	const hasError = !!step.error;
 

--- a/packages/local-explorer-ui/src/components/workflows/Timestamp.tsx
+++ b/packages/local-explorer-ui/src/components/workflows/Timestamp.tsx
@@ -34,7 +34,7 @@ export function Timestamp({
 	value,
 }: {
 	value: string | undefined | null;
-}): JSX.Element {
+}): React.JSX.Element {
 	if (!value) {
 		return <span className="text-sm text-kumo-subtle">—</span>;
 	}

--- a/packages/local-explorer-ui/src/components/workflows/Timestamp.tsx
+++ b/packages/local-explorer-ui/src/components/workflows/Timestamp.tsx
@@ -1,5 +1,6 @@
 import { Tooltip } from "@cloudflare/kumo";
 import { timeAgo } from "./helpers";
+import type { JSX } from "react";
 
 function formatShort(ts: string): string {
 	try {
@@ -34,7 +35,7 @@ export function Timestamp({
 	value,
 }: {
 	value: string | undefined | null;
-}): React.JSX.Element {
+}): JSX.Element {
 	if (!value) {
 		return <span className="text-sm text-kumo-subtle">—</span>;
 	}

--- a/packages/local-explorer-ui/src/drivers/common.ts
+++ b/packages/local-explorer-ui/src/drivers/common.ts
@@ -324,7 +324,7 @@ export abstract class StudioDriverCommon extends IStudioDriver {
 	getQueryTabOverride(
 		_: string,
 		__: StudioResultSet
-	): { label: string; icon: Icon; component: JSX.Element } | null {
+	): { label: string; icon: Icon; component: React.JSX.Element } | null {
 		return null;
 	}
 }

--- a/packages/local-explorer-ui/src/drivers/common.ts
+++ b/packages/local-explorer-ui/src/drivers/common.ts
@@ -11,6 +11,7 @@ import type {
 	StudioTableSchemaChange,
 } from "../types/studio";
 import type { Icon } from "@phosphor-icons/react";
+import type { JSX } from "react";
 
 /**
  * Common SQL driver implementation for databases that use SQL with slight dialect differences.
@@ -324,7 +325,7 @@ export abstract class StudioDriverCommon extends IStudioDriver {
 	getQueryTabOverride(
 		_: string,
 		__: StudioResultSet
-	): { label: string; icon: Icon; component: React.JSX.Element } | null {
+	): { label: string; icon: Icon; component: JSX.Element } | null {
 		return null;
 	}
 }

--- a/packages/local-explorer-ui/src/drivers/sqlite/index.ts
+++ b/packages/local-explorer-ui/src/drivers/sqlite/index.ts
@@ -475,7 +475,7 @@ export class StudioSQLiteDriver extends StudioDriverCommon {
 		statement: string,
 		result: StudioResultSet
 	): {
-		component: JSX.Element;
+		component: React.JSX.Element;
 		icon: Icon;
 		label: string;
 	} | null {

--- a/packages/local-explorer-ui/src/drivers/sqlite/index.ts
+++ b/packages/local-explorer-ui/src/drivers/sqlite/index.ts
@@ -20,6 +20,7 @@ import type {
 	StudioTableSchemaChange,
 } from "../../types/studio";
 import type { Icon } from "@phosphor-icons/react";
+import type { JSX } from "react";
 
 /**
  * Represents a row from SQLite's `sqlite_master` system table.
@@ -475,7 +476,7 @@ export class StudioSQLiteDriver extends StudioDriverCommon {
 		statement: string,
 		result: StudioResultSet
 	): {
-		component: React.JSX.Element;
+		component: JSX.Element;
 		icon: Icon;
 		label: string;
 	} | null {

--- a/packages/local-explorer-ui/src/hooks/leave-guard.ts
+++ b/packages/local-explorer-ui/src/hooks/leave-guard.ts
@@ -15,11 +15,6 @@ interface UseLeaveGuardOptions {
 	enabled: boolean;
 
 	/**
-	 * Optional fallback message when `onBeforeLeave` returns void.
-	 */
-	fallbackMessage?: string;
-
-	/**
 	 * Handle user attempting to leave.
 	 *
 	 * - Return a `string` to show a confirmation message.

--- a/packages/local-explorer-ui/src/hooks/leave-guard.ts
+++ b/packages/local-explorer-ui/src/hooks/leave-guard.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect } from "react";
+import { useCallback, useEffect, type DependencyList } from "react";
 
 type LeaveEvent = "navigation" | "unload";
 
@@ -7,7 +7,7 @@ interface UseLeaveGuardOptions {
 	 * List of reactive dependencies used inside `onBeforeLeave`.
 	 * Similar to a `useCallback` dependency array.
 	 */
-	dependencies?: React.DependencyList;
+	dependencies?: DependencyList;
 
 	/**
 	 * Enable or disable the leave guard. When false, no blocking is applied.

--- a/packages/local-explorer-ui/src/hooks/leave-guard.ts
+++ b/packages/local-explorer-ui/src/hooks/leave-guard.ts
@@ -39,7 +39,6 @@ interface UseLeaveGuardOptions {
 export function useLeaveGuard({
 	dependencies = [],
 	enabled,
-	fallbackMessage = "You have unsaved changes. Are you sure you want to leave?",
 	onBeforeLeave,
 }: UseLeaveGuardOptions): void {
 	const handlerCallback = useCallback(onBeforeLeave, [
@@ -58,17 +57,15 @@ export function useLeaveGuard({
 
 			if (typeof result === "string") {
 				e.preventDefault();
-				e.returnValue = result;
 				return;
 			}
 
 			if (result === true || result === undefined) {
 				e.preventDefault();
-				e.returnValue = fallbackMessage;
 			}
 		};
 
 		window.addEventListener("beforeunload", handleBeforeUnload);
 		return () => window.removeEventListener("beforeunload", handleBeforeUnload);
-	}, [enabled, handlerCallback, fallbackMessage]);
+	}, [enabled, handlerCallback]);
 }

--- a/packages/local-explorer-ui/src/routes/d1/$databaseId.tsx
+++ b/packages/local-explorer-ui/src/routes/d1/$databaseId.tsx
@@ -48,7 +48,7 @@ export const Route = createFileRoute("/d1/$databaseId")({
 
 const rootRoute = getRouteApi("__root__");
 
-function DatabaseView(): JSX.Element {
+function DatabaseView(): React.JSX.Element {
 	const params = Route.useParams();
 	const loaderData = Route.useLoaderData();
 	const searchParams = Route.useSearch();

--- a/packages/local-explorer-ui/src/routes/d1/$databaseId.tsx
+++ b/packages/local-explorer-ui/src/routes/d1/$databaseId.tsx
@@ -11,7 +11,7 @@ import {
 	useRouter,
 	useRouterState,
 } from "@tanstack/react-router";
-import { useCallback, useMemo, useRef, useState } from "react";
+import { useCallback, useMemo, useRef, useState, type JSX } from "react";
 import D1Icon from "../../assets/icons/d1.svg?react";
 import { Breadcrumbs } from "../../components/Breadcrumbs";
 import { ResourceError } from "../../components/ResourceError";
@@ -48,7 +48,7 @@ export const Route = createFileRoute("/d1/$databaseId")({
 
 const rootRoute = getRouteApi("__root__");
 
-function DatabaseView(): React.JSX.Element {
+function DatabaseView(): JSX.Element {
 	const params = Route.useParams();
 	const loaderData = Route.useLoaderData();
 	const searchParams = Route.useSearch();

--- a/packages/local-explorer-ui/src/routes/do/$className/$objectId.tsx
+++ b/packages/local-explorer-ui/src/routes/do/$className/$objectId.tsx
@@ -77,7 +77,7 @@ export const Route = createFileRoute("/do/$className/$objectId")({
 	}),
 });
 
-function ObjectView(): JSX.Element {
+function ObjectView(): React.JSX.Element {
 	const params = Route.useParams();
 	const loaderData = Route.useLoaderData();
 	const { namespaceId, objectId, objectName } = loaderData;

--- a/packages/local-explorer-ui/src/routes/do/$className/$objectId.tsx
+++ b/packages/local-explorer-ui/src/routes/do/$className/$objectId.tsx
@@ -11,7 +11,7 @@ import {
 	useNavigate,
 	useRouter,
 } from "@tanstack/react-router";
-import { useCallback, useMemo, useRef, useState } from "react";
+import { useCallback, useMemo, useRef, useState, type JSX } from "react";
 import { durableObjectsNamespaceListNamespaces } from "../../../api";
 import DOIcon from "../../../assets/icons/durable-objects.svg?react";
 import { Breadcrumbs } from "../../../components/Breadcrumbs";
@@ -77,7 +77,7 @@ export const Route = createFileRoute("/do/$className/$objectId")({
 	}),
 });
 
-function ObjectView(): React.JSX.Element {
+function ObjectView(): JSX.Element {
 	const params = Route.useParams();
 	const loaderData = Route.useLoaderData();
 	const { namespaceId, objectId, objectName } = loaderData;

--- a/packages/local-explorer-ui/src/routes/r2/$bucketName/index.tsx
+++ b/packages/local-explorer-ui/src/routes/r2/$bucketName/index.tsx
@@ -19,7 +19,7 @@ import {
 	notFound,
 	useNavigate,
 } from "@tanstack/react-router";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useState, type JSX } from "react";
 import {
 	r2BucketDeleteObjects,
 	r2BucketListObjects,
@@ -83,7 +83,7 @@ export const Route = createFileRoute("/r2/$bucketName/")({
 	}),
 });
 
-function BucketView(): React.JSX.Element {
+function BucketView(): JSX.Element {
 	const params = Route.useParams();
 	const search = Route.useSearch();
 	const loaderData = Route.useLoaderData();

--- a/packages/local-explorer-ui/src/routes/r2/$bucketName/index.tsx
+++ b/packages/local-explorer-ui/src/routes/r2/$bucketName/index.tsx
@@ -83,7 +83,7 @@ export const Route = createFileRoute("/r2/$bucketName/")({
 	}),
 });
 
-function BucketView(): JSX.Element {
+function BucketView(): React.JSX.Element {
 	const params = Route.useParams();
 	const search = Route.useSearch();
 	const loaderData = Route.useLoaderData();

--- a/packages/local-explorer-ui/src/routes/r2/$bucketName/object.$.tsx
+++ b/packages/local-explorer-ui/src/routes/r2/$bucketName/object.$.tsx
@@ -6,7 +6,7 @@ import {
 	notFound,
 	useNavigate,
 } from "@tanstack/react-router";
-import { useState } from "react";
+import { useState, type JSX } from "react";
 import { r2BucketDeleteObjects, r2BucketGetObject } from "../../../api";
 import R2Icon from "../../../assets/icons/r2.svg?react";
 import { Breadcrumbs } from "../../../components/Breadcrumbs";
@@ -67,9 +67,7 @@ interface ObjectDetailsCardProps {
 	object: R2HeadObjectResult;
 }
 
-function ObjectDetailsCard({
-	object,
-}: ObjectDetailsCardProps): React.JSX.Element {
+function ObjectDetailsCard({ object }: ObjectDetailsCardProps): JSX.Element {
 	const contentType =
 		object.http_metadata?.contentType ?? "application/octet-stream";
 	const formattedDate = formatDate(object.last_modified);
@@ -114,7 +112,7 @@ interface CustomMetadataCardProps {
 
 function CustomMetadataCard({
 	metadata,
-}: CustomMetadataCardProps): React.JSX.Element {
+}: CustomMetadataCardProps): JSX.Element {
 	const entries = metadata ? Object.entries(metadata) : [];
 
 	return (
@@ -139,7 +137,7 @@ function CustomMetadataCard({
 	);
 }
 
-function ObjectDetailView(): React.JSX.Element {
+function ObjectDetailView(): JSX.Element {
 	const params = Route.useParams();
 	const loaderData = Route.useLoaderData();
 	const search = Route.useSearch();

--- a/packages/local-explorer-ui/src/routes/r2/$bucketName/object.$.tsx
+++ b/packages/local-explorer-ui/src/routes/r2/$bucketName/object.$.tsx
@@ -67,7 +67,9 @@ interface ObjectDetailsCardProps {
 	object: R2HeadObjectResult;
 }
 
-function ObjectDetailsCard({ object }: ObjectDetailsCardProps): JSX.Element {
+function ObjectDetailsCard({
+	object,
+}: ObjectDetailsCardProps): React.JSX.Element {
 	const contentType =
 		object.http_metadata?.contentType ?? "application/octet-stream";
 	const formattedDate = formatDate(object.last_modified);
@@ -112,7 +114,7 @@ interface CustomMetadataCardProps {
 
 function CustomMetadataCard({
 	metadata,
-}: CustomMetadataCardProps): JSX.Element {
+}: CustomMetadataCardProps): React.JSX.Element {
 	const entries = metadata ? Object.entries(metadata) : [];
 
 	return (
@@ -137,7 +139,7 @@ function CustomMetadataCard({
 	);
 }
 
-function ObjectDetailView(): JSX.Element {
+function ObjectDetailView(): React.JSX.Element {
 	const params = Route.useParams();
 	const loaderData = Route.useLoaderData();
 	const search = Route.useSearch();

--- a/packages/local-explorer-ui/src/routes/workflows/$workflowName/index.tsx
+++ b/packages/local-explorer-ui/src/routes/workflows/$workflowName/index.tsx
@@ -137,7 +137,7 @@ const StatusSummary = memo(function StatusSummary({
 	statusCounts,
 }: {
 	statusCounts: Record<string, number>;
-}): JSX.Element {
+}): React.JSX.Element {
 	return (
 		<div className="mb-4 flex divide-x divide-kumo-fill overflow-hidden rounded-lg border border-kumo-fill bg-kumo-base">
 			{STATUS_SUMMARY_CONFIG.map(
@@ -200,7 +200,7 @@ const InstanceRow = memo(function InstanceRow({
 	instance: WorkflowsInstance;
 	onActionComplete: () => void;
 	workflowName: string;
-}): JSX.Element {
+}): React.JSX.Element {
 	const navigate = useNavigate();
 	const [actionInProgress, setActionInProgress] = useState<Action | null>(null);
 	const [deleteDialogOpen, setDeleteDialogOpen] = useState<boolean>(false);

--- a/packages/local-explorer-ui/src/routes/workflows/$workflowName/index.tsx
+++ b/packages/local-explorer-ui/src/routes/workflows/$workflowName/index.tsx
@@ -24,6 +24,7 @@ import {
 	useRef,
 	useState,
 	type MouseEvent,
+	type JSX,
 } from "react";
 import {
 	workflowsChangeInstanceStatus,
@@ -137,7 +138,7 @@ const StatusSummary = memo(function StatusSummary({
 	statusCounts,
 }: {
 	statusCounts: Record<string, number>;
-}): React.JSX.Element {
+}): JSX.Element {
 	return (
 		<div className="mb-4 flex divide-x divide-kumo-fill overflow-hidden rounded-lg border border-kumo-fill bg-kumo-base">
 			{STATUS_SUMMARY_CONFIG.map(
@@ -200,7 +201,7 @@ const InstanceRow = memo(function InstanceRow({
 	instance: WorkflowsInstance;
 	onActionComplete: () => void;
 	workflowName: string;
-}): React.JSX.Element {
+}): JSX.Element {
 	const navigate = useNavigate();
 	const [actionInProgress, setActionInProgress] = useState<Action | null>(null);
 	const [deleteDialogOpen, setDeleteDialogOpen] = useState<boolean>(false);

--- a/packages/local-explorer-ui/src/types/studio.ts
+++ b/packages/local-explorer-ui/src/types/studio.ts
@@ -1,4 +1,5 @@
 import type { Icon } from "@phosphor-icons/react";
+import type { JSX } from "react";
 
 export interface IStudioConnection {
 	batch?(statements: string[]): Promise<StudioResultSet[]>; // Optimize for connection that support batch
@@ -134,7 +135,7 @@ export abstract class IStudioDriver {
 	abstract getQueryTabOverride(
 		statement: string,
 		result: StudioResultSet
-	): { label: string; icon: Icon; component: React.JSX.Element } | null;
+	): { label: string; icon: Icon; component: JSX.Element } | null;
 }
 
 export type StudioColumnConflict =

--- a/packages/local-explorer-ui/src/types/studio.ts
+++ b/packages/local-explorer-ui/src/types/studio.ts
@@ -134,7 +134,7 @@ export abstract class IStudioDriver {
 	abstract getQueryTabOverride(
 		statement: string,
 		result: StudioResultSet
-	): { label: string; icon: Icon; component: JSX.Element } | null;
+	): { label: string; icon: Icon; component: React.JSX.Element } | null;
 }
 
 export type StudioColumnConflict =


### PR DESCRIPTION
This PR enabled the `@typescript-eslint/no-deprecated` linting rule for the `local-explorer-ui` package

Followup for https://github.com/cloudflare/workers-sdk/pull/14472, https://github.com/cloudflare/workers-sdk/pull/14491, https://github.com/cloudflare/workers-sdk/pull/14509, https://github.com/cloudflare/workers-sdk/pull/14522 and https://github.com/cloudflare/workers-sdk/pull/14579

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: internal refactoring

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14625" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->