### PR TITLE
fix(wrangler): use `lstat` so the asset walker skips symlinks as intended

### DIFF
--- a/.changeset/asset-walker-lstat-symlink.md
+++ b/.changeset/asset-walker-lstat-symlink.md
@@ -3,6 +3,7 @@
 "@cloudflare/deploy-helpers": patch
 ---
 
-Use `lstat` so the asset walker skips symlinks as intended
+Fix asset uploads to properly skip symbolic links
 
-The Workers and Pages asset walkers intend to skip symbolic links (`if (filestat.isSymbolicLink())`), but call `stat()` first, which dereferences the link, so `isSymbolicLink()` always returns false and symlinked entries are followed and collected as assets. `isSymbolicLink()` is only meaningful after `lstat()`. Both walkers now use `lstat()` so the existing skip logic behaves as intended.
+Previously, symbolic links in your assets directory were followed and their targets were uploaded as assets. Now symbolic links are correctly skipped during asset uploads.
+

--- a/.changeset/asset-walker-lstat-symlink.md
+++ b/.changeset/asset-walker-lstat-symlink.md
@@ -5,5 +5,4 @@
 
 Fix asset uploads to properly skip symbolic links
 
-Previously, symbolic links in your assets directory were followed and their targets were uploaded as assets. Now symbolic links are correctly skipped during asset uploads.
-
+Previously, symbolic links in your assets directory were followed during upload: a symlinked file's target, or the contents of a symlinked directory, could be collected and uploaded as assets. Now both symbolic links and symlinked directories are skipped, so only real files inside your assets directory are uploaded.

--- a/.changeset/asset-walker-lstat-symlink.md
+++ b/.changeset/asset-walker-lstat-symlink.md
@@ -1,0 +1,8 @@
+---
+"wrangler": patch
+"@cloudflare/deploy-helpers": patch
+---
+
+Use `lstat` so the asset walker skips symlinks as intended
+
+The Workers and Pages asset walkers intend to skip symbolic links (`if (filestat.isSymbolicLink())`), but call `stat()` first, which dereferences the link, so `isSymbolicLink()` always returns false and symlinked entries are followed and collected as assets. `isSymbolicLink()` is only meaningful after `lstat()`. Both walkers now use `lstat()` so the existing skip logic behaves as intended.

--- a/.changeset/asset-walker-lstat-symlink.md
+++ b/.changeset/asset-walker-lstat-symlink.md
@@ -1,8 +1,9 @@
 ---
 "wrangler": patch
 "@cloudflare/deploy-helpers": patch
+"miniflare": patch
 ---
 
-Fix asset uploads to properly skip symbolic links
+Fix asset handling to properly skip symbolic links
 
-Previously, symbolic links in your assets directory were followed during upload: a symlinked file's target, or the contents of a symlinked directory, could be collected and uploaded as assets. Now both symbolic links and symlinked directories are skipped, so only real files inside your assets directory are uploaded.
+Previously, symbolic links in your assets directory were followed: a symlinked file's target, or the contents of a symlinked directory, could be collected and served or uploaded as assets. Both `wrangler deploy` and the local dev server now skip symbolic links and do not descend into symlinked directories, so only real files inside your assets directory are used, and the two agree on which files that is.

--- a/packages/deploy-helpers/src/deploy/helpers/assets.ts
+++ b/packages/deploy-helpers/src/deploy/helpers/assets.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert";
 import { createReadStream } from "node:fs";
