### PR TITLE
Fix load time crash on Node.js versions earlier than 22.15

### DIFF
--- a/.changeset/lazy-register-hooks.md
+++ b/.changeset/lazy-register-hooks.md
@@ -1,0 +1,7 @@
+---
+"@cloudflare/vite-plugin": patch
+---
+
+Fix load time crash on Node.js versions earlier than 22.15
+
+The plugin eagerly imported `registerHooks` from `node:module`, which only exists on Node.js v22.15.0+. `registerHooks` is now read lazily, meaning that missing support is only surfaced when using `experimental.newConfig`.

--- a/packages/config/src/load.ts
+++ b/packages/config/src/load.ts
@@ -9,7 +9,7 @@
  */
 
 import { AsyncLocalStorage } from "node:async_hooks";
-import { registerHooks } from "node:module";
+import * as nodeModule from "node:module";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import type { LoadHookContext } from "node:module";
 
@@ -88,6 +88,9 @@ export function registerConfigHooks(): () => void {
 				"Please use Node.js v22.18.0 or higher."
 		);
 	}
+	// Read `registerHooks` lazily rather than via a top-level named import.
+	// This avoids a load-time crash on Node.js versions where it's unsupported.
+	const registerHooks = nodeModule.registerHooks;
 	if (typeof registerHooks !== "function") {
 		throw new Error(
 			"cloudflare.config.ts loading requires Node.js v22.18.0 or higher."


### PR DESCRIPTION
Fixes https://github.com/cloudflare/workers-sdk/issues/14636

Fix load time crash on Node.js versions earlier than 22.15

The plugin eagerly imported `registerHooks` from `node:module`, which only exists on Node.js v22.15.0+. `registerHooks` is now read lazily, meaning that missing support is only surfaced when using `experimental.newConfig`.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: comment provided in code
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bug fix

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
