### PR TITLE
Pass `--no-install` to `@tanstack/cli create` during scaffolding

### DIFF
--- a/.changeset/fix-tanstack-no-install.md
+++ b/.changeset/fix-tanstack-no-install.md
@@ -1,0 +1,7 @@
+---
+"create-cloudflare": patch
+---
+
+Pass `--no-install` to `@tanstack/cli create` during scaffolding
+
+Previously, the TanStack Start template did not pass `--no-install` to the framework CLI, causing dependencies to be installed twice: once by `@tanstack/cli create` and again by C3's own install step. This aligns the TanStack Start template with other framework templates that already skip the framework CLI's install.

--- a/packages/create-cloudflare/templates/tanstack-start/c3.ts
+++ b/packages/create-cloudflare/templates/tanstack-start/c3.ts
@@ -15,6 +15,8 @@ const generate = async (ctx: C3Context) => {
 		"cloudflare",
 		"--framework",
 		"react",
+		// c3 will later install the dependencies
+		"--no-install",
 		// to prevent asking about git twice, just let c3 do it
 		"--no-git",
 	]);


### PR DESCRIPTION
Currently C3 doesn't pass the `--no-install` flag to `@tanstack/cli create` this, when running C3 using pnpm 11 causes the process to fail with:
```
[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: esbuild@0.28.1, sharp@0.34.5, workerd@1.20260708.1

Run "pnpm approve-builds" to pick which dependencies should be allowed to run scripts.
```

Although C3 gracefully handles the deps scripts issue (http://github.com/cloudflare/workers-sdk/blob/7692a6119f49d11289af4ec8cdf9afe95604ef36/packages/create-cloudflare/src/helpers/packages.ts#L155).

This PR adds the `--no-install` flag (which we generally include for all CLIs anyways) so that the tanstack cli doesn't attempt to install the dependencies and leaves this to C3 (who can then recover gracefully)

---

I've also opened https://github.com/TanStack/cli/issues/484 to fix this issue upstream, this would be ideal so that users invoking the tanstack CLI directly would also get a good experience

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: the tanstack functionality is already is already e2e tested, so that ensures that everything still works as intended, we don't generally have more granular tests for flags such as this
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bugfix

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
