### PR TITLE
[config] Improve durableObject export error for invalid state properties

### DIFF
--- a/packages/config/src/exports.ts
+++ b/packages/config/src/exports.ts
@@ -166,6 +166,16 @@ export interface Exports {
 	durableObject(
 		options: DurableObjectExpectingTransferExportOptions
 	): DurableObjectExpectingTransferExport;
+	// Fallback overload. TypeScript only reaches this when none of the precise
+	// overloads above match, and it reports the last overload's error. Typing the
+	// parameter as the full discriminated union means the reported error keys off
+	// `state` and flags the offending property directly (e.g. "'storage' does not
+	// exist in type 'DurableObjectRenamedExportOptions'"), rather than the
+	// confusing "'renamed' is not assignable to 'expecting-transfer'" you get when
+	// the last precise overload happens to be the storage-bearing one. Valid calls
+	// still resolve to a precise overload above, preserving the literal return
+	// types that downstream inference (e.g. `InferDurableNamespaces`) relies on.
+	durableObject(options: DurableObjectExportOptions): DurableObjectExports;
 
 	/** Declares a WorkerEntrypoint export defined by this Worker. */
 	worker(options?: WorkerEntrypointExportOptions): WorkerEntrypointExport;
@@ -186,6 +196,11 @@ function durableObject(
 function durableObject(
 	options: DurableObjectExpectingTransferExportOptions
 ): DurableObjectExpectingTransferExport;
+// Fallback overload; see the matching comment in the `Exports` interface for why
+// this union-typed signature exists.
+function durableObject(
+	options: DurableObjectExportOptions
+): DurableObjectExports;
 function durableObject(
 	options: DurableObjectExportOptions
 ): DurableObjectExports {


### PR DESCRIPTION
_Describe your change..._

The `exports.durableObject()` factory in `@cloudflare/config` uses five overloads, one per Durable Object `state` (`created`, `deleted`, `renamed`, `transferred`, `expecting-transfer`), each with a precise return type that downstream type inference (e.g. `InferDurableNamespaces`) relies on to distinguish live namespaces from tombstones. The problem is that when a user writes something TypeScript can't match to any overload – for example:

```jsonc
exports: {
  NewCounter: exports.durableObject({ storage: "sqlite" }),
  Counter: exports.durableObject({ storage: "sqlite", state: "renamed", renamedTo: "NewCounter" }),
}
```

where `storage` is invalid on a `renamed` entry – TypeScript falls back to reporting the *last* overload's error, which happens to be `expecting-transfer`. So instead of telling you to remove `storage`, it says:

```
Type '"renamed"' is not assignable to type '"expecting-transfer"'.
```

This sends you down the wrong path: `expecting-transfer` is the state that accepts a `storage` object, but the real problem is that `storage` shouldn't be present on a `renamed` entry at all.

This PR adds one extra fallback overload at the end whose parameter is typed as the full discriminated union (`DurableObjectExportOptions`) rather than a single state. When the five precise overloads all fail, TypeScript now falls back to this union overload, and because the parameter is a discriminated union it performs a *discriminant-aware* excess-property check: it reads `state: "renamed"`, narrows to `DurableObjectRenamedExportOptions`, and reports the offending property directly:

```
No overload matches this call.
  The last overload gave the following error.
    Object literal may only specify known properties, and 'storage' does not exist in type 'DurableObjectRenamedExportOptions'.
```

The same improvement applies to the other states (e.g. `storage` on `deleted`, `renamedTo` on `transferred`).

Crucially, valid calls still resolve to one of the five precise overloads first, so return-type precision – and therefore the existing inference behaviour that `InferDurableNamespaces` depends on – is completely unchanged. The union overload is only ever reached to produce a better error message.

Known limitation: this only improves the error when the `state` discriminant is present, since union excess-checking can't flag a stray property when it can't tell which member you meant (e.g. omitting `state` entirely and adding `transferFrom`).

---

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: this is a type-only change to diagnostic wording. The set of inputs that compile vs error is unchanged (invalid input was already rejected, just with a worse message) and is exercised by the existing `tsc` type-check. The `@cloudflare/config` package has no type-error-assertion harness, and the message wording isn't practically assertable in automated tests. Verified locally against `tsc` that valid calls keep their precise return types and invalid calls now point at the offending property.
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: no user-facing API or behaviour change; only a TypeScript diagnostic message is improved.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14648" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->