### PR TITLE
feat(wrangler): access do storage with test harness

### DIFF
--- a/.changeset/smooth-ravens-store.md
+++ b/.changeset/smooth-ravens-store.md
@@ -1,0 +1,28 @@
+---
+"wrangler": minor
+"miniflare": minor
+---
+
+Add Durable Object storage access to `createTestHarness()`
+
+You can now execute SQL against a SQLite-backed Durable Object to seed or assert the storage state.
+
+```ts
+const server = createTestHarness({
+	workers: [{ configPath: "./wrangler.json" }],
+});
+await server.listen();
+
+const worker = server.getWorker();
+const storage = await worker.getDurableObjectStorage("COUNTER", {
+	name: "user-123",
+});
+
+await worker.fetch("/counter/user-123");
+
+const rows = await storage.exec(
+	"SELECT value FROM counters WHERE id = ?",
+	"user-123"
+);
+expect(rows).toEqual([{ value: 1 }]);
+```

--- a/packages/miniflare/src/index.ts
+++ b/packages/miniflare/src/index.ts
@@ -98,6 +98,7 @@ import {
 	parseWithRootPath,
 	stripAnsi,
 } from "./shared";
+import { createDurableObjectStorageHandle } from "./shared/dev-control";
 import { DevRegistry, getWorkerRegistry } from "./shared/dev-registry";
 import {
 	getOutboundDoProxyClassName,
@@ -151,6 +152,8 @@ import type { Log } from "./shared";
 import type {
 	DevControl,
 	DurableObjectEvictionOptions,
+	DurableObjectStorageHandle,
+	DurableObjectStorageOptions,
 } from "./shared/dev-control";
 import type { WorkerDefinition } from "./shared/dev-registry-types";
 import type {
@@ -3080,6 +3083,34 @@ export class Miniflare {
 		}
 		return proxy as T;
 	}
+
+	/**
+	 * Returns remote storage access for a Durable Object instance.
+	 *
+	 * Calling `exec()` runs SQL inside the target Durable Object and returns all
+	 * rows. It may start the object if it is not already active.
+	 */
+	async unsafeGetDurableObjectStorage(
+		scriptName: string,
+		className: string,
+		options: DurableObjectStorageOptions
+	): Promise<DurableObjectStorageHandle> {
+		if (!this.#sharedOpts.core.unsafeInspectDurableObjects) {
+			throw new TypeError(
+				"Durable Object storage inspection requires the `unsafeInspectDurableObjects` option."
+			);
+		}
+
+		const control = await this.#getDevControl();
+		const handle = createDurableObjectStorageHandle(
+			control,
+			scriptName,
+			className,
+			options
+		);
+
+		return handle;
+	}
 	// TODO(someday): would be nice to define these in plugins
 	async getCaches(): Promise<ReplaceWorkersTypes<CacheStorage>> {
 		const proxyClient = await this._getProxyClient();
@@ -3457,6 +3488,8 @@ export * from "./zod-format";
 export type {
 	DurableObjectIdentifier,
 	DurableObjectEvictionOptions,
+	DurableObjectStorageOptions,
+	DurableObjectStorageHandle,
 } from "./shared/dev-control";
 export type {
 	WorkerRegistry,

--- a/packages/miniflare/src/plugins/core/index.ts
+++ b/packages/miniflare/src/plugins/core/index.ts
@@ -322,6 +322,8 @@ export const CoreSharedOptionsSchema = z
 		unsafeRuntimeEnv: z.record(z.string()).optional(),
 		// Enable the local explorer at /cdn-cgi/explorer
 		unsafeLocalExplorer: z.boolean().optional(),
+		// Enable RPC-based Durable Object introspection APIs
+		unsafeInspectDurableObjects: z.boolean().optional(),
 		// Enable logging requests
 		logRequests: z.boolean().default(true),
 
@@ -819,7 +821,8 @@ export const CORE_PLUGIN: Plugin<
 			([, { enableSql }]) => enableSql
 		);
 		if (
-			sharedOptions.unsafeLocalExplorer &&
+			(sharedOptions.unsafeLocalExplorer ||
+				sharedOptions.unsafeInspectDurableObjects) &&
 			// service-format workers are not supported
 			"modules" in workerScript &&
 			sqliteClasses.length > 0 &&

--- a/packages/miniflare/src/shared/dev-control.ts
+++ b/packages/miniflare/src/shared/dev-control.ts
@@ -1,3 +1,5 @@
+import type { SqlStorage, SqlStorageValue } from "@cloudflare/workers-types";
+
 export type DurableObjectIdentifier =
 	| { name: string; id?: never }
 	| { id: string; name?: never };
@@ -6,12 +8,52 @@ export type DurableObjectEvictionOptions = DurableObjectIdentifier & {
 	webSockets?: "close" | "hibernate";
 };
 
+export type DurableObjectStorageOptions = DurableObjectIdentifier;
+
+export type DurableObjectStorageHandle = {
+	exec<
+		Row extends Record<string, SqlStorageValue> = Record<
+			string,
+			SqlStorageValue
+		>,
+	>(
+		...args: Parameters<SqlStorage["exec"]>
+	): Promise<Row[]>;
+};
+
+export type DurableObjectStorageOperationOptions = DurableObjectIdentifier & {
+	query: string;
+	bindings: unknown[];
+};
+
 export interface DevControl {
 	evictDurableObject(
 		scriptName: string,
 		className: string,
 		options: DurableObjectEvictionOptions
 	): Promise<void>;
+	execDurableObjectSql<Row extends Record<string, SqlStorageValue>>(
+		scriptName: string,
+		className: string,
+		options: DurableObjectStorageOperationOptions
+	): Promise<Row[]>;
+}
+
+export function createDurableObjectStorageHandle(
+	control: DevControl,
+	scriptName: string,
+	className: string,
+	options: DurableObjectStorageOptions
+): DurableObjectStorageHandle {
+	return {
+		async exec(query, ...bindings) {
+			return control.execDurableObjectSql(scriptName, className, {
+				...options,
+				query,
+				bindings,
+			});
+		},
+	};
 }
 
 export function getDevControlDurableObjectBindingName(

--- a/packages/miniflare/src/workers/core/dev-control.worker.ts
+++ b/packages/miniflare/src/workers/core/dev-control.worker.ts
@@ -1,31 +1,67 @@
 import { WorkerEntrypoint } from "cloudflare:workers";
 import workerdUnsafe from "workerd:unsafe";
-import {
-	type DevControl as DevControlInterface,
-	type DurableObjectEvictionOptions,
-	getDevControlDurableObjectBindingName,
+import { INTROSPECT_SQLITE_METHOD } from "../../plugins/core/constants";
+import { getDevControlDurableObjectBindingName } from "../../shared/dev-control";
+import type { IntrospectSqliteMethod } from "../../plugins/core/constants";
+import type {
+	DevControl as DevControlInterface,
+	DurableObjectIdentifier,
+	DurableObjectEvictionOptions,
+	DurableObjectStorageOperationOptions,
 } from "../../shared/dev-control";
-import type { DurableObjectNamespace } from "@cloudflare/workers-types/experimental";
+import type {
+	DurableObjectNamespace,
+	SqlStorageValue,
+} from "@cloudflare/workers-types/experimental";
 
-function getDurableObjectNamespace(
+function isDurableObjectNamespace(
+	binding: unknown
+): binding is DurableObjectNamespace {
+	return (
+		typeof binding === "object" &&
+		binding !== null &&
+		"idFromName" in binding &&
+		typeof binding.idFromName === "function" &&
+		"idFromString" in binding &&
+		typeof binding.idFromString === "function" &&
+		"get" in binding &&
+		typeof binding.get === "function"
+	);
+}
+
+function hasIntrospectSqliteMethod(
+	stub: unknown
+): stub is { [INTROSPECT_SQLITE_METHOD]: IntrospectSqliteMethod } {
+	return (
+		INTROSPECT_SQLITE_METHOD in (stub as object) &&
+		typeof (stub as any)[INTROSPECT_SQLITE_METHOD] === "function"
+	);
+}
+
+function getDurableObjectStub(
 	env: Record<string, unknown>,
-	bindingName: string
-): DurableObjectNamespace | null {
+	scriptName: string,
+	className: string,
+	identifier: DurableObjectIdentifier
+) {
+	const bindingName = getDevControlDurableObjectBindingName(
+		scriptName,
+		className
+	);
 	const namespace = env[bindingName];
 
-	if (
-		!(typeof namespace === "object" && namespace !== null) ||
-		!("idFromName" in namespace) ||
-		typeof namespace.idFromName !== "function" ||
-		!("idFromString" in namespace) ||
-		typeof namespace.idFromString !== "function" ||
-		!("get" in namespace) ||
-		typeof namespace.get !== "function"
-	) {
-		return null;
+	if (!isDurableObjectNamespace(namespace)) {
+		throw new TypeError(
+			`Expected Durable Object namespace binding for ${scriptName}:${className}`
+		);
 	}
 
-	return namespace as DurableObjectNamespace;
+	const id =
+		identifier.id === undefined
+			? namespace.idFromName(identifier.name)
+			: namespace.idFromString(identifier.id);
+
+	return namespace.get(id);
 }
 
 export default class DevControl
@@ -37,25 +73,42 @@ export default class DevControl
 		className: string,
 		options: DurableObjectEvictionOptions
 	): Promise<void> {
-		const doNamespace = getDurableObjectNamespace(
-			this.env,
-			getDevControlDurableObjectBindingName(scriptName, className)
-		);
-
-		if (!doNamespace) {
-			throw new TypeError(
-				`Expected Durable Object namespace binding for ${scriptName}:${className}`
-			);
-		}
-
-		const id =
-			options.id === undefined
-				? doNamespace.idFromName(options.name)
-				: doNamespace.idFromString(options.id);
-		const stub = doNamespace.get(id);
+		const stub = getDurableObjectStub(this.env, scriptName, className, options);
 
 		await workerdUnsafe.evict(stub, {
 			webSockets: options.webSockets,
 		});
+	}
+
+	async execDurableObjectSql<Row extends Record<string, SqlStorageValue>>(
+		scriptName: string,
+		className: string,
+		options: DurableObjectStorageOperationOptions
+	): Promise<Row[]> {
+		const stub = getDurableObjectStub(this.env, scriptName, className, options);
+
+		if (!hasIntrospectSqliteMethod(stub)) {
+			throw new TypeError(
+				`Durable Object ${scriptName}:${className} does not support SQLite introspection.`
+			);
+		}
+
+		const [result] = await stub[INTROSPECT_SQLITE_METHOD]([
+			{ sql: options.query, params: options.bindings },
+		]);
+
+		if (result === undefined) {
+			throw new Error("Durable Object SQLite query did not return a result.");
+		}
+
+		const columns = result.columns ?? [];
+		const rawRows = result.rows ?? [];
+		const rows = rawRows.map((rawRow) => {
+			return Object.fromEntries(
+				columns.map((column, index) => [column, rawRow[index]])
+			) as Row;
+		});
+
+		return rows;
 	}
 }

--- a/packages/miniflare/src/workers/core/dev-control.worker.ts
+++ b/packages/miniflare/src/workers/core/dev-control.worker.ts
@@ -11,8 +11,13 @@ import type {
 } from "../../shared/dev-control";
 import type {
 	DurableObjectNamespace,
+	DurableObjectStub,
 	SqlStorageValue,
 } from "@cloudflare/workers-types/experimental";
+
+type IntrospectableDurableObjectStub = DurableObjectStub & {
+	[INTROSPECT_SQLITE_METHOD]: IntrospectSqliteMethod;
+};
 
 function isDurableObjectNamespace(
 	binding: unknown
@@ -29,21 +34,12 @@ function isDurableObjectNamespace(
 	);
 }
 
-function hasIntrospectSqliteMethod(
-	stub: unknown
-): stub is { [INTROSPECT_SQLITE_METHOD]: IntrospectSqliteMethod } {
-	return (
-		INTROSPECT_SQLITE_METHOD in (stub as object) &&
-		typeof (stub as any)[INTROSPECT_SQLITE_METHOD] === "function"
-	);
-}
-
 function getDurableObjectStub(
 	env: Record<string, unknown>,
 	scriptName: string,
 	className: string,
 	identifier: DurableObjectIdentifier
-) {
+): IntrospectableDurableObjectStub {
 	const bindingName = getDevControlDurableObjectBindingName(
 		scriptName,
 		className
@@ -61,7 +57,7 @@ function getDurableObjectStub(
 			? namespace.idFromName(identifier.name)
 			: namespace.idFromString(identifier.id);
 
-	return namespace.get(id);
+	return namespace.get(id) as IntrospectableDurableObjectStub;
 }
 
 export default class DevControl
@@ -86,12 +82,6 @@ export default class DevControl
 		options: DurableObjectStorageOperationOptions
 	): Promise<Row[]> {
 		const stub = getDurableObjectStub(this.env, scriptName, className, options);
-
-		if (!hasIntrospectSqliteMethod(stub)) {
-			throw new TypeError(
-				`Durable Object ${scriptName}:${className} does not support SQLite introspection.`
-			);
-		}
 
 		const [result] = await stub[INTROSPECT_SQLITE_METHOD]([
 			{ sql: options.query, params: options.bindings },

--- a/packages/miniflare/test/plugins/do/index.spec.ts
+++ b/packages/miniflare/test/plugins/do/index.spec.ts
@@ -470,6 +470,96 @@ test("SQLite is available in SQLite backed Durable Objects", async ({
 	expect(await res.text()).toBe("4096");
 });
 
+test("gets SQLite storage for Durable Objects", async ({ expect }) => {
+	const mf = new Miniflare({
+		unsafeInspectDurableObjects: true,
+		modules: true,
+		name: "worker",
+		script: `
+			import { DurableObject } from "cloudflare:workers";
+
+			export class TestObject extends DurableObject {
+				constructor(ctx, env) {
+					super(ctx, env);
+					this.ctx.storage.sql.exec(
+						"CREATE TABLE IF NOT EXISTS entries (id TEXT PRIMARY KEY, value TEXT)"
+					);
+				}
+
+				fetch(request) {
+					const url = new URL(request.url);
+					const sql = this.ctx.storage.sql;
+
+					if (url.pathname === "/write") {
+						sql.exec(
+							"INSERT OR REPLACE INTO entries (id, value) VALUES ('key', ?)",
+							url.searchParams.get("value")
+						);
+						return new Response("ok");
+					}
+
+					const row = sql.exec("SELECT value FROM entries WHERE id = 'key'").one();
+					return new Response(row?.value ?? "missing");
+				}
+			}
+
+			export default {
+				fetch(request, env) {
+					const name = new URL(request.url).searchParams.get("name") ?? "by-name";
+					const id = env.OBJECT.idFromName(name);
+					return env.OBJECT.get(id).fetch(request);
+				}
+			}
+		`,
+		durableObjects: {
+			OBJECT: {
+				className: "TestObject",
+				useSQLite: true,
+			},
+		},
+	});
+	useDispose(mf);
+
+	const storageByName = await mf.unsafeGetDurableObjectStorage(
+		"worker",
+		"TestObject",
+		{
+			name: "by-name",
+		}
+	);
+	await storageByName.exec(
+		"INSERT INTO entries (id, value) VALUES ('key', ?)",
+		"seeded"
+	);
+
+	const response1 = await mf.dispatchFetch("http://localhost/read");
+	expect(await response1.text()).toBe("seeded");
+
+	const response2 = await mf.dispatchFetch("http://localhost/write?value=app");
+	expect(await response2.text()).toBe("ok");
+
+	const rows = await storageByName.exec<{ value: string }>(
+		"SELECT value FROM entries WHERE id = 'key'"
+	);
+	expect(rows).toEqual([{ value: "app" }]);
+
+	const namespace = await mf.getDurableObjectNamespace("OBJECT");
+	const storageById = await mf.unsafeGetDurableObjectStorage(
+		"worker",
+		"TestObject",
+		{
+			id: namespace.idFromName("by-id").toString(),
+		}
+	);
+	await storageById.exec(
+		"INSERT INTO entries (id, value) VALUES ('key', ?)",
+		"seeded-by-id"
+	);
+
+	const response3 = await mf.dispatchFetch("http://localhost/read?name=by-id");
+	expect(await response3.text()).toBe("seeded-by-id");
+});
+
 test("SQLite is not available in default Durable Objects", async ({
 	expect,
 }) => {

--- a/packages/wrangler/e2e/createTestHarness.test.ts
+++ b/packages/wrangler/e2e/createTestHarness.test.ts
@@ -458,6 +458,118 @@ describe("createTestHarness", () => {
 		});
 	});
 
+	it("exposes Durable Object storage", async ({ expect, onTestFailed }) => {
+		await helper.seed({
+			"wrangler.jsonc": dedent`
+				{
+					"name": "do-worker",
+					"main": "src/index.ts",
+					"compatibility_date": "2026-05-20",
+					"durable_objects": {
+						"bindings": [
+							{ "name": "OBJECT", "class_name": "TestObject" }
+						]
+					},
+					"migrations": [
+						{ "tag": "v1", "new_sqlite_classes": ["TestObject"] }
+					]
+				}
+			`,
+			"src/index.ts": dedent`
+				import { DurableObject } from "cloudflare:workers";
+
+				export class TestObject extends DurableObject {
+					constructor(ctx, env) {
+						super(ctx, env);
+						this.ctx.storage.sql.exec(
+							"CREATE TABLE IF NOT EXISTS entries (id TEXT PRIMARY KEY, value TEXT)"
+						);
+					}
+
+					fetch(request) {
+						const url = new URL(request.url);
+						const sql = this.ctx.storage.sql;
+
+						if (url.pathname === "/write") {
+							sql.exec(
+								"INSERT OR REPLACE INTO entries (id, value) VALUES ('key', ?)",
+								url.searchParams.get("value")
+							);
+							return new Response("ok");
+						}
+
+						const row = sql.exec("SELECT value FROM entries WHERE id = 'key'").one();
+						return new Response(row?.value ?? "missing");
+					}
+				}
+
+				export default {
+					fetch(request, env) {
+						const url = new URL(request.url);
+						const id = env.OBJECT.idFromName(url.searchParams.get("name") ?? "user-123");
+						return env.OBJECT.get(id).fetch(request);
+					}
+				}
+			`,
+		});
+
+		const server = createTestHarness({
+			root: helper.tmpPath,
+			workers: [{ configPath: "./wrangler.jsonc" }],
+		});
+		onTestFinished(server.close);
+		onTestFailed(server.debug);
+
+		await server.listen();
+
+		const worker = server.getWorker<
+			{ OBJECT: DurableObjectNamespace },
+			{
+				default: ExportedHandler<{ OBJECT: DurableObjectNamespace }>;
+				TestObject: new (
+					// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Match runtime class exports by instance type.
+					...args: any[]
+				) => CloudflareWorkersModule.DurableObject;
+			}
+		>();
+
+		const storageByClassName = await worker.getDurableObjectStorage(
+			"TestObject",
+			{
+				name: "by-class",
+			}
+		);
+		await storageByClassName.exec(
+			"INSERT INTO entries (id, value) VALUES ('key', ?)",
+			"seeded-by-class"
+		);
+
+		const response3 = await worker.fetch("/read?name=by-class");
+		await expect(response3.text()).resolves.toBe("seeded-by-class");
+
+		const storageByBindingName = await worker.getDurableObjectStorage(
+			"OBJECT",
+			{
+				name: "user-123",
+			}
+		);
+		await storageByBindingName.exec(
+			"INSERT INTO entries (id, value) VALUES ('key', ?)",
+			"seeded"
+		);
+
+		const response1 = await worker.fetch("/read?name=user-123");
+		await expect(response1.text()).resolves.toBe("seeded");
+
+		const response2 = await worker.fetch("/write?name=user-123&value=app");
+		await expect(response2.text()).resolves.toBe("ok");
+
+		const rows = await storageByBindingName.exec<{ value: string }>(
+			"SELECT value FROM entries WHERE id = 'key'"
+		);
+		expect(rows).toEqual([{ value: "app" }]);
+	});
+
 	it("introspects Workflow instances by binding name", async ({ expect }) => {
 		await helper.seed({
 			"wrangler.jsonc": dedent`

--- a/packages/wrangler/src/api/test-harness.ts
+++ b/packages/wrangler/src/api/test-harness.ts
@@ -50,6 +50,8 @@ import type {
 	WorkflowIntrospector,
 } from "@cloudflare/workflows-shared/src/types";
 import type {
+	DurableObjectStorageHandle,
+	DurableObjectStorageOptions,
 	DispatchFetch,
 	Json,
 	Miniflare,
@@ -197,6 +199,30 @@ export type WorkerHandle<
 	 * ```
 	 */
 	applyD1Migrations(bindingName: BindingName<Env, D1Database>): Promise<void>;
+	/**
+	 * Returns remote storage access for a Durable Object instance.
+	 * Pass an exported Durable Object class name, or a Durable Object binding name.
+	 * Class names are resolved before binding names.
+	 *
+	 * Use this to seed state before sending requests to the object, or to inspect
+	 * state after awaited requests. Calling `exec()` runs SQL inside the target
+	 * Durable Object and returns all rows. It may start the object if it is not
+	 * already active.
+	 *
+	 * @example
+	 * ```ts
+	 * const sql = await worker.getDurableObjectStorage("COUNTER", {
+	 *   name: "user-123"
+	 * });
+	 * const rows = await sql.exec("SELECT count FROM counters WHERE id = ?", "user-123");
+	 * ```
+	 */
+	getDurableObjectStorage(
+		classNameOrBindingName:
+			| ExportName<Module, Rpc.DurableObjectBranded>
+			| BindingName<Env, DurableObjectNamespace>,
+		options: DurableObjectStorageOptions
+	): Promise<DurableObjectStorageHandle>;
 	/**
 	 * Creates an introspector for a specific Workflow instance.
 	 */
@@ -1111,6 +1137,22 @@ export function createTestHarness(options?: TestHarnessOptions): TestHarness {
 						scriptName,
 						className,
 						evictionOptions
+					);
+				},
+				async getDurableObjectStorage(classNameOrBindingName, storageOptions) {
+					const session = await resolveSession();
+					const miniflare = await getRuntimeMiniflare(session);
+					const workerName = resolveWorkerName(session, name);
+					const { scriptName, className } = resolveDurableObjectTarget(
+						session,
+						workerName,
+						classNameOrBindingName
+					);
+
+					return miniflare.unsafeGetDurableObjectStorage(
+						scriptName,
+						className,
+						storageOptions
 					);
 				},
 				async getEnv() {

--- a/packages/wrangler/src/dev/miniflare/index.ts
+++ b/packages/wrangler/src/dev/miniflare/index.ts
@@ -1164,6 +1164,7 @@ export async function buildMiniflareOptions(
 		unsafeProxySharedSecret: proxyToUserWorkerAuthenticationSecret,
 		unsafeTriggerHandlers: true,
 		unsafeLocalExplorer: getLocalExplorerEnabledFromEnv(),
+		unsafeInspectDurableObjects: true,
 		telemetry: getMetricsConfig({ sendMetrics: config.sendMetrics }),
 		// The way we run Miniflare instances with wrangler dev is that there are two:
 		//  - one holding the proxy worker,


### PR DESCRIPTION
Fixes n/a.

This adds Durable Object storage access to `createTestHarness()`

You can now execute SQL against a SQLite-backed Durable Object to seed or assert the storage state.

```ts
const server = createTestHarness({
	workers: [{ configPath: "./wrangler.json" }],
});
await server.listen();

const worker = server.getWorker();
const storage = await worker.getDurableObjectStorage("COUNTER", {
	name: "user-123",
});

await worker.fetch("/counter/user-123");

const rows = await storage.exec(
	"SELECT value FROM counters WHERE id = ?",
	"user-123"
);
expect(rows).toEqual([{ value: 1 }]);
```

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [x] Cloudflare docs PR(s): https://github.com/cloudflare/cloudflare-docs/pull/31422
  - [ ] Documentation not necessary because:

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
