### PR TITLE
feat(wrangler): dispatching email handlers with test harness

### DIFF
--- a/.changeset/calm-mails-report.md
+++ b/.changeset/calm-mails-report.md
@@ -1,0 +1,7 @@
+---
+"miniflare": minor
+---
+
+Add JSON output to `/cdn-cgi/handler/email`
+
+The `/cdn-cgi/handler/email` endpoint now accepts `?format=json` to return the email handler result as JSON, including its outcome, rejection reason, forwarded messages, and replies. Requests without `format=json` still return the existing text outcome for backward compatibility.

--- a/.changeset/tidy-pandas-email.md
+++ b/.changeset/tidy-pandas-email.md
@@ -1,0 +1,28 @@
+---
+"wrangler": minor
+---
+
+Add support for dispatching email handlers with `createTestHarness`
+
+You can now call `server.getWorker().email({ from, to, raw })` to dispatch directly to a Worker's `email()` handler and inspect its outcome, rejection reason, forwarded messages, and replies.
+
+```ts
+const result = await server.getWorker().email({
+	from: "sender@example.com",
+	to: "inbox@example.com",
+	raw: [
+		"From: Sender <sender@example.com>",
+		"To: Inbox <inbox@example.com>",
+		"Message-ID: <test@example.com>",
+		"Subject: Test email",
+		"",
+		"Hello from the test harness",
+	].join("\r\n"),
+});
+
+expect(result).toMatchObject({
+	outcome: "ok",
+	forwards: [{ rcptTo: "archive@example.com" }],
+	replies: [{ raw: expect.stringContaining("Thanks for your email") }],
+});
+```

