### PR TITLE
Fix D1 schema editor tab not tracking unsaved changes

### DIFF
--- a/.changeset/fix-schema-editor-dirty-state.md
+++ b/.changeset/fix-schema-editor-dirty-state.md
@@ -5,3 +5,5 @@
 Fix D1 schema editor tab not tracking unsaved changes
 
 The schema editor tab (edit table / create table) now correctly marks the tab as dirty when there are unsaved schema changes. This shows the unsaved changes indicator on the tab, triggers the browser's leave guard when navigating away, and prompts for confirmation when closing the tab.
+
+Additionally, column and constraint deletions now properly mark the schema as dirty. Previously, removing a column or constraint would filter the entry out of the state array entirely, causing the dirty-state check to miss the change.

--- a/.changeset/fix-schema-editor-dirty-state.md
+++ b/.changeset/fix-schema-editor-dirty-state.md
@@ -1,0 +1,7 @@
+---
+"@cloudflare/local-explorer-ui": patch
+---
+
+Fix D1 schema editor tab not tracking unsaved changes
+
+The schema editor tab (edit table / create table) now correctly marks the tab as dirty when there are unsaved schema changes. This shows the unsaved changes indicator on the tab, triggers the browser's leave guard when navigating away, and prompts for confirmation when closing the tab.

--- a/packages/local-explorer-ui/src/components/studio/Table/SchemaEditor/Column.tsx
+++ b/packages/local-explorer-ui/src/components/studio/Table/SchemaEditor/Column.tsx
@@ -81,9 +81,15 @@ export function StudioColumnSchemaEditor({
 							);
 
 						if (pkConstraint.new.primaryColumns.length === 0) {
-							draft.constraints = draft.constraints.filter(
-								(c) => c.key !== pkConstraint?.key
-							);
+							if (pkConstraint.old) {
+								// Mark existing constraint as deleted so dirty-state detection picks it up
+								pkConstraint.new = null;
+							} else {
+								// Newly added constraint — remove it entirely since it was never persisted
+								draft.constraints = draft.constraints.filter(
+									(c) => c.key !== pkConstraint?.key
+								);
+							}
 						}
 					}
 					return;
