### PR TITLE
chore: consolidate most packages on zod 4.4.3 in pnpm catalog

### DIFF
--- a/.changeset/zod-catalog-consolidation.md
+++ b/.changeset/zod-catalog-consolidation.md
@@ -1,0 +1,10 @@
+---
+"@cloudflare/config": patch
+"@cloudflare/deploy-helpers": patch
+"@cloudflare/format-errors": patch
+"@cloudflare/playground-preview-worker": patch
+"@cloudflare/turbo-r2-archive": patch
+"@cloudflare/workflows-shared": patch
+---
+
+Update zod to v4

--- a/fixtures/unsafe-external-plugin/package.json
+++ b/fixtures/unsafe-external-plugin/package.json
@@ -14,6 +14,6 @@
 		"esbuild": "catalog:default",
 		"miniflare": "workspace:*",
 		"tsx": "^3.12.8",
-		"zod": "3.22.3"
+		"zod": "catalog:default"
 	}
 }

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -35,7 +35,7 @@
 		"test:watch": "vitest"
 	},
 	"dependencies": {
-		"zod": "4.4.3"
+		"zod": "catalog:default"
 	},
 	"devDependencies": {
 		"@cloudflare/workers-tsconfig": "workspace:*",

--- a/packages/deploy-helpers/package.json
+++ b/packages/deploy-helpers/package.json
@@ -63,16 +63,7 @@
 		"ts-dedent": "^2.2.0",
 		"tsup": "8.3.0",
 		"typescript": "catalog:default",
-		"vitest": "catalog:default",
-		"zod": "^4.4.3"
-	},
-	"peerDependencies": {
-		"zod": "^4.4.3"
-	},
-	"peerDependenciesMeta": {
-		"zod": {
-			"optional": true
-		}
+		"vitest": "catalog:default"
 	},
 	"volta": {
 		"extends": "../../package.json"

--- a/packages/deploy-helpers/scripts/deps.ts
+++ b/packages/deploy-helpers/scripts/deps.ts
@@ -20,9 +20,4 @@ export const EXTERNAL_DEPENDENCIES = [
 	"p-queue",
 	"pretty-bytes",
 	"undici",
-
-	// Externalized so wrangler bundles a single shared zod copy instead of
-	// inlining one via this package. Declared as a peerDependency (the
-	// consumer provides zod).
-	"zod",
 ];

--- a/packages/deploy-helpers/tsup.config.ts
+++ b/packages/deploy-helpers/tsup.config.ts
@@ -34,9 +34,6 @@ export default defineConfig(() => [
 			"dotenv",
 			"command-exists",
 			"esbuild",
-			// Keep zod external so wrangler (the only consumer) bundles a single
-			// shared copy rather than inlining one here.
-			/^zod(\/.*)?$/,
 		],
 	},
 ]);

--- a/packages/format-errors/package.json
+++ b/packages/format-errors/package.json
@@ -17,7 +17,7 @@
 		"tsconfig": "*",
 		"vitest": "catalog:default",
 		"wrangler": "workspace:*",