--- a/.changeset/tidy-pandas-email.md
+++ b/.changeset/tidy-pandas-email.md
@@ -22,7 +22,12 @@ const result = await server.getWorker().email({
 
 expect(result).toMatchObject({
 	outcome: "ok",
-	forwards: [{ rcptTo: "archive@example.com" }],
-	replies: [{ raw: expect.stringContaining("Thanks for your email") }],
+	forwards: [{ recipient: "archive@example.com" }],
+	replies: [
+		{
+			sender: "inbox@example.com",
+			raw: expect.stringContaining("Thanks for your email"),
+		},
+	],
 });
 ```

--- a/packages/miniflare/src/workers/core/email.ts
+++ b/packages/miniflare/src/workers/core/email.ts
@@ -29,6 +29,13 @@ export async function handleEmail(
 	env: Env,
 	ctx: ExecutionContext
 ): Promise<Response> {
+	const forwards: Array<{
+		rcptTo: string;
+		headers: [string, string][];
+		messageId: string;
+	}> = [];
+	const replies: Array<{ messageId: string; raw: string }> = [];
+
 	// Turn an HTTP request into an EmailMessage, using:
 	//  - `from` and `to` from the URL
 	//    - These refer to the SMTP envelope addresses: https://datatracker.ietf.org/doc/html/rfc5321#section-3
@@ -120,10 +127,10 @@ export async function handleEmail(
 	);
 
 	// Propogate `.setReject()` reasons to the caller
-	let maybeClientError: string | undefined = undefined;
+	let rejectReason: string | undefined = undefined;
 
 	// @ts-expect-error .email is not in the `Fetcher` but it's a valid RPC call.
-	await service.email(
+	const emailEvent = service.email(
 		// Construct a ForwardableEmailMessage-like object. We need
 		// - ForwardableEmailMessage to be able to be passed across JSRPC (to support e.g. userWorker.email(ForwardableEmailMessage))
 		// - ForwardableEmailMessage properties to be synchronously available (to match production). This rules out a class extending `RpcStub`
@@ -145,7 +152,7 @@ export async function handleEmail(
 						}
 					)
 				);
-				maybeClientError = reason;
+				rejectReason = reason;
 			},
 			forward: async (
 				rcptTo: string,
@@ -165,7 +172,15 @@ export async function handleEmail(
 				 * so instead we make a dummy message ID that matches the production format (36 characters followed by a domain)
 				 */
 				const uuid = crypto.randomUUID().replaceAll("-", "");
-				return { messageId: `${uuid}@example.com` };
+				const result = { messageId: `${uuid}@example.com` };
+
+				forwards.push({
+					rcptTo,
+					headers: headers ? [...headers.entries()] : [],
+					messageId: result.messageId,
+				});
+
+				return result;
 			},
 			reply: async (replyMessage): Promise<EmailSendResult> => {
 				assert(
@@ -221,19 +236,50 @@ export async function handleEmail(
 				 * so instead we make a dummy message ID that matches the production format (36 characters followed by a domain)
 				 */
 				const uuid = crypto.randomUUID().replaceAll("-", "");
-				return { messageId: `${uuid}@example.com` };
+				const result = { messageId: `${uuid}@example.com` };
+				replies.push({
+					messageId: result.messageId,
+					raw: new TextDecoder().decode(finalReply),
+				});
+				return result;
 			},
 		} satisfies ForwardableEmailMessage
 	);
 
-	if (maybeClientError !== undefined) {
-		return new Response(
-			`Worker rejected email with the following reason: ${maybeClientError}`,
-			{ status: 400 }
-		);
+	if (params.get("format") !== "json") {
+		await emailEvent;
+
+		if (rejectReason !== undefined) {
+			return new Response(
+				`Worker rejected email with the following reason: ${rejectReason}`,
+				{ status: 400 }
+			);
+		}
+
+		return new Response("Worker successfully processed email", {
+			status: 200,
+		});
 	}
 
-	return new Response("Worker successfully processed email", {
-		status: 200,
-	});
+	let outcome: "ok" | "exception";
+
+	try {
+		await emailEvent;
+		outcome = "ok";
+	} catch {
+		outcome = "exception";
+	}
+
+	// Give an un-awaited `setReject()` call time to cross JSRPC.
+	await scheduler.wait(0);
+
+	return Response.json(
+		{
+			outcome,
+			rejectReason,
+			forwards,
+			replies,
+		},
+		{ status: outcome === "ok" ? 200 : 500 }
+	);
 }

--- a/packages/miniflare/src/workers/core/email.ts
+++ b/packages/miniflare/src/workers/core/email.ts
@@ -29,12 +29,27 @@ export async function handleEmail(
 	env: Env,
 	ctx: ExecutionContext
 ): Promise<Response> {
+	const events: Array<
+		| {
+				type: "forward" | "reply";
+				timestamp: string;
+				messageId: string;
+		  }
+		| {
+				type: "reject";
+				timestamp: string;
+		  }
+	> = [];
 	const forwards: Array<{
-		rcptTo: string;
-		headers: [string, string][];
 		messageId: string;
+		recipient: string;
+		headers: [string, string][];
 	}> = [];
-	const replies: Array<{ messageId: string; raw: string }> = [];
+	const replies: Array<{
+		messageId: string;
+		sender: string;
+		raw: string;
+	}> = [];
 
 	// Turn an HTTP request into an EmailMessage, using:
 	//  - `from` and `to` from the URL
@@ -152,6 +167,11 @@ export async function handleEmail(
 						}
 					)
 				);
+
+				events.push({
+					type: "reject",
+					timestamp: new Date().toISOString(),
+				});
 				rejectReason = reason;
 			},
 			forward: async (
@@ -174,8 +194,13 @@ export async function handleEmail(
 				const uuid = crypto.randomUUID().replaceAll("-", "");
 				const result = { messageId: `${uuid}@example.com` };
 
+				events.push({
+					type: "forward",
+					timestamp: new Date().toISOString(),
+					messageId: result.messageId,
+				});
 				forwards.push({
-					rcptTo,
+					recipient: rcptTo,
 					headers: headers ? [...headers.entries()] : [],
 					messageId: result.messageId,
 				});
@@ -237,8 +262,14 @@ export async function handleEmail(
 				 */
 				const uuid = crypto.randomUUID().replaceAll("-", "");
 				const result = { messageId: `${uuid}@example.com` };
+				events.push({
+					type: "reply",
+					timestamp: new Date().toISOString(),
+					messageId: result.messageId,
+				});
 				replies.push({
 					messageId: result.messageId,
+					sender: replyMessage.from,
 					raw: new TextDecoder().decode(finalReply),
 				});
 				return result;
@@ -279,6 +310,7 @@ export async function handleEmail(
 			rejectReason,
 			forwards,
 			replies,
+			events,
 		},
 		{ status: outcome === "ok" ? 200 : 500 }
 	);

--- a/packages/miniflare/test/index.spec.ts
+++ b/packages/miniflare/test/index.spec.ts
@@ -2070,6 +2070,107 @@ This is a random email body.
 	expect(await res.text()).toBe("true");
 });
 
+test("Miniflare: manually triggered email handler - structured result", async ({
+	expect,
+}) => {
+	const mf = new Miniflare({
+		modules: true,
+		script: `
+			import { EmailMessage } from "cloudflare:email";
+
+			export default {
+				async email(message) {
+					const mode = message.to.split("@")[0];
+					if (mode === "rejected") {
+						message.setReject("blocked sender");
+						return;
+					}
+
+					await message.forward(
+						"archive@example.com",
+						new Headers({ "X-Test": mode })
+					);
+					await message.reply(new EmailMessage(
+						message.to,
+						message.from,
+						\`From: \${message.to}\r\nTo: \${message.from}\r\nIn-Reply-To: <\${mode}@example.com>\r\nMessage-ID: <reply-\${mode}@example.com>\r\nContent-Type: text/plain\r\n\r\nReply for \${mode}\r\n\`
+					));
+
+					if (mode === "exception") {
+						message.setReject("triggered exception");
+						throw new Error("sensitive handler error");
+					}
+				}
+			}`,
+		unsafeTriggerHandlers: true,
+	});
+	useDispose(mf);
+
+	async function dispatchEmail(mode: string) {
+		const response = await mf.dispatchFetch(
+			`http://localhost/cdn-cgi/handler/email?format=json&from=sender@example.com&to=${mode}@example.com`,
+			{
+				method: "POST",
+				body: `From: sender <sender@example.com>\r\nTo: ${mode} <${mode}@example.com>\r\nMessage-ID: <${mode}@example.com>\r\nContent-Type: text/plain\r\n\r\nMessage for ${mode}\r\n`,
+			}
+		);
+		const result = await response.json();
+
+		expect(response.status).toBe(mode === "exception" ? 500 : 200);
+
+		return result as {
+			outcome: string;
+			forwards: {
+				rcptTo: string;
+				headers: [string, string][];
+				messageId: string;
+			}[];
+			replies: { messageId: string; raw: string }[];
+		};
+	}
+
+	await expect(dispatchEmail("ok")).resolves.toMatchObject({
+		outcome: "ok",
+		forwards: [
+			{
+				rcptTo: "archive@example.com",
+				headers: [["x-test", "ok"]],
+				messageId: expect.any(String),
+			},
+		],
+		replies: [
+			{
+				messageId: expect.any(String),
+				raw: expect.stringContaining("Reply for ok"),
+			},
+		],
+	});
+
+	await expect(dispatchEmail("rejected")).resolves.toEqual({
+		outcome: "ok",
+		rejectReason: "blocked sender",
+		forwards: [],
+		replies: [],
+	});
+
+	await expect(dispatchEmail("exception")).resolves.toMatchObject({
+		outcome: "exception",
+		rejectReason: "triggered exception",
+		forwards: [
+			{
+				rcptTo: "archive@example.com",
+				headers: [["x-test", "exception"]],
+			},
+		],
+		replies: [
+			{
+				messageId: expect.any(String),
+				raw: expect.stringContaining("Reply for exception"),
+			},
+		],
+	});
+});
+
 test("Miniflare: unimplemented /cdn-cgi/handler/ routes", async ({
 	expect,
 }) => {

--- a/packages/miniflare/test/index.spec.ts
+++ b/packages/miniflare/test/index.spec.ts
@@ -2091,9 +2091,9 @@ test("Miniflare: manually triggered email handler - structured result", async ({
 						new Headers({ "X-Test": mode })
 					);
 					await message.reply(new EmailMessage(
-						message.to,
+						\`reply-\${mode}@example.com\`,
 						message.from,
-						\`From: \${message.to}\r\nTo: \${message.from}\r\nIn-Reply-To: <\${mode}@example.com>\r\nMessage-ID: <reply-\${mode}@example.com>\r\nContent-Type: text/plain\r\n\r\nReply for \${mode}\r\n\`
+						\`From: reply-\${mode}@example.com\r\nTo: \${message.from}\r\nIn-Reply-To: <\${mode}@example.com>\r\nMessage-ID: <reply-\${mode}@example.com>\r\nContent-Type: text/plain\r\n\r\nReply for \${mode}\r\n\`
 					));
 
 					if (mode === "exception") {
@@ -2120,55 +2120,97 @@ test("Miniflare: manually triggered email handler - structured result", async ({
 
 		return result as {
 			outcome: string;
+			rejectReason?: string;
 			forwards: {
-				rcptTo: string;
+				recipient: string;
 				headers: [string, string][];
 				messageId: string;
 			}[];
-			replies: { messageId: string; raw: string }[];
+			replies: { messageId: string; sender: string; raw: string }[];
+			events: (
+				| {
+						type: "forward" | "reply";
+						timestamp: string;
+						messageId: string;
+				  }
+				| { type: "reject"; timestamp: string }
+			)[];
 		};
 	}
 
-	await expect(dispatchEmail("ok")).resolves.toMatchObject({
+	const okResult = await dispatchEmail("ok");
+	expect(okResult).toMatchObject({
 		outcome: "ok",
 		forwards: [
 			{
-				rcptTo: "archive@example.com",
+				recipient: "archive@example.com",
 				headers: [["x-test", "ok"]],
 				messageId: expect.any(String),
 			},
 		],
 		replies: [
 			{
+				sender: "reply-ok@example.com",
 				messageId: expect.any(String),
 				raw: expect.stringContaining("Reply for ok"),
 			},
 		],
 	});
+	expect(okResult.events).toEqual([
+		{
+			type: "forward",
+			timestamp: expect.any(String),
+			messageId: okResult.forwards[0]?.messageId,
+		},
+		{
+			type: "reply",
+			timestamp: expect.any(String),
+			messageId: okResult.replies[0]?.messageId,
+		},
+	]);
 
-	await expect(dispatchEmail("rejected")).resolves.toEqual({
+	const rejectedResult = await dispatchEmail("rejected");
+	expect(rejectedResult).toMatchObject({
 		outcome: "ok",
 		rejectReason: "blocked sender",
 		forwards: [],
 		replies: [],
 	});
+	expect(rejectedResult.events).toEqual([
+		{ type: "reject", timestamp: expect.any(String) },
+	]);
 
-	await expect(dispatchEmail("exception")).resolves.toMatchObject({
+	const exceptionResult = await dispatchEmail("exception");
+	expect(exceptionResult).toMatchObject({
 		outcome: "exception",
 		rejectReason: "triggered exception",
 		forwards: [
 			{
-				rcptTo: "archive@example.com",
+				recipient: "archive@example.com",
 				headers: [["x-test", "exception"]],
 			},
 		],
 		replies: [
 			{
 				messageId: expect.any(String),
+				sender: "reply-exception@example.com",
 				raw: expect.stringContaining("Reply for exception"),
 			},
 		],
 	});
+	expect(exceptionResult.events).toEqual([
+		{
+			type: "forward",
+			timestamp: expect.any(String),
+			messageId: exceptionResult.forwards[0]?.messageId,
+		},
+		{
+			type: "reply",
+			timestamp: expect.any(String),
+			messageId: exceptionResult.replies[0]?.messageId,
+		},
+		{ type: "reject", timestamp: expect.any(String) },
+	]);
 });
 
 test("Miniflare: unimplemented /cdn-cgi/handler/ routes", async ({

--- a/packages/wrangler/e2e/createTestHarness.test.ts
+++ b/packages/wrangler/e2e/createTestHarness.test.ts
@@ -1918,7 +1918,9 @@ describe("createTestHarness", () => {
 				to: "invalid@example.com",
 				raw: "From: sender@example.com\r\nTo: invalid@example.com\r\n\r\nInvalid",
 			})
-		).rejects.toThrow(SyntaxError);
+		).rejects.toThrow(
+			"Failed to dispatch email event: Email could not be parsed: invalid or no message id provided"
+		);
 
 		await expect(
 			worker.email({

--- a/packages/wrangler/e2e/createTestHarness.test.ts
+++ b/packages/wrangler/e2e/createTestHarness.test.ts
@@ -1827,9 +1827,9 @@ describe("createTestHarness", () => {
 							new Headers({ "X-Test": mode })
 						);
 						await message.reply(new EmailMessage(
-							message.to,
+							\`reply-\${mode}@example.com\`,
 							message.from,
-							\`From: \${message.to}\r\nTo: \${message.from}\r\nIn-Reply-To: <\${mode}@example.com>\r\nMessage-ID: <reply-\${mode}@example.com>\r\nContent-Type: text/plain\r\n\r\nReply for \${mode}\r\n\`
+							\`From: reply-\${mode}@example.com\r\nTo: \${message.from}\r\nIn-Reply-To: <\${mode}@example.com>\r\nMessage-ID: <reply-\${mode}@example.com>\r\nContent-Type: text/plain\r\n\r\nReply for \${mode}\r\n\`
 						));
 
 						if (mode === "exception") {
@@ -1859,11 +1859,11 @@ describe("createTestHarness", () => {
 				to: "ok@example.com",
 				raw: createRawEmail("ok"),
 			})
-		).resolves.toMatchObject({
+		).resolves.toEqual({
 			outcome: "ok",
 			forwards: [
 				{
-					rcptTo: "archive@example.com",
+					recipient: "archive@example.com",
 					headers: [["x-test", "ok"]],
 					messageId: expect.any(String),
 				},
@@ -1871,7 +1871,20 @@ describe("createTestHarness", () => {
 			replies: [
 				{
 					messageId: expect.any(String),
+					sender: "reply-ok@example.com",
 					raw: expect.stringContaining("Reply for ok"),
+				},
+			],
+			events: [
+				{
+					type: "forward",
+					timestamp: expect.any(String),
+					messageId: expect.any(String),
+				},
+				{
+					type: "reply",
+					timestamp: expect.any(String),
+					messageId: expect.any(String),
 				},
 			],
 		});
@@ -1887,6 +1900,7 @@ describe("createTestHarness", () => {
 			rejectReason: "blocked sender",
 			forwards: [],
 			replies: [],
+			events: [{ type: "reject", timestamp: expect.any(String) }],
 		});
 
 		await expect(
@@ -1895,20 +1909,35 @@ describe("createTestHarness", () => {
 				to: "exception@example.com",
 				raw: createRawEmail("exception"),
 			})
-		).resolves.toMatchObject({
+		).resolves.toEqual({
 			outcome: "exception",
 			rejectReason: "triggered exception",
 			forwards: [
 				{
-					rcptTo: "archive@example.com",
+					recipient: "archive@example.com",
 					headers: [["x-test", "exception"]],
+					messageId: expect.any(String),
 				},
 			],
 			replies: [
 				{
 					messageId: expect.any(String),
+					sender: "reply-exception@example.com",
 					raw: expect.stringContaining("Reply for exception"),
 				},
+			],
+			events: [
+				{
+					type: "forward",
+					timestamp: expect.any(String),
+					messageId: expect.any(String),
+				},
+				{
+					type: "reply",
+					timestamp: expect.any(String),
+					messageId: expect.any(String),
+				},
+				{ type: "reject", timestamp: expect.any(String) },
 			],
 		});
 

--- a/packages/wrangler/e2e/createTestHarness.test.ts
+++ b/packages/wrangler/e2e/createTestHarness.test.ts
@@ -1802,6 +1802,139 @@ describe("createTestHarness", () => {
 		`);
 	});
 
+	it("triggers email handlers", async ({ expect }) => {
+		await helper.seed({
+			"wrangler.jsonc": dedent`
+				{
+					"name": "email-worker",
+					"main": "src/index.ts",
+					"compatibility_date": "2026-05-20"
+				}
+			`,
+			"src/index.ts": dedent`
+				import { EmailMessage } from "cloudflare:email";
+
+				export default {
+					async email(message) {
+						const mode = message.to.split("@")[0];
+						if (mode === "rejected") {
+							message.setReject("blocked sender");
+							return;
+						}
+
+						await message.forward(
+							"archive@example.com",
+							new Headers({ "X-Test": mode })
+						);
+						await message.reply(new EmailMessage(
+							message.to,
+							message.from,
+							\`From: \${message.to}\r\nTo: \${message.from}\r\nIn-Reply-To: <\${mode}@example.com>\r\nMessage-ID: <reply-\${mode}@example.com>\r\nContent-Type: text/plain\r\n\r\nReply for \${mode}\r\n\`
+						));
+
+						if (mode === "exception") {
+							message.setReject("triggered exception");
+							throw new Error("sensitive handler error");
+						}
+					}
+				};
+			`,
+		});
+
+		const server = createTestHarness({
+			root: helper.tmpPath,
+			workers: [{ configPath: "./wrangler.jsonc" }],
+		});
+		onTestFinished(server.close);
+		await server.listen();
+		const worker = server.getWorker();
+
+		function createRawEmail(mode: string) {
+			return `From: sender <sender@example.com>\r\nTo: ${mode} <${mode}@example.com>\r\nMessage-ID: <${mode}@example.com>\r\nContent-Type: text/plain\r\n\r\nMessage for ${mode}\r\n`;
+		}
+
+		await expect(
+			worker.email({
+				from: "sender@example.com",
+				to: "ok@example.com",
+				raw: createRawEmail("ok"),
+			})
+		).resolves.toMatchObject({
+			outcome: "ok",
+			forwards: [
+				{
+					rcptTo: "archive@example.com",
+					headers: [["x-test", "ok"]],
+					messageId: expect.any(String),
+				},
+			],
+			replies: [
+				{
+					messageId: expect.any(String),
+					raw: expect.stringContaining("Reply for ok"),
+				},
+			],
+		});
+
+		await expect(
+			worker.email({
+				from: "sender@example.com",
+				to: "rejected@example.com",
+				raw: createRawEmail("rejected"),
+			})
+		).resolves.toEqual({
+			outcome: "ok",
+			rejectReason: "blocked sender",
+			forwards: [],
+			replies: [],
+		});
+
+		await expect(
+			worker.email({
+				from: "sender@example.com",
+				to: "exception@example.com",
+				raw: createRawEmail("exception"),
+			})
+		).resolves.toMatchObject({
+			outcome: "exception",
+			rejectReason: "triggered exception",
+			forwards: [
+				{
+					rcptTo: "archive@example.com",
+					headers: [["x-test", "exception"]],
+				},
+			],
+			replies: [
+				{
+					messageId: expect.any(String),
+					raw: expect.stringContaining("Reply for exception"),
+				},
+			],
+		});
+
+		await expect(
+			worker.email({
+				from: "sender@example.com",
+				to: "invalid@example.com",
+				raw: "From: sender@example.com\r\nTo: invalid@example.com\r\n\r\nInvalid",
+			})
+		).rejects.toThrow(SyntaxError);
+
+		await expect(
+			worker.email({
+				from: "sender@example.com",
+				to: "stream@example.com",
+				raw: new ReadableStream<Uint8Array>({
+					start(controller) {
+						const streamRaw = createRawEmail("stream");
+						controller.enqueue(new TextEncoder().encode(streamRaw));
+						controller.close();
+					},
+				}),
+			})
+		).resolves.toMatchObject({ outcome: "ok" });
+	});
+
 	it("lists Durable Object ids by class name or binding name", async ({
 		expect,
 	}) => {

--- a/packages/wrangler/src/api/test-harness.ts
+++ b/packages/wrangler/src/api/test-harness.ts
@@ -108,14 +108,26 @@ export type FetcherEmailResult = {
 	outcome: "ok" | "exception";
 	rejectReason?: string;
 	forwards: Array<{
-		rcptTo: string;
-		headers: [string, string][];
 		messageId: string;
+		recipient: string;
+		headers: [string, string][];
 	}>;
 	replies: Array<{
 		messageId: string;
+		sender: string;
 		raw: string;
 	}>;
+	events: Array<
+		| {
+				type: "forward" | "reply";
+				timestamp: string;
+				messageId: string;
+		  }
+		| {
+				type: "reject";
+				timestamp: string;
+		  }
+	>;
 };
 
 export type WorkerDefaultExport =

--- a/packages/wrangler/src/api/test-harness.ts
+++ b/packages/wrangler/src/api/test-harness.ts
@@ -1014,9 +1014,11 @@ export function createTestHarness(options?: TestHarnessOptions): TestHarness {
 						method: "POST",
 						body: emailOptions.raw,
 					};
+
 					if (typeof emailOptions.raw !== "string") {
 						requestInit.duplex = "half";
 					}
+
 					const response = await dispatchFetch(
 						miniflare,
 						`/cdn-cgi/handler/email?${searchParams.toString()}`,
@@ -1024,6 +1026,13 @@ export function createTestHarness(options?: TestHarnessOptions): TestHarness {
 						workerName,
 						"email"
 					);
+
+					if (response.status >= 400 && response.status < 500) {
+						throw new Error(
+							`Failed to dispatch email event: ${await response.text()}`
+						);
+					}
+
 					const result = await response.json();
 
 					return result as FetcherEmailResult;

--- a/packages/wrangler/src/api/test-harness.ts
+++ b/packages/wrangler/src/api/test-harness.ts
@@ -98,6 +98,26 @@ export type DurableObjectIdentifier =
 	| { name: string; id?: never }
 	| { id: string; name?: never };
 
+export type FetcherEmailOptions = {
+	from: string;
+	to: string;
+	raw: string | ReadableStream<Uint8Array>;
+};
+
+export type FetcherEmailResult = {
+	outcome: "ok" | "exception";
+	rejectReason?: string;
+	forwards: Array<{
+		rcptTo: string;
+		headers: [string, string][];
+		messageId: string;
+	}>;
+	replies: Array<{
+		messageId: string;
+		raw: string;
+	}>;
+};
+
 export type WorkerDefaultExport =
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Match workers-types Service<T> constructor constraint.
 	| (new (...args: any[]) => Rpc.WorkerEntrypointBranded)
@@ -133,6 +153,19 @@ export type WorkerHandle<
 	 * ```
 	 */
 	fetch: DispatchFetch;
+	/**
+	 * Dispatches an email event directly to this Worker.
+	 *
+	 * @example
+	 * ```ts
+	 * const result = await worker.email({
+	 *   from: "sender@example.com",
+	 *   to: "recipient@example.com",
+	 *   raw: "From: sender@example.com\\r\\n...",
+	 * });
+	 * ```
+	 */
+	email(options: FetcherEmailOptions): Promise<FetcherEmailResult>;
 	/**
 	 * Dispatches a scheduled event directly to this Worker.
 	 *
@@ -967,6 +1000,33 @@ export function createTestHarness(options?: TestHarnessOptions): TestHarness {
 					const workerName = resolveWorkerName(session, name);
 
 					return dispatchFetch(miniflare, input, init, workerName);
+				},
+				async email(emailOptions) {
+					const session = await resolveSession();
+					const miniflare = await getRuntimeMiniflare(session);
+					const workerName = resolveWorkerName(session, name);
+					const searchParams = new URLSearchParams({
+						format: "json",
+						from: emailOptions.from,
+						to: emailOptions.to,
+					});
+					const requestInit: RequestInit & { duplex?: "half" } = {
+						method: "POST",
+						body: emailOptions.raw,
+					};
+					if (typeof emailOptions.raw !== "string") {
+						requestInit.duplex = "half";
+					}
+					const response = await dispatchFetch(
+						miniflare,
+						`/cdn-cgi/handler/email?${searchParams.toString()}`,
+						requestInit,
+						workerName,
+						"email"
+					);
+					const result = await response.json();
+
+					return result as FetcherEmailResult;
 				},
 				async scheduled(scheduledOptions) {
 					const session = await resolveSession();


### PR DESCRIPTION
Fixes n/a.

This adds support for dispatching email handlers with `createTestHarness`

You can now call `server.getWorker().email({ from, to, raw })` to dispatch directly to a Worker's `email()` handler and inspect its outcome, rejection reason, forwarded messages, and replies.

```ts
const result = await server.getWorker().email({
    from: "sender@example.com",
    to: "inbox@example.com",
    raw: [
        "From: Sender <sender@example.com>",
        "To: Inbox <inbox@example.com>",
        "Message-ID: <test@example.com>",
        "Subject: Test email",
        "",
        "Hello from the test harness",
    ].join("\r\n"),
});

expect(result).toMatchObject({
    outcome: "ok",
    forwards: [{ rcptTo: "archive@example.com" }],
    replies: [{ raw: expect.stringContaining("Thanks for your email") }],
});
```

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [x] Cloudflare docs PR(s): https://github.com/cloudflare/cloudflare-docs/pull/32362
  - [ ] Documentation not necessary because: 

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
