### PR TITLE
[wrangler] Remove retired snapshot flag from container E2E

### DIFF
--- a/packages/wrangler/e2e/deployments.test.ts
+++ b/packages/wrangler/e2e/deployments.test.ts
@@ -899,7 +899,6 @@ describe.skipIf(skipContainersTest)("containers", () => {
 						class_name = "MyDurableObject"
 						image = "./Dockerfile"
 						max_instances = 1
-						unsafe = { configuration = { experimental_flags = ["experimental_enable_snapshots"] } }
 
 						[[migrations]]
 						tag = "v1"
@@ -976,7 +975,7 @@ describe.skipIf(skipContainersTest)("containers", () => {
 	}, 30_000);
 
 	it(
-		"can deploy a snapshot-enabled Dockerfile container and skip unchanged rebuilds",
+		"can deploy a digest-pinned Dockerfile container and skip unchanged rebuilds",
 		{ timeout: 60 * 2 * 1000 },
 		async ({ expect }) => {
 			const outputOne = await helper.run(`wrangler deploy`);
@@ -996,13 +995,9 @@ describe.skipIf(skipContainersTest)("containers", () => {
 			);
 			const application = JSON.parse(containerInfo.stdout) as {
 				configuration?: {
-					experimental_flags?: unknown;
 					image?: unknown;
 				};
 			};
-			expect(application.configuration?.experimental_flags).toContain(
-				"experimental_enable_snapshots"
-			);
 			const image = application.configuration?.image;
 			assert(typeof image === "string");
 			const expectedImagePrefix = `registry.cloudflare.com/${CLOUDFLARE_ACCOUNT_ID}/e2e-test-${workerName}@sha256:`;


### PR DESCRIPTION
Cloudchamber no longer accepts `experimental_enable_snapshots` in user-provided application configuration because snapshot access is now controlled at the account level.

Remove the stale flag and its assertion from the container E2E. The test continues to verify that Dockerfile deploys use a digest-pinned image and skip unchanged rebuilds.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: This only updates an internal E2E test for a retired configuration flag.

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14691" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->