### PR TITLE
fix(vitest-pool-workers): avoid hanging on broken DO logs

### DIFF
--- a/.changeset/calm-durable-objects-exit.md
+++ b/.changeset/calm-durable-objects-exit.md
@@ -1,0 +1,7 @@
+---
+"@cloudflare/vitest-pool-workers": patch
+---
+
+Fix test runs hanging after a Durable Object logs and rejects `blockConcurrencyWhile()`
+
+Console messages emitted from another Durable Object are now buffered until execution returns to the test runner, avoiding I/O that cannot complete after the object's input gate breaks.

--- a/packages/vitest-pool-workers/src/worker/index.ts
+++ b/packages/vitest-pool-workers/src/worker/index.ts
@@ -136,6 +136,15 @@ function isDifferentIOContextError(e: unknown) {
 	);
 }
 
+function isUserConsoleLogResponse(response: unknown): boolean {
+	return (
+		typeof response === "object" &&
+		response !== null &&
+		"m" in response &&
+		response.m === "onUserConsoleLog"
+	);
+}
+
 let patchedFunction = false;
 function ensurePatchedFunction(unsafeEval: UnsafeEval) {
 	if (patchedFunction) {
@@ -196,10 +205,25 @@ export class __VITEST_POOL_WORKERS_RUNNER_DURABLE_OBJECT__ extends DurableObject
 			await import("vitest/worker");
 
 		poolSocket.accept();
+		// Sending over the runner's WebSocket from another Durable Object requires
+		// I/O that cannot complete if that object's input gate breaks. Buffer console
+		// messages and flush them on the next successful post from the runner's
+		// context instead. In practice Vitest always sends further RPC messages
+		// (e.g. task updates/results) from the runner once execution returns to it,
+		// so buffered logs are flushed; there's no guarantee for logs emitted with
+		// nothing following, but dropping them is preferable to hanging teardown.
+		const pendingConsoleLogs: unknown[] = [];
+		const sendPendingConsoleLogs = () => {
+			while (pendingConsoleLogs.length > 0) {
+				poolSocket.send(structuredSerializableStringify(pendingConsoleLogs[0]));
+				pendingConsoleLogs.shift();
+			}
+		};
 
 		init({
 			post: (response) => {
 				try {
+					sendPendingConsoleLogs();
 					poolSocket.send(structuredSerializableStringify(response));
 				} catch (error) {
 					// If the user called `console.log()` or similar from inside an
@@ -211,6 +235,10 @@ export class __VITEST_POOL_WORKERS_RUNNER_DURABLE_OBJECT__ extends DurableObject
 					// (Dynamic `import()` cross-DO errors are handled separately by the
 					// onModuleRunner transport patch below — see #12924.)
 					if (isDifferentIOContextError(error)) {
+						if (isUserConsoleLogResponse(response)) {
+							pendingConsoleLogs.push(response);
+							return;
+						}
 						const promise = runInRunnerObject(() => {
 							poolSocket.send(structuredSerializableStringify(response));
 						}).catch((e) => {

--- a/packages/vitest-pool-workers/test/console.test.ts
+++ b/packages/vitest-pool-workers/test/console.test.ts
@@ -108,3 +108,53 @@ test("console.logs() inside `export default`ed handlers with SELF", async ({
 		"stdout | index.test.ts > sends request\none\ntwo"
 	);
 });
+
+test("does not hang after logging from a rejected Durable Object input gate", async ({
+	expect,
+	seed,
+	vitestRun,
+}) => {
+	await seed({
+		"vitest.config.mts": vitestConfig({
+			main: "./index.ts",
+			miniflare: {
+				compatibilityDate: "2025-12-02",
+				compatibilityFlags: ["nodejs_compat"],
+				durableObjects: { BROKEN: "BrokenDurableObject" },
+			},
+		}),
+		"index.ts": dedent`
+			import { DurableObject } from "cloudflare:workers";
+
+			export class BrokenDurableObject extends DurableObject {
+				constructor(ctx, env) {
+					super(ctx, env);
+					ctx.blockConcurrencyWhile(async () => {
+						console.log("before rejection 1");
+						console.log("before rejection 2");
+						throw new Error("intentional rejection");
+					});
+				}
+
+				fetch() {
+					return new Response("unreachable");
+				}
+			}
+		`,
+		"index.test.ts": dedent`
+			import { env } from "cloudflare:test";
+			import { expect, it } from "vitest";
+
+			it("rejects the request", async () => {
+				const stub = env.BROKEN.getByName("broken");
+				await expect(stub.fetch("https://example.com")).rejects.toThrow(
+					"intentional rejection"
+				);
+			});
+		`,
+	});
+	const result = await vitestRun();
+	expect(await result.exitCode).toBe(0);
+	expect(result.stdout).toMatch(/before rejection 1[\s\S]*before rejection 2/);
+	expect(result.stdout.match(/before rejection/g)).toHaveLength(2);
+});


### PR DESCRIPTION
Console forwarding from a failing Durable Object attempted cross-DO I/O that could never complete after its input gate broke, leaving teardown stuck. Buffer those messages and flush them from the runner context instead.

Fixes https://github.com/cloudflare/workers-sdk/issues/14180.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: it's a bug fix
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14678" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->