@@ -162,7 +168,18 @@ export function StudioColumnSchemaEditor({
 	const handleRemoveColumn = useCallback((): void => {
 		onChange((prev) =>
 			produce(prev, (draft) => {
-				draft.columns = draft.columns.filter((c) => c.key !== column?.key);
+				const target = draft.columns.find((c) => c.key === column?.key);
+				if (!target) {
+					return;
+				}
+
+				if (target.old) {
+					// Mark existing column as deleted so dirty-state detection picks it up
+					target.new = null;
+				} else {
+					// Newly added column — remove it entirely since it was never persisted
+					draft.columns = draft.columns.filter((c) => c.key !== column?.key);
+				}
 			})
 		);
 	}, [onChange, column]);

--- a/packages/local-explorer-ui/src/components/studio/Table/SchemaEditor/ConstraintListEditor.tsx
+++ b/packages/local-explorer-ui/src/components/studio/Table/SchemaEditor/ConstraintListEditor.tsx
@@ -22,7 +22,9 @@ export function StudioConstraintListEditor({
 	onChange,
 	value,
 }: StudioConstraintListEditorProps): JSX.Element | null {
-	if (value.constraints.length === 0) {
+	const visibleConstraints = value.constraints.filter((c) => c.new !== null);
+
+	if (visibleConstraints.length === 0) {
 		return null;
 	}
 
@@ -41,9 +43,9 @@ export function StudioConstraintListEditor({
 				</thead>
 
 				<tbody>
-					{(value.constraints ?? []).map(
+					{visibleConstraints.map(
 						(constraintChange, constriantIndex): JSX.Element | null => {
-							const constraint = constraintChange.new || constraintChange.old;
+							const constraint = constraintChange.new;
 							if (!constraint) {
 								return null;
 							}

--- a/packages/local-explorer-ui/src/components/studio/Table/SchemaEditor/index.tsx
+++ b/packages/local-explorer-ui/src/components/studio/Table/SchemaEditor/index.tsx
@@ -3,7 +3,7 @@ import { SplitPane } from "@cloudflare/workers-editor-shared";
 import { KeyIcon } from "@phosphor-icons/react";
 import { produce } from "immer";
 import { useCallback, useEffect, useMemo, useRef } from "react";
-import { isEqual } from "../../../../utils/is-equal";
+import { getIsSchemaDirty } from "../../../../utils/studio";
 import { useModal } from "../../Modal";
 import { StudioCommitConfirmation } from "../../Modal/CommitConfirmation";
 import { StudioSQLEditor } from "../../SQLEditor";
@@ -53,10 +53,7 @@ export function StudioTableSchemaEditor({
 	);
 
 	const isSchemaDirty = useMemo(
-		(): boolean =>
-			value.name.new !== value.name.old ||
-			value.columns.some((change) => !isEqual(change.new, change.old)) ||
-			value.constraints.some((change) => !isEqual(change.new, change.old)),
+		(): boolean => getIsSchemaDirty(value),
 		[value]
 	);
 

--- a/packages/local-explorer-ui/src/components/studio/Tabs/CreateUpdateTable.tsx
+++ b/packages/local-explorer-ui/src/components/studio/Tabs/CreateUpdateTable.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { isEqual } from "../../../utils/is-equal";
+import { getIsSchemaDirty } from "../../../utils/studio";
 import { useStudioContext } from "../Context";
 import { SkeletonBlock } from "../SkeletonBlock";
 import { StudioTableSchemaEditor } from "../Table/SchemaEditor";
@@ -43,10 +43,7 @@ export function StudioCreateUpdateTableTab({
 	const isCreateMode = !value.name.old;
 
 	const isSchemaDirty = useMemo(
-		(): boolean =>
-			value.name.new !== value.name.old ||
-			value.columns.some((change) => !isEqual(change.new, change.old)) ||
-			value.constraints.some((change) => !isEqual(change.new, change.old)),
+		(): boolean => getIsSchemaDirty(value),
 		[value]
 	);
 

--- a/packages/local-explorer-ui/src/components/studio/Tabs/CreateUpdateTable.tsx
+++ b/packages/local-explorer-ui/src/components/studio/Tabs/CreateUpdateTable.tsx
@@ -1,4 +1,5 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { isEqual } from "../../../utils/is-equal";
 import { useStudioContext } from "../Context";
 import { SkeletonBlock } from "../SkeletonBlock";
 import { StudioTableSchemaEditor } from "../Table/SchemaEditor";
@@ -20,7 +21,11 @@ export function StudioCreateUpdateTableTab({
 	tableName,
 }: StudioEditTableTabProps): JSX.Element {
 	const { driver, refreshSchema, replaceStudioTab } = useStudioContext();
-	const { identifier: tabIdentifier } = useStudioCurrentWindowTab();
+	const {
+		identifier: tabIdentifier,
+		setDirtyState,
+		setBeforeTabClosingHandler,
+	} = useStudioCurrentWindowTab();
 
 	const [loading, setLoading] = useState<boolean>(!!schemaName && !!tableName);
 	const [value, setValue] = useState<StudioTableSchemaChange>({
@@ -36,6 +41,32 @@ export function StudioCreateUpdateTableTab({
 
 	// Determines if the editor is in create mode (no previous table name)
 	const isCreateMode = !value.name.old;
+
+	const isSchemaDirty = useMemo(
+		(): boolean =>
+			value.name.new !== value.name.old ||
+			value.columns.some((change) => !isEqual(change.new, change.old)) ||
+			value.constraints.some((change) => !isEqual(change.new, change.old)),
+		[value]
+	);
+
+	// Mark the current tab as dirty if there are unsaved schema changes
+	useEffect((): void => {
+		setDirtyState(isSchemaDirty);
+	}, [setDirtyState, isSchemaDirty]);
+
+	// Prompt the user before closing the tab if there are unsaved changes
+	useEffect((): void => {
+		setBeforeTabClosingHandler((currentTab) => {
+			if (currentTab.isDirty) {
+				return confirm(
+					"You have unsaved changes. Do you want to close without saving?"
+				);
+			}
+
+			return true;
+		});
+	}, [setBeforeTabClosingHandler]);
 
 	useEffect((): void => {
 		async function updateValue(): Promise<void> {

--- a/packages/local-explorer-ui/src/utils/studio/index.ts
+++ b/packages/local-explorer-ui/src/utils/studio/index.ts
@@ -1,3 +1,4 @@
+import { isEqual } from "../is-equal";
 import { formatSqlError, getStudioTableNameFromSQL } from "./formatter";
 import type {
 	IStudioDriver,
@@ -5,7 +6,25 @@ import type {
 	StudioMultipleQueryResult,
 	StudioResultHeader,
 	StudioResultSet,
+	StudioTableSchemaChange,
 } from "../../types/studio";
+
+/**
+ * Determines whether a table schema change contains any unsaved modifications.
+ *
+ * Checks if the table name, any column, or any constraint differs between its
+ * current (`new`) and original (`old`) state.
+ *
+ * @param value - The schema change object to inspect.
+ * @returns `true` if the schema has been modified, `false` otherwise.
+ */
+export function getIsSchemaDirty(value: StudioTableSchemaChange): boolean {
+	return (
+		value.name.new !== value.name.old ||
+		value.columns.some((change) => !isEqual(change.new, change.old)) ||
+		value.constraints.some((change) => !isEqual(change.new, change.old))
+	);
+}
 
 function escapeSqlString(str: string): string {
 	return `'${str.replace(/'/g, `''`)}'`;


### PR DESCRIPTION
I noticed that the D1 schema editor tab (edit table / create table) doesn't get marked as dirty when there are unsaved schema changes. This PR fixes this issue.

Before:
https://github.com/user-attachments/assets/aee1aa40-3b2c-4bd6-aa0c-3f7f3455d998

After:
https://github.com/user-attachments/assets/7cf16c87-2f72-4e81-9803-9fdf3b18176d



---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [x] Automated tests not possible - manual testing has been completed as follows:
     - I've create a worker with a local KV binding and a D1 as well
     - run `wrangler dev` and  (as shown in the videos above)
        - gone to the local explorer 
        - made changes to a D1 table schema
        - noticed that before the tab is not marked as dirty and it is after
        - (note: as far as I can tell this feature is not e2e tested not even for the other tabs)
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bugfix

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14629" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->