### PR TITLE
fix(wrangler): type the public startWorker input as WranglerStartDevWorkerInput

### DIFF
--- a/.changeset/start-worker-public-input-type.md
+++ b/.changeset/start-worker-public-input-type.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Type `unstable_startWorker`, `DevEnv.startWorker`, and `ConfigController.set`/`patch` against `WranglerStartDevWorkerInput`, so the wrangler-specific `dev.structuredLogsHandler` field the runtime already honors is expressible through the public API. Previously the public signatures took the base `StartDevWorkerInput`, and callers passing the handler needed a cast while internal callers (the test harness) routed the wider type around the signature.

--- a/packages/wrangler/src/__tests__/api/startDevWorker/ConfigController.test.ts
+++ b/packages/wrangler/src/__tests__/api/startDevWorker/ConfigController.test.ts
@@ -3,13 +3,13 @@ import { runInTempDir, seed } from "@cloudflare/workers-utils/test-helpers";
 import dedent from "ts-dedent";
 import { afterEach, beforeEach, describe, it, vi } from "vitest";
 import { ConfigController } from "../../../api/startDevWorker/ConfigController";
-import type * as StartDevWorkerApi from "../../../api/startDevWorker";
 import { unwrapHook } from "../../../api/startDevWorker/utils";
 import { logger } from "../../../logger";
 import { FakeBus } from "../../helpers/fake-bus";
 import { mockAccountId, mockApiToken } from "../../helpers/mock-account-id";
 import { mockConsoleMethods } from "../../helpers/mock-console";
 import { runWrangler } from "../../helpers/run-wrangler";
+import type * as StartDevWorkerApi from "../../../api/startDevWorker";
 
 // Declaration-level pins for the exported input chain: a fresh object
 // literal gets excess-property checking, which fails to compile if any of
@@ -17,9 +17,7 @@ import { runWrangler } from "../../helpers/run-wrangler";
 // runtime test below exercises only `ConfigController.set`). Never
 // executed.
 type StartWorkerInput = Parameters<typeof StartDevWorkerApi.startWorker>[0];