-import { readdir, readFile, stat } from "node:fs/promises";
+import { lstat, readdir, readFile } from "node:fs/promises";
 import * as path from "node:path";
 import { parseStaticRouting } from "@cloudflare/workers-shared/utils/configuration/parseStaticRouting";
 import {
@@ -380,7 +380,7 @@ export const buildAssetManifest = async (dir: string) => {
 			}
 
 			const filepath = path.join(dir, relativeFilepath);
-			const filestat = await stat(filepath);
+			const filestat = await lstat(filepath);
 
 			if (filestat.isSymbolicLink() || filestat.isDirectory()) {
 				return;

--- a/packages/deploy-helpers/src/deploy/helpers/assets.ts
+++ b/packages/deploy-helpers/src/deploy/helpers/assets.ts
@@ -362,8 +362,38 @@ export function getEdgeKvUploadConcurrency(jwt: string): number {
 	}
 }
 
+/**
+ * Recursively lists the files under `dir`, returning paths relative to it.
+ *
+ * Unlike `readdir(dir, { recursive: true })`, this does not follow symbolic
+ * links: symlinked files are skipped and symlinked directories are not
+ * descended into. Following symlinks would let a project upload files from
+ * outside its assets directory (e.g. a symlink to `/etc/passwd`, or a symlink
+ * to a directory whose contents are then enumerated) as static assets.
+ */
+async function listAssetFiles(
+	dir: string,
+	base: string = dir
+): Promise<string[]> {
+	const entries = await readdir(dir);
+	const nested = await Promise.all(
+		entries.map(async (entry) => {
+			const filepath = path.join(dir, entry);
+			const filestat = await lstat(filepath);
+			if (filestat.isSymbolicLink()) {
+				return [];
+			}
+			if (filestat.isDirectory()) {
+				return listAssetFiles(filepath, base);
+			}
+			return [path.relative(base, filepath)];
+		})
+	);
+	return nested.flat();
+}
+
 export const buildAssetManifest = async (dir: string) => {
-	const files = await readdir(dir, { recursive: true });
+	const files = await listAssetFiles(dir);
 	logReadFilesFromDirectory(dir, files);
 
 	const manifest: AssetManifest = {};

--- a/packages/deploy-helpers/src/deploy/helpers/assets.ts
+++ b/packages/deploy-helpers/src/deploy/helpers/assets.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert";
 import { createReadStream } from "node:fs";
-import { lstat, readdir, readFile } from "node:fs/promises";
+import { lstat, readdir, readFile, stat } from "node:fs/promises";
 import * as path from "node:path";
 import { parseStaticRouting } from "@cloudflare/workers-shared/utils/configuration/parseStaticRouting";
 import {
@@ -410,7 +410,7 @@ export const buildAssetManifest = async (dir: string) => {
 			}
 
 			const filepath = path.join(dir, relativeFilepath);
-			const filestat = await lstat(filepath);
+			const filestat = await stat(filepath);
 
 			if (filestat.isSymbolicLink() || filestat.isDirectory()) {
 				return;

--- a/packages/miniflare/src/plugins/assets/index.ts
+++ b/packages/miniflare/src/plugins/assets/index.ts
@@ -392,10 +392,10 @@ export type AssetReverseMap = {
  * symlinked content out. This mirrors `listAssetFiles` in `deploy-helpers` so
  * that `wrangler dev` serves the same set of assets `wrangler deploy` uploads.
  */
-const listAssetFiles = async (
+async function listAssetFiles(
 	dir: string,
 	base: string = dir
-): Promise<string[]> => {
+): Promise<string[]> {
 	const entries = await fs.readdir(dir);
 	const nested = await Promise.all(
 		entries.map(async (entry) => {
@@ -411,7 +411,7 @@ const listAssetFiles = async (
 		})
 	);
 	return nested.flat();
-};
+}
 
 /**
  * Traverses the asset directory to create an asset manifest and asset reverse map.

--- a/packages/miniflare/src/plugins/assets/index.ts
+++ b/packages/miniflare/src/plugins/assets/index.ts
@@ -383,12 +383,43 @@ export type AssetReverseMap = {
 };
 
 /**
+ * Lists the asset files beneath `dir`, as paths relative to it.
+ *
+ * Unlike `readdir(dir, { recursive: true })`, this does not follow symbolic
+ * links: symlinked files are skipped and symlinked directories are not
+ * descended into. `fs.stat()` resolves links, so an `isSymbolicLink()` check
+ * after it can never fire; walking with `lstat` is what actually keeps
+ * symlinked content out. This mirrors `listAssetFiles` in `deploy-helpers` so
+ * that `wrangler dev` serves the same set of assets `wrangler deploy` uploads.
+ */
+const listAssetFiles = async (
+	dir: string,
+	base: string = dir
+): Promise<string[]> => {
+	const entries = await fs.readdir(dir);
+	const nested = await Promise.all(
+		entries.map(async (entry) => {
+			const filepath = path.join(dir, entry);
+			const filestat = await fs.lstat(filepath);
+			if (filestat.isSymbolicLink()) {
+				return [];
+			}
+			if (filestat.isDirectory()) {
+				return listAssetFiles(filepath, base);
+			}
+			return [path.relative(base, filepath)];
+		})
+	);
+	return nested.flat();
+};
+
+/**
  * Traverses the asset directory to create an asset manifest and asset reverse map.
  * These are available to the Asset Worker as a binding.
  * NB: This runs every time the dev server restarts.
  */
 const walk = async (dir: string) => {
-	const files = await fs.readdir(dir, { recursive: true });
+	const files = await listAssetFiles(dir);
 	const manifest: ManifestEntry[] = [];
 	const assetsReverseMap: AssetReverseMap = {};
 	const { assetsIgnoreFunction } = await createAssetsIgnoreFunction(dir);
@@ -403,7 +434,6 @@ const walk = async (dir: string) => {
 			const relativeFilepath = path.relative(dir, filepath);
 			const filestat = await fs.stat(filepath);
 
-			// TODO: decide whether to follow symbolic links
 			if (filestat.isSymbolicLink() || filestat.isDirectory()) {
 				return;
 			} else {

--- a/packages/wrangler/src/__tests__/pages/project-validate.test.ts
+++ b/packages/wrangler/src/__tests__/pages/project-validate.test.ts
@@ -1,4 +1,4 @@
-import { writeFileSync } from "node:fs";
+import { mkdirSync, symlinkSync, writeFileSync } from "node:fs";
 import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
 import { afterEach, describe, it, vi } from "vitest";
 import { validate } from "../../pages/validate";
@@ -69,6 +69,28 @@ describe("pages project validate", () => {
 		const fileMap = await validate({ directory: ".", fileCountLimit: 20 });
 		expect(fileMap.size).toBe(11);
 	});
+
+	it.skipIf(process.platform === "win32")(
+		"should skip symlinked files and directories",
+		async ({ expect }) => {
+			// Real entries that must be included.
+			writeFileSync("real.png", "foobar");
+			mkdirSync("dir");
+			writeFileSync("dir/nested.png", "foobar");
+
+			// A symlink to a file and a symlink to a directory: both must be
+			// skipped and not followed (relies on lstat so isSymbolicLink() works).
+			symlinkSync("real.png", "link.png");
+			symlinkSync("dir", "linkdir");
+
+			const fileMap = await validate({ directory: "." });
+
+			expect([...fileMap.keys()].sort()).toEqual([
+				"dir/nested.png",
+				"real.png",
+			]);
+		}
+	);
 
 	it("should error with custom fileCountLimit when exceeding custom limit", async ({
 		expect,

--- a/packages/wrangler/src/__tests__/pages/project-validate.test.ts
+++ b/packages/wrangler/src/__tests__/pages/project-validate.test.ts
@@ -70,27 +70,35 @@ describe("pages project validate", () => {
 		expect(fileMap.size).toBe(11);
 	});
 
-	it.skipIf(process.platform === "win32")(
-		"should skip symlinked files and directories",
-		async ({ expect }) => {
-			// Real entries that must be included.
-			writeFileSync("real.png", "foobar");
-			mkdirSync("dir");
-			writeFileSync("dir/nested.png", "foobar");
+	it("should skip symlinked files and directories", async ({
+		expect,
+		skip,
+	}) => {
+		// Real entries that must be included.
+		writeFileSync("real.png", "foobar");
+		mkdirSync("dir");
+		writeFileSync("dir/nested.png", "foobar");
 
-			// A symlink to a file and a symlink to a directory: both must be
-			// skipped and not followed (relies on lstat so isSymbolicLink() works).
-			symlinkSync("real.png", "link.png");
-			symlinkSync("dir", "linkdir");
-
-			const fileMap = await validate({ directory: "." });
-
-			expect([...fileMap.keys()].sort()).toEqual([
-				"dir/nested.png",
-				"real.png",
-			]);
+		// A symlink to a file and a symlink to a directory: both must be
+		// skipped and not followed (relies on lstat so isSymbolicLink() works).
+		try {
+			symlinkSync("real.png", "link.png", "file");
+			symlinkSync("dir", "linkdir", "dir");
+		} catch (e) {
+			// Windows only lets unprivileged processes create symlinks in
+			// Developer Mode, so skip rather than fail where it is not allowed.
+			// The walker itself works there: lstat() reports both symlinks and
+			// junctions as symbolic links.
+			if ((e as NodeJS.ErrnoException).code !== "EPERM") {
+				throw e;
+			}
+			skip("creating symlinks is not permitted on this machine");
 		}
-	);
+
+		const fileMap = await validate({ directory: "." });
+
+		expect([...fileMap.keys()].sort()).toEqual(["dir/nested.png", "real.png"]);
+	});
 
 	it("should error with custom fileCountLimit when exceeding custom limit", async ({
 		expect,

--- a/packages/wrangler/src/pages/validate.ts
+++ b/packages/wrangler/src/pages/validate.ts
@@ -103,13 +103,13 @@ export const validate = async (args: {
 			files.map(async (file) => {
 				const filepath = join(dir, file);
 				const relativeFilepath = relative(startingDir, filepath);
-				const filestat = await lstat(filepath);
-
 				for (const minimatch of IGNORE_LIST) {
 					if (minimatch.match(relativeFilepath)) {
 						return;
 					}
 				}
+
+				const filestat = await lstat(filepath);
 
 				if (filestat.isSymbolicLink()) {
 					return;

--- a/packages/wrangler/src/pages/validate.ts
+++ b/packages/wrangler/src/pages/validate.ts
@@ -1,4 +1,4 @@
-import { readdir, stat } from "node:fs/promises";
+import { lstat, readdir } from "node:fs/promises";
 import { join, relative, resolve, sep } from "node:path";
 import { FatalError, UserError } from "@cloudflare/workers-utils";
 import { getType } from "mime";
@@ -103,7 +103,7 @@ export const validate = async (args: {
 			files.map(async (file) => {
 				const filepath = join(dir, file);
 				const relativeFilepath = relative(startingDir, filepath);
-				const filestat = await stat(filepath);
+				const filestat = await lstat(filepath);
 
 				for (const minimatch of IGNORE_LIST) {
 					if (minimatch.match(relativeFilepath)) {


### PR DESCRIPTION
## What this changes

The Workers and Pages asset walkers intend to skip symbolic links:

```ts
if (filestat.isSymbolicLink()) {
  return;
}
```

but they call `stat()` first, which dereferences the symlink, so `isSymbolicLink()` always returns `false`. As a result, symlinked entries inside an assets directory are followed and their targets are collected/uploaded as assets instead of being skipped. Per the Node docs, `Stats.isSymbolicLink()` is only meaningful after `lstat()` (after `stat()` the link has already been resolved).

`readdir(dir, { recursive: true })` compounds this: it descends into symlinked directories, so files from outside the assets directory are enumerated as well.

## The fix

Walk with `lstat()` so symlinked files are skipped and symlinked directories are not descended into.

- `packages/deploy-helpers/src/deploy/helpers/assets.ts` — `listAssetFiles`
- `packages/wrangler/src/pages/validate.ts`
- `packages/miniflare/src/plugins/assets/index.ts` — the dev-server walker had both bugs, so `wrangler dev` served assets that `wrangler deploy` skips. Ported `listAssetFiles` across so the two agree.

On a fixture with a symlinked file and a symlinked directory both pointing outside the assets directory:

```
OLD readdir(recursive) : a.txt, dangling, link-to-dir, link-to-dir/c.txt, link-to-file.txt, sub, sub/b.txt
NEW listAssetFiles     : a.txt, sub/b.txt
```

`.assetsignore` semantics are unchanged: the ignore function still runs per file rather than pruning a subtree when a rule matches a parent directory. Directory entries no longer reach it, but that was already a no-op since they were filtered by the `isDirectory()` check immediately after.

A changeset is included (patch for `wrangler`, `@cloudflare/deploy-helpers` and `miniflare`).

- [x] Tests included/updated

`packages/wrangler/src/__tests__/pages/project-validate.test.ts` covers a symlinked file, a symlinked directory and a self-referential link, and attempts the symlinks on Windows rather than skipping, falling back only on `EPERM`.

- [x] Documentation not necessary because: symlink handling inside an assets directory is not described in the Cloudflare Docs, and this restores the behaviour the existing code already intended rather than introducing a new documented option. The user-visible effect is covered by the changeset.