-		"zod": "^3.22.3"
+		"zod": "catalog:default"
 	},
 	"volta": {
 		"extends": "../../package.json"

--- a/packages/format-errors/src/index.ts
+++ b/packages/format-errors/src/index.ts
@@ -33,7 +33,7 @@ export const JsonErrorSchema: z.ZodType<JsonError> = z.lazy(() =>
 export const PayloadSchema = z.object({
 	url: z.string().optional(),
 	method: z.string().optional(),
-	headers: z.record(z.string()),
+	headers: z.record(z.string(), z.string()),
 	error: JsonErrorSchema.optional(),
 });
 

--- a/packages/playground-preview-worker/package.json
+++ b/packages/playground-preview-worker/package.json
@@ -14,7 +14,7 @@
 	},
 	"dependencies": {
 		"hono": "^4.12.5",
-		"zod": "^3.22.3"
+		"zod": "catalog:default"
 	},
 	"devDependencies": {
 		"@cloudflare/workers-types": "catalog:default",

--- a/packages/playground-preview-worker/src/errors.ts
+++ b/packages/playground-preview-worker/src/errors.ts
@@ -1,4 +1,4 @@
-import type { ZodIssue } from "zod";
+import type { z } from "zod";
 
 export class HttpError extends Error {
 	constructor(
@@ -55,7 +55,7 @@ export class ServiceWorkerNotSupported extends HttpError {
 }
 export class ZodSchemaError extends HttpError {
 	name = "ZodSchemaError";
-	constructor(private issues: ZodIssue[]) {
+	constructor(private issues: z.core.$ZodIssue[]) {
 		super("Something went wrong", 500, true);
 	}
 

--- a/packages/playground-preview-worker/src/realish.ts
+++ b/packages/playground-preview-worker/src/realish.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import { PreviewError } from "./errors";
 
-const APIResponse = <T extends z.ZodTypeAny>(resultSchema: T) =>
+const APIResponse = <T extends z.ZodType>(resultSchema: T) =>
 	z.union([
 		z.object({
 			success: z.literal(true),

--- a/packages/playground-preview-worker/src/user.do.ts
+++ b/packages/playground-preview-worker/src/user.do.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert";
-import z from "zod";
+import { z } from "zod";
 import { BadUpload, ServiceWorkerNotSupported, WorkerTimeout } from "./errors";
 import { constructMiddleware } from "./inject-middleware";
 import { doUpload, setupTokens } from "./realish";
@@ -16,9 +16,9 @@ function switchRemote(url: URL, remote: string) {
 }
 
 const UploadedMetadata = z.object({
-	body_part: z.ostring(),
-	main_module: z.ostring(),
-	compatibility_date: z.ostring(),
+	body_part: z.string().optional(),
+	main_module: z.string().optional(),
+	compatibility_date: z.string().optional(),
 	compatibility_flags: z.array(z.string()).optional(),
 });
 

--- a/packages/turbo-r2-archive/package.json
+++ b/packages/turbo-r2-archive/package.json
@@ -17,9 +17,9 @@
 		"type:check": "tsc"
 	},
 	"dependencies": {
-		"@hono/zod-validator": "^0.4.2",
+		"@hono/zod-validator": "^0.8.0",
 		"hono": "^4.12.5",
-		"zod": "^3.22.3"
+		"zod": "catalog:default"
 	},
 	"devDependencies": {
 		"@cloudflare/workers-tsconfig": "workspace:*",

--- a/packages/workflows-shared/package.json
+++ b/packages/workflows-shared/package.json
@@ -36,7 +36,7 @@
 		"heap-js": "^2.5.0",
 		"itty-time": "^2.0.2",
 		"mime": "^3.0.0",
-		"zod": "^3.22.3"
+		"zod": "catalog:default"
 	},
 	"devDependencies": {
 		"@cloudflare/vitest-pool-workers": "catalog:default",

--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -182,7 +182,7 @@
 		"xxhash-wasm": "^1.0.1",
 		"yaml": "^2.8.1",
 		"yargs": "^17.7.2",
-		"zod": "^4.4.3"
+		"zod": "catalog:default"
 	},
 	"peerDependencies": {
 		"@cloudflare/workers-types": "catalog:default"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,6 +90,9 @@ catalogs:
     ws:
       specifier: 8.21.0
       version: 8.21.0
+    zod:
+      specifier: 4.4.3
+      version: 4.4.3
 
 overrides:
   '@types/react-dom@18>@types/react': ^18
@@ -1213,8 +1216,8 @@ importers:
         specifier: ^3.12.8
         version: 3.12.10
       zod:
-        specifier: 3.22.3
-        version: 3.22.3
+        specifier: catalog:default
+        version: 4.4.3
 
   fixtures/vitest-pool-workers-examples:
     devDependencies:
@@ -1758,7 +1761,7 @@ importers:
   packages/config:
     dependencies:
       zod:
-        specifier: 4.4.3
+        specifier: catalog:default
         version: 4.4.3
     devDependencies:
       '@cloudflare/workers-tsconfig':
@@ -2032,9 +2035,6 @@ importers:
       vitest:
         specifier: catalog:default
         version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@22.15.17)(@vitest/ui@4.1.0)(msw@2.12.4(@types/node@22.15.17)(typescript@5.8.3))(vite@8.0.13(@types/node@22.15.17)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.1))
-      zod:
-        specifier: ^4.4.3
-        version: 4.4.3
 
   packages/devprod-status-bot:
     devDependencies:
@@ -2105,8 +2105,8 @@ importers:
         specifier: workspace:*
         version: link:../wrangler
       zod:
-        specifier: ^3.22.3
-        version: 3.22.3
+        specifier: catalog:default
+        version: 4.4.3
 
   packages/kv-asset-handler:
     devDependencies:
@@ -2486,8 +2486,8 @@ importers:
         specifier: ^4.12.5
         version: 4.12.5
       zod:
-        specifier: ^3.22.3
-        version: 3.22.3
+        specifier: catalog:default
+        version: 4.4.3
     devDependencies:
       '@cloudflare/workers-types':
         specifier: catalog:default
@@ -2590,14 +2590,14 @@ importers:
   packages/turbo-r2-archive:
     dependencies:
       '@hono/zod-validator':
-        specifier: ^0.4.2
-        version: 0.4.2(hono@4.12.5)(zod@3.22.3)
+        specifier: ^0.8.0
+        version: 0.8.0(hono@4.12.5)(zod@4.4.3)
       hono:
         specifier: ^4.12.5
         version: 4.12.5
       zod:
-        specifier: ^3.22.3
-        version: 3.22.3
+        specifier: catalog:default
+        version: 4.4.3
     devDependencies:
       '@cloudflare/workers-tsconfig':
         specifier: workspace:*
@@ -4284,8 +4284,8 @@ importers:
         specifier: ^3.0.0
         version: 3.0.0
       zod:
-        specifier: ^3.22.3
-        version: 3.22.3
+        specifier: catalog:default
+        version: 4.4.3
     devDependencies:
       '@cloudflare/vitest-pool-workers':
         specifier: catalog:default
@@ -4622,7 +4622,7 @@ importers:
         specifier: ^17.7.2
         version: 17.7.2
       zod:
-        specifier: ^4.4.3
+        specifier: catalog:default
         version: 4.4.3
     optionalDependencies:
       fsevents:
@@ -6731,11 +6731,11 @@ packages:
     peerDependencies:
       hono: ^4
 
-  '@hono/zod-validator@0.4.2':
-    resolution: {integrity: sha512-1rrlBg+EpDPhzOV4hT9pxr5+xDVmKuz6YJl+la7VCwK6ass5ldyKm5fD+umJdV2zhHD6jROoCCv8NbTwyfhT0g==}
+  '@hono/zod-validator@0.8.0':
+    resolution: {integrity: sha512-5uS4S1/LKtZQYvD4BtpPUFkOv8d1wNxHHrChm26buMiEYc1FrHWvDUaKVBwkiVtvSExHSpLGDvcnpI2Copyj9w==}
     peerDependencies:
-      hono: '>=3.9.0'
-      zod: ^3.19.1
+      hono: '>=4.10.0'
+      zod: ^3.25.0 || ^4.0.0
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -15644,14 +15644,8 @@ packages:
   zeptomatch@2.0.2:
     resolution: {integrity: sha512-H33jtSKf8Ijtb5BW6wua3G5DhnFjbFML36eFu+VdOoVY4HD9e7ggjqdM6639B+L87rjnR6Y+XeRzBXZdy52B/g==}
 
-  zod@3.22.3:
-    resolution: {integrity: sha512-EjIevzuJRiRPbVH4mGc8nApb/lVLKVpmUhAaR5R5doKGfAnGJ6Gr3CViAVjP+4FWSxCsybeWQdcgCtbX+7oZug==}
-
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
-
-  zod@4.3.6:
-    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
 
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
@@ -16602,7 +16596,7 @@ snapshots:
       better-call: 1.3.2(zod@4.4.3)
       defu: 6.1.4
       stripe: 20.4.1(@types/node@22.15.17)
-      zod: 4.3.6
+      zod: 4.4.3
 
   '@better-auth/telemetry@1.5.4(@better-auth/core@1.5.4(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@5.20260710.1)(better-call@1.3.2(zod@4.4.3))(jose@5.9.3)(kysely@0.28.11)(nanostores@1.1.1))':
     dependencies:
@@ -17970,10 +17964,10 @@ snapshots:
     dependencies:
       hono: 4.7.10
 
-  '@hono/zod-validator@0.4.2(hono@4.12.5)(zod@3.22.3)':
+  '@hono/zod-validator@0.8.0(hono@4.12.5)(zod@4.4.3)':
     dependencies:
       hono: 4.12.5
-      zod: 3.22.3
+      zod: 4.4.3
 
   '@humanfs/core@0.19.1': {}
 
@@ -27452,11 +27446,7 @@ snapshots:
     dependencies:
       grammex: 3.1.11
 
-  zod@3.22.3: {}
-
   zod@3.25.76: {}
-
-  zod@4.3.6: {}
 
   zod@4.4.3: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -128,6 +128,7 @@ catalog:
   "tree-kill": "1.2.2"
   "capnp-es": "0.0.14"
   "capnweb": "0.5.0"
+  zod: "4.4.3"
   "ci-info": "4.4.0"
   "open": "11.0.0"
   "signal-exit": "4.1.0"

--- a/tools/deployments/validate-catalog-usage.ts
+++ b/tools/deployments/validate-catalog-usage.ts
@@ -12,7 +12,12 @@ const ROOT = resolve(__dirname, "../..");
 
 // Deps that are deliberately pinned outside the catalog (e.g. workerd is
 // bumped in coordinated PRs with its own automation).
-const IGNORED_DEPS = new Set(["workerd"]);
+const IGNORED_DEPS = new Set([
+	"workerd",
+	// miniflare, vitest-pool-workers, and workers-shared still use zod v3
+	// and cannot adopt the v4 catalog version yet.
+	"zod",
+]);
 
 /**
  * Parses the `catalog:` block of a pnpm-workspace.yaml into a map of


### PR DESCRIPTION
Some cleanup ahead of miniflare v5 moving to zod v4.

This just adds zod to the pnpm catalog. A few internal packages had to be bumped from zod 3 to 4.

Miniflare and its colleagues vitest-pool-workers and workers-shared need to be bumped to zod 4 together, so that is happening elsewhere on the miniflare v5 branch.


---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: should have no impact
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: internal packages

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14707" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->