### PR TITLE
add deprecation script

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
 		"test:e2e:c3": "dotenv -- node -r esbuild-register packages/create-cloudflare/scripts/e2e/run-tests.ts",
 		"test:e2e:wrangler": "dotenv -- node -r esbuild-register tools/e2e/runIndividualE2EFiles.ts",
 		"test:watch": "turbo test:watch",
-		"type:tests": "dotenv -- turbo type:tests"
+		"type:tests": "dotenv -- turbo type:tests",
+		"deprecate-packages": "node -r esbuild-register tools/deployments/deprecate.ts"
 	},
 	"dependencies": {
 		"@changesets/changelog-github": "^0.5.0",

--- a/tools/deployments/__tests__/deprecate.test.ts
+++ b/tools/deployments/__tests__/deprecate.test.ts
@@ -1,10 +1,11 @@
-import { execSync } from "node:child_process";
+import { execSync, spawnSync } from "node:child_process";
 import { describe, it, vitest } from "vitest";
 import {
 	buildCommands,
 	buildDependantsGraph,
 	checkNpmLogin,
 	getRequiredDependants,
+	main,
 	parseArgs,
 	resolveVersion,
 } from "../deprecate";
@@ -470,5 +471,45 @@ describe("checkNpmLogin()", () => {
 			throw new Error("ENEEDAUTH");
 		});
 		expect(checkNpmLogin()).toBeNull();
+	});
+});
+
+describe("main()", () => {
+	const mockRegistryInfo = {
+		"dist-tags": { latest: "2.0.0" },
+		time: {
+			created: "2024-01-01T00:00:00.000Z",
+			modified: "2025-01-02T00:00:00.000Z",
+			"1.0.0": "2025-01-01T10:00:00.000Z",
+			"2.0.0": "2025-01-02T10:00:00.000Z",
+		},
+		versions: {
+			"1.0.0": {},
+			"2.0.0": {},
+		},
+	};
+
+	it("should not call execSync or spawnSync in dry-run mode", async ({
+		expect,
+	}) => {
+		(execSync as Mock).mockClear();
+		(spawnSync as Mock).mockClear();
+		vitest.spyOn(console, "log").mockImplementation(() => {});
+		vitest.spyOn(globalThis, "fetch").mockResolvedValue(
+			new Response(JSON.stringify(mockRegistryInfo), {
+				status: 200,
+				headers: { "Content-Type": "application/json" },
+			})
+		);
+
+		await main([
+			"--dry-run",
+			"--reason",
+			"test regression",
+			"create-cloudflare@latest",
+		]);
+
+		expect(execSync).not.toHaveBeenCalled();
+		expect(spawnSync).not.toHaveBeenCalled();
 	});
 });

--- a/tools/deployments/__tests__/deprecate.test.ts
+++ b/tools/deployments/__tests__/deprecate.test.ts
@@ -295,15 +295,38 @@ describe("buildCommands()", () => {
 			},
 		];
 		const commands = buildCommands(resolved, "Regression in X");
-		expect(commands).toEqual([
-			"npm dist-tag add wrangler@4.107.1 latest",
-			"npm dist-tag add @cloudflare/vite-plugin@1.43.1 latest",
-			'npm deprecate wrangler@4.108.0 "Regression in X. Downgrade to 4.107.1"',
-			'npm deprecate @cloudflare/vite-plugin@1.43.2 "Regression in X. Downgrade to 1.43.1"',
+		expect(commands.map((c) => c.args)).toEqual([
+			["dist-tag", "add", "wrangler@4.107.1", "latest"],
+			["dist-tag", "add", "@cloudflare/vite-plugin@1.43.1", "latest"],
+			[
+				"deprecate",
+				"wrangler@4.108.0",
+				"Regression in X. Downgrade to 4.107.1",
+			],
+			[
+				"deprecate",
+				"@cloudflare/vite-plugin@1.43.2",
+				"Regression in X. Downgrade to 1.43.1",
+			],
 		]);
 	});
 
