### PR TITLE
Fix `wrangler dev` corrupting external hostnames in proxied headers

### DIFF
--- a/.changeset/fix-proxyworker-substring-host-rewrite.md
+++ b/.changeset/fix-proxyworker-substring-host-rewrite.md
@@ -1,0 +1,9 @@
+---
+"wrangler": patch
+---
+
+Fix `wrangler dev` corrupting external hostnames in proxied response headers
+
+When a Worker was run with `routes` configured, `wrangler dev`'s proxy rewrote the host inside URL-valued headers (such as `Location`) using a boundary-less substring replace. Any host that merely _contained_ the route host as a substring was corrupted — e.g. with an `example.com` route, a `Location: https://books.example.com/read/ch01` header became `https://books.127.0.0.1:8788/read/ch01`, and `https://myexample.com/path` became `https://my127.0.0.1:8788/path`.
+
+The proxy now only rewrites absolute URLs whose host is exactly the proxied host, swapping the scheme and host together (which also fixes a related case where an `https:` scheme survived on a plain-HTTP dev address). Unrelated hosts and subdomains pass through untouched.

--- a/packages/wrangler/src/__tests__/api/startDevWorker/utils.test.ts
+++ b/packages/wrangler/src/__tests__/api/startDevWorker/utils.test.ts
@@ -3,6 +3,7 @@ import {
 	convertConfigBindingsToStartWorkerBindings,
 	convertStartDevOptionsToBindings,
 } from "../../../api/startDevWorker/binding-utils";
+import { rewriteUrlInHeaderValue } from "../../../api/startDevWorker/utils";
 
 describe("convertConfigBindingsToStartWorkerBindings", () => {
 	it("converts config bindings into startWorker bindings", async ({
@@ -230,5 +231,67 @@ describe("convertConfigBindingsToStartWorkerBindings", () => {
 				type: "stream",
 			},
 		});
+	});
+});
+
+describe("rewriteUrlInHeaderValue", () => {
+	// Response path: map the proxied host (`example.com`, inferred from `routes`)
+	// back to the local dev address, matching the scenario in issue #14577.
+	const from = new URL("http://example.com");
+	const to = new URL("http://127.0.0.1:8788");
+
+	it("rewrites a URL whose host is exactly the proxied host", ({ expect }) => {
+		expect(
+			rewriteUrlInHeaderValue("https://example.com/somewhere", from, to)
+		).toBe(
+			// scheme is swapped too, so the value points at the plain-HTTP dev address
+			"http://127.0.0.1:8788/somewhere"
+		);
+	});
+
+	it("does not corrupt a subdomain of the proxied host", ({ expect }) => {
+		expect(
+			rewriteUrlInHeaderValue("https://books.example.com/read/ch01", from, to)
+		).toBe("https://books.example.com/read/ch01");
+	});
+
+	it("does not corrupt a host that merely contains the proxied host as a substring", ({
+		expect,
+	}) => {
+		expect(
+			rewriteUrlInHeaderValue("https://myexample.com/path", from, to)
+		).toBe("https://myexample.com/path");
+	});
+
+	it("leaves an unrelated host untouched", ({ expect }) => {
+		expect(
+			rewriteUrlInHeaderValue("https://unrelated-domain.org/path", from, to)
+		).toBe("https://unrelated-domain.org/path");
+	});
+
+	it("does not append a trailing slash to a bare origin (e.g. an Origin header)", ({
+		expect,
+	}) => {
+		expect(rewriteUrlInHeaderValue("https://example.com", from, to)).toBe(
+			"http://127.0.0.1:8788"
+		);
+	});
+
+	it("preserves host-like substrings inside the query string", ({ expect }) => {
+		expect(
+			rewriteUrlInHeaderValue(
+				"https://example.com/oauth?redirect_uri=https://example.com/next",
+				from,
+				to
+			)
+		).toBe("http://127.0.0.1:8788/oauth?redirect_uri=https://example.com/next");
+	});
+
+	it("maps the local dev address back to the proxied host (request path)", ({
+		expect,
+	}) => {
+		expect(rewriteUrlInHeaderValue("http://127.0.0.1:8788/cb", to, from)).toBe(
+			"http://example.com/cb"
+		);
 	});
 });

--- a/packages/wrangler/src/api/startDevWorker/utils.ts
+++ b/packages/wrangler/src/api/startDevWorker/utils.ts
@@ -58,6 +58,47 @@ export function urlFromParts(
 	return url;
 }
 
