### PR TITLE
[wrangler] Add Flagship auto-provisioning

### DIFF
--- a/.changeset/blue-pandas-care.md
+++ b/.changeset/blue-pandas-care.md
@@ -1,0 +1,7 @@
+---
+"wrangler": minor
+---
+
+Add automatic provisioning for draft Flagship bindings
+
+Wrangler can now deploy a `flagship` binding that only specifies `binding`, matching the automatic provisioning flow already available for other draft bindings. On first deploy, Wrangler can inherit an existing app, connect an existing Flagship app, or create a new one and write the resulting `app_id` back to your config.

--- a/.changeset/blue-pandas-care.md
+++ b/.changeset/blue-pandas-care.md
@@ -1,5 +1,8 @@
 ---
 "wrangler": minor
+"miniflare": minor
+"@cloudflare/workers-utils": minor
+"@cloudflare/deploy-helpers": minor
 ---
 
 Add automatic provisioning for draft Flagship bindings

--- a/packages/deploy-helpers/src/deploy/helpers/create-worker-upload-form.ts
+++ b/packages/deploy-helpers/src/deploy/helpers/create-worker-upload-form.ts
@@ -433,16 +433,27 @@ export function createWorkerUploadForm(
 	});
 
 	flagship.forEach(({ binding, app_id }) => {
-		if (app_id === undefined) {
+		let appId: string | typeof INHERIT_SYMBOL | undefined = app_id;
+		if (options?.dryRun) {
+			appId ??= INHERIT_SYMBOL;
+		}
+		if (appId === undefined) {
 			throw new UserError(`${binding} bindings must have an "app_id" field`, {
 				telemetryMessage: "flagship binding missing app_id",
 			});
 		}
-		metadataBindings.push({
-			name: binding,
-			type: "flagship",
-			app_id,
-		});
+		if (appId === INHERIT_SYMBOL) {
+			metadataBindings.push({
+				name: binding,
+				type: "inherit",
+			});
+		} else {
+			metadataBindings.push({
+				name: binding,
+				type: "flagship",
+				app_id: appId,
+			});
+		}
 	});
 
 	ratelimits.forEach(({ name, namespace_id, simple }) => {

--- a/packages/deploy-helpers/src/deploy/helpers/create-worker-upload-form.ts
+++ b/packages/deploy-helpers/src/deploy/helpers/create-worker-upload-form.ts
@@ -433,6 +433,11 @@ export function createWorkerUploadForm(
 	});
 
 	flagship.forEach(({ binding, app_id }) => {
+		if (app_id === undefined) {
+			throw new UserError(`${binding} bindings must have an "app_id" field`, {
+				telemetryMessage: "flagship binding missing app_id",
+			});
+		}
 		metadataBindings.push({
 			name: binding,
 			type: "flagship",

--- a/packages/deploy-helpers/src/deploy/helpers/provision-bindings.ts
+++ b/packages/deploy-helpers/src/deploy/helpers/provision-bindings.ts
@@ -520,10 +520,10 @@ class FlagshipAppHandler extends ProvisionResourceHandler<
 
 	canInherit(settings: Settings | undefined): boolean {
 		const existing = settings?.bindings.find(
-			(existing) =>
-				existing.type === this.type &&
-				existing.name === this.bindingName &&
-				(this.binding.app_id ? this.binding.app_id === existing.app_id : true)
+			(candidate) =>
+				candidate.type === this.type &&
+				candidate.name === this.bindingName &&
+				(this.binding.app_id ? this.binding.app_id === candidate.app_id : true)
 		) as Extract<WorkerMetadataBinding, { type: "flagship" }> | undefined;
 		if (existing) {
 			this.inheritedAppId = existing.app_id;

--- a/packages/deploy-helpers/src/deploy/helpers/provision-bindings.ts
+++ b/packages/deploy-helpers/src/deploy/helpers/provision-bindings.ts
@@ -861,14 +861,6 @@ export async function provisionBindings(
 			configPath,
 			"Provisioning resources is not possible without a config file"
 		);
-		if (useServiceEnvironments(config)) {
-			throw new UserError(
-				"Provisioning resources is not supported with a service environment",
-				{
-					telemetryMessage: "provision resources with service environment",
-				}
-			);
-		}
 		logger.log();
 
 		printBindings(

--- a/packages/deploy-helpers/src/deploy/helpers/provision-bindings.ts
+++ b/packages/deploy-helpers/src/deploy/helpers/provision-bindings.ts
@@ -8,13 +8,20 @@ import {
 	PatchConfigError,
 	UserError,
 } from "@cloudflare/workers-utils";
-import { fetchResult, logger, prompt, select } from "../../shared/context";
+import {
+	fetchPagedListResult,
+	fetchResult,
+	logger,
+	prompt,
+	select,
+} from "../../shared/context";
 import { printBindings } from "./print-bindings";
 import type {
 	Binding,
 	CfAgentMemory,
 	CfAISearchNamespace,
 	CfD1Database,
+	CfFlagship,
 	CfKvNamespace,
 	CfR2Bucket,
 	ComplianceConfig,
@@ -60,6 +67,11 @@ type AgentMemoryNamespace = {
 	account_id: string;
 	created_at: string;
 	updated_at: string;
+};
+
+type FlagshipApp = {
+	id: string;
+	name: string;
 };
 
 type KVNamespaceInfo = {
@@ -471,12 +483,75 @@ class D1Handler extends ProvisionResourceHandler<
 	}
 }
 
+class FlagshipAppHandler extends ProvisionResourceHandler<
+	"flagship",
+	Extract<Binding, { type: "flagship" }>
+> {
+	private inheritedAppId: string | undefined;
+
+	get name(): string | undefined {
+		return undefined;
+	}
+
+	async create(name: string) {
+		const app = await createFlagshipApp(
+			this.complianceConfig,
+			this.accountId,
+			name
+		);
+		return app.id;
+	}
+
+	constructor(
+		bindingName: string,
+		binding: Extract<Binding, { type: "flagship" }>,
+		complianceConfig: ComplianceConfig,
+		accountId: string
+	) {
+		super(
+			"flagship",
+			bindingName,
+			binding,
+			"app_id",
+			complianceConfig,
+			accountId
+		);
+	}
+
+	canInherit(settings: Settings | undefined): boolean {
+		const existing = settings?.bindings.find(
+			(existing) =>
+				existing.type === this.type &&
+				existing.name === this.bindingName &&
+				(this.binding.app_id ? this.binding.app_id === existing.app_id : true)
+		) as Extract<WorkerMetadataBinding, { type: "flagship" }> | undefined;
+		if (existing) {
+			this.inheritedAppId = existing.app_id;
+			return true;
+		}
+		return false;
+	}
+
+	override inherit(): void {
+		if (this.inheritedAppId) {
+			this.connect(this.inheritedAppId);
+			return;
+		}
+		super.inherit();
+	}
+
+	isFullySpecified(): boolean {
+		return !!this.binding.app_id;
+	}
+}
+
 type ProvisionableBinding =
 	| Extract<Binding, { type: "kv_namespace" }>
 	| Extract<Binding, { type: "d1" }>
 	| Extract<Binding, { type: "r2_bucket" }>
 	| Extract<Binding, { type: "ai_search_namespace" }>
-	| Extract<Binding, { type: "agent_memory" }>;
+	| Extract<Binding, { type: "agent_memory" }>
+	| Extract<Binding, { type: "flagship" }>;
 
 const HANDLERS = {
 	kv_namespace: {
@@ -605,6 +680,27 @@ const HANDLERS = {
 			};
 		},
 	},
+	flagship: {
+		Handler: FlagshipAppHandler,
+		sort: 5,
+		name: "Flagship App",
+		keyDescription: "name or id",
+		configField: "flagship" as const,
+		load: async (complianceConfig: ComplianceConfig, accountId: string) => {
+			const apps = await listFlagshipApps(complianceConfig, accountId);
+			return apps.map((app) => ({ title: app.name, value: app.id }));
+		},
+		toConfig: (
+			bindingName: string,
+			binding: Extract<Binding, { type: "flagship" }>
+		): CfFlagship => {
+			const { type: _, ...rest } = binding;
+			return {
+				...rest,
+				binding: bindingName,
+			};
+		},
+	},
 };
 
 type PendingResource = {
@@ -614,13 +710,15 @@ type PendingResource = {
 		| "d1"
 		| "r2_bucket"
 		| "ai_search_namespace"
-		| "agent_memory";
+		| "agent_memory"
+		| "flagship";
 	handler:
 		| KVHandler
 		| D1Handler
 		| R2Handler
 		| AISearchNamespaceHandler
-		| AgentMemoryNamespaceHandler;
+		| AgentMemoryNamespaceHandler
+		| FlagshipAppHandler;
 };
 
 function isProvisionableBinding(
@@ -639,7 +737,8 @@ function createHandler(
 	| D1Handler
 	| R2Handler
 	| AISearchNamespaceHandler
-	| AgentMemoryNamespaceHandler {
+	| AgentMemoryNamespaceHandler
+	| FlagshipAppHandler {
 	switch (binding.type) {
 		case "kv_namespace":
 			return new KVHandler(bindingName, binding, complianceConfig, accountId);
@@ -661,6 +760,13 @@ function createHandler(
 				complianceConfig,
 				accountId
 			);
+		case "flagship":
+			return new FlagshipAppHandler(
+				bindingName,
+				binding,
+				complianceConfig,
+				accountId
+			);
 	}
 }
 
@@ -672,7 +778,8 @@ function toConfigBinding(
 	| CfR2Bucket
 	| CfD1Database
 	| CfAISearchNamespace
-	| CfAgentMemory {
+	| CfAgentMemory
+	| CfFlagship {
 	switch (binding.type) {
 		case "kv_namespace":
 			return HANDLERS.kv_namespace.toConfig(bindingName, binding);
@@ -684,6 +791,8 @@ function toConfigBinding(
 			return HANDLERS.ai_search_namespace.toConfig(bindingName, binding);
 		case "agent_memory":
 			return HANDLERS.agent_memory.toConfig(bindingName, binding);
+		case "flagship":
+			return HANDLERS.flagship.toConfig(bindingName, binding);
 	}
 }
 
@@ -752,7 +861,14 @@ export async function provisionBindings(
 			configPath,
 			"Provisioning resources is not possible without a config file"
 		);
-
+		if (useServiceEnvironments(config)) {
+			throw new UserError(
+				"Provisioning resources is not supported with a service environment",
+				{
+					telemetryMessage: "provision resources with service environment",
+				}
+			);
+		}
 		logger.log();
 
 		printBindings(
@@ -1279,6 +1395,32 @@ async function createAgentMemoryNamespace(
 			method: "POST",
 			headers: { "Content-Type": "application/json" },
 			body: JSON.stringify({ name: namespaceName }),
+		}
+	);
+}
+
+async function listFlagshipApps(
+	complianceConfig: ComplianceConfig,
+	accountId: string
+): Promise<FlagshipApp[]> {
+	return await fetchPagedListResult<FlagshipApp>(
+		complianceConfig,
+		`/accounts/${accountId}/flagship/apps`
+	);
+}
+
+async function createFlagshipApp(
+	complianceConfig: ComplianceConfig,
+	accountId: string,
+	name: string
+): Promise<FlagshipApp> {
+	return await fetchResult<FlagshipApp>(
+		complianceConfig,
+		`/accounts/${accountId}/flagship/apps`,
+		{
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ name }),
 		}
 	);
 }

--- a/packages/miniflare/src/plugins/flagship/index.ts
+++ b/packages/miniflare/src/plugins/flagship/index.ts
@@ -8,7 +8,7 @@ import type { Worker_Binding } from "../../runtime";
 import type { Plugin, RemoteProxyConnectionString } from "../shared";
 
 const FlagshipSchema = z.object({
-	app_id: z.string().optional(),
+	app_id: z.string(),
 	remoteProxyConnectionString: z
 		.custom<RemoteProxyConnectionString>()
 		.optional(),

--- a/packages/miniflare/src/plugins/flagship/index.ts
+++ b/packages/miniflare/src/plugins/flagship/index.ts
@@ -1,17 +1,11 @@
 import { z } from "zod";
-import {
-	getUserBindingServiceName,
-	ProxyNodeBinding,
-	remoteProxyClientWorker,
-} from "../shared";
+import { getUserBindingServiceName, ProxyNodeBinding, remoteProxyClientWorker } from "../shared";
 import type { Worker_Binding } from "../../runtime";
 import type { Plugin, RemoteProxyConnectionString } from "../shared";
 
 const FlagshipSchema = z.object({
-	app_id: z.string(),
-	remoteProxyConnectionString: z
-		.custom<RemoteProxyConnectionString>()
-		.optional(),
+	app_id: z.string().optional(),
+	remoteProxyConnectionString: z.custom<RemoteProxyConnectionString>().optional(),
 });
 
 export const FlagshipOptionsSchema = z.object({
@@ -28,28 +22,23 @@ export const FLAGSHIP_PLUGIN: Plugin<typeof FlagshipOptionsSchema> = {
 			return [];
 		}
 
-		return Object.entries(options.flagship).map<Worker_Binding>(
-			([name, config]) => ({
-				name,
-				service: {
-					name: getUserBindingServiceName(
-						FLAGSHIP_PLUGIN_NAME,
-						name,
-						config.remoteProxyConnectionString
-					),
-				},
-			})
-		);
+		return Object.entries(options.flagship).map<Worker_Binding>(([name, config]) => ({
+			name,
+			service: {
+				name: getUserBindingServiceName(
+					FLAGSHIP_PLUGIN_NAME,
+					name,
+					config.remoteProxyConnectionString,
+				),
+			},
+		}));
 	},
 	getNodeBindings(options: z.infer<typeof FlagshipOptionsSchema>) {
 		if (!options.flagship) {
 			return {};
 		}
 		return Object.fromEntries(
-			Object.keys(options.flagship).map((name) => [
-				name,
-				new ProxyNodeBinding(),
-			])
+			Object.keys(options.flagship).map((name) => [name, new ProxyNodeBinding()]),
 		);
 	},
 	async getServices({ options }) {
@@ -57,17 +46,11 @@ export const FLAGSHIP_PLUGIN: Plugin<typeof FlagshipOptionsSchema> = {
 			return [];
 		}
 
-		return Object.entries(options.flagship).map(
-			([name, { remoteProxyConnectionString }]) => {
-				return {
-					name: getUserBindingServiceName(
-						FLAGSHIP_PLUGIN_NAME,
-						name,
-						remoteProxyConnectionString
-					),
-					worker: remoteProxyClientWorker(remoteProxyConnectionString, name),
-				};
-			}
-		);
+		return Object.entries(options.flagship).map(([name, { remoteProxyConnectionString }]) => {
+			return {
+				name: getUserBindingServiceName(FLAGSHIP_PLUGIN_NAME, name, remoteProxyConnectionString),
+				worker: remoteProxyClientWorker(remoteProxyConnectionString, name),
+			};
+		});
 	},
 };

--- a/packages/miniflare/src/plugins/flagship/index.ts
+++ b/packages/miniflare/src/plugins/flagship/index.ts
@@ -1,11 +1,17 @@
 import { z } from "zod";
-import { getUserBindingServiceName, ProxyNodeBinding, remoteProxyClientWorker } from "../shared";
+import {
+	getUserBindingServiceName,
+	ProxyNodeBinding,
+	remoteProxyClientWorker,
+} from "../shared";
 import type { Worker_Binding } from "../../runtime";
 import type { Plugin, RemoteProxyConnectionString } from "../shared";
 
 const FlagshipSchema = z.object({
 	app_id: z.string().optional(),
-	remoteProxyConnectionString: z.custom<RemoteProxyConnectionString>().optional(),
+	remoteProxyConnectionString: z
+		.custom<RemoteProxyConnectionString>()
+		.optional(),
 });
 
 export const FlagshipOptionsSchema = z.object({
@@ -22,23 +28,28 @@ export const FLAGSHIP_PLUGIN: Plugin<typeof FlagshipOptionsSchema> = {
 			return [];
 		}
 
-		return Object.entries(options.flagship).map<Worker_Binding>(([name, config]) => ({
-			name,
-			service: {
-				name: getUserBindingServiceName(
-					FLAGSHIP_PLUGIN_NAME,
-					name,
-					config.remoteProxyConnectionString,
-				),
-			},
-		}));
+		return Object.entries(options.flagship).map<Worker_Binding>(
+			([name, config]) => ({
+				name,
+				service: {
+					name: getUserBindingServiceName(
+						FLAGSHIP_PLUGIN_NAME,
+						name,
+						config.remoteProxyConnectionString
+					),
+				},
+			})
+		);
 	},
 	getNodeBindings(options: z.infer<typeof FlagshipOptionsSchema>) {
 		if (!options.flagship) {
 			return {};
 		}
 		return Object.fromEntries(
-			Object.keys(options.flagship).map((name) => [name, new ProxyNodeBinding()]),
+			Object.keys(options.flagship).map((name) => [
+				name,
+				new ProxyNodeBinding(),
+			])
 		);
 	},
 	async getServices({ options }) {
@@ -46,11 +57,17 @@ export const FLAGSHIP_PLUGIN: Plugin<typeof FlagshipOptionsSchema> = {
 			return [];
 		}
 
-		return Object.entries(options.flagship).map(([name, { remoteProxyConnectionString }]) => {
-			return {
-				name: getUserBindingServiceName(FLAGSHIP_PLUGIN_NAME, name, remoteProxyConnectionString),
-				worker: remoteProxyClientWorker(remoteProxyConnectionString, name),
-			};
-		});
+		return Object.entries(options.flagship).map(
+			([name, { remoteProxyConnectionString }]) => {
+				return {
+					name: getUserBindingServiceName(
+						FLAGSHIP_PLUGIN_NAME,
+						name,
+						remoteProxyConnectionString
+					),
+					worker: remoteProxyClientWorker(remoteProxyConnectionString, name),
+				};
+			}
+		);
 	},
 };

--- a/packages/miniflare/test/plugins/flagship/index.spec.ts
+++ b/packages/miniflare/test/plugins/flagship/index.spec.ts
@@ -12,9 +12,7 @@ test("FlagshipOptionsSchema: accepts valid flagship options", ({ expect }) => {
 	expect(result.success).toBe(true);
 });
 
-test("FlagshipOptionsSchema: accepts flagship with remoteProxyConnectionString", ({
-	expect,
-}) => {
+test("FlagshipOptionsSchema: accepts flagship with remoteProxyConnectionString", ({ expect }) => {
 	const result = FlagshipOptionsSchema.safeParse({
 		flagship: {
 			FLAGS: {
@@ -28,5 +26,14 @@ test("FlagshipOptionsSchema: accepts flagship with remoteProxyConnectionString",
 
 test("FlagshipOptionsSchema: accepts empty flagship", ({ expect }) => {
 	const result = FlagshipOptionsSchema.safeParse({});
+	expect(result.success).toBe(true);
+});
+
+test("FlagshipOptionsSchema: accepts a draft flagship binding without app_id", ({ expect }) => {
+	const result = FlagshipOptionsSchema.safeParse({
+		flagship: {
+			FLAGS: {},
+		},
+	});
 	expect(result.success).toBe(true);
 });

--- a/packages/miniflare/test/plugins/flagship/index.spec.ts
+++ b/packages/miniflare/test/plugins/flagship/index.spec.ts
@@ -12,7 +12,9 @@ test("FlagshipOptionsSchema: accepts valid flagship options", ({ expect }) => {
 	expect(result.success).toBe(true);
 });
 
-test("FlagshipOptionsSchema: accepts flagship with remoteProxyConnectionString", ({ expect }) => {
+test("FlagshipOptionsSchema: accepts flagship with remoteProxyConnectionString", ({
+	expect,
+}) => {
 	const result = FlagshipOptionsSchema.safeParse({
 		flagship: {
 			FLAGS: {
@@ -29,7 +31,9 @@ test("FlagshipOptionsSchema: accepts empty flagship", ({ expect }) => {
 	expect(result.success).toBe(true);
 });
 
-test("FlagshipOptionsSchema: accepts a draft flagship binding without app_id", ({ expect }) => {
+test("FlagshipOptionsSchema: accepts a draft flagship binding without app_id", ({
+	expect,
+}) => {
 	const result = FlagshipOptionsSchema.safeParse({
 		flagship: {
 			FLAGS: {},

--- a/packages/miniflare/test/plugins/flagship/index.spec.ts
+++ b/packages/miniflare/test/plugins/flagship/index.spec.ts
@@ -31,7 +31,7 @@ test("FlagshipOptionsSchema: accepts empty flagship", ({ expect }) => {
 	expect(result.success).toBe(true);
 });
 
-test("FlagshipOptionsSchema: accepts a draft flagship binding without app_id", ({
+test("FlagshipOptionsSchema: rejects a flagship binding without app_id", ({
 	expect,
 }) => {
 	const result = FlagshipOptionsSchema.safeParse({
@@ -39,5 +39,5 @@ test("FlagshipOptionsSchema: accepts a draft flagship binding without app_id", (
 			FLAGS: {},
 		},
 	});
-	expect(result.success).toBe(true);
+	expect(result.success).toBe(false);
 });

--- a/packages/workers-utils/src/config/environment.ts
+++ b/packages/workers-utils/src/config/environment.ts
@@ -1562,8 +1562,11 @@ export interface EnvironmentNonInheritable {
 		/** The binding name used to refer to the bound Flagship service. */
 		binding: string;
 
-		/** The Flagship app ID to bind to. */
-		app_id: string;
+		/**
+		 * The Flagship app ID to bind to.
+		 * When omitted, `wrangler deploy` can auto-provision a new Flagship app.
+		 */
+		app_id?: string;
 
 		/** Set to `true` to suppress the remote binding warning in local dev. Flagship bindings are always remote. */
 		remote?: boolean;

--- a/packages/workers-utils/src/config/validation.ts
+++ b/packages/workers-utils/src/config/validation.ts
@@ -5248,9 +5248,9 @@ const validateFlagshipBinding: ValidatorFn = (diagnostics, field, value) => {
 		);
 		isValid = false;
 	}
-	if (!isRequiredProperty(value, "app_id", "string")) {
+	if (!isOptionalProperty(value, "app_id", "string")) {
 		diagnostics.errors.push(
-			`"${field}" bindings must have a string "app_id" field but got ${JSON.stringify(
+			`"${field}" bindings must have a string "app_id" field when provided, but got ${JSON.stringify(
 				value
 			)}.`
 		);

--- a/packages/workers-utils/src/worker.ts
+++ b/packages/workers-utils/src/worker.ts
@@ -1,4 +1,9 @@
-import type { CacheOptions, Exports, Observability, Route } from "./config/environment";
+import type {
+	CacheOptions,
+	Exports,
+	Observability,
+	Route,
+} from "./config/environment";
 import type { INHERIT_SYMBOL } from "./constants";
 import type { Json, WorkerMetadata } from "./types";
 import type { AssetConfig, RouterConfig } from "@cloudflare/workers-shared";

--- a/packages/workers-utils/src/worker.ts
+++ b/packages/workers-utils/src/worker.ts
@@ -1,9 +1,4 @@
-import type {
-	CacheOptions,
-	Exports,
-	Observability,
-	Route,
-} from "./config/environment";
+import type { CacheOptions, Exports, Observability, Route } from "./config/environment";
 import type { INHERIT_SYMBOL } from "./constants";
 import type { Json, WorkerMetadata } from "./types";
 import type { AssetConfig, RouterConfig } from "@cloudflare/workers-shared";
@@ -279,7 +274,7 @@ export interface CfHelloWorld {
 
 export interface CfFlagship {
 	binding: string;
-	app_id: string;
+	app_id?: string;
 	remote?: boolean;
 }
 

--- a/packages/workers-utils/tests/config/validation/normalize-and-validate-config.test.ts
+++ b/packages/workers-utils/tests/config/validation/normalize-and-validate-config.test.ts
@@ -5967,6 +5967,9 @@ describe("normalizeAndValidateConfig()", () => {
 					{
 						flagship: [
 							{
+								binding: "DRAFT_FLAGS",
+							},
+							{
 								binding: "FLAGS",
 								app_id: "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
 							},
@@ -5988,9 +5991,9 @@ describe("normalizeAndValidateConfig()", () => {
 							// @ts-expect-error purposely using an invalid value
 							{},
 							// @ts-expect-error purposely using an invalid value
-							{ binding: "VALID" },
-							// @ts-expect-error purposely using an invalid value
 							{ binding: 2000, app_id: 2111 },
+							// @ts-expect-error purposely using an invalid value
+							{ binding: "BAD_APP", app_id: 2111 },
 							{
 								binding: "BINDING_2",
 								app_id: "valid-app-id",
@@ -6006,10 +6009,9 @@ describe("normalizeAndValidateConfig()", () => {
 				expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
 					"Processing wrangler configuration:
 					  - "flagship[0]" bindings must have a string "binding" field but got {}.
-					  - "flagship[0]" bindings must have a string "app_id" field but got {}.
-					  - "flagship[1]" bindings must have a string "app_id" field but got {"binding":"VALID"}.
-					  - "flagship[2]" bindings must have a string "binding" field but got {"binding":2000,"app_id":2111}.
-					  - "flagship[2]" bindings must have a string "app_id" field but got {"binding":2000,"app_id":2111}."
+					  - "flagship[1]" bindings must have a string "binding" field but got {"binding":2000,"app_id":2111}.
+					  - "flagship[1]" bindings must have a string "app_id" field when provided, but got {"binding":2000,"app_id":2111}.
+					  - "flagship[2]" bindings must have a string "app_id" field when provided, but got {"binding":"BAD_APP","app_id":2111}."
 				`);
 			});
 

--- a/packages/wrangler/src/__tests__/create-worker-upload-form/bindings.test.ts
+++ b/packages/wrangler/src/__tests__/create-worker-upload-form/bindings.test.ts
@@ -480,7 +480,7 @@ describe("createWorkerUploadForm — bindings", () => {
 			expect,
 		}) => {
 			const bindings: StartDevWorkerInput["bindings"] = {
-				FLAGS: { type: "flagship", app_id: INHERIT_SYMBOL },
+				FLAGS: { type: "flagship", app_id: INHERIT_SYMBOL } as never,
 			};
 			const form = createWorkerUploadForm(createEsmWorker(), bindings);
 			expect(getBindings(form)).toContainEqual({

--- a/packages/wrangler/src/__tests__/create-worker-upload-form/bindings.test.ts
+++ b/packages/wrangler/src/__tests__/create-worker-upload-form/bindings.test.ts
@@ -434,6 +434,62 @@ describe("createWorkerUploadForm — bindings", () => {
 		});
 	});
 
+	describe("flagship bindings", () => {
+		it("should include flagship binding with app_id", ({ expect }) => {
+			const bindings: StartDevWorkerInput["bindings"] = {
+				FLAGS: {
+					type: "flagship",
+					app_id: "flagship-app-id",
+				},
+			};
+			const form = createWorkerUploadForm(createEsmWorker(), bindings);
+			expect(getBindings(form)).toContainEqual({
+				name: "FLAGS",
+				type: "flagship",
+				app_id: "flagship-app-id",
+			});
+		});
+
+		it("should throw when flagship has no app_id and not in dry run", ({
+			expect,
+		}) => {
+			const bindings: StartDevWorkerInput["bindings"] = {
+				FLAGS: { type: "flagship" } as never,
+			};
+			expect(() => createWorkerUploadForm(createEsmWorker(), bindings)).toThrow(
+				'FLAGS bindings must have an "app_id" field'
+			);
+		});
+
+		it("should convert flagship to inherit binding during dry run when app_id is missing", ({
+			expect,
+		}) => {
+			const bindings: StartDevWorkerInput["bindings"] = {
+				FLAGS: { type: "flagship" } as never,
+			};
+			const form = createWorkerUploadForm(createEsmWorker(), bindings, {
+				dryRun: true,
+			});
+			expect(getBindings(form)).toContainEqual({
+				name: "FLAGS",
+				type: "inherit",
+			});
+		});
+
+		it("should convert flagship with INHERIT_SYMBOL to inherit binding", ({
+			expect,
+		}) => {
+			const bindings: StartDevWorkerInput["bindings"] = {
+				FLAGS: { type: "flagship", app_id: INHERIT_SYMBOL },
+			};
+			const form = createWorkerUploadForm(createEsmWorker(), bindings);
+			expect(getBindings(form)).toContainEqual({
+				name: "FLAGS",
+				type: "inherit",
+			});
+		});
+	});
+
 	describe("singleton bindings", () => {
 		it.for([
 			{ bindingName: "BROWSER", type: "browser" as const },

--- a/packages/wrangler/src/__tests__/dev/remote-bindings-errors.test.ts
+++ b/packages/wrangler/src/__tests__/dev/remote-bindings-errors.test.ts
@@ -23,6 +23,20 @@ describe("errors during dev with remote bindings", () => {
 		msw.use(...mswSuccessUserHandlers);
 	});
 
+	it("explains how to provision a draft Flagship binding", async ({
+		expect,
+	}) => {
+		await expect(
+			startRemoteProxySession({
+				FLAGS: {
+					type: "flagship",
+				},
+			})
+		).rejects.toThrow(
+			'Flagship binding "FLAGS" has no app_id. Run `wrangler deploy` to provision it, or add `app_id` to your config.'
+		);
+	});
+
 	it("errors triggered when creating the remote proxy session are surfaced", async ({
 		expect,
 	}) => {

--- a/packages/wrangler/src/__tests__/provision.test.ts
+++ b/packages/wrangler/src/__tests__/provision.test.ts
@@ -1398,6 +1398,172 @@ describe("resource provisioning", () => {
 			expect(std.err).toMatchInlineSnapshot(`""`);
 		});
 	});
+	describe("provisions flagship bindings", () => {
+		beforeEach(() => {
+			writeWranglerConfig({
+				main: "index.js",
+				flagship: [{ binding: "FLAGS" }],
+			});
+		});
+
+		it("should inherit flagship binding if found in the deployed settings", async ({
+			expect,
+		}) => {
+			let uploadedBindings: unknown[] | undefined;
+			mockSubDomainRequest();
+			mockGetSettings({
+				result: {
+					bindings: [
+						{
+							type: "flagship",
+							name: "FLAGS",
+							app_id: "existing-flagship-app-id",
+						},
+					],
+				},
+			});
+			msw.use(
+				http.post(
+					"*/accounts/:accountId/workers/scripts/:scriptName/versions",
+					async ({ request }) => {
+						const formBody = await request.formData();
+						const metadataEntry = formBody.get("metadata");
+						const metadataText =
+							typeof metadataEntry === "string"
+								? metadataEntry
+								: await metadataEntry?.text();
+						const metadata = JSON.parse(metadataText ?? "{}") as {
+							bindings?: unknown[];
+						};
+						uploadedBindings = metadata.bindings;
+						return HttpResponse.json(
+							createFetchResult({
+								id: "Galaxy-Class",
+								startup_time_ms: 100,
+								resources: { script: { etag: "etag98765" } },
+							})
+						);
+					}
+				),
+				http.post(
+					"*/accounts/:accountId/workers/scripts/:scriptName/deployments",
+					() => HttpResponse.json(createFetchResult({ id: "Deployment-ID" }))
+				),
+				http.patch(
+					"*/accounts/:accountId/workers/scripts/:scriptName/script-settings",
+					() => HttpResponse.json(createFetchResult({}))
+				),
+				http.get(
+					"*/accounts/:accountId/workers/scripts/:scriptName/subdomain",
+					() =>
+						HttpResponse.json(
+							createFetchResult({
+								enabled: true,
+								previews_enabled: true,
+							})
+						)
+				),
+				http.post(
+					"*/accounts/:accountId/workers/scripts/:scriptName/subdomain",
+					() =>
+						HttpResponse.json(
+							createFetchResult({
+								enabled: true,
+								previews_enabled: true,
+							})
+						)
+				),
+				...mswListNewDeploymentsLatestFull
+			);
+
+			await runWrangler("deploy");
+			expect(uploadedBindings).toEqual([
+				{
+					name: "FLAGS",
+					type: "flagship",
+					app_id: "existing-flagship-app-id",
+				},
+			]);
+			expect(std.out).toContain("env.FLAGS (existing-flagship-app-id)");
+			expect(std.err).toMatchInlineSnapshot(`""`);
+		});
+
+		it("should connect to an existing flagship app when selected", async ({
+			expect,
+		}) => {
+			mockGetSettings();
+			mockListFlagshipApps([
+				{ id: "existing-flagship-app-id", name: "checkout" },
+			]);
+			mockSelect({
+				text: "Would you like to connect an existing Flagship App or create a new one?",
+				result: "existing-flagship-app-id",
+			});
+			mockUploadWorkerRequest({
+				expectedBindings: [
+					{
+						name: "FLAGS",
+						type: "flagship",
+						app_id: "existing-flagship-app-id",
+					},
+				],
+			});
+
+			await runWrangler("deploy --x-auto-create=false");
+			expect(std.out).toContain("env.FLAGS (existing-flagship-app-id)");
+			expect(std.err).toMatchInlineSnapshot(`""`);
+		});
+
+		it("should create a flagship app for a draft binding and write it back to config", async ({
+			expect,
+		}) => {
+			mockListFlagshipApps([]);
+			mockGetSettings();
+			mockCreateFlagshipApp(expect, {
+				assertName: "test-name-flags",
+				resultId: "new-flagship-app-id",
+			});
+			mockUploadWorkerRequest({
+				expectedBindings: [
+					{
+						name: "FLAGS",
+						type: "flagship",
+						app_id: "new-flagship-app-id",
+					},
+				],
+			});
+
+			await runWrangler("deploy");
+
+			expect(std.out).toContain(
+				'🌀 Creating new Flagship App "test-name-flags"...'
+			);
+			expect(std.out).toContain("env.FLAGS (new-flagship-app-id)");
+			expect(std.err).toMatchInlineSnapshot(`""`);
+			expect(await readFile("wrangler.toml", "utf-8")).toMatchInlineSnapshot(`
+				"compatibility_date = "2022-01-12"
+				name = "test-name"
+				main = "index.js"
+
+				[[flagship]]
+				binding = "FLAGS"
+				app_id = "new-flagship-app-id"
+				"
+			`);
+		});
+	});
+
+	it("should error if used with a service environment", async ({ expect }) => {
+		writeWorkerSource();
+		writeWranglerConfig({
+			main: "index.js",
+			legacy_env: false,
+			kv_namespaces: [{ binding: "KV" }],
+		});
+		await expect(runWrangler("deploy --x-auto-create=false")).rejects.toThrow(
+			"Provisioning resources is not supported with a service environment"
+		);
+	});
 });
 
 function mockCreateD1Database(
@@ -1548,6 +1714,46 @@ function mockCreateAgentMemoryNamespace(
 					createFetchResult({
 						id: "new-agent-memory-namespace-id",
 						name: options.assertName ?? "test-namespace",
+					})
+				);
+			},
+			{ once: true }
+		)
+	);
+}
+
+function mockListFlagshipApps(apps: Array<{ id: string; name: string }>) {
+	msw.use(
+		http.get("*/accounts/:accountId/flagship/apps", async () => {
+			return HttpResponse.json(
+				createFetchResult(apps, true, [], [], {
+					count: apps.length,
+					cursor: null,
+				})
+			);
+		})
+	);
+}
+
+function mockCreateFlagshipApp(
+	expect: ExpectStatic,
+	options: {
+		resultId?: string;
+		assertName?: string;
+	} = {}
+) {
+	msw.use(
+		http.post(
+			"*/accounts/:accountId/flagship/apps",
+			async ({ request }) => {
+				if (options.assertName) {
+					const requestBody = await request.json();
+					expect(requestBody).toEqual({ name: options.assertName });
+				}
+				return HttpResponse.json(
+					createFetchResult({
+						id: options.resultId ?? "new-flagship-app-id",
+						name: options.assertName ?? "test-name-flags",
 					})
 				);
 			},

--- a/packages/wrangler/src/__tests__/provision.test.ts
+++ b/packages/wrangler/src/__tests__/provision.test.ts
@@ -25,6 +25,7 @@ import {
 } from "./helpers/msw";
 import { mswListNewDeploymentsLatestFull } from "./helpers/msw/handlers/versions";
 import { runWrangler } from "./helpers/run-wrangler";
+import { toString } from "./helpers/serialize-form-data-entry";
 import { writeWorkerSource } from "./helpers/write-worker-source";
 import type { DatabaseInfo } from "../d1/types";
 import type { ExpectStatic } from "vitest";
@@ -1426,13 +1427,11 @@ describe("resource provisioning", () => {
 				http.post(
 					"*/accounts/:accountId/workers/scripts/:scriptName/versions",
 					async ({ request }) => {
+						// eslint-disable-next-line @typescript-eslint/no-deprecated -- formData() is the standard Web API; only deprecated on undici's server-side types
 						const formBody = await request.formData();
-						const metadataEntry = formBody.get("metadata");
-						const metadataText =
-							typeof metadataEntry === "string"
-								? metadataEntry
-								: await metadataEntry?.text();
-						const metadata = JSON.parse(metadataText ?? "{}") as {
+						const metadata = JSON.parse(
+							await toString(formBody.get("metadata"))
+						) as {
 							bindings?: unknown[];
 						};
 						uploadedBindings = metadata.bindings;

--- a/packages/wrangler/src/__tests__/provision.test.ts
+++ b/packages/wrangler/src/__tests__/provision.test.ts
@@ -1551,18 +1551,6 @@ describe("resource provisioning", () => {
 			`);
 		});
 	});
-
-	it("should error if used with a service environment", async ({ expect }) => {
-		writeWorkerSource();
-		writeWranglerConfig({
-			main: "index.js",
-			legacy_env: false,
-			kv_namespaces: [{ binding: "KV" }],
-		});
-		await expect(runWrangler("deploy --x-auto-create=false")).rejects.toThrow(
-			"Provisioning resources is not supported with a service environment"
-		);
-	});
 });
 
 function mockCreateD1Database(

--- a/packages/wrangler/src/api/remoteBindings/start-remote-proxy-session.ts
+++ b/packages/wrangler/src/api/remoteBindings/start-remote-proxy-session.ts
@@ -87,6 +87,15 @@ export async function startRemoteProxySession(
 	bindings: StartDevWorkerInput["bindings"],
 	options?: StartRemoteProxySessionOptions
 ): Promise<RemoteProxySession> {
+	for (const [name, binding] of Object.entries(bindings ?? {})) {
+		if (binding.type === "flagship" && binding.app_id === undefined) {
+			throw new UserError(
+				`Flagship binding "${name}" has no app_id. Run \`wrangler deploy\` to provision it, or add \`app_id\` to your config.`,
+				{ telemetryMessage: "flagship remote binding missing app_id" }
+			);
+		}
+	}
+
 	logger.log(chalk.dim("⎔ Establishing remote connection..."));
 	// Transform all bindings to use "raw" mode
 	const rawBindings = Object.fromEntries(

--- a/packages/wrangler/src/dev/miniflare/index.ts
+++ b/packages/wrangler/src/dev/miniflare/index.ts
@@ -913,13 +913,16 @@ export function buildMiniflareBindingOptions(
 			helloWorldBindings.map((binding) => [binding.binding, binding])
 		),
 		flagship: Object.fromEntries(
-			flagshipBindings.map((binding) => [
-				binding.binding,
-				{
-					app_id: binding.app_id,
-					remoteProxyConnectionString,
-				},
-			])
+			flagshipBindings.map((binding) => {
+				assert(binding.app_id !== undefined);
+				return [
+					binding.binding,
+					{
+						app_id: binding.app_id,
+						remoteProxyConnectionString,
+					},
+				];
+			})
 		),
 		artifacts: Object.fromEntries(
 			artifactsBindings.map((binding) => [


### PR DESCRIPTION
Enables https://developers.cloudflare.com/flagship/ bindings for automatic provisioning: https://developers.cloudflare.com/workers/wrangler/configuration/#automatic-provisioning

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [x] Cloudflare docs PR(s): https://github.com/cloudflare/cloudflare-docs/pull/31990
  - [ ] Documentation not necessary because:

*A picture of a cute animal (not mandatory, but encouraged)*
🐯

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

## Manual validation

Prerequisites: use an account with Workers and Flagship access, and authenticate with `wrangler login` if needed.

1. Build this branch's Wrangler and create an isolated project:

```sh
cd /path/to/workers-sdk
pnpm install
pnpm --filter wrangler build

export WORKERS_SDK_ROOT="$PWD"
wrangler() {
  node "$WORKERS_SDK_ROOT/packages/wrangler/bin/wrangler.js" "$@"
}

export WORKER_NAME="flagship-autoprovision-$(date +%s)"
export TEST_DIR="$(mktemp -d)"
cd "$TEST_DIR"

cat > index.js <<'EOF'
export default {
  async fetch(_request, env) {
    return Response.json({
      flagshipBindingAvailable: typeof env.FLAGS === "object",
    });
  },
};
EOF

cat > wrangler.jsonc <<EOF
{
  "name": "$WORKER_NAME",
  "main": "index.js",
  "compatibility_date": "2026-07-15",
  "flagship": [
    {
      "binding": "FLAGS"
    }
  ]
}
EOF
```

2. Verify that local development rejects an unprovisioned remote-only binding:

```sh
wrangler dev
```

Expected: Wrangler exits before starting the dev server with:

```text
Flagship binding "FLAGS" has no app_id. Run `wrangler deploy` to provision it, or add `app_id` to your config.
```

Actual:

```sh
 ⛅️ wrangler 4.111.0
────────────────────
Your Worker has access to the following bindings:
Binding           Resource      Mode
env.FLAGS         Flagship      remote

╭───────────────────────────╮
│  [b] open a browser       │
│  [d] open devtools        │
│  [e] open local explorer  │
│  [t] start tunnel         │
│  [c] clear console        │
│  [x] to exit              │
╰───────────────────────────╯

✘ [ERROR] Flagship binding "FLAGS" has no app_id. Run `wrangler deploy` to provision it, or add `app_id` to your config.
```

3. Deploy the draft binding:

```sh
wrangler deploy
```

Expected: Wrangler automatically creates a Flagship app named `$WORKER_NAME-flags`, reports output similar to the following, and deploys successfully:

```text
Creating new Flagship App "<worker-name>-flags"...
FLAGS provisioned
```

Actual:

```sh
⛅️ wrangler 4.111.0
────────────────────
Total Upload: 0.24 KiB / gzip: 0.19 KiB

Experimental: The following bindings need to be provisioned:
Binding           Resource      
env.FLAGS         Flagship      


Provisioning FLAGS (Flagship App)...
🌀 Creating new Flagship App "flagship-autoprovision-1784129957-flags"...
✨ FLAGS provisioned 🎉

Your Worker was deployed with provisioned resources. We've written the IDs of these resources to your config file, which you can choose to save or discard. Either way future deploys will continue to work.
🎉 All resources provisioned, continuing with deployment...

Your Worker has access to the following bindings:
Binding                                               Resource      
env.FLAGS (74ebaf8f-5d53-416a-be42-a4bae43f1908)      Flagship      

Uploaded flagship-autoprovision-1784129957 (4.02 sec)
Deployed flagship-autoprovision-1784129957 triggers (1.54 sec)
  https://flagship-autoprovision-1784129957.cloudflare-workers-ci-staging.workers.dev
Current Version ID: 81ae49e1-53b5-4199-bdf1-9af310a5e025
```

4. Verify that Wrangler wrote the provisioned app ID back to the config:

```sh
grep -A3 '"flagship"' wrangler.jsonc
export APP_ID="$(node -e 'const fs = require("node:fs"); const config = JSON.parse(fs.readFileSync("wrangler.jsonc", "utf8")); process.stdout.write(config.flagship[0].app_id)')"
test -n "$APP_ID"
wrangler flagship apps get "$APP_ID"
```

Expected: `wrangler.jsonc` now contains a non-empty `app_id`, and `flagship apps get` returns the app named `$WORKER_NAME-flags`.

Actual:

```sh
{
        "name": "flagship-autoprovision-1784129957",
        "main": "index.js",
        "compatibility_date": "2026-07-15",
        "flagship": [
                {
                        "binding": "FLAGS",
                        "app_id": "74ebaf8f-5d53-416a-be42-a4bae43f1908"
                }
        ]
}%   
```

5. Verify local development now starts with the remote Flagship binding. In one terminal:

```sh
cd "$TEST_DIR"
wrangler dev --port 8787
```

Expected: Wrangler establishes a remote connection, lists `env.FLAGS` as a remote Flagship binding, and reports that the server is ready. In another terminal:

```sh
curl --fail http://localhost:8787
```

Expected:

```json
{"flagshipBindingAvailable":true}
```

Actual:

```json
{"flagshipBindingAvailable":true}
```

6. Stop `wrangler dev`, then remove the Worker and the provisioned Flagship app:

```sh
cd "$TEST_DIR"
wrangler delete --name "$WORKER_NAME"
wrangler flagship apps delete "$APP_ID" --force
rm -rf "$TEST_DIR"
```

Actual:

```sh
❯ wrangler delete --name "$WORKER_NAME"                       

 ⛅️ wrangler 4.111.0
────────────────────
✔ Are you sure you want to delete flagship-autoprovision-1784129957? This action cannot be undone. … yes
Successfully deleted flagship-autoprovision-1784129957

msdfmy193hg5yc5xl8zcb9fm0000gn/T/tmp.aaEepGqG3A via  v24.18.0 took 5s 
❯ wrangler flagship apps delete "74ebaf8f-5d53-416a-be42-a4bae43f1908" --force

 ⛅️ wrangler 4.111.0
────────────────────
▲ [WARNING] 🚧 `wrangler flagship apps delete` is an open beta command. Please report any issues to https://github.com/cloudflare/workers-sdk/issues/new/choose
```