### PR TITLE
Add `exclude_packages` option to `dependencies_instrumentation` configuration

### DIFF
--- a/.changeset/exclude-packages-instrumentation.md
+++ b/.changeset/exclude-packages-instrumentation.md
@@ -1,0 +1,16 @@
+---
+"wrangler": minor
+---
+
+Add `exclude_packages` option to `dependencies_instrumentation` configuration
+
+The `dependencies_instrumentation` config object now accepts an optional `exclude_packages` field — an array of package name patterns (with glob-style `*` wildcards) to exclude from the dependency metadata collected during deploy and version uploads.
+
+```jsonc
+// wrangler.json
+{
+	"dependencies_instrumentation": {
+		"exclude_packages": ["@internal/*", "secret-tool"],
+	},
+}
+```

--- a/packages/deploy-helpers/src/deploy/deploy.ts
+++ b/packages/deploy-helpers/src/deploy/deploy.ts
@@ -328,7 +328,10 @@ export default async function deploy(
 		cache: config.cache,
 		package_dependencies:
 			config.dependencies_instrumentation?.enabled !== false && projectRoot
-				? await collectPackageDependencies(projectRoot)
+				? await collectPackageDependencies(
+						projectRoot,
+						config.dependencies_instrumentation?.exclude_packages
+					)
 				: undefined,
 	};
 