+/**
+ * Rewrite the absolute URLs inside a single header value (e.g. `Location`,
+ * `Origin`, `Access-Control-Allow-Origin`), mapping only those whose host is
+ * exactly `from.host` onto `to`'s origin.
+ *
+ * The proxy previously replaced every substring occurrence of `from.host`,
+ * which corrupted unrelated hosts that merely *contained* the proxied host as a
+ * substring. For example, with a `example.com` route rewritten to a local
+ * `127.0.0.1:8788` dev address, `https://books.example.com/x` became
+ * `https://books.127.0.0.1:8788/x` and `https://myexample.com/x` became
+ * `https://my127.0.0.1:8788/x`. Matching on the parsed host and swapping the
+ * whole origin (scheme included) also avoids leaving a mismatched `https:`
+ * scheme on a plain-HTTP dev address.
+ */
+export function rewriteUrlInHeaderValue(
+	value: string,
+	from: URL,
+	to: URL
+): string {
+	// Split each absolute URL into its `scheme://authority` origin and the
+	// literal remainder (path/query/fragment). Keeping the remainder verbatim
+	// avoids URL normalization such as appending a trailing slash to a bare
+	// origin (which would corrupt an `Origin` header), and leaves host-like
+	// substrings inside query strings untouched.
+	return value.replace(
+		/(https?:\/\/[^/?#\s,;"']+)([^\s,;"']*)/gi,
+		(match, origin: string, rest: string) => {
+			let url: URL;
+			try {
+				url = new URL(origin);
+			} catch {
+				return match;
+			}
+			if (url.host !== from.host) {
+				return match;
+			}
+			return to.origin + rest;
+		}
+	);
+}
+
 type UnwrapHook<
 	T extends HookValues | Promise<HookValues>,
 	Args extends unknown[],

--- a/packages/wrangler/src/api/startDevWorker/utils.ts
+++ b/packages/wrangler/src/api/startDevWorker/utils.ts
@@ -59,18 +59,17 @@ export function urlFromParts(
 }
 
 /**
- * Rewrite the absolute URLs inside a single header value (e.g. `Location`,
- * `Origin`, `Access-Control-Allow-Origin`), mapping only those whose host is
- * exactly `from.host` onto `to`'s origin.
+ * Rewrites the absolute URLs inside a single header value (e.g. `Location`,
+ * `Origin`, `Access-Control-Allow-Origin`), mapping only those whose host
+ * that match the target host.
  *
- * The proxy previously replaced every substring occurrence of `from.host`,
- * which corrupted unrelated hosts that merely *contained* the proxied host as a
- * substring. For example, with a `example.com` route rewritten to a local
- * `127.0.0.1:8788` dev address, `https://books.example.com/x` became
- * `https://books.127.0.0.1:8788/x` and `https://myexample.com/x` became
- * `https://my127.0.0.1:8788/x`. Matching on the parsed host and swapping the
- * whole origin (scheme included) also avoids leaving a mismatched `https:`
- * scheme on a plain-HTTP dev address.
+ * This function ensures that the host is replaced in a robust manner avoiding
+ * corruptions (that can happen for example if a naive replacement was used).
+ *
+ * @param value - The raw header value string that may contain absolute URLs to rewrite.
+ * @param from - The URL whose host should be matched against URLs found in the header value.
+ * @param to - The URL whose origin will replace the matched origin in the header value.
+ * @returns The header value string with all matching absolute URLs rewritten to use the target origin.
  */
 export function rewriteUrlInHeaderValue(
 	value: string,

--- a/packages/wrangler/templates/startDevWorker/ProxyWorker.ts
+++ b/packages/wrangler/templates/startDevWorker/ProxyWorker.ts
@@ -1,6 +1,7 @@
 import {
 	createDeferred,
 	DeferredPromise,
+	rewriteUrlInHeaderValue,
 	urlFromParts,
 } from "../../src/api/startDevWorker/utils";
 import type {
@@ -350,10 +351,7 @@ function rewriteUrlRelatedHeaders(headers: Headers, from: URL, to: URL) {
 	headers.delete("Set-Cookie");
 	headers.forEach((value, key) => {
 		if (typeof value === "string" && value.includes(from.host)) {
-			headers.set(
-				key,
-				value.replaceAll(from.origin, to.origin).replaceAll(from.host, to.host)
-			);
+			headers.set(key, rewriteUrlInHeaderValue(value, from, to));
 		}
 	});
 	for (const cookie of setCookie) {


### PR DESCRIPTION
Fixes #14577

## Problem

With a `routes`-configured Worker, `wrangler dev`'s proxy corrupts external hostnames inside URL-valued response headers (most visibly `Location` from `_redirects`). `rewriteUrlRelatedHeaders` in `templates/startDevWorker/ProxyWorker.ts` rewrites the host with a boundary-less substring replace:

```ts
value.replaceAll(from.origin, to.origin).replaceAll(from.host, to.host)
```

So with a `example.com` route mapped to a local `127.0.0.1:8788` dev address, any host that merely *contains* `example.com` as a substring is mangled:

| header value | before | after (this PR) |
|---|---|---|
| `https://books.example.com/read/ch01` | `https://books.127.0.0.1:8788/read/ch01` ❌ | unchanged ✅ |
| `https://myexample.com/path` | `https://my127.0.0.1:8788/path` ❌ | unchanged ✅ |
| `https://example.com/somewhere` | `https://127.0.0.1:8788/somewhere` (stale `https:`) ⚠️ | `http://127.0.0.1:8788/somewhere` ✅ |
| `https://unrelated-domain.org/path` | unchanged ✅ | unchanged ✅ |

## Fix

Extract a `rewriteUrlInHeaderValue` helper (in `startDevWorker/utils.ts`, alongside `urlFromParts`) that scans each absolute URL in the header value, parses it, and rewrites it **only when its host is exactly `from.host`**, swapping the scheme and host together onto `to`'s origin. The path/query/fragment remainder is preserved verbatim, so:

- Bare origins (e.g. an `Origin` header) don't gain a spurious trailing slash.
- Host-like substrings inside query strings (e.g. a `redirect_uri=`) are left untouched — consistent with the existing intent noted at the `MF-Original-URL` call site.

Swapping scheme+host together also resolves the stale-`https:` artifact in row 3.

---

- Tests
  - [x] Tests included/updated — `rewriteUrlInHeaderValue` unit tests in `src/__tests__/api/startDevWorker/utils.test.ts` covering each row above (they fail against the previous substring behavior and pass with this change)
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: internal dev-proxy bug fix with no user-facing API change

🐢

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14658" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->