### PR TITLE
Enforce the use of `detectAgent` instead of using `am-i-vibing` directly

### DIFF
--- a/.oxlintrc.jsonc
+++ b/.oxlintrc.jsonc
@@ -83,6 +83,10 @@
 						"importNames": ["expect"],
 						"message": "Import 'expect' from the test context instead of 'vitest' for concurrency safety. Use: test('name', ({ expect }) => { ... })",
 					},
+					{
+						"name": "am-i-vibing",
+						"message": "Use `detectAgent()` from `src/utils/detect-agent` instead.",
+					},
 				],
 			},
 		],

--- a/packages/wrangler/src/__tests__/agents-skills-install.test.ts
+++ b/packages/wrangler/src/__tests__/agents-skills-install.test.ts
@@ -3,7 +3,6 @@ import os from "node:os";
 import path from "node:path";
 import { getGlobalConfigPath } from "@cloudflare/workers-utils";
 import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
-import { detectAgenticEnvironment } from "am-i-vibing";
 import ci from "ci-info";
 import { http, HttpResponse } from "msw";
 import prompts from "prompts";
@@ -14,6 +13,7 @@ import {
 	type telemetryCurrentAgentSkillsInstalled as TelemetryFnType,
 } from "../agents-skills-install";
 import { sendMetricsEvent } from "../metrics/send-event";
+import { detectAgent } from "../utils/detect-agent";
 import { mockConsoleMethods } from "./helpers/mock-console";
 import { clearDialogs, mockConfirm } from "./helpers/mock-dialogs";
 import { useMockIsTTY } from "./helpers/mock-istty";
@@ -23,10 +23,8 @@ import type * as SendEventModule from "../metrics/send-event";
 // Undo the global no-op mock from vitest.setup.ts so we test the real implementation
 vi.unmock("../agents-skills-install");
 
-vi.mock("am-i-vibing");
-
-// eslint-disable-next-line @typescript-eslint/no-deprecated -- the function has a deprecated overload; we only reference it here for mocking
-const mockDetectAgenticEnvironment = vi.mocked(detectAgenticEnvironment);
+vi.mock("../utils/detect-agent");
+const mockDetectAgent = vi.mocked(detectAgent);
 
 // Mock rosie-skills to avoid real network/WASM calls.
 // vi.hoisted() is required because vi.mock() factories are hoisted above normal
