### PR TITLE
[workers-shared] Retry null KV reads when serving static assets

### DIFF
--- a/.changeset/asset-worker-kv-null-retries.md
+++ b/.changeset/asset-worker-kv-null-retries.md
@@ -1,0 +1,7 @@
+---
+"@cloudflare/workers-shared": patch
+---
+
+Retry KV reads that return null when serving static assets, not just reads that error.
+
+Immediately after a deploy there is a brief window where an asset referenced by the manifest may not yet have propagated to every KV storage provider, causing a read to return null. Previously this surfaced as an intermittent 500. The Asset Worker now retries these null reads (in addition to errored reads) using a jittered exponential backoff before giving up, reducing intermittent 500s in the moments following a deployment. Retried reads continue to use a short cache TTL so a transient miss is never cached long-term.

--- a/packages/workers-shared/asset-worker/src/utils/kv.ts
+++ b/packages/workers-shared/asset-worker/src/utils/kv.ts
@@ -4,45 +4,79 @@ export type AssetMetadata = {
 	contentType: string;
 };
 
+// The first read of a hot asset can be cached for a long time. Any retry,
+// however, is the result of a null or an error, so we cache those with a short
+// TTL to avoid caching a transient 404 for a year.
+const LONG_CACHE_TTL = 31536000; // 1 year
+const SHORT_CACHE_TTL = 60; // Minimum value allowed by KV
+
+// Jittered exponential backoff bounds, in milliseconds. Kept deliberately
+// small: a single page load can fan out into hundreds of asset requests, so
+// long per-request stalls would be catastrophic for page load time. Full
+// jitter (random between 0 and the current ceiling) avoids synchronised
+// retries stampeding a storage provider that is still catching up.
+const BACKOFF_BASE_MS = 50;
+const BACKOFF_CAP_MS = 1000;
+
+function backoffDelayMs(attempt: number): number {
+	const ceiling = Math.min(
+		BACKOFF_CAP_MS,
+		BACKOFF_BASE_MS * Math.pow(2, attempt - 1)
+	);
+	return Math.random() * ceiling;
+}
+
 export async function getAssetWithMetadataFromKV(
 	assetsKVNamespace: KVNamespace,
 	assetKey: string,
 	sentry?: Toucan,
-	retries = 1
+	retries = 3
 ) {
-	let attempts = 0;
+	for (let attempt = 0; attempt <= retries; attempt++) {
+		const isRetry = attempt > 0;
 
-	while (attempts <= retries) {
+		// Back off before every attempt after the first.
+		if (isRetry) {
+			await new Promise((resolvePromise) =>
+				setTimeout(resolvePromise, backoffDelayMs(attempt))
+			);
+		}
+
 		try {
 			const asset = await assetsKVNamespace.getWithMetadata<AssetMetadata>(
 				assetKey,
 				{
 					type: "stream",
-					cacheTtl: 31536000, // 1 year
+					cacheTtl: isRetry ? SHORT_CACHE_TTL : LONG_CACHE_TTL,
 				}
 			);
 
 			if (asset.value === null) {
-				// Don't cache a 404 for a year by re-requesting with a minimum cacheTtl
-				const retriedAsset =
-					await assetsKVNamespace.getWithMetadata<AssetMetadata>(assetKey, {
-						type: "stream",
-						cacheTtl: 60, // Minimum value allowed
-					});
-
-				if (retriedAsset.value !== null && sentry) {
-					sentry.captureException(
-						new Error(
-							`Initial request for asset ${assetKey} failed, but subsequent request succeeded.`
-						)
-					);
+				// The asset key is taken from the manifest, so a null here almost
+				// always means the value has not yet propagated to the KV storage
+				// provider we read from (the eventual-consistency window right after
+				// a deploy). Retry with backoff to give propagation time to complete.
+				if (attempt < retries) {
+					continue;
 				}
 
-				return retriedAsset;
+				// Out of retries. Return the (null) result and let the caller decide
+				// how to surface it. With the default retries (>= 1) this final read
+				// used the short TTL, so we never cache a null for the long TTL.
+				return asset;
 			}
+
+			if (isRetry && sentry) {
+				sentry.captureException(
+					new Error(
+						`Initial request for asset ${assetKey} failed, but subsequent request succeeded.`
+					)
+				);
+			}
+
 			return asset;
 		} catch (err) {
-			if (attempts >= retries) {
+			if (attempt >= retries) {
 				let message = `KV GET ${assetKey} failed.`;
 				if (err instanceof Error) {
 					message = `KV GET ${assetKey} failed: ${err.message}`;
@@ -50,10 +84,7 @@ export async function getAssetWithMetadataFromKV(
 				throw new Error(message);
 			}
 
-			// Exponential backoff, 1 second first time, then 2 second, then 4 second etc.
-			await new Promise((resolvePromise) =>
-				setTimeout(resolvePromise, Math.pow(2, attempts++) * 1000)
-			);
+			// Otherwise fall through to the next iteration and retry after backoff.
 		}
 	}
 }

--- a/packages/workers-shared/asset-worker/tests/kv.test.ts
+++ b/packages/workers-shared/asset-worker/tests/kv.test.ts
@@ -43,6 +43,25 @@ describe("[Asset Worker] Fetching assets from KV", () => {
 			expect(spy).toHaveBeenCalledOnce();
 		});
 
+		it("should cache a found asset with the long (1 year) TTL on the first read", async ({
+			expect,
+		}) => {
+			spy.mockReturnValueOnce(
+				Promise.resolve({
+					value: "<html>Hello world</html>",
+					metadata: { contentType: "text/html" },
+				}) as unknown as Promise<
+					KVNamespaceGetWithMetadataResult<ReadableStream, AssetMetadata>
+				>
+			);
+
+			await getAssetWithMetadataFromKV(mockKVNamespace, "abcd");
+			expect(spy).toHaveBeenNthCalledWith(1, "abcd", {
+				type: "stream",
+				cacheTtl: 31536000,
+			});
+		});
+
 		it("should throw an error if something went wrong while fetching the asset", async ({
 			expect,
 		}) => {
@@ -53,7 +72,7 @@ describe("[Asset Worker] Fetching assets from KV", () => {
 			).rejects.toThrow("KV GET abcd failed.");
 		});
 
-		it("should retry once by default if something went wrong while fetching the asset", async ({
+		it("should retry up to 3 times by default if something went wrong while fetching the asset", async ({
 			expect,
 		}) => {
 			spy.mockReturnValue(Promise.reject("Oeps! Something went wrong"));
@@ -61,15 +80,17 @@ describe("[Asset Worker] Fetching assets from KV", () => {
 			await expect(() =>
 				getAssetWithMetadataFromKV(mockKVNamespace, "abcd")
 			).rejects.toThrow("KV GET abcd failed.");
-			expect(spy).toHaveBeenCalledTimes(2);
+			// Initial attempt + 3 retries
+			expect(spy).toHaveBeenCalledTimes(4);
 		});
 
-		it("should support custom number of retries", async ({ expect }) => {
+		it("should support a custom number of retries", async ({ expect }) => {
 			spy.mockReturnValue(Promise.reject("Oeps! Something went wrong"));
 
 			await expect(() =>
 				getAssetWithMetadataFromKV(mockKVNamespace, "abcd", undefined, 2)
 			).rejects.toThrow("KV GET abcd failed.");
+			// Initial attempt + 2 retries
 			expect(spy).toHaveBeenCalledTimes(3);
 		});
 
@@ -79,12 +100,14 @@ describe("[Asset Worker] Fetching assets from KV", () => {
 			);
 
 			await expect(() =>
-				getAssetWithMetadataFromKV(mockKVNamespace, "abcd")
+				getAssetWithMetadataFromKV(mockKVNamespace, "abcd", undefined, 1)
 			).rejects.toThrow("KV GET abcd failed: Oeps! Something went wrong");
 			expect(spy).toHaveBeenCalledTimes(2);
 		});
 
-		it("should retry on 404 and cache with shorter ttl", async ({ expect }) => {
+		it("should retry on a null value and resolve once the asset has propagated", async ({
+			expect,
+		}) => {
 			let attempts = 0;
 			spy.mockImplementation(() => {
 				if (attempts++ === 0) {
@@ -107,8 +130,54 @@ describe("[Asset Worker] Fetching assets from KV", () => {
 
 			const asset = await getAssetWithMetadataFromKV(mockKVNamespace, "abcd");
 			expect(asset?.value).toBeTruthy();
-			// Once for the initial call, once for the 404
+			// Once for the initial (null) call, once for the successful retry
 			expect(spy).toHaveBeenCalledTimes(2);
+		});
+
+		it("should use the short (60s) TTL when retrying after a null value", async ({
+			expect,
+		}) => {
+			let attempts = 0;
+			spy.mockImplementation(() => {
+				if (attempts++ === 0) {
+					return Promise.resolve({
+						value: null,
+					}) as unknown as Promise<
+						KVNamespaceGetWithMetadataResult<ReadableStream, AssetMetadata>
+					>;
+				}
+				return Promise.resolve({
+					value: "<html>Hello world</html>",
+					metadata: { contentType: "text/html" },
+				}) as unknown as Promise<
+					KVNamespaceGetWithMetadataResult<ReadableStream, AssetMetadata>
+				>;
+			});
+
+			await getAssetWithMetadataFromKV(mockKVNamespace, "abcd");
+			expect(spy).toHaveBeenNthCalledWith(1, "abcd", {
+				type: "stream",
+				cacheTtl: 31536000,
+			});
+			expect(spy).toHaveBeenNthCalledWith(2, "abcd", {
+				type: "stream",
+				cacheTtl: 60,
+			});
+		});
+
+		it("should retry a persistent null up to the retry limit then return the null result", async ({
+			expect,
+		}) => {
+			spy.mockReturnValue(
+				Promise.resolve({ value: null }) as unknown as Promise<
+					KVNamespaceGetWithMetadataResult<ReadableStream, AssetMetadata>
+				>
+			);
+
+			const asset = await getAssetWithMetadataFromKV(mockKVNamespace, "abcd");
+			expect(asset?.value).toBeNull();
+			// Initial attempt + 3 retries, all null
+			expect(spy).toHaveBeenCalledTimes(4);
 		});
 	});
 });


### PR DESCRIPTION
Retry KV reads that return `null` when serving static assets, not just reads that error.

Immediately after a deploy there is a brief window where an asset referenced by the manifest may not yet have propagated to every KV storage provider, so a read can return `null` even though the asset exists. Previously this surfaced as an intermittent `500`.

There are two failure routes in `getAssetWithMetadataFromKV`:

- **Route A** – the KV read throws (a storage-layer error). Already retried with backoff.
- **Route B** – the KV read returns `null` (asset not yet propagated). Previously did a single immediate re-read and then gave up. Now retried with the same jittered exponential backoff before returning.

The backoff is deliberately small with full jitter (roughly 0–50ms, 0–100ms, 0–200ms) because a single page load can fan out into hundreds of asset requests: long per-request stalls would hurt page load, and jitter avoids synchronised retries stampeding a provider that is still catching up. Retried reads continue to use the short cache TTL so a transient miss is never cached long-term.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: internal change to the Asset Worker's KV retry behaviour; no user-facing API or configuration surface.

*A picture of a cute animal (not mandatory, but encouraged)*

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14649" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->