### PR TITLE
[workers-shared] Retry KV asset reads when they fail

### DIFF
--- a/.changeset/kv-asset-retry.md
+++ b/.changeset/kv-asset-retry.md
@@ -1,0 +1,7 @@
+---
+"@cloudflare/workers-shared": patch
+---
+
+Retry asset reads from KV when they fail
+
+The asset worker reads static assets from KV, and a read can occasionally fail with a transient error. It previously retried only once before giving up. It now retries a few times with exponential backoff, which reduces the chance of serving an error. A missing asset is not treated as a failure and is not retried.

--- a/packages/workers-shared/asset-worker/src/utils/kv.ts
+++ b/packages/workers-shared/asset-worker/src/utils/kv.ts
@@ -8,7 +8,7 @@ export async function getAssetWithMetadataFromKV(
 	assetsKVNamespace: KVNamespace,
 	assetKey: string,
 	sentry?: Toucan,
-	retries = 1
+	retries = 3
 ) {
 	let attempts = 0;
 

--- a/packages/workers-shared/asset-worker/tests/kv.test.ts
+++ b/packages/workers-shared/asset-worker/tests/kv.test.ts
@@ -53,7 +53,7 @@ describe("[Asset Worker] Fetching assets from KV", () => {
 			).rejects.toThrow("KV GET abcd failed.");
 		});
 
-		it("should retry once by default if something went wrong while fetching the asset", async ({
+		it("should retry three times by default if something went wrong while fetching the asset", async ({
 			expect,
 		}) => {
 			spy.mockReturnValue(Promise.reject("Oeps! Something went wrong"));
@@ -61,7 +61,7 @@ describe("[Asset Worker] Fetching assets from KV", () => {
 			await expect(() =>
 				getAssetWithMetadataFromKV(mockKVNamespace, "abcd")
 			).rejects.toThrow("KV GET abcd failed.");
-			expect(spy).toHaveBeenCalledTimes(2);
+			expect(spy).toHaveBeenCalledTimes(4);
 		});
 
 		it("should support custom number of retries", async ({ expect }) => {
@@ -81,7 +81,7 @@ describe("[Asset Worker] Fetching assets from KV", () => {
 			await expect(() =>
 				getAssetWithMetadataFromKV(mockKVNamespace, "abcd")
 			).rejects.toThrow("KV GET abcd failed: Oeps! Something went wrong");
-			expect(spy).toHaveBeenCalledTimes(2);
+			expect(spy).toHaveBeenCalledTimes(4);
 		});
 
 		it("should retry on 404 and cache with shorter ttl", async ({ expect }) => {


### PR DESCRIPTION
The asset worker reads static assets from KV, and a read can occasionally fail with a transient error. It previously retried only once before giving up. Retry a few times with exponential backoff to reduce the chance of serving an error. A missing asset is not treated as a failure. Fixes WC-5444.

Fixes #[insert GH or internal issue link(s)].

_Describe your change..._

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: n/a

*A picture of a cute animal (not mandatory, but encouraged)*
<img width="296" height="386" alt="Screenshot 2026-07-15 at 12 04 00 PM" src="https://github.com/user-attachments/assets/c42dfa4b-e3ed-408f-a501-5031f3b7239a" />


<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14705" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->