### PR TITLE
[tools] Capture unquoted pnpm catalog keys in dependabot changeset generator

### DIFF
--- a/tools/dependabot/__tests__/generate-dependabot-pr-changesets.test.ts
+++ b/tools/dependabot/__tests__/generate-dependabot-pr-changesets.test.ts
@@ -126,10 +126,9 @@ describe("parseDiffForChanges()", () => {
 	it("should capture an unquoted catalog key even when no package.json bumps it", ({
 		expect,
 	}) => {
-		// Reproduces cloudflare/workers-sdk#14642: Dependabot bumped workerd only
-		// in the pnpm-workspace.yaml catalog (an unquoted YAML key), leaving the
-		// package.json pins untouched. workerd must still make it into the
-		// changeset.
+		// When Dependabot bumps workerd only in the pnpm-workspace.yaml catalog
+		// (an unquoted YAML key), leaving the package.json pins untouched, workerd
+		// must still make it into the changeset.
 		const changes = parseDiffForChanges([
 			`-  "@cloudflare/workers-types": "^5.20260708.1"`,
 			`+  "@cloudflare/workers-types": "^5.20260710.1"`,

--- a/tools/dependabot/__tests__/generate-dependabot-pr-changesets.test.ts
+++ b/tools/dependabot/__tests__/generate-dependabot-pr-changesets.test.ts
@@ -86,23 +86,22 @@ describe("parseDiffForChanges()", () => {
 		expect(changes.size).toBe(0);
 	});
 
-	it("should capture quoted pnpm catalog entries and ignore unquoted keys", ({
+	it("should capture both quoted and unquoted pnpm catalog entries", ({
 		expect,
 	}) => {
 		const changes = parseDiffForChanges([
-			// A literal dependency in a package.json
+			// A literal dependency in a package.json (quoted, JSON key)
 			`-		"workerd": "1.20260702.1",`,
 			`+		"workerd": "1.20260706.1",`,
 			// A quoted catalog entry in pnpm-workspace.yaml (caret preserved)
 			`-  "@cloudflare/workers-types": "^4.20260702.1"`,
 			`+  "@cloudflare/workers-types": "^5.20260706.1"`,
 			// workerd also appears in pnpm-workspace.yaml, but as an *unquoted*
-			// YAML key. The "quoted name" regex must skip it. Distinct versions
-			// are used here so that if the regex ever matched unquoted keys,
-			// these values would overwrite the workerd change captured from the
-			// package.json above and this assertion would fail.
-			`-  workerd: "9.99999990.0"`,
-			`+  workerd: "9.99999999.9"`,
+			// YAML key. The catalog is the source of truth and always carries the
+			// same version as the package.json pin, so capturing it here merges
+			// into the same map entry rather than conflicting.
+			`-  workerd: "1.20260702.1"`,
+			`+  workerd: "1.20260706.1"`,
 		]);
 		expect(changes).toEqual(
 			new Map([
@@ -118,6 +117,39 @@ describe("parseDiffForChanges()", () => {
 					{
 						from: "^4.20260702.1",
 						to: "^5.20260706.1",
+					},
+				],
+			])
+		);
+	});
+
+	it("should capture an unquoted catalog key even when no package.json bumps it", ({
+		expect,
+	}) => {
+		// Reproduces cloudflare/workers-sdk#14642: Dependabot bumped workerd only
+		// in the pnpm-workspace.yaml catalog (an unquoted YAML key), leaving the
+		// package.json pins untouched. workerd must still make it into the
+		// changeset.
+		const changes = parseDiffForChanges([
+			`-  "@cloudflare/workers-types": "^5.20260708.1"`,
+			`+  "@cloudflare/workers-types": "^5.20260710.1"`,
+			`-  workerd: "1.20260708.1"`,
+			`+  workerd: "1.20260710.1"`,
+		]);
+		expect(changes).toEqual(
+			new Map([
+				[
+					"@cloudflare/workers-types",
+					{
+						from: "^5.20260708.1",
+						to: "^5.20260710.1",
+					},
+				],
+				[
+					"workerd",
+					{
+						from: "1.20260708.1",
+						to: "1.20260710.1",
 					},
 				],
 			])

--- a/tools/dependabot/generate-dependabot-pr-changesets.ts
+++ b/tools/dependabot/generate-dependabot-pr-changesets.ts
@@ -113,9 +113,7 @@ export function parseDiffForChanges(
 	// Matches a dependency line in either a package.json diff (JSON, so the key
 	// is always quoted, e.g. `"workerd": "1.2.3"`) or a pnpm-workspace.yaml
 	// catalog diff (YAML, where the key may be unquoted, e.g. `workerd: "1.2.3"`).
-	// The quotes around the key are therefore optional — earlier this regex
-	// required them, which silently dropped unquoted catalog keys such as
-	// `workerd` when only the catalog (and not a package.json) was bumped.
+	// The quotes around the key are therefore optional.
 	const diffLineRegex = new RegExp(`^[+-]\\s*"?([^":]+?)"?:\\s"(.*)",?`);
 	const changes = new Map<string, Change>();
 	for (const line of diffLines) {

--- a/tools/dependabot/generate-dependabot-pr-changesets.ts
+++ b/tools/dependabot/generate-dependabot-pr-changesets.ts
@@ -110,7 +110,13 @@ export function getDependencyChanges(diffPaths: string[]): Map<string, Change> {
 export function parseDiffForChanges(
 	diffLines: (string | undefined)[]
 ): Map<string, Change> {
-	const diffLineRegex = new RegExp(`^[+-]\\s*"(.*)":\\s"(.*)",?`);
+	// Matches a dependency line in either a package.json diff (JSON, so the key
+	// is always quoted, e.g. `"workerd": "1.2.3"`) or a pnpm-workspace.yaml
+	// catalog diff (YAML, where the key may be unquoted, e.g. `workerd: "1.2.3"`).
+	// The quotes around the key are therefore optional — earlier this regex
+	// required them, which silently dropped unquoted catalog keys such as
+	// `workerd` when only the catalog (and not a package.json) was bumped.
+	const diffLineRegex = new RegExp(`^[+-]\\s*"?([^":]+?)"?:\\s"(.*)",?`);
 	const changes = new Map<string, Change>();
 	for (const line of diffLines) {
 		const match = line?.match(diffLineRegex);


### PR DESCRIPTION
_Describe your change..._

Fixes the Dependabot changeset generator (`tools/dependabot/generate-dependabot-pr-changesets.ts`) dropping `workerd` from the auto-generated changelog.

The `parseDiffForChanges()` regex required dependency keys to be quoted (JSON style). In the `pnpm-workspace.yaml` catalog, `"@cloudflare/workers-types"` is a quoted YAML key but `workerd` is an **unquoted** YAML key, so it was silently skipped. This normally went unnoticed because Dependabot also bumps the quoted `"workerd"` pins in `packages/miniflare/package.json`, so workerd got captured from there — but in [#14642](https://github.com/cloudflare/workers-sdk/pull/14642) Dependabot bumped `workerd` **only** in the catalog, so it was missing from the generated changeset entirely.

The regex now treats the quotes around the key as optional, capturing both `"workerd": "1.2.3"` (JSON) and `workerd: "1.2.3"` (unquoted YAML).

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: internal build tooling change with no user-facing surface

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
