### PR TITLE
[vite-plugin] Support auxiliary Workers with new config

### DIFF
--- a/.changeset/quiet-pears-help.md
+++ b/.changeset/quiet-pears-help.md
@@ -1,0 +1,7 @@
+---
+"@cloudflare/vite-plugin": minor
+---
+
+Support auxiliary Workers with `experimental.newConfig`
+
+Point each `auxiliaryWorkers[].configPath` at that Worker's TypeScript config to launch multiple Workers from one Vite development or build command. Existing Wrangler config paths continue to work when `experimental.newConfig` is disabled.

--- a/packages/vite-plugin-cloudflare/playground/experimental-config/__tests__/worker.spec.ts
+++ b/packages/vite-plugin-cloudflare/playground/experimental-config/__tests__/worker.spec.ts
@@ -9,3 +9,10 @@ test("serves the correct response for a worker configured via cloudflare.config.
 		`The mode is ${isBuild ? "production" : "development"}`
 	);
 });
+
+test("serves an auxiliary Worker configured via a TypeScript config", async ({
+	expect,
+}) => {
+	const response = await getTextResponse("/auxiliary");
+	expect(response).toBe("Hello from the auxiliary Worker");
+});

--- a/packages/vite-plugin-cloudflare/playground/experimental-config/auxiliary/cloudflare.config.ts
+++ b/packages/vite-plugin-cloudflare/playground/experimental-config/auxiliary/cloudflare.config.ts
@@ -1,0 +1,8 @@
+import { defineWorker } from "@cloudflare/vite-plugin/experimental-config";
+import * as entrypoint from "./index.ts" with { type: "cf-worker" };
+
+export default defineWorker({
+	name: "auxiliary-worker",
+	entrypoint,
+	compatibilityDate: "2026-05-18",
+});

--- a/packages/vite-plugin-cloudflare/playground/experimental-config/auxiliary/index.ts
+++ b/packages/vite-plugin-cloudflare/playground/experimental-config/auxiliary/index.ts
@@ -1,0 +1,5 @@
+export default {
+	fetch() {
+		return new Response("Hello from the auxiliary Worker");
+	},
+} satisfies ExportedHandler;

--- a/packages/vite-plugin-cloudflare/playground/experimental-config/cloudflare.config.ts
+++ b/packages/vite-plugin-cloudflare/playground/experimental-config/cloudflare.config.ts
@@ -9,6 +9,7 @@ export default defineWorker((ctx) => ({
 	entrypoint,
 	compatibilityDate: "2026-05-18",
 	env: {
+		AUXILIARY: bindings.worker({ workerName: "auxiliary-worker" }),
 		MY_TEXT: bindings.text(`The mode is ${ctx.mode}`),
 	},
 }));

