### PR TITLE
[local-explorer-ui] Fix worker selector scrolling

### DIFF
--- a/.changeset/local-explorer-selector-scroll.md
+++ b/.changeset/local-explorer-selector-scroll.md
@@ -1,0 +1,7 @@
+---
+"@cloudflare/local-explorer-ui": patch
+---
+
+Make long worker selector lists scrollable
+
+Workers beyond the visible selector limit can now be reached with a mouse, trackpad, or keyboard without scrolling the Local Explorer page.

--- a/packages/local-explorer-ui/src/__e2e__/worker-selector.spec.ts
+++ b/packages/local-explorer-ui/src/__e2e__/worker-selector.spec.ts
@@ -1,0 +1,132 @@
+import { afterEach, describe, test } from "vitest";
+import { page, viteUrl } from "./utils";
+
+const WORKERS_ROUTE = "**/cdn-cgi/explorer/api/local/workers";
+
+function createWorkers(count: number) {
+	return Array.from({ length: count }, (_, index) => ({
+		isSelf: index === 0,
+		name: `worker-${index + 1}`,
+	}));
+}
+
+async function loadWorkers(count: number): Promise<void> {
+	await page.route(WORKERS_ROUTE, async (route) => {
+		await route.fulfill({
+			contentType: "application/json",
+			body: JSON.stringify({
+				errors: [],
+				messages: [],
+				result: createWorkers(count),
+				success: true,
+			}),
+		});
+	});
+
+	await page.goto(viteUrl);
+}
+
+function waitForWorkersResponse() {
+	return page.waitForResponse((response) =>
+		response.url().endsWith("/cdn-cgi/explorer/api/local/workers")
+	);
+}
+
+afterEach(async () => {
+	await page.unroute(WORKERS_ROUTE);
+});
+
+describe("worker selector", () => {
+	test("stays hidden when there is only one worker", async ({ expect }) => {
+		await loadWorkers(1);
+
+		expect(await page.getByRole("combobox").count()).toBe(0);
+	});
+
+	test("keeps nine workers fully visible", async ({ expect }) => {
+		await loadWorkers(9);
+
+		await page.getByRole("combobox").click();
+		const listBounds = await page.getByRole("listbox").boundingBox();
+		const lastOptionBounds = await page
+			.getByRole("option", { name: "worker-9" })
+			.boundingBox();
+
+		expect(listBounds).not.toBeNull();
+		expect(lastOptionBounds).not.toBeNull();
+		if (listBounds && lastOptionBounds) {
+			expect(lastOptionBounds.y + lastOptionBounds.height).toBeLessThanOrEqual(
+				listBounds.y + listBounds.height
+			);
+		}
+	});
+
+	test("scrolls to and selects workers beyond the visible limit", async ({
+		expect,
+	}) => {
+		await page.setViewportSize({ height: 720, width: 1280 });
+		await loadWorkers(12);
+
+		await page.getByRole("combobox").click();
+		const list = page.getByRole("listbox");
+
+		const dimensions = await list.evaluate((element) => ({
+			clientHeight: element.clientHeight,
+			scrollHeight: element.scrollHeight,
+		}));
+		expect(dimensions.scrollHeight).toBeGreaterThan(dimensions.clientHeight);
+
+		const main = page.locator("main");
+		const pageScrollTop = await main.evaluate((element) => element.scrollTop);
+		await list.hover();
+		await page.mouse.wheel(0, dimensions.scrollHeight);
+		await expect
+			.poll(async () => await list.evaluate((element) => element.scrollTop))
+			.toBeGreaterThan(0);
+		expect(await main.evaluate((element) => element.scrollTop)).toBe(
+			pageScrollTop
+		);
+
+		const workersResponse = waitForWorkersResponse();
+		await page.getByRole("option", { name: "worker-12" }).click();
+		await workersResponse;
+		await expect
+			.poll(() => new URL(page.url()).searchParams.get("worker"))
+			.toBe("worker-12");
+		await page.getByRole("combobox").getByText("worker-12").waitFor();
+		await page.waitForLoadState("networkidle");
+	});
+
+	test("reaches later workers with the keyboard in a narrow viewport", async ({
+		expect,
+	}) => {
+		await loadWorkers(12);
+		await page.setViewportSize({ height: 640, width: 800 });
+
+		await page.getByRole("combobox").click({ timeout: 5_000 });
+		const list = page.getByRole("listbox");
+		const lastOption = page.getByRole("option", { name: "worker-12" });
+		let reachedLastOption = false;
+		for (let index = 0; index < 12; index++) {
+			await page.keyboard.press("ArrowDown");
+			reachedLastOption =
+				(await lastOption.getAttribute("data-highlighted")) !== null;
+			if (reachedLastOption) {
+				break;
+			}
+		}
+		expect(reachedLastOption).toBe(true);
+		expect(await list.evaluate((element) => element.scrollTop)).toBeGreaterThan(
+			0
+		);
+		const workersResponse = waitForWorkersResponse();
+		await page.keyboard.press("Enter");
+		await workersResponse;
+
+		await expect
+			.poll(() => new URL(page.url()).searchParams.get("worker"))
+			.toBe("worker-12");
+		await page.getByRole("combobox").getByText("worker-12").waitFor();
+		await page.waitForLoadState("networkidle");
+	});
+});

--- a/packages/local-explorer-ui/src/components/WorkerSelector.tsx
+++ b/packages/local-explorer-ui/src/components/WorkerSelector.tsx
@@ -113,7 +113,7 @@ export function WorkerSelector({
 					sideOffset={sidebar.open ? 4 : 8}
 				>
 					<Select.Popup className="max-h-72 min-w-48 overflow-hidden rounded-lg border border-kumo-fill bg-kumo-base shadow-[0_4px_12px_rgba(0,0,0,0.15)] transition-[opacity,transform] duration-150 data-ending-style:-translate-y-1 data-ending-style:opacity-0 data-starting-style:-translate-y-1 data-starting-style:opacity-0">
-						<Select.List className="p-1">
+						<Select.List className="max-h-72 overflow-y-auto p-1">
 							{workers.map((worker) => {
 								const isSelected = selectedWorker === worker.name;
 								const Icon = isSelected ? CheckIcon : TerminalIcon;


### PR DESCRIPTION
Fixes #14624.

Makes long worker selector lists vertically scrollable while preserving the existing selection and keyboard behavior. Adds browser coverage for the previous nine-worker boundary, mouse-wheel scrolling, keyboard navigation, URL selection, narrow layouts, and page-scroll containment.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: this fixes existing Local Explorer UI behavior without changing its public API.

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14668" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->