### PR TITLE
[ci] Respond to issues with a triage report comment + labels

### DIFF
--- a/.github/skills/issue-review.md
+++ b/.github/skills/issue-review.md
@@ -274,12 +274,17 @@ For **feature requests**, evaluate:
 
 ## Output Format
 
+**How the output is used:** `report.md` is posted verbatim as a maintainer-facing triage comment on the issue (attributed to an automated bot), and the labels in `summary.json` are applied automatically. Because of this:
+
+- Write `report.md` for maintainers, not the reporter. The **Suggested Comment** section is a _draft_ for a maintainer to send to the reporter — it is **not** posted automatically, so do not phrase the surrounding report as though a reply has already been made.
+- Only put labels in the **Suggested Labels** fields that already exist in the repository. If unsure whether a label exists, omit it rather than guess — non-existent labels are dropped before applying, so inventing labels only weakens the report's accuracy.
+
 ### Report Directory Structure
 
 ```
 ./data/<issue_number>/
 ├── report.md          # Full detailed report
-└── summary.md         # Single-line tab-separated summary
+└── summary.json       # Structured JSON summary
 ```
 
 ### Output Step 1: Write Full Report
@@ -340,20 +345,32 @@ duplicate candidates. Only include what's relevant.>
 
 ### Output Step 2: Write Summary File
 
-Write a single tab-separated line to `./data/<issue_number>/summary.md` with these 7 fields:
+Write a machine-readable summary as **JSON** to `./data/<issue_number>/summary.json`. This file is parsed by the triage workflow (to build the dashboard payload and apply labels), so it must be valid JSON with exactly these keys:
 
+```json
+{
+  "issueNumber": <issue_number as a number>,
+  "title": "<issue title, with emoji/template prefixes like 'Bug:' removed>",
+  "githubUrl": "https://github.com/<owner>/<repo>/issues/<issue_number>",
+  "recommendation": "<CLOSE | KEEP OPEN | NEEDS MORE INFO | NEEDS VERIFICATION>",
+  "difficulty": "<easy | medium | hard | n/a>",
+  "reasoning": "<brief reasoning, 1-2 sentences>",
+  "suggestedAction": "<brief description of next steps>",
+  "hasSuggestedComment": <true if a Suggested Comment section is present in the report, false otherwise>,
+  "suggestedLabels": ["<label>", "..."]
+}
 ```
