### PR TITLE
Fail fast when account_id is not accessible by the current login

### DIFF
--- a/.changeset/account-id-reachability-check.md
+++ b/.changeset/account-id-reachability-check.md
@@ -1,0 +1,16 @@
+---
+"wrangler": minor
+---
+
+Fail fast with a clearer error when `account_id` is not accessible by the current login
+
+When `account_id` (from your `wrangler.json` file, the `CLOUDFLARE_ACCOUNT_ID` environment variable, or a previous account selection) is not one of the accounts your current login can access, Wrangler now stops before making the request and explains the problem, instead of surfacing a generic `Authentication error [code: 10000]` from the API.
+
+The message names the account, the active auth profile, and the accounts your login can reach, and points at auth profiles as the way to work across multiple accounts:
+
+```
+wrangler auth create <name>
+wrangler auth activate <name>
+```
+
+The check is best-effort: if reachability cannot be determined (offline, a token without permission to read accounts, or a temporary preview account) Wrangler proceeds as before. On commands that resolve an account from a static source it adds a single lightweight account lookup; the fuller account list is only fetched when that lookup fails, to build the error message.

--- a/packages/wrangler/src/__tests__/helpers/msw/index.ts
+++ b/packages/wrangler/src/__tests__/helpers/msw/index.ts
@@ -2,6 +2,7 @@ import {
 	mswAccessHandlers,
 	mswSuccessOauthHandlers,
 } from "@cloudflare/workers-auth/test-helpers";