@@ -1074,11 +1072,9 @@ describe("telemetryCurrentAgentSkillsInstalled", () => {
 
 	beforeEach(() => {
 		// Default: no agent detected
-		mockDetectAgenticEnvironment.mockReturnValue({
-			isAgentic: false,
+		mockDetectAgent.mockReturnValue({
+			isAgent: false,
 			id: null,
-			name: null,
-			type: null,
 		});
 	});
 
@@ -1090,11 +1086,12 @@ describe("telemetryCurrentAgentSkillsInstalled", () => {
 		expect(result).toBe(null);
 	});
 
-	test("resolves to null when detectAgenticEnvironment throws", async ({
+	test("resolves to null when detectAgent returns null id", async ({
 		expect,
 	}) => {
-		mockDetectAgenticEnvironment.mockImplementation(() => {
-			throw new Error("Detection failed");
+		mockDetectAgent.mockReturnValue({
+			isAgent: false,
+			id: null,
 		});
 		const telemetryCurrentAgentSkillsInstalled = await freshTelemetryImport();
 
@@ -1106,11 +1103,9 @@ describe("telemetryCurrentAgentSkillsInstalled", () => {
 	test("resolves to null when agent is detected but not in telemetryAgentMappings", async ({
 		expect,
 	}) => {
-		mockDetectAgenticEnvironment.mockReturnValue({
-			isAgentic: true,
+		mockDetectAgent.mockReturnValue({
+			isAgent: true,
 			id: "jules",
-			name: "Jules",
-			type: "agent",
 		});
 		const telemetryCurrentAgentSkillsInstalled = await freshTelemetryImport();
 
@@ -1122,11 +1117,9 @@ describe("telemetryCurrentAgentSkillsInstalled", () => {
 	test("resolves to false when GitHub API fetch fails and no cache exists", async ({
 		expect,
 	}) => {
-		mockDetectAgenticEnvironment.mockReturnValue({
-			isAgentic: true,
+		mockDetectAgent.mockReturnValue({
+			isAgent: true,
 			id: "claude-code",
-			name: "Claude Code",
-			type: "agent",
 		});
 		createAgentDir(".claude");
 		mockGitHubSkillsApiNetworkError();
@@ -1140,11 +1133,9 @@ describe("telemetryCurrentAgentSkillsInstalled", () => {
 	test("resolves to false when no skills are present in agent's globalSkillsPath", async ({
 		expect,
 	}) => {
-		mockDetectAgenticEnvironment.mockReturnValue({
-			isAgentic: true,
+		mockDetectAgent.mockReturnValue({
+			isAgent: true,
 			id: "claude-code",
-			name: "Claude Code",
-			type: "agent",
 		});
 		createAgentDir(".claude");
 		mockGitHubSkillsApi(["cloudflare", "wrangler"]);
@@ -1158,11 +1149,9 @@ describe("telemetryCurrentAgentSkillsInstalled", () => {
 	test("resolves to 'manual' when some skills exist but no metadata file", async ({
 		expect,
 	}) => {
-		mockDetectAgenticEnvironment.mockReturnValue({
-			isAgentic: true,
+		mockDetectAgent.mockReturnValue({
+			isAgent: true,
 			id: "claude-code",
-			name: "Claude Code",
-			type: "agent",
 		});
 		createAgentDir(".claude");
 		const claudeSkills = path.join(os.homedir(), ".claude", "skills");
@@ -1178,11 +1167,9 @@ describe("telemetryCurrentAgentSkillsInstalled", () => {
 	test("resolves to 'automatic' when skills exist and metadata confirms successful install", async ({
 		expect,
 	}) => {
-		mockDetectAgenticEnvironment.mockReturnValue({
-			isAgentic: true,
+		mockDetectAgent.mockReturnValue({
+			isAgent: true,
 			id: "claude-code",
-			name: "Claude Code",
-			type: "agent",
 		});
 		createAgentDir(".claude");
 		const claudeSkills = path.join(os.homedir(), ".claude", "skills");
@@ -1211,11 +1198,9 @@ describe("telemetryCurrentAgentSkillsInstalled", () => {
 	test("resolves to 'manual' when metadata says install failed entirely (installFailed: true)", async ({
 		expect,
 	}) => {
-		mockDetectAgenticEnvironment.mockReturnValue({
-			isAgentic: true,
+		mockDetectAgent.mockReturnValue({
+			isAgent: true,
 			id: "claude-code",
-			name: "Claude Code",
-			type: "agent",
 		});
 		createAgentDir(".claude");
 		const claudeSkills = path.join(os.homedir(), ".claude", "skills");
@@ -1244,11 +1229,9 @@ describe("telemetryCurrentAgentSkillsInstalled", () => {
 	test("resolves to 'manual' when metadata says install failed for this agent (installFailed: string[])", async ({
 		expect,
 	}) => {
-		mockDetectAgenticEnvironment.mockReturnValue({
-			isAgentic: true,
+		mockDetectAgent.mockReturnValue({
+			isAgent: true,
 			id: "claude-code",
-			name: "Claude Code",
-			type: "agent",
 		});
 		createAgentDir(".claude");
 		const claudeSkills = path.join(os.homedir(), ".claude", "skills");
@@ -1277,11 +1260,9 @@ describe("telemetryCurrentAgentSkillsInstalled", () => {
 	test("resolves to 'manual' when agent is not in detectedAgents", async ({
 		expect,
 	}) => {
-		mockDetectAgenticEnvironment.mockReturnValue({
-			isAgentic: true,
+		mockDetectAgent.mockReturnValue({
+			isAgent: true,
 			id: "claude-code",
-			name: "Claude Code",
-			type: "agent",
 		});
 		createAgentDir(".claude");
 		const claudeSkills = path.join(os.homedir(), ".claude", "skills");
@@ -1304,11 +1285,9 @@ describe("telemetryCurrentAgentSkillsInstalled", () => {
 	test("resolves to 'manual' when metadata has accepted='unanswered' (user interrupted prompt)", async ({
 		expect,
 	}) => {
-		mockDetectAgenticEnvironment.mockReturnValue({
-			isAgentic: true,
+		mockDetectAgent.mockReturnValue({
+			isAgent: true,
 			id: "claude-code",
-			name: "Claude Code",
-			type: "agent",
 		});
 		createAgentDir(".claude");
 		const claudeSkills = path.join(os.homedir(), ".claude", "skills");
@@ -1336,11 +1315,9 @@ describe("telemetryCurrentAgentSkillsInstalled", () => {
 	});
 
 	test("uses cached GitHub API response within TTL", async ({ expect }) => {
-		mockDetectAgenticEnvironment.mockReturnValue({
-			isAgentic: true,
+		mockDetectAgent.mockReturnValue({
+			isAgent: true,
 			id: "claude-code",
-			name: "Claude Code",
-			type: "agent",
 		});
 		createAgentDir(".claude");
 		const claudeSkills = path.join(os.homedir(), ".claude", "skills");
@@ -1385,11 +1362,9 @@ describe("telemetryCurrentAgentSkillsInstalled", () => {
 	test("falls back to stale cache when GitHub API returns an error", async ({
 		expect,
 	}) => {
-		mockDetectAgenticEnvironment.mockReturnValue({
-			isAgentic: true,
+		mockDetectAgent.mockReturnValue({
+			isAgent: true,
 			id: "claude-code",
-			name: "Claude Code",
-			type: "agent",
 		});
 		createAgentDir(".claude");
 		const claudeSkills = path.join(os.homedir(), ".claude", "skills");
@@ -1431,11 +1406,9 @@ describe("telemetryCurrentAgentSkillsInstalled", () => {
 	});
 
 	test("works with cursor-agent amIVibingId mapping", async ({ expect }) => {
-		mockDetectAgenticEnvironment.mockReturnValue({
-			isAgentic: true,
+		mockDetectAgent.mockReturnValue({
+			isAgent: true,
 			id: "cursor-agent",
-			name: "Cursor Agent",
-			type: "agent",
 		});
 		createAgentDir(".cursor");
 		const cursorSkills = path.join(os.homedir(), ".cursor", "skills");
@@ -1464,11 +1437,9 @@ describe("telemetryCurrentAgentSkillsInstalled", () => {
 	test("resolves to 'manual' when skills exist at an alternativeGlobalPath but no metadata", async ({
 		expect,
 	}) => {
-		mockDetectAgenticEnvironment.mockReturnValue({
-			isAgentic: true,
+		mockDetectAgent.mockReturnValue({
+			isAgent: true,
 			id: "opencode",
-			name: "OpenCode",
-			type: "agent",
 		});
 		// Primary rosie path (~/.config/opencode/skills) is empty, but skills
 		// exist in the alternative path (~/.agents/skills).
@@ -1486,11 +1457,9 @@ describe("telemetryCurrentAgentSkillsInstalled", () => {
 	test("resolves to 'automatic' when skills at alternativeGlobalPath were installed for another agent", async ({
 		expect,
 	}) => {
-		mockDetectAgenticEnvironment.mockReturnValue({
-			isAgentic: true,
+		mockDetectAgent.mockReturnValue({
+			isAgent: true,
 			id: "opencode",
-			name: "OpenCode",
-			type: "agent",
 		});
 		// Primary rosie path (~/.config/opencode/skills) is empty, but skills
 		// exist in ~/.agents/skills (which is Warp's rosie install target).
@@ -1520,11 +1489,9 @@ describe("telemetryCurrentAgentSkillsInstalled", () => {
 	test("resolves to 'manual' when skills at alternativeGlobalPath were installed for another agent but failed", async ({
 		expect,
 	}) => {
-		mockDetectAgenticEnvironment.mockReturnValue({
-			isAgentic: true,
+		mockDetectAgent.mockReturnValue({
+			isAgent: true,
 			id: "opencode",
-			name: "OpenCode",
-			type: "agent",
 		});
 		createAgentDir(".config/opencode");
 		const agentsSkills = path.join(os.homedir(), ".agents", "skills");
@@ -1552,11 +1519,9 @@ describe("telemetryCurrentAgentSkillsInstalled", () => {
 	test("resolves to false when skills are not at primary or any alternativeGlobalPath", async ({
 		expect,
 	}) => {
-		mockDetectAgenticEnvironment.mockReturnValue({
-			isAgentic: true,
+		mockDetectAgent.mockReturnValue({
+			isAgent: true,
 			id: "opencode",
-			name: "OpenCode",
-			type: "agent",
 		});
 		// Create the primary path dir but leave it empty, and don't create
 		// any alternative paths either.
@@ -1575,11 +1540,9 @@ describe("telemetryCurrentAgentSkillsInstalled", () => {
 		test("resolves to 'automatic' when metadata uses the legacy flat AgentInfo schema", async ({
 			expect,
 		}) => {
-			mockDetectAgenticEnvironment.mockReturnValue({
-				isAgentic: true,
+			mockDetectAgent.mockReturnValue({
+				isAgent: true,
 				id: "claude-code",
-				name: "Claude Code",
-				type: "agent",
 			});
 			createAgentDir(".claude");
 			const claudeSkills = path.join(os.homedir(), ".claude", "skills");
@@ -1608,11 +1571,9 @@ describe("telemetryCurrentAgentSkillsInstalled", () => {
 		test("migrates legacy metadata to version 1 on disk when read", async ({
 			expect,
 		}) => {
-			mockDetectAgenticEnvironment.mockReturnValue({
-				isAgentic: true,
+			mockDetectAgent.mockReturnValue({
+				isAgent: true,
 				id: "claude-code",
-				name: "Claude Code",
-				type: "agent",
 			});
 			createAgentDir(".claude");
 			const claudeSkills = path.join(os.homedir(), ".claude", "skills");
@@ -1655,11 +1616,9 @@ describe("telemetryCurrentAgentSkillsInstalled", () => {
 		test("resolves to 'manual' when legacy metadata says install failed", async ({
 			expect,
 		}) => {
-			mockDetectAgenticEnvironment.mockReturnValue({
-				isAgentic: true,
+			mockDetectAgent.mockReturnValue({
+				isAgent: true,
 				id: "claude-code",
-				name: "Claude Code",
-				type: "agent",
 			});
 			createAgentDir(".claude");
 			const claudeSkills = path.join(os.homedir(), ".claude", "skills");
@@ -1687,11 +1646,9 @@ describe("telemetryCurrentAgentSkillsInstalled", () => {
 	});
 
 	test("memoises the result across multiple calls", async ({ expect }) => {
-		mockDetectAgenticEnvironment.mockReturnValue({
-			isAgentic: false,
+		mockDetectAgent.mockReturnValue({
+			isAgent: false,
 			id: null,
-			name: null,
-			type: null,
 		});
 		const telemetryCurrentAgentSkillsInstalled = await freshTelemetryImport();
 

--- a/packages/wrangler/src/__tests__/metrics.test.ts
+++ b/packages/wrangler/src/__tests__/metrics.test.ts
@@ -3,7 +3,6 @@ import {
 	runInTempDir,
 	writeWranglerConfig,
 } from "@cloudflare/workers-utils/test-helpers";
-import { detectAgenticEnvironment } from "am-i-vibing";
 import ci from "ci-info";
 import { http, HttpResponse } from "msw";
 import { afterEach, beforeEach, describe, it, vi } from "vitest";
@@ -26,15 +25,15 @@ import {
 	getMetricsDispatcher,
 } from "../metrics/metrics-dispatcher";
 import { sniffUserAgent } from "../package-manager";
+import { detectAgent } from "../utils/detect-agent";
 import { mockConsoleMethods } from "./helpers/mock-console";
 import { useMockIsTTY } from "./helpers/mock-istty";
 import { msw } from "./helpers/msw";
 import { runWrangler } from "./helpers/run-wrangler";
 import type { ExpectStatic } from "vitest";
 
-vi.mock("am-i-vibing");
-// eslint-disable-next-line @typescript-eslint/no-deprecated -- the function has a deprecated overload; we only reference it here for mocking
-const mockDetectAgenticEnvironment = vi.mocked(detectAgenticEnvironment);
+vi.mock("../utils/detect-agent");
+const mockDetectAgent = vi.mocked(detectAgent);
 vi.mock("../metrics/helpers");
 vi.mock("../metrics/send-event");
 vi.mock("../package-manager");
@@ -92,11 +91,9 @@ describe("metrics", () => {
 		describe("sendAdhocEvent()", () => {
 			beforeEach(() => {
 				// Default: no agent detected
-				mockDetectAgenticEnvironment.mockReturnValue({
-					isAgentic: false,
+				mockDetectAgent.mockReturnValue({
+					isAgent: false,
 					id: null,
-					name: null,
-					type: null,
 				});
 			});
 
@@ -198,11 +195,9 @@ describe("metrics", () => {
 			});
 
 			it("should include agent ID when detected", async ({ expect }) => {
-				mockDetectAgenticEnvironment.mockReturnValue({
-					isAgentic: true,
+				mockDetectAgent.mockReturnValue({
+					isAgent: true,
 					id: "claude-code",
-					name: "Claude Code",
-					type: "agent",
 				});
 
 				const requests = mockMetricRequest();
@@ -216,9 +211,12 @@ describe("metrics", () => {
 				expect(std.debug).toContain('"agent":"claude-code"');
 			});
 
-			it("should set agent to null if detection throws", async ({ expect }) => {
-				mockDetectAgenticEnvironment.mockImplementation(() => {
-					throw new Error("Detection failed");
+			it("should set agent to null if detection returns null id", async ({
+				expect,
+			}) => {
+				mockDetectAgent.mockReturnValue({
+					isAgent: false,
+					id: null,
 				});
 
 				const requests = mockMetricRequest();
@@ -259,11 +257,9 @@ describe("metrics", () => {
 			};
 			beforeEach(() => {
 				// Default: no agent detected
-				mockDetectAgenticEnvironment.mockReturnValue({
-					isAgentic: false,
+				mockDetectAgent.mockReturnValue({
+					isAgent: false,
 					id: null,
-					name: null,
-					type: null,
 				});
 				globalThis.ALGOLIA_APP_ID = "FAKE-ID";
 				globalThis.ALGOLIA_PUBLIC_KEY = "FAKE-KEY";
@@ -532,11 +528,9 @@ describe("metrics", () => {
 			it("should include agent ID in command events when detected", async ({
 				expect,
 			}) => {
-				mockDetectAgenticEnvironment.mockReturnValue({
-					isAgentic: true,
+				mockDetectAgent.mockReturnValue({
+					isAgent: true,
 					id: "cursor-agent",
-					name: "Cursor Agent",
-					type: "agent",
 				});
 
 				writeWranglerConfig();

--- a/packages/wrangler/src/__tests__/utils/detect-agent.test.ts
+++ b/packages/wrangler/src/__tests__/utils/detect-agent.test.ts
@@ -1,11 +1,14 @@
-import { detectAgenticEnvironment } from "am-i-vibing";
 import { beforeEach, describe, it, vi } from "vitest";
 import { detectAgent } from "../../utils/detect-agent";
 
-vi.mock("am-i-vibing");
+// Undo the global no-op mock from vitest.setup.ts so we test the real implementation
+vi.unmock("../../utils/detect-agent");
 
-// eslint-disable-next-line @typescript-eslint/no-deprecated -- the function has a deprecated overload; we only reference it here for mocking
-const mockDetectAgenticEnvironment = vi.mocked(detectAgenticEnvironment);
+const mockDetectAgenticEnvironment = vi.hoisted(() => vi.fn());
+
+vi.mock("am-i-vibing", () => ({
+	detectAgenticEnvironment: mockDetectAgenticEnvironment,
+}));
 
 describe("detect-agent", () => {
 	beforeEach(() => {

--- a/packages/wrangler/src/__tests__/vitest.setup.ts
+++ b/packages/wrangler/src/__tests__/vitest.setup.ts
@@ -234,18 +234,16 @@ afterEach(() => {
 	vi.mocked(_ci.default).CLOUDFLARE_WORKERS = false;
 });
 
-// Mock `am-i-vibing` globally so AI-agent detection is disabled by default,
+// Mock `detectAgent` globally so AI-agent detection is disabled by default,
 // regardless of the environment the tests run in (e.g. inside an AI agent shell
 // such as Claude Code or Cursor, where the relevant env vars would otherwise be
 // present). This keeps agent-gated behaviour (e.g. the Pages-to-Workers delegation)
 // deterministically off. Tests that need to exercise agent behaviour mock
-// `../utils/detect-agent` or `am-i-vibing` themselves, which takes precedence.
-vi.mock("am-i-vibing", () => ({
-	detectAgenticEnvironment: vi.fn(() => ({
-		isAgentic: false,
+// `../utils/detect-agent` themselves, which takes precedence.
+vi.mock("../utils/detect-agent", () => ({
+	detectAgent: vi.fn(() => ({
+		isAgent: false,
 		id: null,
-		name: null,
-		type: null,
 	})),
 }));
 

--- a/packages/wrangler/src/agents-skills-install.ts
+++ b/packages/wrangler/src/agents-skills-install.ts
@@ -1,15 +1,18 @@
 import { mkdirSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { getGlobalConfigPath, parseJSONC } from "@cloudflare/workers-utils";
-import { isInteractive } from "@cloudflare/workers-utils";
-import { detectAgenticEnvironment } from "am-i-vibing";
+import {
+	getGlobalConfigPath,
+	parseJSONC,
+	isInteractive,
+} from "@cloudflare/workers-utils";
 import ci from "ci-info";
 import { install as rosieInstall, agents as rosieAgents } from "rosie-skills";
 import { fetch } from "undici";
 import { confirm } from "./dialogs";
 import { logger } from "./logger";
 import { sendMetricsEvent } from "./metrics";
+import { detectAgent } from "./utils/detect-agent";
 
 /**
  * Options for {@link runSkillsInstallFlow}.
@@ -513,14 +516,14 @@ async function fetchSkillNamesFromGitHub(): Promise<string[] | undefined> {
 type AgentSkillsInstallStatus = "automatic" | "manual" | false | null;
 
 /**
- * Maps an `am-i-vibing` agent ID to its global skills paths (both the rosie
- * install path and any alternative paths the agent natively reads from).
- * This is used by the telemetry function to check whether skills exist on
- * disk without calling `rosie.agents()`, which loads WASM and is too slow
- * for process-startup telemetry.
+ * Maps a detected agent ID (from {@link detectAgent}) to its global skills
+ * paths (both the rosie install path and any alternative paths the agent
+ * natively reads from). This is used by the telemetry function to check
+ * whether skills exist on disk without calling `rosie.agents()`, which
+ * loads WASM and is too slow for process-startup telemetry.
  */
 interface AmIVibingDataMappingEntry {
-	/** `am-i-vibing` provider ID(s) that identify this agent. */
+	/** Agent provider ID(s) as returned by {@link detectAgent}. */
 	amIVibingIds: string[];
 	/**
 	 * Rosie agent metadata.
@@ -543,11 +546,10 @@ interface AmIVibingDataMappingEntry {
 }
 
 /**
- * Static mapping from `am-i-vibing` agent IDs to their global skills paths,
+ * Static mapping from detected agent IDs to their global skills paths,
  * used only for telemetry.
  *
- * The `amIVibingIds` are the provider IDs returned by the `am-i-vibing`
- * package's `detectAgenticEnvironment()` function.
+ * The `amIVibingIds` are the provider IDs returned by {@link detectAgent}.
  *
  * The `rosie.globalPath` values correspond to the `global_path` field from
  * rosie's agent registry, constructed as absolute paths via
@@ -681,13 +683,7 @@ function directoryContainsAnySkill(
  * @returns The {@link AgentSkillsInstallStatus} for the current agent.
  */
 async function computeTelemetryCurrentAgentSkillsInstalled(): Promise<AgentSkillsInstallStatus> {
-	let agentId: string | null = null;
-	try {
-		const detection = detectAgenticEnvironment();
-		agentId = detection.id;
-	} catch {
-		return null;
-	}
+	const agentId = detectAgent().id;
 	if (!agentId) {
 		return null;
 	}

--- a/packages/wrangler/src/metrics/metrics-dispatcher.ts
+++ b/packages/wrangler/src/metrics/metrics-dispatcher.ts
@@ -1,12 +1,11 @@
-import { configFormat } from "@cloudflare/workers-utils";
-import { isInteractive } from "@cloudflare/workers-utils";
-import { detectAgenticEnvironment } from "am-i-vibing";
+import { configFormat, isInteractive } from "@cloudflare/workers-utils";
 import chalk from "chalk";
 import ci from "ci-info";
 import { fetch } from "undici";
 import { telemetryCurrentAgentSkillsInstalled } from "../agents-skills-install";
 import { logger } from "../logger";
 import { sniffUserAgent } from "../package-manager";
+import { detectAgent } from "../utils/detect-agent";
 import {
 	getNodeVersion,
 	getOS,
@@ -53,17 +52,7 @@ export function getMetricsDispatcher(options: MetricsConfigOptions) {
 	let amplitude_event_id = 0;
 
 	// Detect agent environment once when dispatcher is created.
-	// Environment variable detection is sufficient for identifying most agentic
-	// environments — process tree traversal (checkProcesses) is disabled by
-	// default since it uses execSync('ps ...') which is slow and can cause
-	// timeouts, especially in CI environments.
-	let agent: string | null = null;
-	try {
-		const agentDetection = detectAgenticEnvironment();
-		agent = agentDetection.id;
-	} catch {
-		// Silent failure - agent remains null
-	}
+	const agent = detectAgent().id;
 
 	function getCommonEventProperties(): CommonEventProperties {
 		return {

--- a/packages/wrangler/src/utils/detect-agent.ts
+++ b/packages/wrangler/src/utils/detect-agent.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports -- This is the canonical wrapper around am-i-vibing all other code should use detectAgent() from this module
 import { detectAgenticEnvironment } from "am-i-vibing";
 
 // Pass an empty array for processAncestry to skip process tree checks entirely.


### PR DESCRIPTION
In Wrangler we have our own `detectAgent()` utility (in `src/utils/detect-agent`) that wraps the `am-i-vibing` logic.

This PR enforces us to use our utility instead of duplicating the same type of wrapper logic around am-i-vibing multiple times.

(This would also be pretty helpful later on if for whatever reason we wanted to replace `am-i-vibing` with something else)

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: internal change

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