--- a/packages/deploy-helpers/src/deploy/helpers/package-dependencies.ts
+++ b/packages/deploy-helpers/src/deploy/helpers/package-dependencies.ts
@@ -27,6 +27,34 @@ export type PackageDependency = {
 const MAX_PACKAGE_DEPENDENCIES = 200;
 
 /**
+ * Converts a glob pattern (supporting `*` wildcards) to a regular expression.
+ *
+ * The `*` character matches any sequence of characters. All other regex-special
+ * characters in the pattern are escaped.
+ *
+ * @param pattern - A glob-style pattern, e.g. `"@internal/*"` or `"*-utils"`
+ * @returns A `RegExp` that matches strings against the given pattern
+ */
+function globPatternToRegExp(pattern: string): RegExp {
+	const escaped = pattern.replace(/[.+?^${}()|[\]\\]/g, "\\$&");
+	const regexStr = escaped.replace(/\*/g, ".*");
+	return new RegExp(`^${regexStr}$`);
+}
+
+/**
+ * Tests whether a package name matches any of the given exclusion patterns.
+ *
+ * @param name - The package name to test
+ * @param excludePatterns - An array of glob patterns to match against
+ * @returns `true` if the name matches at least one pattern
+ */
+function isExcludedPackage(name: string, excludePatterns: string[]): boolean {
+	return excludePatterns.some((pattern) =>
+		globPatternToRegExp(pattern).test(name)
+	);
+}
+
+/**
  * Collects npm package dependency metadata from the project's package.json.
  *
  * Reads both `dependencies` and `devDependencies`, resolves each package's
@@ -35,15 +63,19 @@ const MAX_PACKAGE_DEPENDENCIES = 200;
  * - Pnpm catalog packages (version prefixed with `catalog:`)
  * - Local packages (version prefixed with `file:` or `link:`)
  * - Packages whose installed version cannot be resolved
+ * - Packages matching any pattern in `excludePackages`
  *
  * The result is capped at {@link MAX_PACKAGE_DEPENDENCIES} entries.
  *
  * @param projectPath - Path to the project directory (where package.json is located)
+ * @param excludePackages - Optional list of package name patterns (glob-style with
+ *        `*` wildcards) to exclude from the collected dependencies
  * @returns An array of package dependency entries, or `undefined` if package.json
  *          cannot be read or no valid dependencies are found
  */
 export async function collectPackageDependencies(
-	projectPath: string
+	projectPath: string,
+	excludePackages?: string[]
 ): Promise<PackageDependency[] | undefined> {
 	const packageJsonPath = path.join(projectPath, "package.json");
 
@@ -76,6 +108,13 @@ export async function collectPackageDependencies(
 				packageJsonVersion.startsWith("catalog:") ||
 				packageJsonVersion.startsWith("file:") ||
 				packageJsonVersion.startsWith("link:")
+			) {
+				continue;
+			}
+
+			if (
+				excludePackages?.length &&
+				isExcludedPackage(dependencyName, excludePackages)
 			) {
 				continue;
 			}

--- a/packages/deploy-helpers/src/deploy/versions-upload.ts
+++ b/packages/deploy-helpers/src/deploy/versions-upload.ts
@@ -192,7 +192,10 @@ export default async function versionsUpload(
 		cache: config.cache, // cache is a versioned setting
 		package_dependencies:
 			config.dependencies_instrumentation?.enabled !== false && projectRoot
-				? await collectPackageDependencies(projectRoot)
+				? await collectPackageDependencies(
+						projectRoot,
+						config.dependencies_instrumentation?.exclude_packages
+					)
 				: undefined,
 	};
 

--- a/packages/deploy-helpers/tests/package-dependencies.test.ts
+++ b/packages/deploy-helpers/tests/package-dependencies.test.ts
@@ -1,7 +1,7 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
-import { describe, it } from "vitest";
+import { assert, describe, it } from "vitest";
 import { collectPackageDependencies } from "../src/deploy/helpers/package-dependencies";
 
 describe("collectPackageDependencies", () => {
@@ -297,6 +297,326 @@ describe("collectPackageDependencies", () => {
 
 		expect(result).toBeDefined();
 		expect(result).toHaveLength(200);
+	});
+
+	describe("exclude_packages", () => {
+		it("should exclude packages matching an exact name", async ({ expect }) => {
+			const nodeModulesPath = path.join(process.cwd(), "node_modules");
+
+			for (const pkgName of ["keep-me", "exclude-me"]) {
+				const pkgPath = path.join(nodeModulesPath, pkgName);
+				fs.mkdirSync(pkgPath, { recursive: true });
+				fs.writeFileSync(path.join(pkgPath, "index.js"), "module.exports = {}");
+				fs.writeFileSync(
+					path.join(pkgPath, "package.json"),
+					JSON.stringify({ name: pkgName, version: "1.0.0" }, null, 2)
+				);
+			}
+
+			fs.writeFileSync(
+				"package.json",
+				JSON.stringify(
+					{
+						name: "test-project",
+						dependencies: {
+							"keep-me": "^1.0.0",
+							"exclude-me": "^1.0.0",
+						},
+					},
+					null,
+					2
+				)
+			);
+
+			const result = await collectPackageDependencies(process.cwd(), [
+				"exclude-me",
+			]);
+
+			expect(result).toEqual([
+				{
+					name: "keep-me",
+					packageJsonVersion: "^1.0.0",
+					installedVersion: "1.0.0",
+				},
+			]);
+		});
+
+		it("should exclude packages matching a glob pattern with wildcard prefix", async ({
+			expect,
+		}) => {
+			const nodeModulesPath = path.join(process.cwd(), "node_modules");
+
+			for (const pkgName of ["my-utils", "other-utils", "keep-pkg"]) {
+				const pkgPath = path.join(nodeModulesPath, pkgName);
+				fs.mkdirSync(pkgPath, { recursive: true });
+				fs.writeFileSync(path.join(pkgPath, "index.js"), "module.exports = {}");
+				fs.writeFileSync(
+					path.join(pkgPath, "package.json"),
+					JSON.stringify({ name: pkgName, version: "1.0.0" }, null, 2)
+				);
+			}
+
+			fs.writeFileSync(
+				"package.json",
+				JSON.stringify(
+					{
+						name: "test-project",
+						dependencies: {
+							"my-utils": "^1.0.0",
+							"other-utils": "^1.0.0",
+							"keep-pkg": "^1.0.0",
+						},
+					},
+					null,
+					2
+				)
+			);
+
+			const result = await collectPackageDependencies(process.cwd(), [
+				"*-utils",
+			]);
+
+			expect(result).toEqual([
+				{
+					name: "keep-pkg",
+					packageJsonVersion: "^1.0.0",
+					installedVersion: "1.0.0",
+				},
+			]);
+		});
+
+		it("should exclude scoped packages matching a glob pattern", async ({
+			expect,
+		}) => {
+			const nodeModulesPath = path.join(process.cwd(), "node_modules");
+
+			// Create scoped packages
+			const scopedPkgs = ["@internal/foo", "@internal/bar", "@public/baz"];
+			for (const pkgName of scopedPkgs) {
+				const pkgPath = path.join(nodeModulesPath, pkgName);
+				fs.mkdirSync(pkgPath, { recursive: true });
+				fs.writeFileSync(path.join(pkgPath, "index.js"), "module.exports = {}");
+				fs.writeFileSync(
+					path.join(pkgPath, "package.json"),
+					JSON.stringify({ name: pkgName, version: "2.0.0" }, null, 2)
+				);
+			}
+
+			fs.writeFileSync(
+				"package.json",
+				JSON.stringify(
+					{
+						name: "test-project",
+						dependencies: {
+							"@internal/foo": "^2.0.0",
+							"@internal/bar": "^2.0.0",
+							"@public/baz": "^2.0.0",
+						},
+					},
+					null,
+					2
+				)
+			);
+
+			const result = await collectPackageDependencies(process.cwd(), [
+				"@internal/*",
+			]);
+
+			expect(result).toEqual([
+				{
+					name: "@public/baz",
+					packageJsonVersion: "^2.0.0",
+					installedVersion: "2.0.0",
+				},
+			]);
+		});
+
+		it("should not exclude anything when excludePackages is an empty array", async ({
+			expect,
+		}) => {
+			const nodeModulesPath = path.join(process.cwd(), "node_modules");
+
+			const pkgPath = path.join(nodeModulesPath, "some-pkg");
+			fs.mkdirSync(pkgPath, { recursive: true });
+			fs.writeFileSync(path.join(pkgPath, "index.js"), "module.exports = {}");
+			fs.writeFileSync(
+				path.join(pkgPath, "package.json"),
+				JSON.stringify({ name: "some-pkg", version: "1.0.0" }, null, 2)
+			);
+
+			fs.writeFileSync(
+				"package.json",
+				JSON.stringify(
+					{
+						name: "test-project",
+						dependencies: {
+							"some-pkg": "^1.0.0",
+						},
+					},
+					null,
+					2
+				)
+			);
+
+			const result = await collectPackageDependencies(process.cwd(), []);
+
+			expect(result).toEqual([
+				{
+					name: "some-pkg",
+					packageJsonVersion: "^1.0.0",
+					installedVersion: "1.0.0",
+				},
+			]);
+		});
+
+		it("should not exclude anything when no pattern matches", async ({
+			expect,
+		}) => {
+			const nodeModulesPath = path.join(process.cwd(), "node_modules");
+
+			const pkgPath = path.join(nodeModulesPath, "some-pkg");
+			fs.mkdirSync(pkgPath, { recursive: true });
+			fs.writeFileSync(path.join(pkgPath, "index.js"), "module.exports = {}");
+			fs.writeFileSync(
+				path.join(pkgPath, "package.json"),
+				JSON.stringify({ name: "some-pkg", version: "1.0.0" }, null, 2)
+			);
+
+			fs.writeFileSync(
+				"package.json",
+				JSON.stringify(
+					{
+						name: "test-project",
+						dependencies: {
+							"some-pkg": "^1.0.0",
+						},
+					},
+					null,
+					2
+				)
+			);
+
+			const result = await collectPackageDependencies(process.cwd(), [
+				"@other/*",
+				"unrelated-*",
+			]);
+
+			expect(result).toEqual([
+				{
+					name: "some-pkg",
+					packageJsonVersion: "^1.0.0",
+					installedVersion: "1.0.0",
+				},
+			]);
+		});
+
+		it("should not count excluded packages toward the 200 cap", async ({
+			expect,
+		}) => {
+			const nodeModulesPath = path.join(process.cwd(), "node_modules");
+			const dependencies: Record<string, string> = {};
+
+			// Create 201 packages: 1 excluded + 200 kept
+			const excludedPkg = "excluded-pkg";
+			const excludedPath = path.join(nodeModulesPath, excludedPkg);
+			fs.mkdirSync(excludedPath, { recursive: true });
+			fs.writeFileSync(
+				path.join(excludedPath, "index.js"),
+				"module.exports = {}"
+			);
+			fs.writeFileSync(
+				path.join(excludedPath, "package.json"),
+				JSON.stringify({ name: excludedPkg, version: "1.0.0" }, null, 2)
+			);
+			dependencies[excludedPkg] = "^1.0.0";
+
+			for (let i = 0; i < 200; i++) {
+				const pkgName = `pkg-${String(i).padStart(3, "0")}`;
+				const pkgPath = path.join(nodeModulesPath, pkgName);
+				fs.mkdirSync(pkgPath, { recursive: true });
+				fs.writeFileSync(path.join(pkgPath, "index.js"), "module.exports = {}");
+				fs.writeFileSync(
+					path.join(pkgPath, "package.json"),
+					JSON.stringify({ name: pkgName, version: `1.0.${i}` }, null, 2)
+				);
+				dependencies[pkgName] = `^1.0.${i}`;
+			}
+
+			fs.writeFileSync(
+				"package.json",
+				JSON.stringify(
+					{
+						name: "test-project",
+						dependencies,
+					},
+					null,
+					2
+				)
+			);
+
+			const result = await collectPackageDependencies(process.cwd(), [
+				"excluded-pkg",
+			]);
+
+			assert(result);
+			expect(result).toHaveLength(200);
+			expect(result.find((d) => d.name === "excluded-pkg")).toBeUndefined();
+		});
+
+		it("should support multiple exclusion patterns", async ({ expect }) => {
+			const nodeModulesPath = path.join(process.cwd(), "node_modules");
+
+			const pkgNames = [
+				"@internal/core",
+				"lodash",
+				"secret-tool",
+				"public-lib",
+			];
+			for (const pkgName of pkgNames) {
+				const pkgPath = path.join(nodeModulesPath, pkgName);
+				fs.mkdirSync(pkgPath, { recursive: true });
+				fs.writeFileSync(path.join(pkgPath, "index.js"), "module.exports = {}");
+				fs.writeFileSync(
+					path.join(pkgPath, "package.json"),
+					JSON.stringify({ name: pkgName, version: "1.0.0" }, null, 2)
+				);
+			}
+
+			fs.writeFileSync(
+				"package.json",
+				JSON.stringify(
+					{
+						name: "test-project",
+						dependencies: {
+							"@internal/core": "^1.0.0",
+							lodash: "^1.0.0",
+							"secret-tool": "^1.0.0",
+							"public-lib": "^1.0.0",
+						},
+					},
+					null,
+					2
+				)
+			);
+
+			const result = await collectPackageDependencies(process.cwd(), [
+				"@internal/*",
+				"secret-*",
+			]);
+
+			expect(result).toEqual([
+				{
+					name: "lodash",
+					packageJsonVersion: "^1.0.0",
+					installedVersion: "1.0.0",
+				},
+				{
+					name: "public-lib",
+					packageJsonVersion: "^1.0.0",
+					installedVersion: "1.0.0",
+				},
+			]);
+		});
 	});
 
 	it("should use devDependencies version when duplicate exists in dependencies", async ({

--- a/packages/workers-utils/src/config/config.ts
+++ b/packages/workers-utils/src/config/config.ts
@@ -82,6 +82,15 @@ export interface ConfigFields<Dev extends RawDevConfig> {
 		| {
 				/** Whether dependency instrumentation is enabled. Defaults to `true`. */
 				enabled: boolean;
+				/**
+				 * An optional list of package name patterns to exclude from the
+				 * collected dependency metadata.
+				 *
+				 * Each entry can be an exact package name (e.g. `"lodash"`) or a glob
+				 * pattern using `*` as a wildcard (e.g. `"@internal/*"` to exclude all
+				 * packages under the `@internal` scope).
+				 */
+				exclude_packages?: string[];
 		  }
 		| undefined;
 

--- a/packages/workers-utils/src/config/validation.ts
+++ b/packages/workers-utils/src/config/validation.ts
@@ -322,13 +322,20 @@ export function normalizeAndValidateConfig(
 				"boolean"
 			);
 
+			validateOptionalTypedArray(
+				diagnostics,
+				"dependencies_instrumentation.exclude_packages",
+				rawConfig.dependencies_instrumentation.exclude_packages,
+				"string"
+			);
+
 			validateAdditionalProperties(
 				diagnostics,
 				"dependencies_instrumentation",
 				Object.keys(
 					rawConfig.dependencies_instrumentation as Record<string, unknown>
 				),
-				["enabled"]
+				["enabled", "exclude_packages"]
 			);
 		}
 	}

--- a/packages/workers-utils/tests/config/validation/normalize-and-validate-config.test.ts
+++ b/packages/workers-utils/tests/config/validation/normalize-and-validate-config.test.ts
@@ -213,6 +213,89 @@ describe("normalizeAndValidateConfig()", () => {
 			`);
 		});
 
+		it("should accept a valid dependencies_instrumentation with exclude_packages", ({
+			expect,
+		}) => {
+			const { diagnostics } = normalizeAndValidateConfig(
+				{
+					dependencies_instrumentation: {
+						enabled: true,
+						exclude_packages: ["@internal/*", "secret-pkg"],
+					},
+				} as unknown as RawConfig,
+				undefined,
+				undefined,
+				{ env: undefined }
+			);
+
+			expect(diagnostics.hasErrors()).toBe(false);
+			expect(diagnostics.hasWarnings()).toBe(false);
+		});
+
+		it("should error on invalid dependencies_instrumentation.exclude_packages type", ({
+			expect,
+		}) => {
+			const { diagnostics } = normalizeAndValidateConfig(
+				{
+					dependencies_instrumentation: {
+						exclude_packages: "not-an-array" as unknown,
+					},
+				} as unknown as RawConfig,
+				undefined,
+				undefined,
+				{ env: undefined }
+			);
+
+			expect(diagnostics.hasWarnings()).toBe(false);
+			expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
+				"Processing wrangler configuration:
+				  - Expected "dependencies_instrumentation.exclude_packages" to be an array of strings but got "not-an-array""
+			`);
+		});
+
+		it("should error on non-string entries in dependencies_instrumentation.exclude_packages", ({
+			expect,
+		}) => {
+			const { diagnostics } = normalizeAndValidateConfig(
+				{
+					dependencies_instrumentation: {
+						exclude_packages: ["valid", 123] as unknown,
+					},
+				} as unknown as RawConfig,
+				undefined,
+				undefined,
+				{ env: undefined }
+			);
+
+			expect(diagnostics.hasWarnings()).toBe(false);
+			expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
+				"Processing wrangler configuration:
+				  - Expected "dependencies_instrumentation.exclude_packages.[1]" to be of type string but got 123."
+			`);
+		});
+
+		it("should warn on unknown properties in dependencies_instrumentation", ({
+			expect,
+		}) => {
+			const { diagnostics } = normalizeAndValidateConfig(
+				{
+					dependencies_instrumentation: {
+						enabled: true,
+						unknown_field: "bad",
+					},
+				} as unknown as RawConfig,
+				undefined,
+				undefined,
+				{ env: undefined }
+			);
+
+			expect(diagnostics.hasErrors()).toBe(false);
+			expect(diagnostics.renderWarnings()).toMatchInlineSnapshot(`
+				"Processing wrangler configuration:
+				  - Unexpected fields found in dependencies_instrumentation field: "unknown_field""
+			`);
+		});
+
 		it("should error if the deprecated `legacy_env` field is present", ({
 			expect,
 		}) => {

--- a/packages/wrangler/src/__tests__/versions/versions.upload.test.ts
+++ b/packages/wrangler/src/__tests__/versions/versions.upload.test.ts
@@ -2648,6 +2648,58 @@ describe("versions upload", () => {
 			const metadata = await getMetadata(requests[0]);
 			expect(metadata.package_dependencies).toBeUndefined();
 		});
+
+		test("should exclude packages matching exclude_packages patterns from upload metadata", async ({
+			expect,
+		}) => {
+			mockGetScript();
+			const requests = mockUploadVersion(false, 0);
+
+			// Create two resolvable packages in node_modules
+			for (const [name, version] of [
+				["@internal/secret", "1.0.0"],
+				["public-lib", "2.0.0"],
+			] as const) {
+				const pkgPath = path.join(process.cwd(), "node_modules", name);
+				fs.mkdirSync(pkgPath, { recursive: true });
+				fs.writeFileSync(path.join(pkgPath, "index.js"), "module.exports = {}");
+				fs.writeFileSync(
+					path.join(pkgPath, "package.json"),
+					JSON.stringify({ name, version })
+				);
+			}
+
+			writeWranglerConfig({
+				name: "test-name",
+				main: "./index.js",
+				dependencies_instrumentation: {
+					enabled: true,
+					exclude_packages: ["@internal/*"],
+				},
+			});
+			fs.writeFileSync(
+				"package.json",
+				JSON.stringify({
+					name: "test-project",
+					dependencies: {
+						"@internal/secret": "^1.0.0",
+						"public-lib": "^2.0.0",
+					},
+				})
+			);
+			writeWorkerSource();
+
+			await runWrangler("versions upload");
+
+			const metadata = await getMetadata(requests[0]);
+			expect(metadata.package_dependencies).toEqual([
+				{
+					name: "public-lib",
+					packageJsonVersion: "^2.0.0",
+					installedVersion: "2.0.0",
+				},
+			]);
+		});
 	});
 });
 


### PR DESCRIPTION
The `dependencies_instrumentation` config object now accepts an optional `exclude_packages` field — an array of package name patterns (with glob-style `*` wildcards) to exclude from the dependency metadata collected during deploy and version uploads.

```jsonc
// wrangler.json
{
	"dependencies_instrumentation": {
		"exclude_packages": ["@internal/*", "secret-tool"],
	},
}
```

---

Followup for https://github.com/cloudflare/workers-sdk/pull/14591

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: it's automatically generated?

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