+import { http, HttpResponse } from "msw";
 import { setupServer } from "msw/node";
 import {
 	mswSuccessDeploymentDetails,
@@ -27,7 +28,25 @@ import {
 } from "./handlers/versions";
 import { default as mswZoneHandlers } from "./handlers/zones";
 
-export const msw = setupServer();
+// A permissive default for the single-account lookup (`GET /accounts/:id`)
+// that `getOrSelectAccountId` uses to check the configured/env/cache account
+// is reachable by the current login. Returning the requested account keeps the
+// happy-path account-reachability check green for every command test without
+// each one having to register its own handler. Tests that exercise the
+// "account not accessible" path register a `.use()` override that fails this
+// request. This exact path has no other handlers (sub-paths like
+// `*/accounts/:accountId/workers/...` are matched by their own handlers).
+const mswDefaultSingleAccountHandler = http.get(
+	"*/accounts/:accountId",
+	({ params }) => {
+		const accountId = String(params.accountId);
+		return HttpResponse.json(
+			createFetchResult({ id: accountId, name: "Mock Account" })
+		);
+	}
+);
+
+export const msw = setupServer(mswDefaultSingleAccountHandler);
 
 function createFetchResult(
 	result: unknown,

--- a/packages/wrangler/src/__tests__/user.test.ts
+++ b/packages/wrangler/src/__tests__/user.test.ts
@@ -44,6 +44,7 @@ import {
 import {
 	createFetchResult,
 	msw,
+	mswFailAccountsHandler,
 	mswSuccessOauthHandlers,
 	mswSuccessUserHandlers,
 } from "./helpers/msw";
@@ -2078,10 +2079,12 @@ describe("User", () => {
 			vi.stubEnv("CLOUDFLARE_API_TOKEN", "test-api-token");
 		});
 
-		it("should return env var without making API calls", async ({ expect }) => {
+		it("should return env var without prompting", async ({ expect }) => {
 			vi.stubEnv("CLOUDFLARE_ACCOUNT_ID", "env-account-id");
 
-			// No getMswSuccessMembershipHandlers — if an API call is made, it will fail
+			// The env-var account is resolved directly and only the lightweight
+			// reachability probe (`GET /accounts/:id`, served by the default
+			// handler) runs — no interactive account selection prompt.
 			const accountId = await getOrSelectAccountId({});
 			expect(accountId).toBe("env-account-id");
 		});
@@ -2138,6 +2141,101 @@ describe("User", () => {
 				id: "api-account",
 				name: "API Account",
 			});
+		});
+	});
+
+	describe("getOrSelectAccountId account reachability", () => {
+		// The outer `describe("User")` beforeEach registers the default
+		// membership handlers, which report `account-1`/`account-2`/`account-3`
+		// as the accounts the login can access.
+		beforeEach(() => {
+			vi.stubEnv("CLOUDFLARE_API_TOKEN", "test-api-token");
+		});
+
+		// Force the single-account reachability probe (`GET /accounts/:id`) to
+		// fail so the confirmation step (the account list) is exercised.
+		function failAccountProbe() {
+			msw.use(
+				http.get("*/accounts/:accountId", () =>
+					HttpResponse.json(
+						createFetchResult(null, false, [
+							{ code: 10000, message: "Authentication error" },
+						])
+					)
+				)
+			);
+		}
+
+		it("throws a profile-aware error when config account_id is not accessible", async ({
+			expect,
+		}) => {
+			failAccountProbe();
+			await expect(
+				getOrSelectAccountId({ account_id: "unreachable-account-id" })
+			).rejects.toThrowErrorMatchingInlineSnapshot(`
+				[Error: The account ID \`unreachable-account-id\` (set as \`account_id\` in your Wrangler configuration file) is not accessible with your current login.
+				Accounts this login can access (\`<name>\`: \`<account_id>\`):
+				  \`Account One\`: \`account-1\`
+				  \`Account Two\`: \`account-2\`
+				  \`Account Three\`: \`account-3\`
+				To use one of these accounts, set \`account_id\` to its ID (or remove \`account_id\` to be prompted).
+				To use \`unreachable-account-id\`, log in with an account that can access it. If you work across multiple accounts, create an auth profile scoped to it and activate it in this directory:
+				  wrangler auth create <name>
+				  wrangler auth activate <name>
+				Learn more: https://developers.cloudflare.com/workers/wrangler/profiles/]
+			`);
+		});
+
+		it("throws when CLOUDFLARE_ACCOUNT_ID is not accessible", async ({
+			expect,
+		}) => {
+			failAccountProbe();
+			vi.stubEnv("CLOUDFLARE_ACCOUNT_ID", "unreachable-account-id");
+			await expect(getOrSelectAccountId({})).rejects
+				.toThrowErrorMatchingInlineSnapshot(`
+				[Error: The account ID \`unreachable-account-id\` (set via the CLOUDFLARE_ACCOUNT_ID environment variable) is not accessible with your current login.
+				Accounts this login can access (\`<name>\`: \`<account_id>\`):
+				  \`Account One\`: \`account-1\`
+				  \`Account Two\`: \`account-2\`
+				  \`Account Three\`: \`account-3\`
+				To use one of these accounts, set \`account_id\` to its ID (or remove \`account_id\` to be prompted).
+				To use \`unreachable-account-id\`, log in with an account that can access it. If you work across multiple accounts, create an auth profile scoped to it and activate it in this directory:
+				  wrangler auth create <name>
+				  wrangler auth activate <name>
+				Learn more: https://developers.cloudflare.com/workers/wrangler/profiles/]
+			`);
+		});
+
+		it("throws a UserError (not a reportable bug)", async ({ expect }) => {
+			failAccountProbe();
+			await expect(
+				getOrSelectAccountId({ account_id: "unreachable-account-id" })
+			).rejects.toBeInstanceOf(UserError);
+		});
+
+		it("does not throw when the config account_id is accessible", async ({
+			expect,
+		}) => {
+			// The default single-account probe handler reports the account as
+			// reachable, so no confirmation step or error is needed.
+			const accountId = await getOrSelectAccountId({
+				account_id: "account-2",
+			});
+			expect(accountId).toBe("account-2");
+		});
+
+		it("proceeds when the set of reachable accounts cannot be determined", async ({
+			expect,
+		}) => {
+			// Probe fails AND the account list can't be fetched, so the
+			// best-effort check degrades and lets the id through rather than
+			// blocking.
+			failAccountProbe();
+			msw.use(mswFailAccountsHandler);
+			const accountId = await getOrSelectAccountId({
+				account_id: "unreachable-account-id",
+			});
+			expect(accountId).toBe("unreachable-account-id");
 		});
 	});
 });