-	it("should include the reason and downgrade version in deprecation message", ({
+	it("should produce display strings for logging", ({ expect }) => {
+		const resolved = [
+			{
+				name: "wrangler",
+				badVersion: "4.108.0",
+				goodVersion: "4.107.1",
+			},
+		];
+		const commands = buildCommands(resolved, "Regression in X");
+		expect(commands.map((c) => c.display)).toEqual([
+			"npm dist-tag add wrangler@4.107.1 latest",
+			'npm deprecate wrangler@4.108.0 "Regression in X. Downgrade to 4.107.1"',
+		]);
+	});
+
+	it("should include the reason and downgrade version in deprecation args", ({
 		expect,
 	}) => {
 		const resolved = [
@@ -314,9 +337,11 @@ describe("buildCommands()", () => {
 			},
 		];
 		const commands = buildCommands(resolved, "Scheduled handlers broken");
-		expect(commands[1]).toBe(
-			'npm deprecate miniflare@4.20260706.0 "Scheduled handlers broken. Downgrade to 4.20260702.0"'
-		);
+		expect(commands[1].args).toEqual([
+			"deprecate",
+			"miniflare@4.20260706.0",
+			"Scheduled handlers broken. Downgrade to 4.20260702.0",
+		]);
 	});
 });
 

--- a/tools/deployments/__tests__/deprecate.test.ts
+++ b/tools/deployments/__tests__/deprecate.test.ts
@@ -1,0 +1,449 @@
+import { execSync } from "node:child_process";
+import { describe, it, vitest } from "vitest";
+import {
+	buildCommands,
+	buildDependantsGraph,
+	checkNpmLogin,
+	getRequiredDependants,
+	parseArgs,
+	resolveVersion,
+} from "../deprecate";
+import type { Mock } from "vitest";
+
+vitest.mock("node:child_process", async () => {
+	return {
+		execSync: vitest.fn(),
+		spawnSync: vitest.fn(),
+	};
+});
+
+describe("buildDependantsGraph()", () => {
+	it("should build the graph from local package.json files", ({ expect }) => {
+		const graph = buildDependantsGraph();
+
+		// Core packages must be present
+		expect(graph).toHaveProperty("miniflare");
+		expect(graph).toHaveProperty("wrangler");
+		expect(graph).toHaveProperty("@cloudflare/vite-plugin");
+		expect(graph).toHaveProperty("@cloudflare/vitest-pool-workers");
+		expect(graph).toHaveProperty("create-cloudflare");
+
+		expect(graph["miniflare"]).toContain("wrangler");
+		expect(graph["miniflare"]).toContain("@cloudflare/vitest-pool-workers");
+		expect(graph["miniflare"]).toContain("@cloudflare/vite-plugin");
+
+		expect(graph["wrangler"]).toContain("@cloudflare/vite-plugin");
+		expect(graph["wrangler"]).toContain("@cloudflare/vitest-pool-workers");
+		expect(graph["wrangler"]).not.toContain("miniflare");
+
+		// Private packages should not be in the graph
+		expect(graph).not.toHaveProperty("@cloudflare/workers-shared");
+		expect(graph).not.toHaveProperty("@cloudflare/containers-shared");
+	});
+});
+
+// A fixed graph for unit-testing getRequiredDependants in isolation
+const TEST_GRAPH: Record<string, string[]> = {
+	miniflare: ["wrangler", "pkg-a", "pkg-b"],
+	wrangler: ["pkg-a", "pkg-b"],
+	"pkg-a": [],
+	"pkg-b": [],
+	"pkg-c": [],
+};
+
+describe("getRequiredDependants()", () => {
+	it("should return missing dependants when deprecating miniflare alone", ({
+		expect,
+	}) => {
+		expect(getRequiredDependants(["miniflare"], TEST_GRAPH)).toEqual([
+			"wrangler",
+			"pkg-a",
+			"pkg-b",
+		]);
+	});
+
+	it("should return missing dependants when deprecating wrangler alone", ({
+		expect,
+	}) => {
+		expect(getRequiredDependants(["wrangler"], TEST_GRAPH)).toEqual([
+			"pkg-a",
+			"pkg-b",
+		]);
+	});
+
+	it("should return empty when wrangler + all dependants are provided", ({
+		expect,
+	}) => {
+		expect(
+			getRequiredDependants(["wrangler", "pkg-a", "pkg-b"], TEST_GRAPH)
+		).toEqual([]);
+	});
+
+	it("should return empty when miniflare + all dependants are provided", ({
+		expect,
+	}) => {
+		expect(
+			getRequiredDependants(
+				["miniflare", "wrangler", "pkg-a", "pkg-b"],
+				TEST_GRAPH
+			)
+		).toEqual([]);
+	});
+
+	it("should return empty for a leaf package alone", ({ expect }) => {
+		expect(getRequiredDependants(["pkg-c"], TEST_GRAPH)).toEqual([]);
+	});
+
+	it("should not duplicate missing dependants when multiple packages share them", ({
+		expect,
+	}) => {
+		expect(
+			getRequiredDependants(["miniflare", "wrangler"], TEST_GRAPH)
+		).toEqual(["pkg-a", "pkg-b"]);
+	});
+
+	it("should throw for an unknown package", ({ expect }) => {
+		expect(() => getRequiredDependants(["unknown-pkg"], TEST_GRAPH)).toThrow(
+			/"unknown-pkg" is not a known package/
+		);
+	});
+});
+
+describe("resolveVersion()", () => {
+	const registryInfo = {
+		"dist-tags": { latest: "4.108.0" },
+		time: {
+			created: "2024-01-01T00:00:00.000Z",
+			modified: "2025-07-06T00:00:00.000Z",
+			"4.106.0": "2025-06-25T10:00:00.000Z",
+			"4.107.0": "2025-07-01T10:00:00.000Z",
+			"4.107.1": "2025-07-02T10:00:00.000Z",
+			"4.108.0": "2025-07-06T10:00:00.000Z",
+		},
+		versions: {
+			"4.106.0": {},
+			"4.107.0": {},
+			"4.107.1": {},
+			"4.108.0": {},
+		},
+	};
+
+	it("should resolve a concrete version and find the previous one", async ({
+		expect,
+	}) => {
+		const result = await resolveVersion(
+			{ name: "wrangler", version: "4.108.0" },
+			registryInfo
+		);
+		expect(result).toEqual({
+			name: "wrangler",
+			badVersion: "4.108.0",
+			goodVersion: "4.107.1",
+		});
+	});
+
+	it("should resolve 'latest' to the concrete version", async ({ expect }) => {
+		const result = await resolveVersion(
+			{ name: "wrangler", version: "latest" },
+			registryInfo
+		);
+		expect(result).toEqual({
+			name: "wrangler",
+			badVersion: "4.108.0",
+			goodVersion: "4.107.1",
+		});
+	});
+
+	it("should find the correct previous version when it's not the latest", async ({
+		expect,
+	}) => {
+		const result = await resolveVersion(
+			{ name: "wrangler", version: "4.107.1" },
+			registryInfo
+		);
+		expect(result).toEqual({
+			name: "wrangler",
+			badVersion: "4.107.1",
+			goodVersion: "4.107.0",
+		});
+	});
+
+	it("should throw when the version does not exist on npm", async ({
+		expect,
+	}) => {
+		await expect(
+			resolveVersion({ name: "wrangler", version: "9.99.99" }, registryInfo)
+		).rejects.toThrow(/Version 9.99.99 not found on npm for wrangler/);
+	});
+
+	it("should throw when there is no previous version", async ({ expect }) => {
+		const singleVersionInfo = {
+			"dist-tags": { latest: "1.0.0" },
+			time: {
+				created: "2024-01-01T00:00:00.000Z",
+				modified: "2024-01-01T00:00:00.000Z",
+				"1.0.0": "2024-01-01T12:00:00.000Z",
+			},
+			versions: { "1.0.0": {} },
+		};
+		await expect(
+			resolveVersion({ name: "wrangler", version: "1.0.0" }, singleVersionInfo)
+		).rejects.toThrow(/No previous version found/);
+	});
+
+	it("should use the rollback version override when provided", async ({
+		expect,
+	}) => {
+		const result = await resolveVersion(
+			{ name: "wrangler", version: "4.108.0", rollbackVersion: "4.106.0" },
+			registryInfo
+		);
+		expect(result).toEqual({
+			name: "wrangler",
+			badVersion: "4.108.0",
+			goodVersion: "4.106.0",
+		});
+	});
+
+	it("should throw when the rollback version override does not exist on npm", async ({
+		expect,
+	}) => {
+		await expect(
+			resolveVersion(
+				{ name: "wrangler", version: "4.108.0", rollbackVersion: "9.0.0" },
+				registryInfo
+			)
+		).rejects.toThrow(/Rollback version 9.0.0 not found on npm for wrangler/);
+	});
+
+	it("should throw when latest dist-tag is missing", async ({ expect }) => {
+		const noLatest = {
+			"dist-tags": {},
+			time: { created: "2024-01-01T00:00:00.000Z" },
+			versions: {},
+		};
+		await expect(
+			resolveVersion({ name: "wrangler", version: "latest" }, noLatest)
+		).rejects.toThrow(/No "latest" dist-tag found/);
+	});
+
+	it("should throw when the auto-resolved rollback version is deprecated", async ({
+		expect,
+	}) => {
+		const infoWithDeprecated = {
+			"dist-tags": { latest: "4.108.0" },
+			time: {
+				created: "2024-01-01T00:00:00.000Z",
+				modified: "2025-07-06T00:00:00.000Z",
+				"4.107.1": "2025-07-02T10:00:00.000Z",
+				"4.108.0": "2025-07-06T10:00:00.000Z",
+			},
+			versions: {
+				"4.107.1": { deprecated: "Known issue. Downgrade to 4.107.0" },
+				"4.108.0": {},
+			},
+		};
+		await expect(
+			resolveVersion(
+				{ name: "wrangler", version: "4.108.0" },
+				infoWithDeprecated
+			)
+		).rejects.toThrow(
+			/Rollback version wrangler@4.107.1 is already deprecated/
+		);
+	});
+
+	it("should throw when the user-provided rollback version is deprecated", async ({
+		expect,
+	}) => {
+		const infoWithDeprecated = {
+			...registryInfo,
+			versions: {
+				...registryInfo.versions,
+				"4.106.0": { deprecated: "Old version" },
+			},
+		};
+		await expect(
+			resolveVersion(
+				{
+					name: "wrangler",
+					version: "4.108.0",
+					rollbackVersion: "4.106.0",
+				},
+				infoWithDeprecated
+			)
+		).rejects.toThrow(
+			/Rollback version wrangler@4.106.0 is already deprecated/
+		);
+	});
+});
+
+describe("buildCommands()", () => {
+	it("should generate dist-tag commands before deprecate commands", ({
+		expect,
+	}) => {
+		const resolved = [
+			{
+				name: "wrangler",
+				badVersion: "4.108.0",
+				goodVersion: "4.107.1",
+			},
+			{
+				name: "@cloudflare/vite-plugin",
+				badVersion: "1.43.2",
+				goodVersion: "1.43.1",
+			},
+		];
+		const commands = buildCommands(resolved, "Regression in X");
+		expect(commands).toEqual([
+			"npm dist-tag add wrangler@4.107.1 latest",
+			"npm dist-tag add @cloudflare/vite-plugin@1.43.1 latest",
+			'npm deprecate wrangler@4.108.0 "Regression in X. Downgrade to 4.107.1"',
+			'npm deprecate @cloudflare/vite-plugin@1.43.2 "Regression in X. Downgrade to 1.43.1"',
+		]);
+	});
+
+	it("should include the reason and downgrade version in deprecation message", ({
+		expect,
+	}) => {
+		const resolved = [
+			{
+				name: "miniflare",
+				badVersion: "4.20260706.0",
+				goodVersion: "4.20260702.0",
+			},
+		];
+		const commands = buildCommands(resolved, "Scheduled handlers broken");
+		expect(commands[1]).toBe(
+			'npm deprecate miniflare@4.20260706.0 "Scheduled handlers broken. Downgrade to 4.20260702.0"'
+		);
+	});
+});
+
+describe("parseArgs()", () => {
+	it("should parse a single package with reason", ({ expect }) => {
+		const result = parseArgs(["--reason", "Bug in deploy", "wrangler@4.108.0"]);
+		expect(result).toEqual({
+			packages: [{ name: "wrangler", version: "4.108.0" }],
+			reason: "Bug in deploy",
+			dryRun: false,
+		});
+	});
+
+	it("should parse multiple packages", ({ expect }) => {
+		const result = parseArgs([
+			"--reason",
+			"Regression",
+			"wrangler@4.108.0",
+			"@cloudflare/vite-plugin@1.43.2",
+		]);
+		expect(result.packages).toEqual([
+			{ name: "wrangler", version: "4.108.0" },
+			{ name: "@cloudflare/vite-plugin", version: "1.43.2" },
+		]);
+	});
+
+	it("should handle scoped packages with latest", ({ expect }) => {
+		const result = parseArgs([
+			"--reason",
+			"Test",
+			"@cloudflare/vite-plugin@latest",
+		]);
+		expect(result.packages).toEqual([
+			{ name: "@cloudflare/vite-plugin", version: "latest" },
+		]);
+	});
+
+	it("should parse --dry-run flag", ({ expect }) => {
+		const result = parseArgs([
+			"--reason",
+			"Bug",
+			"--dry-run",
+			"wrangler@latest",
+		]);
+		expect(result.dryRun).toBe(true);
+	});
+
+	it("should parse rollback version override with arrow syntax", ({
+		expect,
+	}) => {
+		const result = parseArgs(["--reason", "Bug", "wrangler@4.108.0>4.106.0"]);
+		expect(result.packages).toEqual([
+			{
+				name: "wrangler",
+				version: "4.108.0",
+				rollbackVersion: "4.106.0",
+			},
+		]);
+	});
+
+	it("should parse scoped package with rollback version override", ({
+		expect,
+	}) => {
+		const result = parseArgs([
+			"--reason",
+			"Bug",
+			"@cloudflare/vite-plugin@1.43.2>1.42.0",
+		]);
+		expect(result.packages).toEqual([
+			{
+				name: "@cloudflare/vite-plugin",
+				version: "1.43.2",
+				rollbackVersion: "1.42.0",
+			},
+		]);
+	});
+
+	it("should throw for malformed arrow syntax with missing parts", ({
+		expect,
+	}) => {
+		expect(() => parseArgs(["--reason", "Bug", "wrangler@4.108.0>"])).toThrow(
+			/Invalid package specifier/
+		);
+		expect(() => parseArgs(["--reason", "Bug", "wrangler@>4.106.0"])).toThrow(
+			/Invalid package specifier/
+		);
+	});
+
+	it("should throw when --reason is missing", ({ expect }) => {
+		expect(() => parseArgs(["wrangler@4.108.0"])).toThrow(
+			/--reason is required/
+		);
+	});
+
+	it("should throw when --reason has no value", ({ expect }) => {
+		expect(() => parseArgs(["--reason"])).toThrow(/--reason requires a value/);
+	});
+
+	it("should throw when no packages are provided", ({ expect }) => {
+		expect(() => parseArgs(["--reason", "Bug"])).toThrow(
+			/No packages specified/
+		);
+	});
+
+	it("should throw for malformed package specifiers", ({ expect }) => {
+		expect(() => parseArgs(["--reason", "Bug", "wrangler"])).toThrow(
+			/Invalid package specifier/
+		);
+	});
+
+	it("should throw for unknown flags", ({ expect }) => {
+		expect(() =>
+			parseArgs(["--reason", "Bug", "--unknown", "wrangler@1.0.0"])
+		).toThrow(/Unknown flag: --unknown/);
+	});
+});
+
+describe("checkNpmLogin()", () => {
+	it("should return the username when logged in", ({ expect }) => {
+		(execSync as Mock).mockReturnValueOnce("wrangler-publisher\n");
+		expect(checkNpmLogin()).toBe("wrangler-publisher");
+	});
+
+	it("should return null when not logged in", ({ expect }) => {
+		(execSync as Mock).mockImplementationOnce(() => {
+			throw new Error("ENEEDAUTH");
+		});
+		expect(checkNpmLogin()).toBeNull();
+	});
+});

--- a/tools/deployments/deprecate.ts
+++ b/tools/deployments/deprecate.ts
@@ -187,38 +187,51 @@ export async function resolveVersion(
 	return { name, badVersion, goodVersion };
 }
 
+export interface NpmCommand {
+	args: string[];
+	display: string;
+}
+
 /**
- * Builds the list of npm CLI commands to execute.
+ * Builds the list of npm commands to execute.
  * dist-tag commands come first (to stop users getting the bad version),
  * then deprecation commands.
  */
 export function buildCommands(
 	resolved: ResolvedPackage[],
 	reason: string
-): string[] {
-	const commands: string[] = [];
+): NpmCommand[] {
+	const commands: NpmCommand[] = [];
 
 	for (const { name, goodVersion } of resolved) {
-		commands.push(`npm dist-tag add ${name}@${goodVersion} latest`);
+		commands.push({
+			args: ["dist-tag", "add", `${name}@${goodVersion}`, "latest"],
+			display: `npm dist-tag add ${name}@${goodVersion} latest`,
+		});
 	}
 
 	for (const { name, badVersion, goodVersion } of resolved) {
-		commands.push(
-			`npm deprecate ${name}@${badVersion} "${reason}. Downgrade to ${goodVersion}"`
-		);
+		const message = `${reason}. Downgrade to ${goodVersion}`;
+		commands.push({
+			args: ["deprecate", `${name}@${badVersion}`, message],
+			display: `npm deprecate ${name}@${badVersion} "${message}"`,
+		});
 	}
 
 	return commands;
 }
 
 /**
- * Executes a list of npm CLI commands sequentially.
+ * Executes a list of npm commands sequentially via spawnSync.
  * Aborts on the first failure.
  */
-export function executeCommands(commands: string[]): void {
-	for (const cmd of commands) {
-		console.log(`  $ ${cmd}`);
-		execSync(cmd, { stdio: "inherit" });
+export function executeCommands(commands: NpmCommand[]): void {
+	for (const { args, display } of commands) {
+		console.log(`  $ ${display}`);
+		const result = spawnSync("npm", args, { stdio: "inherit" });
+		if (result.status !== 0) {
+			throw new Error(`Command failed: npm ${args.join(" ")}`);
+		}
 	}
 }
 
@@ -448,7 +461,7 @@ export async function main(argv: string[] = process.argv.slice(2)) {
 
 	console.log("\nCommands to execute:");
 	for (let i = 0; i < commands.length; i++) {
-		console.log(`  ${i + 1}. ${commands[i]}`);
+		console.log(`  ${i + 1}. ${commands[i].display}`);
 	}
 
 	if (dryRun) {

--- a/tools/deployments/deprecate.ts
+++ b/tools/deployments/deprecate.ts
@@ -1,0 +1,477 @@
+import { execSync, spawnSync } from "node:child_process";
+import { readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { createInterface } from "node:readline";
+
+/**
+ * Reads packages/.../package.json to build a dependants graph for all
+ * non-private packages. For each package, lists which other non-private
+ * packages depend on it (via workspace: references in dependencies or
+ * peerDependencies).
+ */
+export function buildDependantsGraph(
+	packagesDir: string = path.resolve(__dirname, "../../packages")
+): Record<string, string[]> {
+	const packageDirs = readdirSync(packagesDir, { withFileTypes: true })
+		.filter((d) => d.isDirectory())
+		.map((d) => path.resolve(packagesDir, d.name));
+
+	// Collect all non-private packages
+	const packages: { name: string; deps: string[] }[] = [];
+	const knownNames = new Set<string>();
+
+	for (const dir of packageDirs) {
+		let pkg: {
+			name?: string;
+			private?: boolean;
+			dependencies?: Record<string, string>;
+			peerDependencies?: Record<string, string>;
+		};
+		try {
+			pkg = JSON.parse(
+				readFileSync(path.resolve(dir, "package.json"), "utf-8")
+			);
+		} catch {
+			continue;
+		}
+		if (pkg.private || !pkg.name) {
+			continue;
+		}
+		knownNames.add(pkg.name);
+
+		const allDeps = {
+			...pkg.dependencies,
+			...pkg.peerDependencies,
+		};
+		const workspaceDeps = Object.entries(allDeps)
+			.filter(([, v]) => v.startsWith("workspace:"))
+			.map(([k]) => k);
+
+		packages.push({ name: pkg.name, deps: workspaceDeps });
+	}
+
+	// Build the dependants graph: for each package, which known packages depend on it
+	const dependants: Record<string, string[]> = {};
+	for (const name of knownNames) {
+		dependants[name] = [];
+	}
+	for (const { name, deps } of packages) {
+		for (const dep of deps) {
+			if (dep in dependants) {
+				dependants[dep].push(name);
+			}
+		}
+	}
+
+	return dependants;
+}
+
+export interface PackageSpec {
+	name: string;
+	version: string;
+	rollbackVersion?: string;
+}
+
+export interface ResolvedPackage {
+	name: string;
+	badVersion: string;
+	goodVersion: string;
+}
+
+interface NpmRegistryResponse {
+	"dist-tags": Record<string, string>;
+	time: Record<string, string>;
+	versions: Record<string, { deprecated?: string }>;
+}
+
+/**
+ * Given a list of package names the user wants to deprecate,
+ * returns any dependants from the graph that are missing.
+ */
+export function getRequiredDependants(
+	packageNames: string[],
+	graph: Record<string, string[]>
+): string[] {
+	const knownPackages = Object.keys(graph);
+	const provided = new Set(packageNames);
+	const missing: string[] = [];
+
+	for (const name of packageNames) {
+		if (!(name in graph)) {
+			throw new Error(
+				`"${name}" is not a known package. Known packages:\n  ${knownPackages.join(", ")}`
+			);
+		}
+		for (const dep of graph[name]) {
+			if (!provided.has(dep) && !missing.includes(dep)) {
+				missing.push(dep);
+			}
+		}
+	}
+
+	return missing;
+}
+
+/**
+ * Fetches package metadata from the npm registry.
+ */
+export async function fetchRegistryInfo(
+	name: string
+): Promise<NpmRegistryResponse> {
+	const url = `https://registry.npmjs.org/${name}`;
+	const res = await fetch(url, {
+		headers: { Accept: "application/json" },
+	});
+	if (!res.ok) {
+		throw new Error(`Failed to fetch ${url}: ${res.status} ${res.statusText}`);
+	}
+	return (await res.json()) as NpmRegistryResponse;
+}
+
+/**
+ * Resolves a package spec (which may use "latest" as the version) to
+ * concrete bad and good (rollback) versions using the npm registry.
+ */
+export async function resolveVersion(
+	spec: PackageSpec,
+	registryInfo: NpmRegistryResponse
+): Promise<ResolvedPackage> {
+	const { name } = spec;
+	let badVersion = spec.version;
+
+	if (badVersion === "latest") {
+		const latest = registryInfo["dist-tags"]?.latest;
+		if (!latest) {
+			throw new Error(`No "latest" dist-tag found for ${name}`);
+		}
+		badVersion = latest;
+	}
+
+	const { time } = registryInfo;
+	if (!time[badVersion]) {
+		throw new Error(`Version ${badVersion} not found on npm for ${name}`);
+	}
+
+	let goodVersion: string;
+
+	if (spec.rollbackVersion) {
+		if (!time[spec.rollbackVersion]) {
+			throw new Error(
+				`Rollback version ${spec.rollbackVersion} not found on npm for ${name}`
+			);
+		}
+		goodVersion = spec.rollbackVersion;
+	} else {
+		// Sort versions by publish time to find the one immediately before the bad version.
+		// Exclude "created" and "modified" metadata keys.
+		const versions = Object.entries(time)
+			.filter(([v]) => v !== "created" && v !== "modified")
+			.sort(([, a], [, b]) => new Date(a).getTime() - new Date(b).getTime());
+
+		const badIndex = versions.findIndex(([v]) => v === badVersion);
+		if (badIndex <= 0) {
+			throw new Error(
+				`No previous version found for ${name}@${badVersion} to roll back to`
+			);
+		}
+		goodVersion = versions[badIndex - 1][0];
+	}
+
+	const versionInfo = registryInfo.versions[goodVersion];
+	if (versionInfo?.deprecated) {
+		throw new Error(
+			`Rollback version ${name}@${goodVersion} is already deprecated: "${versionInfo.deprecated}"`
+		);
+	}
+
+	return { name, badVersion, goodVersion };
+}
+
+/**
+ * Builds the list of npm CLI commands to execute.
+ * dist-tag commands come first (to stop users getting the bad version),
+ * then deprecation commands.
+ */
+export function buildCommands(
+	resolved: ResolvedPackage[],
+	reason: string
+): string[] {
+	const commands: string[] = [];
+
+	for (const { name, goodVersion } of resolved) {
+		commands.push(`npm dist-tag add ${name}@${goodVersion} latest`);
+	}
+
+	for (const { name, badVersion, goodVersion } of resolved) {
+		commands.push(
+			`npm deprecate ${name}@${badVersion} "${reason}. Downgrade to ${goodVersion}"`
+		);
+	}
+
+	return commands;
+}
+
+/**
+ * Executes a list of npm CLI commands sequentially.
+ * Aborts on the first failure.
+ */
+export function executeCommands(commands: string[]): void {
+	for (const cmd of commands) {
+		console.log(`  $ ${cmd}`);
+		execSync(cmd, { stdio: "inherit" });
+	}
+}
+
+/**
+ * Runs `npm login` interactively so the user can authenticate.
+ */
+export function npmLogin(): void {
+	console.log("Opening npm login...\n");
+	const result = spawnSync("npm", ["login"], { stdio: "inherit" });
+	if (result.status !== 0) {
+		throw new Error("npm login failed");
+	}
+	console.log();
+}
+
+/**
+ * Checks whether the user is logged in to npm.
+ * Returns the username, or null if not logged in.
+ */
+export function checkNpmLogin(): string | null {
+	try {
+		return execSync("npm whoami", { encoding: "utf-8" }).trim();
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Prompts the user for y/n confirmation.
+ */
+export async function confirm(message: string): Promise<boolean> {
+	const rl = createInterface({
+		input: process.stdin,
+		output: process.stdout,
+	});
+
+	return new Promise((resolve) => {
+		rl.question(`${message} (y/n) `, (answer) => {
+			rl.close();
+			resolve(answer.trim().toLowerCase() === "y");
+		});
+	});
+}
+
+/**
+ * Parses CLI arguments.
+ */
+export function parseArgs(argv: string[]): {
+	packages: PackageSpec[];
+	reason: string;
+	dryRun: boolean;
+} {
+	const packages: PackageSpec[] = [];
+	let reason = "";
+	let dryRun = false;
+
+	let i = 0;
+	while (i < argv.length) {
+		const arg = argv[i];
+		if (arg === "--reason") {
+			i++;
+			if (i >= argv.length) {
+				throw new Error("--reason requires a value");
+			}
+			reason = argv[i];
+		} else if (arg === "--dry-run") {
+			dryRun = true;
+		} else if (arg.startsWith("--")) {
+			throw new Error(`Unknown flag: ${arg}`);
+		} else {
+			const atIndex = arg.lastIndexOf("@");
+			if (atIndex <= 0) {
+				throw new Error(
+					`Invalid package specifier: "${arg}". Expected format: <package>@<version>[>rollback-version]`
+				);
+			}
+			const name = arg.slice(0, atIndex);
+			const versionPart = arg.slice(atIndex + 1);
+			if (!versionPart) {
+				throw new Error(
+					`Invalid package specifier: "${arg}". Expected format: <package>@<version>[>rollback-version]`
+				);
+			}
+			const arrowIndex = versionPart.indexOf(">");
+			if (arrowIndex !== -1) {
+				const version = versionPart.slice(0, arrowIndex);
+				const rollbackVersion = versionPart.slice(arrowIndex + 1);
+				if (!version || !rollbackVersion) {
+					throw new Error(
+						`Invalid package specifier: "${arg}". Expected format: <package>@<version>><rollback-version>`
+					);
+				}
+				packages.push({ name, version, rollbackVersion });
+			} else {
+				packages.push({ name, version: versionPart });
+			}
+		}
+		i++;
+	}
+
+	if (packages.length === 0) {
+		throw new Error(
+			'No packages specified.\n\nUsage: pnpm deprecate-packages --reason "..." <package>@<version>[>rollback] [...]'
+		);
+	}
+
+	if (!reason) {
+		throw new Error("--reason is required");
+	}
+
+	return { packages, reason, dryRun };
+}
+
+const HELP = `
+Deprecate and roll back bad npm releases for workers-sdk packages.
+
+Usage:
+  pnpm deprecate-packages --reason "..." <pkg>@<version> [<pkg>@<version> ...]
+
+Version can be "latest" to resolve the current latest tag on npm.
+Append ">version" to override the rollback target (default: previous version).
+
+Options:
+  --reason "..."   Required. Deprecation message shown to users.
+  --dry-run        Print what would happen without executing or logging in.
+  --help           Show this help.
+
+Examples:
+  pnpm deprecate-packages --reason "Deploy regression" \\
+    wrangler@latest \\
+    @cloudflare/vite-plugin@latest \\
+    @cloudflare/vitest-pool-workers@latest
+
+  pnpm deprecate-packages --reason "Broken scheduled handlers" \\
+    miniflare@4.20260706.0 \\
+    wrangler@4.108.0>4.106.0 \\
+    @cloudflare/vite-plugin@1.43.2 \\
+    @cloudflare/vitest-pool-workers@0.18.2
+
+Dependency rules are derived from local package.json files and enforced automatically.
+For example, deprecating wrangler also requires deprecating @cloudflare/vite-plugin
+and @cloudflare/vitest-pool-workers because they depend on it.
+`.trim();
+
+export async function main(argv: string[] = process.argv.slice(2)) {
+	if (argv.includes("--help") || argv.includes("-h")) {
+		console.log(HELP);
+		return;
+	}
+
+	const { packages, reason, dryRun } = parseArgs(argv);
+
+	const graph = buildDependantsGraph();
+	const knownPackages = Object.keys(graph);
+
+	// Validate all packages are known
+	for (const { name } of packages) {
+		if (!(name in graph)) {
+			console.error(
+				`Error: "${name}" is not a known package. Known packages:\n  ${knownPackages.join(", ")}`
+			);
+			process.exit(1);
+		}
+	}
+
+	// Validate the dependency graph is satisfied
+	const packageNames = packages.map((p) => p.name);
+	const missing = getRequiredDependants(packageNames, graph);
+	if (missing.length > 0) {
+		const sources = packageNames
+			.filter((name) => graph[name].some((d) => missing.includes(d)))
+			.join(", ");
+		console.error(
+			`Error: Deprecating ${sources} requires also deprecating:\n  ${missing.map((m) => `- ${m}`).join("\n  ")}\n\nRe-run with versions for all affected packages.`
+		);
+		process.exit(1);
+	}
+
+	if (!dryRun) {
+		// npm login
+		const existingUser = checkNpmLogin();
+		if (existingUser) {
+			console.log(`Already logged in to npm as ${existingUser}\n`);
+		} else {
+			npmLogin();
+		}
+	}
+
+	// Resolve versions from npm registry
+	console.log("Resolving versions...");
+	const resolved: ResolvedPackage[] = [];
+	for (const spec of packages) {
+		const info = await fetchRegistryInfo(spec.name);
+		const result = await resolveVersion(spec, info);
+		if (spec.version === "latest") {
+			console.log(`  ${spec.name}@latest → ${spec.name}@${result.badVersion}`);
+		}
+		resolved.push(result);
+	}
+
+	// Display summary table
+	const nameWidth = Math.max(
+		...resolved.map((r) => r.name.length),
+		"Package".length
+	);
+	const badWidth = Math.max(
+		...resolved.map((r) => r.badVersion.length),
+		"Deprecate".length
+	);
+	const goodWidth = Math.max(
+		...resolved.map((r) => r.goodVersion.length),
+		"Rollback To".length
+	);
+
+	console.log();
+	console.log(
+		`  ${"Package".padEnd(nameWidth)}  ${"Deprecate".padEnd(badWidth)}  ${"Rollback To".padEnd(goodWidth)}`
+	);
+	for (const { name, badVersion, goodVersion } of resolved) {
+		console.log(
+			`  ${name.padEnd(nameWidth)}  ${badVersion.padEnd(badWidth)}  ${goodVersion.padEnd(goodWidth)}`
+		);
+	}
+
+	// Build and display commands
+	const commands = buildCommands(resolved, reason);
+
+	console.log("\nCommands to execute:");
+	for (let i = 0; i < commands.length; i++) {
+		console.log(`  ${i + 1}. ${commands[i]}`);
+	}
+
+	if (dryRun) {
+		console.log("\n--dry-run specified, not executing.");
+		return;
+	}
+
+	// Confirm and execute
+	console.log();
+	const proceed = await confirm("Proceed?");
+	if (!proceed) {
+		console.log("Aborted.");
+		return;
+	}
+
+	console.log("\nExecuting...\n");
+	executeCommands(commands);
+	console.log("\nDone.");
+}
+
+if (require.main === module) {
+	main().catch((err) => {
+		console.error(`Error: ${err.message}`);
+		process.exit(1);
+	});
+}


### PR DESCRIPTION
mini cli to deprecate multiple packages in lock step.

Examples:
```
  pnpm deprecate-packages --reason "Deploy regression" \
    wrangler@latest \
    @cloudflare/vite-plugin@latest \
    @cloudflare/vitest-pool-workers@latest

  pnpm deprecate-packages --reason "Broken scheduled handlers" \
    miniflare@4.20260706.0 \
    wrangler@4.108.0>4.106.0 \
    @cloudflare/vite-plugin@1.43.2 \
    @cloudflare/vitest-pool-workers@0.18.2
```
Dependency rules (enforced automatically):
  miniflare    -> must also deprecate wrangler, vite-plugin, vitest-pool-workers
  wrangler     -> must also deprecate vite-plugin, vitest-pool-workers


1. runs npm login, opening up the browser for the user to auth to our publisher account
2. validates that we're deprecating all dependencies (ie if deprecating wrangler, vite and vitest must be included)
3. resolves tags (e.g. 'latest'), finds the last 'good' version if not provided
4. prints commands it is going to run - `npm dist-tag add <package>@<good-version> latest` on the good version, `npm deprecate <package>@<bad-version> <reason>`
5. asks for user confirmation
6. executes commands

you can also test this manually with --dry-run

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: internal tool

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
