### PR TITLE
Enable `@typescript-eslint/no-deprecated` linting rule for `workflows-shared`

### DIFF
--- a/.oxlintrc.jsonc
+++ b/.oxlintrc.jsonc
@@ -202,13 +202,9 @@
 				"workers-sdk/no-wrangler-named-imports": "error",
 			},
 		},
-		// Gradually rolling out @typescript-eslint/no-deprecated.
-		// TODO: Remove the following overrides, one package at a time.
+		// TODO: Remove the following override.
 		{
-			"files": [
-				"packages/vite-plugin-cloudflare/**",
-				"packages/workflows-shared/**",
-			],
+			"files": ["packages/vite-plugin-cloudflare/**"],
 			"rules": {
 				"@typescript-eslint/no-deprecated": "off",
 			},

--- a/packages/workflows-shared/tests/context.test.ts
+++ b/packages/workflows-shared/tests/context.test.ts
@@ -1,4 +1,5 @@
-import { env, runInDurableObject } from "cloudflare:test";
+import { runInDurableObject } from "cloudflare:test";
+import { env } from "cloudflare:workers";
 import { afterEach, describe, it, vi } from "vitest";
 import workerdUnsafe from "workerd:unsafe";
 import { InstanceEvent } from "../src";

--- a/packages/workflows-shared/tests/engine.test.ts
+++ b/packages/workflows-shared/tests/engine.test.ts
@@ -1729,7 +1729,7 @@ describe("Rollback", () => {
 						ctx.output !== "out" ||
 						ctx.ctx.step.name !== "ctx-step" ||
 						ctx.ctx.step.count !== 1 ||
-						ctx.stepName !== "ctx-step-1"
+						`${ctx.ctx.step.name}-${ctx.ctx.step.count}` !== "ctx-step-1"
 					) {
 						throw new Error("unexpected rollback context");
 					}
@@ -1762,7 +1762,7 @@ describe("Rollback", () => {
 							ctx.output !== undefined ||
 							ctx.ctx.step.name !== "failed-step" ||
 							ctx.ctx.step.count !== 1 ||
-							ctx.stepName !== "failed-step-1"
+							`${ctx.ctx.step.name}-${ctx.ctx.step.count}` !== "failed-step-1"
 						) {
 							throw new Error("unexpected failed-step rollback context");
 						}

--- a/packages/workflows-shared/tests/utils.ts
+++ b/packages/workflows-shared/tests/utils.ts
@@ -1,4 +1,4 @@
-import { env } from "cloudflare:test";
+import { env } from "cloudflare:workers";
 import { setTestWorkflowCallback } from "./test-entry";
 import type {
 	DatabaseInstance,


### PR DESCRIPTION
This PR enables the `@typescript-eslint/no-deprecated` linting rule for the `workflows-shared` package

Followup for https://github.com/cloudflare/workers-sdk/pull/14472, https://github.com/cloudflare/workers-sdk/pull/14491, https://github.com/cloudflare/workers-sdk/pull/14509, https://github.com/cloudflare/workers-sdk/pull/14522, https://github.com/cloudflare/workers-sdk/pull/14579 and https://github.com/cloudflare/workers-sdk/pull/14625

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: internal refactoring