--- a/packages/wrangler/src/user/user.ts
+++ b/packages/wrangler/src/user/user.ts
@@ -27,6 +27,7 @@ import {
 import ci from "ci-info";
 import { formatDistanceToNowStrict } from "date-fns";
 import { dedent } from "ts-dedent";
+import { fetchResult } from "../cfetch";
 import { getConfigCache, saveToConfigCache } from "../config-cache";
 import { purgeConfigCaches } from "../config-cache";
 import { NoDefaultValueProvided, select } from "../dialogs";
@@ -453,10 +454,131 @@ export function getActiveAccountId(config: {
 }
 
 /**
+ * Describes where a resolved account ID came from, for use in error messages.
+ */
+function describeAccountIdSource(
+	config: { account_id?: string },
+	accountId: string
+): string {
+	if (config.account_id === accountId) {
+		return `set as \`account_id\` in your ${configFileName(undefined)} file`;
+	}
+	if (getCloudflareAccountIdFromEnv() === accountId) {
+		return "set via the CLOUDFLARE_ACCOUNT_ID environment variable";
+	}
+	return "remembered from a previous account selection";
+}
+
+/**
+ * Fails fast when an account ID resolved from a non-interactive source
+ * (`account_id` in the Wrangler configuration file, the `CLOUDFLARE_ACCOUNT_ID`
+ * environment variable, or the per-profile account cache) is not one of the
+ * accounts the current login can reach.
+ *
+ * Without this check the request continues and the Cloudflare API rejects it
+ * with a generic `Authentication error [code: 10000]`, which does not explain
+ * that the real problem is an account the current login cannot access. Here we
+ * surface a message that names the account, the active auth profile, and the
+ * accounts this login can reach, and points at auth profiles as the way to work
+ * across multiple accounts.
+ *
+ * The check runs in two steps so the common case is cheap:
+ *  1. A direct `GET /accounts/<id>` probe. When the login can reach the
+ *     account this is a single request and we return immediately.
+ *  2. Only if the probe fails do we list the reachable accounts (via
+ *     {@link fetchAllAccounts}) to build the rich error — and to guard against
+ *     false positives where the probe failed for an unrelated reason (e.g. a
+ *     token without account-read scope), in which case we let it proceed.
+ *
+ * The check is best-effort. If reachability cannot be determined — offline, a
+ * token without permission to list accounts, or a temporary preview account —
+ * it does nothing and lets the request proceed as it did before.
+ *
+ * @throws {UserError} If the account is definitively not reachable by the
+ *   current login.
+ */
+async function assertAccountIsReachable(
+	config: ComplianceConfig & { account_id?: string },
+	accountId: string
+): Promise<void> {
+	// A temporary preview account's id is its whole identity; there is no
+	// account list to validate it against.
+	if (oauthFlow.getActiveTemporaryAccount()) {
+		return;
+	}
+
+	// Fast path: look the account up directly. When the current login can
+	// reach it this is a single request and we're done. Any failure (not
+	// accessible, offline, missing scope, ...) drops through to the slower
+	// confirmation step rather than being treated as proof of inaccessibility
+	// on its own.
+	try {
+		await fetchResult<Account>(config, `/accounts/${accountId}`);
+		return;
+	} catch (probeError) {
+		logger.debug(
+			`Could not directly access account \`${accountId}\`; confirming against the account list:`,
+			probeError
+		);
+	}
+
+	// Confirmation: list the accounts this login can reach. Only reached when
+	// the direct lookup failed, so the extra request cost is paid on the error
+	// path, not the happy path.
+	let accounts: Account[];
+	try {
+		accounts = await fetchAllAccounts(config, { throwOnEmpty: false });
+	} catch (e) {
+		// If we can't list the reachable accounts (offline, insufficient token
+		// permissions, ...) fall back to the previous behaviour and let the
+		// upcoming API request surface any error.
+		logger.debug("Could not verify account access; skipping check:", e);
+		return;
+	}
+
+	// An empty list means we couldn't determine access — don't block. If the
+	// account turns out to be in the list after all (i.e. the direct lookup
+	// failed for an unrelated reason such as a missing account-read scope),
+	// also let it proceed.
+	if (accounts.length === 0 || accounts.some((a) => a.id === accountId)) {
+		return;
+	}
+
+	const activeProfile = getActiveProfile();
+	const profileSuffix =
+		activeProfile === "default" ? "" : ` (profile "${activeProfile}")`;
+	// Account names may contain email addresses; redact them in CI logs.
+	const redactAccountName = ci.isCI;
+	const accountList = accounts
+		.map(
+			(account) =>
+				`  \`${redactAccountName ? "(redacted)" : account.name}\`: \`${account.id}\``
+		)
+		.join("\n");
+
+	throw new UserError(
+		`The account ID \`${accountId}\` (${describeAccountIdSource(
+			config,
+			accountId
+		)}) is not accessible with your current login${profileSuffix}.
+Accounts this login can access (\`<name>\`: \`<account_id>\`):
+${accountList}
+To use one of these accounts, set \`account_id\` to its ID (or remove \`account_id\` to be prompted).
+To use \`${accountId}\`, log in with an account that can access it. If you work across multiple accounts, create an auth profile scoped to it and activate it in this directory:
+  wrangler auth create <name>
+  wrangler auth activate <name>
+Learn more: https://developers.cloudflare.com/workers/wrangler/profiles/`,
+		{ telemetryMessage: "account id not accessible with current login" }
+	);
+}
+
+/**
  * Resolves the account ID to use for API requests.
  *
  * First tries static sources via {@link getActiveAccountId} (config, env var,
- * cache). If none are available, falls back to fetching accounts from the API:
+ * cache). When an account is resolved this way, it is checked against the
+ * accounts the current login can reach (see {@link assertAccountIsReachable}).
+ * If none are available, falls back to fetching accounts from the API:
  * - Auto-selects if only one account is available
  * - Prompts the user to select an account interactively if multiple are available
  *
@@ -465,6 +587,8 @@ export function getActiveAccountId(config: {
  *
  * @param config - Configuration containing an optional `account_id` and compliance settings
  * @returns The resolved account ID
+ * @throws {UserError} If a statically-resolved `account_id` is not one of the
+ *   accounts the current login can access
  * @throws {UserError} If in a non-interactive environment and multiple accounts are
  *   available (the user must set `account_id` in config or `CLOUDFLARE_ACCOUNT_ID` env var)
  * @throws {UserError} If no accounts are found for the authenticated user
@@ -476,6 +600,7 @@ export async function getOrSelectAccountId(
 	// for consistency with other env vars.
 	const activeAccountId = getActiveAccountId(config);
 	if (activeAccountId) {
+		await assertAccountIsReachable(config, activeAccountId);
 		return activeAccountId;
 	}
 


### PR DESCRIPTION
## What this changes

When Wrangler resolves an `account_id` from a static source — the Wrangler config file, the `CLOUDFLARE_ACCOUNT_ID` environment variable, or the per-profile account cache — and that account is not one the current login can access, the request previously continued until the Cloudflare API rejected it with a generic:

```
Authentication error [code: 10000]
```

That error does not explain that the real problem is an account the current login cannot reach.

`getOrSelectAccountId` now checks reachability before proceeding and, when the account is not accessible, fails fast with a message that names the account, the active auth profile, and the accounts this login can reach, and points at auth profiles for working across multiple accounts.

## How it works

The check runs in two steps so the common case stays cheap:

1. A direct `GET /accounts/<id>` probe. When the login can reach the account this is a single request and we return immediately.
2. Only if the probe fails do we fetch the reachable-account list — both to build the rich error and to guard against false positives (e.g. the probe failing for an unrelated reason such as a token without account-read scope), in which case we let the request proceed.

The check is best-effort. If reachability cannot be determined — offline, a token without permission to read accounts, or a temporary preview account — it does nothing and lets the request proceed as before.

### Before

```
✘ [ERROR] Authentication error [code: 10000]
```

### After

```
✘ [ERROR] The account ID `deadbeefdeadbeefdeadbeefdeadbeef` (set as `account_id` in your Wrangler configuration file) is not accessible with your current login.

  Accounts this login can access (`<name>`: `<account_id>`):
    `Example Account`: `f7f78ebb28c2a224a9a46a3007350b7a`
    ...
  To use one of these accounts, set `account_id` to its ID (or remove `account_id` to be prompted).
  To use `deadbeefdeadbeefdeadbeefdeadbeef`, log in with an account that can access it. If you work across multiple accounts, create an auth profile scoped to it and activate it in this directory:
    wrangler auth create <name>
    wrangler auth activate <name>
  Learn more: https://developers.cloudflare.com/workers/wrangler/profiles/
```

## Testing

- Added unit tests in `user.test.ts` covering the config and env-var not-accessible paths (profile-aware message), that the error is a `UserError`, that a reachable account proceeds, and that the check degrades when reachability cannot be determined.
- Added a permissive default `GET */accounts/:accountId` MSW handler so the happy-path reachability probe is served for existing command tests without each registering its own handler.
- Full `wrangler` test suite passes locally; `check:type`, `check:lint`, and `check:format` pass.
- Manually verified against a repro project: a config `account_id` the login cannot access now produces the new error (previously `code: 10000`), and a reachable account resolves normally.

A changeset is included (`wrangler` minor).