--- a/packages/vite-plugin-cloudflare/playground/experimental-config/src/index.ts
+++ b/packages/vite-plugin-cloudflare/playground/experimental-config/src/index.ts
@@ -1,7 +1,10 @@
 import { env } from "cloudflare:workers";
 
 export default {
-	fetch() {
+	async fetch(request) {
+		if (new URL(request.url).pathname === "/auxiliary") {
+			return env.AUXILIARY.fetch(request);
+		}
 		return new Response(env.MY_TEXT);
 	},
 } satisfies ExportedHandler;

--- a/packages/vite-plugin-cloudflare/playground/experimental-config/vite.config.ts
+++ b/packages/vite-plugin-cloudflare/playground/experimental-config/vite.config.ts
@@ -4,6 +4,7 @@ import { defineConfig } from "vite";
 export default defineConfig({
 	plugins: [
 		cloudflare({
+			auxiliaryWorkers: [{ configPath: "./auxiliary/cloudflare.config.ts" }],
 			inspectorPort: false,
 			persistState: false,
 			experimental: { newConfig: true },

--- a/packages/vite-plugin-cloudflare/src/__tests__/experimental-new-config.spec.ts
+++ b/packages/vite-plugin-cloudflare/src/__tests__/experimental-new-config.spec.ts
@@ -79,7 +79,60 @@ describe("resolvePluginConfig - experimental.newConfig", () => {
 		).rejects.toThrow(/`configPath` cannot be used together/);
 	});
 
-	test("throws when auxiliaryWorkers are combined with experimental.newConfig", async ({
+	test("loads auxiliary Workers from TypeScript config files for build output", async ({
+		expect,
+	}) => {
+		seedWorkerSource();
+		writeWorkerConfig(
+			[
+				"import { defineWorker } from '@cloudflare/config';",
+				"export default defineWorker({",
+				"  name: 'w',",
+				"  entrypoint: './src/index.ts',",
+				"  compatibilityDate: '2024-12-30',",
+				"});",
+			].join("\n")
+		);
+		fs.mkdirSync(path.join(tempDir, "aux"), { recursive: true });
+		fs.writeFileSync(
+			path.join(tempDir, "aux/index.ts"),
+			"export default { fetch() { return new Response('aux'); } }"
+		);
+		fs.writeFileSync(
+			path.join(tempDir, "aux/cloudflare.config.ts"),
+			[
+				"import { defineWorker } from '@cloudflare/config';",
+				"export default defineWorker({",
+				"  name: 'aux-worker',",
+				"  entrypoint: './aux/index.ts',",
+				"  compatibilityDate: '2025-01-02',",
+				"});",
+			].join("\n")
+		);
+
+		const pluginConfig: PluginConfig = {
+			experimental: { newConfig: { cfBuildOutput: true } },
+			auxiliaryWorkers: [{ configPath: "aux/cloudflare.config.ts" }],
+		};
+
+		const result = (await resolvePluginConfig(
+			pluginConfig,
+			{ root: tempDir },
+			{ mode: "production", command: "build" }
+		)) as WorkersResolvedConfig;
+
+		const auxiliaryWorker = result.environmentNameToWorkerMap.get("aux_worker");
+		expect(auxiliaryWorker?.config.main).toBe(
+			path.join(tempDir, "aux/index.ts")
+		);
+		expect(auxiliaryWorker?.config.compatibility_date).toBe("2025-01-02");
+		expect(auxiliaryWorker?.parsedNewConfig?.name).toBe("aux-worker");
+		expect(result.configPaths).toContain(
+			path.join(tempDir, "aux/cloudflare.config.ts")
+		);
+	});
+
+	test("requires auxiliary Workers to use configPath with experimental.newConfig", async ({
 		expect,
 	}) => {
 		seedWorkerSource();
@@ -94,14 +147,16 @@ describe("resolvePluginConfig - experimental.newConfig", () => {
 			].join("\n")
 		);
 
-		const pluginConfig: PluginConfig = {
-			experimental: { newConfig: true },
-			auxiliaryWorkers: [{ configPath: "aux.jsonc" }],
-		};
-
 		await expect(
-			resolvePluginConfig(pluginConfig, { root: tempDir }, viteEnv)
-		).rejects.toThrow(/auxiliaryWorkers/);
+			resolvePluginConfig(
+				{
+					experimental: { newConfig: true },
+					auxiliaryWorkers: [{ config: { name: "aux" } }],
+				},
+				{ root: tempDir },
+				viteEnv
+			)
+		).rejects.toThrow(/must specify a `configPath`/);
 	});
 
 	test("throws when experimental.prerenderWorker is combined with experimental.newConfig", async ({

--- a/packages/vite-plugin-cloudflare/src/__tests__/experimental-new-config.spec.ts
+++ b/packages/vite-plugin-cloudflare/src/__tests__/experimental-new-config.spec.ts
@@ -104,7 +104,7 @@ describe("resolvePluginConfig - experimental.newConfig", () => {
 				"import { defineWorker } from '@cloudflare/config';",
 				"export default defineWorker({",
 				"  name: 'aux-worker',",
-				"  entrypoint: './aux/index.ts',",
+				"  entrypoint: './index.ts',",
 				"  compatibilityDate: '2025-01-02',",
 				"});",
 			].join("\n")

--- a/packages/vite-plugin-cloudflare/src/plugin-config.ts
+++ b/packages/vite-plugin-cloudflare/src/plugin-config.ts
@@ -663,6 +663,7 @@ export async function resolvePluginConfig(
 				mode: viteEnv.mode,
 				generateTypes: false,
 			});
+			workerConfigPath = result.configPath;
 			auxiliaryRawConfigOverride = result.rawConfig;
 			auxiliaryParsedNewConfig = result.parsedConfig;
 			configPaths.add(result.configPath);
@@ -680,7 +681,7 @@ export async function resolvePluginConfig(
 		// Build auxiliary worker config: defaults → file config → config()
 		const workerResolvedConfig = resolveWorkerConfig({
 			root,
-			configPath: resolvedNewConfig ? undefined : workerConfigPath,
+			configPath: workerConfigPath,
 			env: cloudflareEnv,
 			configCustomizer: resolvedNewConfig
 				? undefined

--- a/packages/vite-plugin-cloudflare/src/plugin-config.ts
+++ b/packages/vite-plugin-cloudflare/src/plugin-config.ts
@@ -71,6 +71,11 @@ interface EntryWorkerConfig extends BaseWorkerConfig {
 }
 
 interface AuxiliaryWorkerFileConfig extends BaseWorkerConfig {
+	/**
+	 * Path to this Worker's config file. When `experimental.newConfig` is
+	 * enabled, this must point to a TypeScript config created with
+	 * `defineWorker`; otherwise it points to a Wrangler config file.
+	 */
 	configPath: string;
 	devOnly?: DevOnly;
 }
@@ -470,11 +475,6 @@ export async function resolvePluginConfig(
 				"`configPath` cannot be used together with `experimental.newConfig`. Configure the entry Worker via `cloudflare.config.ts` instead."
 			);
 		}
-		if (pluginConfig.auxiliaryWorkers?.length) {
-			throw new Error(
-				"`auxiliaryWorkers` are not yet supported when `experimental.newConfig` is enabled."
-			);
-		}
 		if (pluginConfig.experimental?.prerenderWorker) {
 			throw new Error(
 				"`experimental.prerenderWorker` is not yet supported when `experimental.newConfig` is enabled."
@@ -641,19 +641,53 @@ export async function resolvePluginConfig(
 	const auxiliaryWorkersResolvedConfigs: WorkerResolvedConfig[] = [];
 
 	for (const auxiliaryWorker of pluginConfig.auxiliaryWorkers ?? []) {
-		const workerConfigPath = getValidatedWranglerConfigPath(
-			root,
-			auxiliaryWorker.configPath,
-			true
-		);
+		let workerConfigPath: string | undefined;
+		let auxiliaryRawConfigOverride: RawConfig | undefined;
+		let auxiliaryParsedNewConfig: ParsedInputWorkerConfig | undefined;
+
+		if (resolvedNewConfig) {
+			if (!auxiliaryWorker.configPath) {
+				throw new Error(
+					"Auxiliary Workers must specify a `configPath` when `experimental.newConfig` is enabled."
+				);
+			}
+			if ("config" in auxiliaryWorker) {
+				throw new Error(
+					"Auxiliary Worker `config` customizers cannot be used when `experimental.newConfig` is enabled. Configure the Worker in its TypeScript config file instead."
+				);
+			}
+
+			const result = await loadNewConfig({
+				root,
+				configPath: auxiliaryWorker.configPath,
+				mode: viteEnv.mode,
+				generateTypes: false,
+			});
+			auxiliaryRawConfigOverride = result.rawConfig;
+			auxiliaryParsedNewConfig = result.parsedConfig;
+			configPaths.add(result.configPath);
+			for (const dep of result.dependencies) {
+				configPaths.add(dep);
+			}
+		} else {
+			workerConfigPath = getValidatedWranglerConfigPath(
+				root,
+				auxiliaryWorker.configPath,
+				true
+			);
+		}
 
 		// Build auxiliary worker config: defaults → file config → config()
 		const workerResolvedConfig = resolveWorkerConfig({
 			root,
-			configPath: workerConfigPath,
+			configPath: resolvedNewConfig ? undefined : workerConfigPath,
 			env: cloudflareEnv,
-			configCustomizer:
-				"config" in auxiliaryWorker ? auxiliaryWorker.config : undefined,
+			configCustomizer: resolvedNewConfig
+				? undefined
+				: "config" in auxiliaryWorker
+					? auxiliaryWorker.config
+					: undefined,
+			rawConfigOverride: auxiliaryRawConfigOverride,
 			entryWorkerConfig: entryWorkerResolvedConfig.config,
 			visitedConfigPaths: configPaths,
 		});
@@ -674,7 +708,8 @@ export async function resolvePluginConfig(
 			workerEnvironmentName,
 			resolveWorker(
 				workerResolvedConfig.config as ResolvedWorkerConfig,
-				auxiliaryWorker.devOnly
+				auxiliaryWorker.devOnly,
+				auxiliaryParsedNewConfig
 			)
 		);
 
@@ -775,6 +810,7 @@ const EXPERIMENTAL_CONFIG_PKG = "@cloudflare/vite-plugin/experimental-config";
  */
 async function loadNewConfig(options: {
 	root: string;
+	configPath?: string;
 	mode: string;
 	generateTypes: boolean;
 }): Promise<{
@@ -783,11 +819,15 @@ async function loadNewConfig(options: {
 	configPath: string;
 	dependencies: Set<string>;
 }> {
-	const configPath = path.resolve(options.root, NEW_CONFIG_FILENAME);
+	const configPath = path.resolve(
+		options.root,
+		options.configPath ?? NEW_CONFIG_FILENAME
+	);
+	const configDisplayName = options.configPath ?? NEW_CONFIG_FILENAME;
 
 	if (!fs.existsSync(configPath)) {
 		throw new Error(
-			`\`experimental.newConfig\` is enabled but no \`${NEW_CONFIG_FILENAME}\` was found at ${configPath}.`
+			`\`experimental.newConfig\` is enabled but no \`${configDisplayName}\` was found at ${configPath}.`
 		);
 	}
 
@@ -800,7 +840,7 @@ async function loadNewConfig(options: {
 	const parsed = InputWorkerSchema.safeParse(resolved);
 	if (!parsed.success) {
 		throw new Error(
-			`Invalid \`${NEW_CONFIG_FILENAME}\`:\n${parsed.error.message}`
+			`Invalid \`${configDisplayName}\`:\n${parsed.error.message}`
 		);
 	}
 


### PR DESCRIPTION
Adds auxiliary Worker support when `experimental.newConfig` is enabled. Existing `auxiliaryWorkers[].configPath` entries now point to each auxiliary Worker's TypeScript config, while legacy Wrangler config behavior remains unchanged when the experiment is disabled.

The auxiliary configs use the same `@cloudflare/config` conversion path as the entry Worker, participate in config dependency watching, and retain parsed config data for Build Output API emission.

**This is to maiintain parity with https://developers.cloudflare.com/workers/local-development/multi-workers/#single-dev-command. My preference is instead having something like this:**

```ts
import * as api from "@repo/api" with { type: "cf-worker" }

...
env: {
  API: bindings.worker(api)
}
```

But that's just an incremental step to eventually having `defineProject(...)`!

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: this extends an experimental API and includes a changeset plus an executable playground example.

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14654" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->