-type DevEnvStartInput = Parameters<
-	StartDevWorkerApi.DevEnv["startWorker"]
->[0];
+type DevEnvStartInput = Parameters<StartDevWorkerApi.DevEnv["startWorker"]>[0];
 type SetConfigInput = Parameters<StartDevWorkerApi.Worker["setConfig"]>[0];
 type PatchConfigInput = Parameters<StartDevWorkerApi.Worker["patchConfig"]>[0];
 const _publicInputPins: [

--- a/packages/wrangler/src/__tests__/api/startDevWorker/ConfigController.test.ts
+++ b/packages/wrangler/src/__tests__/api/startDevWorker/ConfigController.test.ts
@@ -3,12 +3,37 @@ import { runInTempDir, seed } from "@cloudflare/workers-utils/test-helpers";
 import dedent from "ts-dedent";
 import { afterEach, beforeEach, describe, it, vi } from "vitest";
 import { ConfigController } from "../../../api/startDevWorker/ConfigController";
+import type * as StartDevWorkerApi from "../../../api/startDevWorker";
 import { unwrapHook } from "../../../api/startDevWorker/utils";
 import { logger } from "../../../logger";
 import { FakeBus } from "../../helpers/fake-bus";
 import { mockAccountId, mockApiToken } from "../../helpers/mock-account-id";
 import { mockConsoleMethods } from "../../helpers/mock-console";
 import { runWrangler } from "../../helpers/run-wrangler";
+
+// Declaration-level pins for the exported input chain: a fresh object
+// literal gets excess-property checking, which fails to compile if any of
+// these signatures regresses to the base `StartDevWorkerInput` (the
+// runtime test below exercises only `ConfigController.set`). Never
+// executed.
+type StartWorkerInput = Parameters<typeof StartDevWorkerApi.startWorker>[0];
+type DevEnvStartInput = Parameters<
+	StartDevWorkerApi.DevEnv["startWorker"]
+>[0];
+type SetConfigInput = Parameters<StartDevWorkerApi.Worker["setConfig"]>[0];
+type PatchConfigInput = Parameters<StartDevWorkerApi.Worker["patchConfig"]>[0];
+const _publicInputPins: [
+	StartWorkerInput,
+	DevEnvStartInput,
+	SetConfigInput,
+	PatchConfigInput,
+] = [
+	{ entrypoint: "pin.ts", dev: { structuredLogsHandler: () => {} } },
+	{ entrypoint: "pin.ts", dev: { structuredLogsHandler: () => {} } },
+	{ entrypoint: "pin.ts", dev: { structuredLogsHandler: () => {} } },
+	{ dev: { structuredLogsHandler: () => {} } },
+];
+void _publicInputPins;
 
 describe("ConfigController", () => {
 	runInTempDir();
@@ -139,6 +164,33 @@ describe("ConfigController", () => {
 				entrypoint: path.join(process.cwd(), "src/index.ts"),
 			},
 		});
+	});
+
+	it("should accept wrangler-specific dev fields through the public input", async ({
+		expect,
+	}) => {
+		const event = bus.waitFor("configUpdate");
+		await seed({
+			"src/index.ts": dedent /* javascript */ `
+				export default {
+					fetch(request, env, ctx) {
+						return new Response("hello world")
+					}
+				} satisfies ExportedHandler
+			`,
+		});
+
+		// Would not compile against the base `StartDevWorkerInput`: the
+		// wrangler-specific dev fields live on `WranglerStartDevWorkerInput`,
+		// which is the public input type `set()` (and `startWorker`) accept.
+		const structuredLogsHandler = () => {};
+		await controller.set({
+			entrypoint: "src/index.ts",
+			dev: { structuredLogsHandler },
+		});
+
+		const { config } = await event;
+		expect(config.dev?.structuredLogsHandler).toBe(structuredLogsHandler);
 	});
 
 	it("should apply module root to parent if main is nested from base_dir", async ({

--- a/packages/wrangler/src/api/startDevWorker/ConfigController.ts
+++ b/packages/wrangler/src/api/startDevWorker/ConfigController.ts
@@ -569,7 +569,7 @@ function getDevCompatibilityDate(
 }
 
 export class ConfigController extends Controller {
-	latestInput?: StartDevWorkerInput;
+	latestInput?: WranglerStartDevWorkerInput;
 	latestWranglerConfig?: Config;
 	latestConfig?: StartDevWorkerOptions;
 	#printCurrentBindings?: (registry: WorkerRegistry | null) => void;
@@ -611,20 +611,20 @@ export class ConfigController extends Controller {
 		});
 	}
 
-	public set(input: StartDevWorkerInput, throwErrors = false) {
+	public set(input: WranglerStartDevWorkerInput, throwErrors = false) {
 		logger.debug("setting config");
 		return runWithLogLevel(input.dev?.logLevel, () =>
 			this.#updateConfig(input, throwErrors)
 		);
 	}
-	public patch(input: Partial<StartDevWorkerInput>) {
+	public patch(input: Partial<WranglerStartDevWorkerInput>) {
 		logger.debug("patching config");
 		assert(
 			this.latestInput,
 			"Cannot call updateConfig without previously calling setConfig"
 		);
 
-		const config: StartDevWorkerInput = {
+		const config: WranglerStartDevWorkerInput = {
 			...this.latestInput,
 			...input,
 		};
@@ -634,7 +634,7 @@ export class ConfigController extends Controller {
 		);
 	}
 
-	async #updateConfig(input: StartDevWorkerInput, throwErrors = false) {
+	async #updateConfig(input: WranglerStartDevWorkerInput, throwErrors = false) {
 		logger.debug(
 			"Updating config...",
 			this.#abortController?.signal,

--- a/packages/wrangler/src/api/startDevWorker/DevEnv.ts
+++ b/packages/wrangler/src/api/startDevWorker/DevEnv.ts
@@ -27,7 +27,7 @@ import type {
 	RuntimeController,
 } from "./BaseController";
 import type { ErrorEvent } from "./events";
-import type { StartDevWorkerInput, Worker } from "./types";
+import type { Worker, WranglerStartDevWorkerInput } from "./types";
 
 type ControllerFactory<C extends Controller> = (devEnv: DevEnv) => C;
 
@@ -37,7 +37,7 @@ export class DevEnv extends EventEmitter implements ControllerBus {
 	runtimes: RuntimeController[];
 	proxy: ProxyController;
 
-	async startWorker(options: StartDevWorkerInput): Promise<Worker> {
+	async startWorker(options: WranglerStartDevWorkerInput): Promise<Worker> {
 		initDeployHelpersContext({
 			logger,
 			fetchResult,

--- a/packages/wrangler/src/api/startDevWorker/index.ts
+++ b/packages/wrangler/src/api/startDevWorker/index.ts
@@ -1,5 +1,5 @@
 import { DevEnv } from "./DevEnv";
-import type { StartDevWorkerInput, Worker } from "./types";
+import type { Worker, WranglerStartDevWorkerInput } from "./types";
 
 export { convertConfigBindingsToStartWorkerBindings } from "./binding-utils";
 
@@ -8,7 +8,7 @@ export * from "./types";
 export * from "./events";
 
 export async function startWorker(
-	options: StartDevWorkerInput
+	options: WranglerStartDevWorkerInput
 ): Promise<Worker> {
 	const devEnv = new DevEnv();
 


### PR DESCRIPTION
`WranglerStartDevWorkerInput` (`api/startDevWorker/types.ts`) declares the wrangler-specific `dev.structuredLogsHandler`, and the runtime honors it: `ConfigController` maps `input.dev?.structuredLogsHandler` into the resolved config. But the public input chain (`unstable_startWorker`, `DevEnv.startWorker`, `ConfigController.set`/`patch`) is typed against the base `StartDevWorkerInput`, so external callers can't express the field without a cast — while wrangler's own `createTestHarness` types its inputs as `WranglerStartDevWorkerInput[]` and routes the wider type around the public signature (structural widening quietly accepts it).

This PR widens the public input chain to the type the runtime actually reads: `startWorker`, `DevEnv.startWorker`, and `ConfigController.set`/`patch`/`latestInput`/`#updateConfig` now take `WranglerStartDevWorkerInput`. Resolved-config types (`StartDevWorkerOptions`) are unchanged, and there is no runtime change.

For context on where this bites: we host `unstable_startWorker` in a long-lived dev-supervision daemon and consume `structuredLogsHandler` for structured log intake; today that takes a local one-property type bridge mirroring the extension. The alternative fix — moving the field into the base `StartDevWorkerInput` in workers-utils — would contradict that type's own design note ("The base StartDevWorkerInput in workers-utils is kept dependency-free"): the handler's `WorkerdStructuredLog` parameter is a miniflare type, which is exactly why the wrangler-side extension exists.

---

- Tests
  - [x] Tests included/updated — a `ConfigController` test pins the `structuredLogsHandler` mapping at runtime, and declaration-level literal pins compile-check each exported surface (`startWorker`, `DevEnv.startWorker`, `Worker.setConfig`/`patchConfig`)
- Public documentation
  - [x] Documentation not necessary because: type-level fix to an `unstable_`-prefixed programmatic API; no documented behavior or runtime change
