### PR TITLE
[ci] Repair workerd lockfile entry

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2640,7 +2640,7 @@ importers:
         version: 2.0.0-rc.24
       workerd:
         specifier: catalog:default
-        version: 1.20260708.1
+        version: 1.20260710.1
       wrangler:
         specifier: workspace:*
         version: link:../wrangler


### PR DESCRIPTION
Synchronise the Vite plugin lockfile importer with the current `workerd` catalog version.

The importer retained `1.20260708.1` after the catalog and resolved package entries moved to `1.20260710.1`, causing every frozen CI install to fail with `ERR_PNPM_LOCKFILE_MISSING_DEPENDENCY`.

---

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: `pnpm install --frozen-lockfile --ignore-scripts` succeeds after regenerating the lockfile with pnpm 10.33.0.
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: this only repairs generated dependency metadata.

*A picture of a cute animal (not mandatory, but encouraged)*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14680" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->