-[<issue_number>](https://github.com/<owner>/<repo>/issues/<issue_number>)	<title>	<CLOSE|KEEP OPEN|NEEDS MORE INFO|NEEDS VERIFICATION>	<easy|medium|hard|n/a>	<brief reasoning>	<brief suggested action>	<Yes|No>
-```
 
-**Column definitions:**
+**Key definitions:**
 
-- **Issue #**: Link to the issue in markdown format `[number](url)`
-- **Title**: Issue title (remove any emoji prefixes like "Bug:" or template prefixes)
-- **Recommendation**: One of CLOSE, KEEP OPEN, NEEDS MORE INFO, NEEDS VERIFICATION
-- **Difficulty**: Estimated fix difficulty - `easy`, `medium`, `hard`, or `n/a` (for feature requests or closures)
-- **Reasoning**: Brief summary of why (1-2 sentences)
-- **Suggested Action**: Brief description of next steps
-- **Suggested Comment**: "Yes" if a comment template is provided, "No" otherwise
+- **issueNumber**: The issue number as a JSON number (not a string).
+- **title**: Issue title with any emoji prefixes (e.g. "🐛 Bug:") or template prefixes removed.
+- **githubUrl**: Full URL to the issue.
+- **recommendation**: One of `CLOSE`, `KEEP OPEN`, `NEEDS MORE INFO`, `NEEDS VERIFICATION`.
+- **difficulty**: Estimated fix difficulty — `easy`, `medium`, `hard`, or `n/a` (for feature requests or closures).
+- **reasoning**: Brief summary of why (1-2 sentences).
+- **suggestedAction**: Brief description of next steps.
+- **hasSuggestedComment**: Boolean — `true` if the report includes a Suggested Comment, `false` otherwise.
+- **suggestedLabels**: JSON array of labels to apply, matching the **Suggested Labels** field in the report. Use existing repo labels only (see above). Use an empty array `[]` if there are no labels to apply.
 
-**CRITICAL:** Use actual tab characters (`\t`) as column delimiters. Write only the single data line, no header.
+**CRITICAL:** Write valid, parseable JSON only (no trailing commas, no comments, no surrounding markdown fences). Because JSON strings are escaped, `reasoning`/`suggestedAction` may safely contain any punctuation.

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -83,6 +83,18 @@ Workflow changes should avoid unsuppressed `zizmor` findings. In particular:
 - Actions
   - Add the issue to a GitHub project.
 
+### Triage Issue (triage-issue.yml)
+
+- Triggers
+  - A new issue is opened (skips PRs and bot-authored issues).
+  - A new comment is created on an issue — re-triages with the latest context. Skips PRs, bot comments, and the triage bot's own sticky comment (matched by the sticky-comment marker) to avoid re-triage loops.
+  - Manual `workflow_dispatch` with an `issue-number` input.
+- Actions
+  - Runs an OpenCode agent with the `.github/skills/issue-review.md` skill against the pre-fetched issue data (including existing comments) to produce a markdown triage report (`report.md`) and a structured JSON summary (`summary.json`).
+  - Uploads the report to the triage dashboard.
+  - Posts the report and structured summary as a maintainer-facing sticky comment on the issue and applies the suggested labels (validated against existing repo labels). Because the comment is sticky, re-triage updates the existing comment rather than posting a duplicate. Comments and labels are attributed to the workers-devprod bot via `GH_ACCESS_TOKEN`.
+  - The AI agent itself runs sandboxed (no shell or network access); all GitHub writes happen in workflow steps from the generated files.
+
 ### Generate changesets for dependabot PRs (c3-dependabot-versioning-prs.yml and miniflare-dependabot-versioning-prs.yml)
 
 - Triggers

--- a/.github/workflows/triage-issue.yml
+++ b/.github/workflows/triage-issue.yml
@@ -1,8 +1,10 @@
-name: Triage New Issue
+name: Triage Issue
 
 on:
   issues:
     types: [opened]
+  issue_comment:
+    types: [created]
   workflow_dispatch:
     inputs:
       issue-number:
@@ -12,6 +14,9 @@ on:
 
 permissions:
   contents: read
+  # Writes (comment + labels) are performed with GH_ACCESS_TOKEN (the
+  # workers-devprod bot) so they are attributed to that identity, not
+  # github-actions[bot]. Only read access is needed from the default token.
   issues: read
 
 # Cancel in-progress runs for the same issue
@@ -22,11 +27,19 @@ concurrency:
 jobs:
   triage:
     runs-on: ubuntu-latest
-    # For issue events: skip PRs and bot-created issues. Always run for workflow_dispatch.
+    # Always run for manual dispatch. For issue events, skip PRs and
+    # bot-created issues. For comment events, skip PRs, bot comments, and the
+    # triage bot's own sticky comment (identified by the marocchino marker) to
+    # avoid infinite re-triage loops.
     if: >-
       github.event_name == 'workflow_dispatch' ||
-      (!github.event.issue.pull_request &&
-      github.event.issue.user.type != 'Bot')
+      (github.event_name == 'issues' &&
+        !github.event.issue.pull_request &&
+        github.event.issue.user.type != 'Bot') ||
+      (github.event_name == 'issue_comment' &&
+        !github.event.issue.pull_request &&
+        github.event.comment.user.type != 'Bot' &&
+        !contains(github.event.comment.body, '<!-- Sticky Pull Request Comment'))
     timeout-minutes: 60
     steps:
       - name: Resolve issue number
@@ -84,8 +97,8 @@ jobs:
           Read it with the read tool and follow the triage process.
 
           Create:
-          - data/${ISSUE}/report.md (full report)
-          - data/${ISSUE}/summary.md (single tab-separated summary line)
+          - data/${ISSUE}/report.md (full markdown report)
+          - data/${ISSUE}/summary.json (structured JSON summary)
           "
 
       - name: Upload report to dashboard
@@ -101,41 +114,32 @@ jobs:
             echo "::error::report.md was not generated"
             exit 1
           fi
-          if [ ! -f "data/${ISSUE}/summary.md" ]; then
-            echo "::error::summary.md was not generated"
+          if [ ! -f "data/${ISSUE}/summary.json" ]; then
+            echo "::error::summary.json was not generated"
             exit 1
           fi
 
-          # Parse the tab-separated summary.md into variables
-          SUMMARY=$(cat "data/${ISSUE}/summary.md")
-          TITLE=$(echo "$SUMMARY" | cut -f2)
-          RECOMMENDATION=$(echo "$SUMMARY" | cut -f3)
-          DIFFICULTY=$(echo "$SUMMARY" | cut -f4)
-          REASONING=$(echo "$SUMMARY" | cut -f5)
-          SUGGESTED_ACTION=$(echo "$SUMMARY" | cut -f6)
-          SUGGESTED_COMMENT=$(echo "$SUMMARY" | cut -f7)
-          REPORT=$(cat "data/${ISSUE}/report.md")
+          # Validate the summary is parseable JSON before doing anything with it.
+          if ! jq empty "data/${ISSUE}/summary.json" 2>/dev/null; then
+            echo "::error::summary.json is not valid JSON"
+            exit 1
+          fi
 
-          # Build JSON payload
-          PAYLOAD=$(jq -n \
-            --arg title "$TITLE" \
+          # Build the dashboard payload from the structured summary + markdown report.
+          # suggestedComment is kept as a "Yes"/"No" string for dashboard compatibility.
+          PAYLOAD=$(jq \
             --arg githubUrl "https://github.com/${REPO}/issues/${ISSUE}" \
-            --arg recommendation "$RECOMMENDATION" \
-            --arg difficulty "$DIFFICULTY" \
-            --arg reasoning "$REASONING" \
-            --arg suggestedAction "$SUGGESTED_ACTION" \
-            --arg suggestedComment "$SUGGESTED_COMMENT" \
-            --arg reportMarkdown "$REPORT" \
+            --rawfile reportMarkdown "data/${ISSUE}/report.md" \
             '{
-              title: $title,
+              title: .title,
               githubUrl: $githubUrl,
-              recommendation: $recommendation,
-              difficulty: $difficulty,
-              reasoning: $reasoning,
-              suggestedAction: $suggestedAction,
-              suggestedComment: $suggestedComment,
+              recommendation: .recommendation,
+              difficulty: .difficulty,
+              reasoning: .reasoning,
+              suggestedAction: .suggestedAction,
+              suggestedComment: (if .hasSuggestedComment then "Yes" else "No" end),
               reportMarkdown: $reportMarkdown
-            }')
+            }' "data/${ISSUE}/summary.json")
 
           # POST to dashboard API
           HTTP_STATUS=$(curl -L --post302 -s -o response.json -w "%{http_code}" \
@@ -154,3 +158,78 @@ jobs:
           fi
 
           echo "Report uploaded for issue #${ISSUE}"
+
+      - name: Build triage comment
+        env:
+          ISSUE: ${{ steps.issue.outputs.number }}
+        run: |
+          {
+            echo "> [!NOTE]"
+            echo "> This is an automated, advisory triage report generated by workers-devprod. It is not an official maintainer response — a maintainer will follow up."
+            echo ""
+            echo "<details>"
+            echo "<summary>🤖 Automated triage report</summary>"
+            echo ""
+            cat "data/${ISSUE}/report.md"
+            echo ""
+            echo "</details>"
+            echo ""
+            echo "<details>"
+            echo "<summary>Structured summary (JSON)</summary>"
+            echo ""
+            echo '```json'
+            cat "data/${ISSUE}/summary.json"
+            echo ""
+            echo '```'
+            echo ""
+            echo "</details>"
+          } > "data/${ISSUE}/comment.md"
+
+      - name: Post triage comment
+        uses: marocchino/sticky-pull-request-comment@d4d6b0936434b21bc8345ad45a440c5f7d2c40ff # v3.0.3
+        with:
+          header: triage-report
+          number: ${{ steps.issue.outputs.number }}
+          path: data/${{ steps.issue.outputs.number }}/comment.md
+          GITHUB_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
+
+      - name: Apply suggested labels
+        env:
+          GH_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
+          ISSUE: ${{ steps.issue.outputs.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          SUMMARY_PATH="data/${ISSUE}/summary.json"
+          if [ ! -f "$SUMMARY_PATH" ]; then
+            echo "No summary.json; skipping label application"
+            exit 0
+          fi
+
+          # suggestedLabels is a JSON array; emit one label per line.
+          jq -r '.suggestedLabels // [] | .[]' "$SUMMARY_PATH" > suggested-labels.txt
+          if [ ! -s suggested-labels.txt ]; then
+            echo "No suggested labels"
+            exit 0
+          fi
+
+          # Only apply labels that actually exist in the repo.
+          gh label list --repo "$REPO" --limit 500 --json name --jq '.[].name' > repo-labels.txt
+
+          ARGS=()
+          while IFS= read -r label; do
+            if [ -z "$label" ]; then
+              continue
+            fi
+            if grep -Fxq "$label" repo-labels.txt; then
+              ARGS+=(--add-label "$label")
+            else
+              echo "Skipping unknown label: ${label}"
+            fi
+          done < suggested-labels.txt
+
+          if [ ${#ARGS[@]} -eq 0 ]; then
+            echo "No valid labels to apply"
+            exit 0
+          fi
+
+          gh issue edit "$ISSUE" --repo "$REPO" "${ARGS[@]}"


### PR DESCRIPTION
Automatically respond to issues on workers-sdk with an AI triage report, combining our existing triage-report generation with an Astro-style "respond on the issue" behaviour.

Previously `triage-issue.yml` only uploaded a report to the reports dashboard. This PR makes it respond directly on the issue:

- Posts the AI triage report as a maintainer-facing **sticky comment** (attributed to the workers-devprod bot via `GH_ACCESS_TOKEN`), including the structured summary JSON in a collapsible block. Framed as advisory — not an official maintainer response.
- **Applies the report's suggested labels**, validated against existing repo labels (only ever adds labels; unknown labels are dropped).
- **Re-triages on new issue comments**, with loop protection that skips the bot's own sticky comment (matched by the marocchino marker) and `Bot`-type commenters. The sticky comment means re-triage updates the existing comment rather than duplicating.
- Switches the machine-readable summary from a fragile tab-separated `summary.md` to **`summary.json`** (parsed with `jq`), which also simplifies the dashboard payload.

The AI agent stays sandboxed (no shell/network access per `.github/opencode.json`); all GitHub writes happen in workflow steps from the generated files, preserving the current prompt-injection posture.

Files:
- `.github/workflows/triage-issue.yml` — triggers, comment/label steps, JSON parsing
- `.github/skills/issue-review.md` — JSON summary output + comment-usage guidance
- `.github/workflows/README.md` — updated workflow docs

---

- Tests
  - [x] Additional testing not necessary because: this only changes a GitHub Actions workflow and its AI skill/docs (no package code). The `jq` payload/label parsing and workflow structure were validated manually; behaviour will be verified via `workflow_dispatch` on real issues.
- Public documentation
  - [x] Documentation not necessary because: internal repo automation only; no user-facing product behaviour changes.