### PR TITLE
maybe fix miniflare browser rendering flakes

### DIFF
--- a/fixtures/browser-run/test/index.spec.ts
+++ b/fixtures/browser-run/test/index.spec.ts
@@ -6,7 +6,8 @@ import { runWranglerDev } from "../../shared/src/run-wrangler-long-lived";
 
 const BROWSER_RENDERING_RETRY = {
 	retry: {
-		condition: /Chrome readiness probe .* timed out|Test timed out/i,
+		condition:
+			/Chrome readiness probe .* timed out|Test timed out|connection refused|ConnectEx|WSARecv|ECONNRESET|EPIPE|network connection lost|disconnected/i,
 		count: 3,
 		delay: 1_000,
 	},

--- a/packages/miniflare/src/plugins/browser-rendering/index.ts
+++ b/packages/miniflare/src/plugins/browser-rendering/index.ts
@@ -331,7 +331,11 @@ async function waitForBrowserReady(
 	wsEndpoint: string,
 	log: Log
 ): Promise<void> {
-	const timeoutMs = 5000;
+	// Windows CI runners are significantly slower to make Chrome's listening
+	// socket accept connections after the DevTools URL is printed. Use a
+	// larger timeout there to avoid spurious "Chrome readiness probe timed
+	// out" failures that would otherwise force a full test-level retry.
+	const timeoutMs = process.platform === "win32" ? 15_000 : 5_000;
 	const initialDelayMs = 25;
 	const maxDelayMs = 250;
 	const perRequestTimeoutMs = 500;

--- a/packages/miniflare/test/plugins/browser/index.spec.ts
+++ b/packages/miniflare/test/plugins/browser/index.spec.ts
@@ -64,7 +64,8 @@ async function waitForClosedConnection(ws: WebSocket): Promise<void> {
 
 const BROWSER_RENDERING_RETRY = {
 	retry: {
-		condition: /Chrome readiness probe .* timed out|Test timed out/i,
+		condition:
+			/Chrome readiness probe .* timed out|Test timed out|connection refused|ConnectEx|WSARecv|ECONNRESET|EPIPE|network connection lost|disconnected/i,
 		count: 3,
 		delay: 1_000,
 	},

--- a/packages/miniflare/test/plugins/browser/index.spec.ts
+++ b/packages/miniflare/test/plugins/browser/index.spec.ts
@@ -1,25 +1,17 @@
 import { Miniflare } from "miniflare";
 import {
-	afterAll,
 	afterEach,
-	beforeAll,
 	beforeEach,
 	describe,
 	test,
 	type TestOptions,
 	vi,
 } from "vitest";
-import { disposeWithRetry, useDispose } from "../../test-shared";
+import { useDispose } from "../../test-shared";
+import type { MiniflareOptions } from "miniflare";
 
-/**
- * Send a chunked-framing message over a WebSocket.
- *
- * Adapted from https://github.com/cloudflare/puppeteer/blob/b4984452165437e26dd1c8e516581cec2a02b4cd/packages/puppeteer-core/src/cloudflare/chunking.ts#L6-L30
- *
- * @param ws - The WebSocket to send the message on.
- * @param message - The message payload to JSON-serialize and send.
- */
 async function sendMessage(ws: WebSocket, message: unknown) {
+	// adapted from https://github.com/cloudflare/puppeteer/blob/b4984452165437e26dd1c8e516581cec2a02b4cd/packages/puppeteer-core/src/cloudflare/chunking.ts#L6-L30
 	const messageToChunks = (data: string): Uint8Array[] => {
 		const HEADER_SIZE = 4; // Uint32
 		const MAX_MESSAGE_SIZE = 1048575; // Workers size is < 1MB
@@ -56,12 +48,6 @@ async function sendMessage(ws: WebSocket, message: unknown) {
 	}
 }
 
-/**
- * Wait for a WebSocket connection to be fully closed.
- *
- * @param ws - The WebSocket to wait on.
- * @returns A promise that resolves when the connection is closed.
- */
 async function waitForClosedConnection(ws: WebSocket): Promise<void> {
 	if (ws.readyState === ws.CLOSED) {
 		return;
@@ -76,40 +62,6 @@ async function waitForClosedConnection(ws: WebSocket): Promise<void> {
 	});
 }
 
-/**
- * Wait for a single chunked-framing message from a WebSocket.
- *
- * Reassembles multi-chunk messages using the 4-byte little-endian length
- * header in the first chunk.
- *
- * @param ws - The WebSocket to listen on.
- * @returns A promise that resolves with the parsed JSON message.
- */
-async function waitForMessage(ws: WebSocket): Promise<unknown> {
-	const chunks: { data: Uint8Array; totalLength: number }[] = [];
-	return new Promise((resolve) => {
-		ws.addEventListener("message", function handler(event) {
-			const data = new Uint8Array(event.data as ArrayBuffer);
-			if (chunks.length === 0) {
-				// First chunk contains a 4-byte little-endian length header
-				const view = new DataView(data.buffer);
-				const totalLength = view.getUint32(0, true);
-				chunks.push({ data: data.slice(4), totalLength });
-			} else {
-				chunks[0].data = new Uint8Array([...chunks[0].data, ...data]);
-			}
-			const accumulated = chunks[0];
-			if (accumulated.data.length >= accumulated.totalLength) {
-				ws.removeEventListener("message", handler);
-				const text = new TextDecoder().decode(
-					accumulated.data.slice(0, accumulated.totalLength)
-				);
-				resolve(JSON.parse(text));
-			}
-		});
-	});
-}
-
 const BROWSER_RENDERING_RETRY = {
 	retry: {
 		condition:
@@ -119,438 +71,12 @@ const BROWSER_RENDERING_RETRY = {
 	},
 } satisfies TestOptions;
 
-/**
- * A single "mega-worker" script that handles all browser rendering test
- * scenarios via URL path routing.  Each test dispatches a fetch to a unique
- * path (e.g. `/session`, `/close`, `/reuse`) and the worker runs the
- * corresponding browser rendering logic.  This allows the entire test suite
- * to share one Miniflare (and therefore one workerd) instance, eliminating
- * ~16 workerd start/stop cycles and the associated cleanup races that cause
- * flakiness on Windows CI runners.
- *
- * Helper functions (`sendMessage`, `waitForClosedConnection`,
- * `waitForMessage`) are embedded via `.toString()` so they are available
- * inside the worker script string.
- */
-const MEGA_WORKER_SCRIPT = `
-${sendMessage.toString()}
-${waitForClosedConnection.toString()}
-${waitForMessage.toString()}
-
+const BROWSER_WORKER_SCRIPT = () => `
 export default {
 	async fetch(request, env) {
-		const url = new URL(request.url);
-		switch (url.pathname) {
-
-			// --- /session: acquire a browser session ---
-			case "/session": {
-				const resp = await env.MYBROWSER.fetch("https://localhost/v1/acquire");
-				return new Response(await resp.text());
-			}
-
-			// --- /close: acquire, connect via legacy WS, send Browser.close ---
-			case "/close": {
-				const acquireResponse = await env.MYBROWSER.fetch("https://localhost/v1/acquire");
-				const { sessionId } = await acquireResponse.json();
-				const { webSocket: ws } = await env.MYBROWSER.fetch(
-					\`https://localhost/v1/connectDevtools?browser_session=\${sessionId}\`,
-					{ headers: { "Upgrade": "websocket" } }
-				);
-				ws.accept();
-				sendMessage(ws, { method: "Browser.close", id: -1 });
-				await waitForClosedConnection(ws);
-				return new Response("Browser closed");
-			}
-
-			// --- /reuse: acquire, connect, disconnect, reconnect ---
-			case "/reuse": {
-				const acquireResponse = await env.MYBROWSER.fetch("https://localhost/v1/acquire");
-				const { sessionId } = await acquireResponse.json();
-				const { webSocket: ws } = await env.MYBROWSER.fetch(
-					\`https://localhost/v1/connectDevtools?browser_session=\${sessionId}\`,
-					{ headers: { "Upgrade": "websocket" } }
-				);
-				ws.accept();
-				ws.close();
-				await waitForClosedConnection(ws);
-
-				// Reuse the same session by connecting to it again
-				const { webSocket: ws2 } = await env.MYBROWSER.fetch(
-					\`https://localhost/v1/connectDevtools?browser_session=\${sessionId}\`,
-					{ headers: { "Upgrade": "websocket" } }
-				);
-				ws2.accept();
-				ws2.close();
-				return new Response("Browser session reused");
-			}
-
-			// --- /reconnect: disconnect and reconnect, sending CDP commands ---
-			case "/reconnect": {
-				const acquireResponse = await env.MYBROWSER.fetch("https://localhost/v1/acquire");
-				const { sessionId } = await acquireResponse.json();
-
-				// First connection
-				const { webSocket: ws } = await env.MYBROWSER.fetch(
-					\`https://localhost/v1/connectDevtools?browser_session=\${sessionId}\`,
-					{ headers: { "Upgrade": "websocket" } }
-				);
-				ws.accept();
-
-				// Send a CDP command and verify we get a response
-				sendMessage(ws, { method: "Target.getTargets", id: 1 });
-				const msg1 = await waitForMessage(ws);
-				if (!msg1 || !msg1.result) {
-					return new Response("First CDP command failed: " + JSON.stringify(msg1));
-				}
-
-				// Disconnect
-				ws.close();
-				await waitForClosedConnection(ws);
-
-				// Reconnect with the same sessionId
-				const resp2 = await env.MYBROWSER.fetch(
-					\`https://localhost/v1/connectDevtools?browser_session=\${sessionId}\`,
-					{ headers: { "Upgrade": "websocket" } }
-				);
-				if (!resp2.webSocket) {
-					return new Response("Reconnect failed with status: " + resp2.status);
-				}
-				const ws2 = resp2.webSocket;
-				ws2.accept();
-
-				// Send a CDP command on the reconnected socket
-				sendMessage(ws2, { method: "Target.getTargets", id: 2 });
-				const msg2 = await waitForMessage(ws2);
-				if (!msg2 || !msg2.result) {
-					return new Response("Second CDP command failed: " + JSON.stringify(msg2));
-				}
-
-				ws2.close();
-				return new Response("Reconnect successful");
-			}
-
-			// --- /already-used: try to open two legacy WS connections ---
-			case "/already-used": {
-				const acquireResponse = await env.MYBROWSER.fetch("https://localhost/v1/acquire");
-				const { sessionId } = await acquireResponse.json();
-				const { webSocket: ws } = await env.MYBROWSER.fetch(
-					\`https://localhost/v1/connectDevtools?browser_session=\${sessionId}\`,
-					{ headers: { "Upgrade": "websocket" } }
-				);
-				ws.accept();
-
-				await new Promise(resolve => setTimeout(resolve, 100));
-
-				// try to open new connection for the same session
-				const resp2 = await env.MYBROWSER.fetch(
-					\`https://localhost/v1/connectDevtools?browser_session=\${sessionId}\`,
-					{ headers: { "Upgrade": "websocket" } }
-				);
-				if (resp2.status === 409) {
-					return new Response("Failed to connect to browser session");
-				}
-				return new Response("Should not reach here");
-			}
-
-			// --- /get-sessions: acquire, connect, close, check sessions ---
-			case "/get-sessions": {
-				const { sessions: beforeSessions } = await env.MYBROWSER.fetch("https://localhost/v1/sessions").then(r => r.json());
-				const baselineCount = beforeSessions.length;
-				const { sessionId } = await env.MYBROWSER.fetch("https://localhost/v1/acquire").then(r => r.json());
-				const { sessions: allAfterAcquire } = await env.MYBROWSER.fetch("https://localhost/v1/sessions").then(r => r.json());
-				// Filter to only our session to avoid interference from other tests
-				const ourSession = allAfterAcquire.find(s => s.sessionId === sessionId);
-				const newCount = allAfterAcquire.length - baselineCount;
-
-				const { webSocket: ws } = await env.MYBROWSER.fetch(
-					\`https://localhost/v1/connectDevtools?browser_session=\${sessionId}\`,
-					{ headers: { "Upgrade": "websocket" } }
-				);
-				ws.accept();
-
-				// send a close message to the browser
-				sendMessage(ws, { method: "Browser.close", id: -1 });
-				await waitForClosedConnection(ws);
-				await new Promise((resolve) => setTimeout(resolve, 1000));
-
-				const { sessions: afterClosedSessions } = await env.MYBROWSER.fetch("https://localhost/v1/sessions").then(r => r.json());
-				const sessionStillPresent = afterClosedSessions.some(s => s.sessionId === sessionId);
-				return Response.json({ baselineCount, ourSession, newCount, sessionStillPresent });
-			}
-
-			// --- /get-sessions-disconnect: acquire, connect, disconnect, check sessions ---
-			case "/get-sessions-disconnect": {
-				const { sessionId } = await env.MYBROWSER.fetch("https://localhost/v1/acquire").then(r => r.json());
-				const { webSocket: ws } = await env.MYBROWSER.fetch(
-					\`https://localhost/v1/connectDevtools?browser_session=\${sessionId}\`,
-					{ headers: { "Upgrade": "websocket" } }
-				);
-				ws.accept();
-
-				const { sessions: allConnected } = await env.MYBROWSER.fetch("https://localhost/v1/sessions").then(r => r.json());
-				const connectedSession = allConnected.find(s => s.sessionId === sessionId);
-				ws.close();
-				await waitForClosedConnection(ws);
-
-				const { sessions: allDisconnected } = await env.MYBROWSER.fetch("https://localhost/v1/sessions").then(r => r.json());
-				const disconnectedSession = allDisconnected.find(s => s.sessionId === sessionId);
-				return Response.json({ connectedSession, disconnectedSession });
-			}
-
-			// --- /limits: proxy to limits endpoint ---
-			case "/limits": {
-				return env.MYBROWSER.fetch("https://localhost/v1/limits");
-			}
-
-			// --- /history: proxy to history endpoint ---
-			case "/history": {
-				return env.MYBROWSER.fetch("https://localhost/v1/history");
-			}
-
-			// --- /devtools-session: list and detail endpoints ---
-			case "/devtools-session": {
-				const beforeList = await env.MYBROWSER.fetch("https://localhost/v1/devtools/session").then(r => r.json());
-				const baselineCount = beforeList.length;
-				const { sessionId } = await env.MYBROWSER.fetch("https://localhost/v1/acquire").then(r => r.json());
-				const afterList = await env.MYBROWSER.fetch("https://localhost/v1/devtools/session").then(r => r.json());
-				const newCount = afterList.length - baselineCount;
-				const ourSession = afterList.find(s => s.sessionId === sessionId);
-				const detail = await env.MYBROWSER.fetch(\`https://localhost/v1/devtools/session/\${sessionId}\`).then(r => r.json());
-				const missing = await env.MYBROWSER.fetch("https://localhost/v1/devtools/session/does-not-exist");
-				return Response.json({ baselineCount, newCount, ourSession, detail, missingStatus: missing.status });
-			}
-
-			// --- /devtools-json: json/version, json/list, json endpoints ---
-			case "/devtools-json": {
-				const { sessionId } = await env.MYBROWSER.fetch("https://localhost/v1/acquire").then(r => r.json());
-				const version = await env.MYBROWSER.fetch(
-					\`https://localhost/v1/devtools/browser/\${sessionId}/json/version\`
-				).then(r => r.json());
-				const list = await env.MYBROWSER.fetch(
-					\`https://localhost/v1/devtools/browser/\${sessionId}/json/list\`
-				).then(r => r.json());
-				const listAlias = await env.MYBROWSER.fetch(
-					\`https://localhost/v1/devtools/browser/\${sessionId}/json\`
-				).then(r => r.json());
-				return Response.json({ version, list, listAlias });
-			}
-
-			// --- /devtools-delete: DELETE closes browser session ---
-			case "/devtools-delete": {
-				const { sessionId } = await env.MYBROWSER.fetch("https://localhost/v1/acquire").then(r => r.json());
-				const { webSocket: ws } = await env.MYBROWSER.fetch(
-					\`https://localhost/v1/devtools/browser/\${sessionId}\`,
-					{ headers: { Upgrade: "websocket" } }
-				);
-				ws.accept();
-				const deleteResp = await env.MYBROWSER.fetch(
-					\`https://localhost/v1/devtools/browser/\${sessionId}\`,
-					{ method: "DELETE" }
-				);
-				const deleteBody = await deleteResp.json();
-				// Verify our session is gone after DELETE (filter by sessionId)
-				const { sessions } = await env.MYBROWSER.fetch("https://localhost/v1/sessions").then(r => r.json());
-				const sessionGone = !sessions.some(s => s.sessionId === sessionId);
-				await waitForClosedConnection(ws);
-				const wsClosed = ws.readyState === WebSocket.CLOSED;
-				return Response.json({ deleteStatus: deleteResp.status, deleteBody, sessionGone, wsClosed });
-			}
-
-			// --- /devtools-browser-ws: POST acquires, GET connects via WS ---
-			case "/devtools-browser-ws": {
-				const postResp = await env.MYBROWSER.fetch("https://localhost/v1/devtools/browser", {
-					method: "POST",
-				});
-				const { sessionId } = await postResp.json();
-
-				await new Promise(resolve => setTimeout(resolve, 200));
-
-				const getResp = await env.MYBROWSER.fetch(
-					\`https://localhost/v1/devtools/browser/\${sessionId}\`,
-					{ headers: { Upgrade: "websocket" } }
-				);
-				const sessionIdFromGet = getResp.headers.get("cf-browser-session-id");
-				const ws = getResp.webSocket;
-				ws.accept();
-				const browserVersion = await new Promise((resolve) => {
-					ws.addEventListener("message", (m) => resolve(JSON.parse(m.data)));
-					ws.send(JSON.stringify({ id: 1, method: "Browser.getVersion" }));
-				});
-				ws.close();
-				return Response.json({
-					postStatus: postResp.status,
-					sessionId,
-					getStatus: getResp.status,
-					sessionIdFromGet,
-					browserProduct: browserVersion.result?.product,
-				});
-			}
-
-			// --- /devtools-browser-get: GET acquires and connects in one step ---
-			case "/devtools-browser-get": {
-				const resp = await env.MYBROWSER.fetch("https://localhost/v1/devtools/browser", {
-					headers: { Upgrade: "websocket" },
-				});
-				const sessionId = resp.headers.get("cf-browser-session-id");
-				const ws = resp.webSocket;
-				ws.accept();
-				const browserVersion = await new Promise((resolve) => {
-					ws.addEventListener("message", (m) => resolve(JSON.parse(m.data)));
-					ws.send(JSON.stringify({ id: 1, method: "Browser.getVersion" }));
-				});
-				ws.close();
-				return Response.json({
-					status: resp.status,
-					sessionId,
-					browserProduct: browserVersion.result?.product,
-				});
-			}
-
-			// --- /devtools-protocol: json/protocol endpoint ---
-			case "/devtools-protocol": {
-				const { sessionId } = await env.MYBROWSER.fetch("https://localhost/v1/acquire").then(r => r.json());
-				const protocol = await env.MYBROWSER.fetch(
-					\`https://localhost/v1/devtools/browser/\${sessionId}/json/protocol\`
-				).then(r => r.json());
-				return Response.json({ hasDomains: Array.isArray(protocol.domains) });
-			}
-
-			// --- /devtools-new-activate-close: json/new, json/activate, json/close ---
-			case "/devtools-new-activate-close": {
-				const { sessionId } = await env.MYBROWSER.fetch("https://localhost/v1/acquire").then(r => r.json());
-				const newTarget = await env.MYBROWSER.fetch(
-					\`https://localhost/v1/devtools/browser/\${sessionId}/json/new?url=about:blank\`,
-					{ method: "PUT" }
-				).then(r => r.json());
-				const activateResp = await env.MYBROWSER.fetch(
-					\`https://localhost/v1/devtools/browser/\${sessionId}/json/activate/\${newTarget.id}\`
-				);
-				const closeResp = await env.MYBROWSER.fetch(
-					\`https://localhost/v1/devtools/browser/\${sessionId}/json/close/\${newTarget.id}\`
-				);
-				return Response.json({
-					targetType: newTarget.type,
-					activateStatus: activateResp.status,
-					closeStatus: closeResp.status,
-				});
-			}
-
-			// --- /devtools-page-ws: page-level WebSocket endpoint ---
-			case "/devtools-page-ws": {
-				const { sessionId } = await env.MYBROWSER.fetch("https://localhost/v1/acquire").then(r => r.json());
-				const targets = await env.MYBROWSER.fetch(
-					\`https://localhost/v1/devtools/browser/\${sessionId}/json/list\`
-				).then(r => r.json());
-				const targetId = targets[0].id;
-				const { webSocket: ws } = await env.MYBROWSER.fetch(
-					\`https://localhost/v1/devtools/browser/\${sessionId}/page/\${targetId}\`,
-					{ headers: { Upgrade: "websocket" } }
-				);
-				ws.accept();
-				const result = await new Promise((resolve) => {
-					ws.addEventListener("message", (m) => resolve(JSON.parse(m.data)));
-					ws.send(JSON.stringify({ id: 1, method: "Runtime.evaluate", params: { expression: "1+1" } }));
-				});
-				ws.close();
-				return Response.json({ resultValue: result.result?.result?.value });
-			}
-
-			// --- /devtools-delete-no-ws: DELETE without prior WebSocket ---
-			case "/devtools-delete-no-ws": {
-				const { sessionId } = await env.MYBROWSER.fetch("https://localhost/v1/acquire").then(r => r.json());
-				const deleteResp = await env.MYBROWSER.fetch(
-					\`https://localhost/v1/devtools/browser/\${sessionId}\`,
-					{ method: "DELETE" }
-				);
-				const deleteBody = await deleteResp.json();
-				const { sessions } = await env.MYBROWSER.fetch("https://localhost/v1/sessions").then(r => r.json());
-				return Response.json({
-					deleteStatus: deleteResp.status,
-					deleteBody,
-					sessionGone: !sessions.some(s => s.sessionId === sessionId),
-				});
-			}
-
-			// --- /devtools-delete-all-ws: DELETE closes browser + page WebSockets ---
-			case "/devtools-delete-all-ws": {
-				const { sessionId } = await env.MYBROWSER.fetch("https://localhost/v1/acquire").then(r => r.json());
-
-				// Connect browser-level WebSocket
-				const { webSocket: browserWs } = await env.MYBROWSER.fetch(
-					\`https://localhost/v1/devtools/browser/\${sessionId}\`,
-					{ headers: { Upgrade: "websocket" } }
-				);
-				browserWs.accept();
-
-				// Connect page-level WebSocket
-				const targets = await env.MYBROWSER.fetch(
-					\`https://localhost/v1/devtools/browser/\${sessionId}/json/list\`
-				).then(r => r.json());
-				const { webSocket: pageWs } = await env.MYBROWSER.fetch(
-					\`https://localhost/v1/devtools/browser/\${sessionId}/page/\${targets[0].id}\`,
-					{ headers: { Upgrade: "websocket" } }
-				);
-				pageWs.accept();
-
-				// DELETE should close everything
-				const deleteResp = await env.MYBROWSER.fetch(
-					\`https://localhost/v1/devtools/browser/\${sessionId}\`,
-					{ method: "DELETE" }
-				);
-				const deleteBody = await deleteResp.json();
-
-				await Promise.all([
-					waitForClosedConnection(browserWs),
-					waitForClosedConnection(pageWs),
-				]);
-
-				return Response.json({
-					deleteStatus: deleteResp.status,
-					deleteBody,
-					browserWsClosed: browserWs.readyState === WebSocket.CLOSED,
-					pageWsClosed: pageWs.readyState === WebSocket.CLOSED,
-				});
-			}
-
-			// --- /devtools-concurrent-ws: multiple raw WS connections ---
-			case "/devtools-concurrent-ws": {
-				const { sessionId } = await env.MYBROWSER.fetch("https://localhost/v1/acquire").then(r => r.json());
-
-				// Open two raw WebSocket connections to the same browser session
-				const { webSocket: ws1 } = await env.MYBROWSER.fetch(
-					\`https://localhost/v1/devtools/browser/\${sessionId}\`,
-					{ headers: { Upgrade: "websocket" } }
-				);
-				ws1.accept();
-
-				const { webSocket: ws2 } = await env.MYBROWSER.fetch(
-					\`https://localhost/v1/devtools/browser/\${sessionId}\`,
-					{ headers: { Upgrade: "websocket" } }
-				);
-				ws2.accept();
-
-				// Send Browser.getVersion on both and verify responses
-				const v1 = new Promise((resolve) => {
-					ws1.addEventListener("message", (m) => resolve(JSON.parse(m.data)));
-					ws1.send(JSON.stringify({ id: 1, method: "Browser.getVersion" }));
-				});
-				const v2 = new Promise((resolve) => {
-					ws2.addEventListener("message", (m) => resolve(JSON.parse(m.data)));
-					ws2.send(JSON.stringify({ id: 2, method: "Browser.getVersion" }));
-				});
-
-				const [r1, r2] = await Promise.all([v1, v2]);
-				ws1.close();
-				ws2.close();
-
-				return Response.json({
-					product1: r1.result?.product,
-					product2: r2.result?.product,
-				});
-			}
-
-			default:
-				return new Response("Unknown route: " + url.pathname, { status: 404 });
+		if (request.url.endsWith("session")) {
+			const newBrowserSession = await env.MYBROWSER.fetch("https://localhost/v1/acquire")
+			return new Response(await newBrowserSession.text())
 		}
 	}
 };
@@ -559,23 +85,6 @@ export default {
 // We need to run browser rendering tests in a serial manner to avoid a race condition installing the browser.
 // We set the timeout quite high here as one of these tests will need to download the Chrome headless browser.
 describe.sequential("browser rendering", { timeout: 120_000 }, () => {
-	// Shared Miniflare instance for all tests except the multi-binding test.
-	// A single workerd process is reused across all tests, eliminating ~16
-	// start/stop cycles and their associated cleanup races.
-	let mf: Miniflare;
-
-	beforeAll(async () => {
-		mf = new Miniflare({
-			name: "worker",
-			compatibilityDate: "2024-11-20",
-			modules: true,
-			script: MEGA_WORKER_SCRIPT,
-			browserRendering: { binding: "MYBROWSER" },
-		});
-	});
-
-	afterAll(() => disposeWithRetry(mf));
-
 	// The CLI spinner outputs to stdout, so we mute it during tests
 	beforeEach(() => {
 		vi.spyOn(process.stdout, "write").mockImplementation(() => true);
@@ -588,6 +97,16 @@ describe.sequential("browser rendering", { timeout: 120_000 }, () => {
 		"it creates a browser session",
 		BROWSER_RENDERING_RETRY,
 		async ({ expect }) => {
+			const opts: MiniflareOptions = {
+				name: "worker",
+				compatibilityDate: "2024-11-20",
+				modules: true,
+				script: BROWSER_WORKER_SCRIPT(),
+				browserRendering: { binding: "MYBROWSER" },
+			};
+			const mf = new Miniflare(opts);
+			useDispose(mf);
+
 			const res = await mf.dispatchFetch("https://localhost/session");
 			const text = await res.text();
 			expect(text.includes("sessionId")).toBe(true);
@@ -608,7 +127,7 @@ describe.sequential("browser rendering", { timeout: 120_000 }, () => {
 				}
 			};
 			`;
-			const multiMf = new Miniflare({
+			const mf = new Miniflare({
 				workers: [
 					{
 						name: "worker-a",
@@ -626,75 +145,333 @@ describe.sequential("browser rendering", { timeout: 120_000 }, () => {
 					},
 				],
 			});
-			useDispose(multiMf);
+			useDispose(mf);
 
-			const res = await multiMf.dispatchFetch("https://localhost/session");
+			const res = await mf.dispatchFetch("https://localhost/session");
 			const text = await res.text();
 			expect(text.includes("sessionId")).toBe(true);
 		}
 	);
 
+	const BROWSER_WORKER_CLOSE_SCRIPT = `
+${sendMessage.toString()}
+${waitForClosedConnection.toString()}
+
+export default {
+	async fetch(request, env) {
+		const acquireResponse = await env.MYBROWSER.fetch("https://localhost/v1/acquire");
+		const { sessionId } = await acquireResponse.json();
+		const { webSocket: ws } = await env.MYBROWSER.fetch(\`https://localhost/v1/connectDevtools?browser_session=\${sessionId}\`, {
+			headers: { "Upgrade": "websocket" },
+		});
+		ws.accept();
+
+		sendMessage(ws, { method: "Browser.close", id: -1 });
+		await waitForClosedConnection(ws);
+
+		return new Response("Browser closed");
+	}
+};
+`;
+
 	test(
 		"it closes a browser session",
 		BROWSER_RENDERING_RETRY,
 		async ({ expect }) => {
+			const opts: MiniflareOptions = {
+				name: "worker",
+				compatibilityDate: "2024-11-20",
+				modules: true,
+				script: BROWSER_WORKER_CLOSE_SCRIPT,
+				browserRendering: { binding: "MYBROWSER" },
+			};
+			const mf = new Miniflare(opts);
+			useDispose(mf);
+
 			const res = await mf.dispatchFetch("https://localhost/close");
 			expect(await res.text()).toBe("Browser closed");
 		}
 	);
 
+	const BROWSER_WORKER_REUSE_SCRIPT = `
+${sendMessage.toString()}
+${waitForClosedConnection.toString()}
+
+export default {
+	async fetch(request, env) {
+		const acquireResponse = await env.MYBROWSER.fetch("https://localhost/v1/acquire");
+		const { sessionId } = await acquireResponse.json();
+		const { webSocket: ws } = await env.MYBROWSER.fetch(\`https://localhost/v1/connectDevtools?browser_session=\${sessionId}\`, {
+			headers: { "Upgrade": "websocket" },
+		});
+		ws.accept();
+		ws.close();
+
+		await waitForClosedConnection(ws);
+
+		// Reuse the same session by connecting to it again
+		const { webSocket: ws2 } = await env.MYBROWSER.fetch(\`https://localhost/v1/connectDevtools?browser_session=\${sessionId}\`, {
+			headers: { "Upgrade": "websocket" },
+		});
+		ws2.accept();
+		ws2.close();
+
+		return new Response("Browser session reused");
+	}
+};
+`;
+
 	test(
 		"it reuses a browser session",
 		BROWSER_RENDERING_RETRY,
 		async ({ expect }) => {
-			const res = await mf.dispatchFetch("https://localhost/reuse");
+			const opts: MiniflareOptions = {
+				name: "worker",
+				compatibilityDate: "2024-11-20",
+				modules: true,
+				script: BROWSER_WORKER_REUSE_SCRIPT,
+				browserRendering: { binding: "MYBROWSER" },
+			};
+			const mf = new Miniflare(opts);
+			useDispose(mf);
+
+			const res = await mf.dispatchFetch("https://localhost");
 			expect(await res.text()).toBe("Browser session reused");
 		}
 	);
+
+	const BROWSER_WORKER_RECONNECT_SCRIPT = `
+${sendMessage.toString()}
+${waitForClosedConnection.toString()}
+
+async function waitForMessage(ws) {
+	const chunks = [];
+	return new Promise((resolve) => {
+		ws.addEventListener("message", function handler(event) {
+			const data = new Uint8Array(event.data);
+			if (chunks.length === 0) {
+				// First chunk contains a 4-byte little-endian length header
+				const view = new DataView(data.buffer);
+				const totalLength = view.getUint32(0, true);
+				chunks.push({ data: data.slice(4), totalLength });
+			} else {
+				chunks[0].data = new Uint8Array([...chunks[0].data, ...data]);
+			}
+			const accumulated = chunks[0];
+			if (accumulated.data.length >= accumulated.totalLength) {
+				ws.removeEventListener("message", handler);
+				const text = new TextDecoder().decode(accumulated.data.slice(0, accumulated.totalLength));
+				resolve(JSON.parse(text));
+			}
+		});
+	});
+}
+
+export default {
+	async fetch(request, env) {
+		const acquireResponse = await env.MYBROWSER.fetch("https://localhost/v1/acquire");
+		const { sessionId } = await acquireResponse.json();
+
+		// First connection
+		const { webSocket: ws } = await env.MYBROWSER.fetch(\`https://localhost/v1/connectDevtools?browser_session=\${sessionId}\`, {
+			headers: { "Upgrade": "websocket" },
+		});
+		ws.accept();
+
+		// Send a CDP command and verify we get a response
+		sendMessage(ws, { method: "Target.getTargets", id: 1 });
+		const msg1 = await waitForMessage(ws);
+		if (!msg1 || !msg1.result) {
+			return new Response("First CDP command failed: " + JSON.stringify(msg1));
+		}
+
+		// Disconnect
+		ws.close();
+		await waitForClosedConnection(ws);
+
+		// Reconnect with the same sessionId
+		const resp2 = await env.MYBROWSER.fetch(\`https://localhost/v1/connectDevtools?browser_session=\${sessionId}\`, {
+			headers: { "Upgrade": "websocket" },
+		});
+		if (!resp2.webSocket) {
+			return new Response("Reconnect failed with status: " + resp2.status);
+		}
+		const ws2 = resp2.webSocket;
+		ws2.accept();
+
+		// Send a CDP command on the reconnected socket
+		sendMessage(ws2, { method: "Target.getTargets", id: 2 });
+		const msg2 = await waitForMessage(ws2);
+		if (!msg2 || !msg2.result) {
+			return new Response("Second CDP command failed: " + JSON.stringify(msg2));
+		}
+
+		ws2.close();
+		return new Response("Reconnect successful");
+	}
+};
+`;
 
 	test(
 		"it reconnects and sends CDP commands after disconnect",
 		BROWSER_RENDERING_RETRY,
 		async ({ expect }) => {
-			const res = await mf.dispatchFetch("https://localhost/reconnect");
+			const opts: MiniflareOptions = {
+				name: "worker",
+				compatibilityDate: "2024-11-20",
+				modules: true,
+				script: BROWSER_WORKER_RECONNECT_SCRIPT,
+				browserRendering: { binding: "MYBROWSER" },
+			};
+			const mf = new Miniflare(opts);
+			useDispose(mf);
+
+			const res = await mf.dispatchFetch("https://localhost");
 			expect(await res.text()).toBe("Reconnect successful");
 		}
 	);
+
+	const BROWSER_WORKER_ALREADY_USED_SCRIPT = `
+export default {
+	async fetch(request, env) {
+		const acquireResponse = await env.MYBROWSER.fetch("https://localhost/v1/acquire");
+		const { sessionId } = await acquireResponse.json();
+		const { webSocket: ws } = await env.MYBROWSER.fetch(\`https://localhost/v1/connectDevtools?browser_session=\${sessionId}\`, {
+			headers: { "Upgrade": "websocket" },
+		});
+		ws.accept();
+
+		await new Promise(resolve => setTimeout(resolve, 100));
+
+		// try to open new connection for the same session
+		const resp2 = await env.MYBROWSER.fetch(\`https://localhost/v1/connectDevtools?browser_session=\${sessionId}\`, {
+			headers: { "Upgrade": "websocket" },
+		});
+		if (resp2.status === 409) {
+			return new Response("Failed to connect to browser session");
+		}
+
+		return new Response("Should not reach here");
+	}
+};
+`;
 
 	test.skipIf(process.platform === "win32")(
 		"fails if browser session already in use",
 		BROWSER_RENDERING_RETRY,
 		async ({ expect }) => {
-			const res = await mf.dispatchFetch("https://localhost/already-used");
+			const opts: MiniflareOptions = {
+				name: "worker",
+				compatibilityDate: "2024-11-20",
+				modules: true,
+				script: BROWSER_WORKER_ALREADY_USED_SCRIPT,
+				browserRendering: { binding: "MYBROWSER" },
+			};
+			const mf = new Miniflare(opts);
+			useDispose(mf);
+
+			const res = await mf.dispatchFetch("https://localhost");
 			expect(await res.text()).toBe("Failed to connect to browser session");
 		}
 	);
+
+	const GET_SESSIONS_SCRIPT = `
+${sendMessage.toString()}
+${waitForClosedConnection.toString()}
+
+export default {
+	async fetch(request, env) {
+		const { sessions: emptySessions } = await env.MYBROWSER.fetch("https://localhost/v1/sessions").then(res => res.json());
+		const { sessionId } = await env.MYBROWSER.fetch("https://localhost/v1/acquire").then(res => res.json());
+		const { sessions: acquiredSessions } = await env.MYBROWSER.fetch("https://localhost/v1/sessions").then(res => res.json());
+
+		const { webSocket: ws } = await env.MYBROWSER.fetch(\`https://localhost/v1/connectDevtools?browser_session=\${sessionId}\`, {
+			headers: { "Upgrade": "websocket" },
+		});
+		ws.accept();
+
+		// send a close message to the browser
+		sendMessage(ws, { method: "Browser.close", id: -1 });
+
+		await waitForClosedConnection(ws);
+
+		await new Promise((resolve) => setTimeout(resolve, 1000));
+
+		const { sessions: afterClosedSessions } = await env.MYBROWSER.fetch("https://localhost/v1/sessions").then(res => res.json());
+
+		return Response.json({ emptySessions, acquiredSessions, afterClosedSessions });
+	}
+};
+`;
 
 	test(
 		"gets sessions while acquiring and closing session",
 		BROWSER_RENDERING_RETRY,
 		async ({ expect }) => {
-			const { ourSession, newCount, sessionStillPresent } = (await mf
-				.dispatchFetch("https://localhost/get-sessions")
+			const opts: MiniflareOptions = {
+				name: "worker",
+				compatibilityDate: "2024-11-20",
+				modules: true,
+				script: GET_SESSIONS_SCRIPT,
+				browserRendering: { binding: "MYBROWSER" },
+			};
+			const mf = new Miniflare(opts);
+			useDispose(mf);
+
+			const { emptySessions, acquiredSessions, afterClosedSessions } = (await mf
+				.dispatchFetch("https://localhost")
 				.then((res) => res.json())) as any;
-			// Exactly one new session should have been added by this test's acquire
-			expect(newCount).toBe(1);
+			expect(emptySessions.length).toBe(0);
+			expect(acquiredSessions.length).toBe(1);
 			expect(
-				typeof ourSession.sessionId === "string" &&
-					typeof ourSession.startTime === "number" &&
-					!ourSession.connectionId
+				typeof acquiredSessions[0].sessionId === "string" &&
+					typeof acquiredSessions[0].startTime === "number" &&
+					!acquiredSessions[0].connectionId &&
+					!acquiredSessions[0].connectionId
 			).toBe(true);
-			// After Browser.close, our session should no longer be listed
-			expect(sessionStillPresent).toBe(false);
+			expect(afterClosedSessions.length).toBe(0);
 		}
 	);
+
+	const GET_SESSIONS_AFTER_DISCONNECT_SCRIPT = `
+${waitForClosedConnection.toString()}
+
+export default {
+	async fetch(request, env) {
+		const { sessionId } = await env.MYBROWSER.fetch("https://localhost/v1/acquire").then(res => res.json());
+		const { webSocket: ws } = await env.MYBROWSER.fetch(\`https://localhost/v1/connectDevtools?browser_session=\${sessionId}\`, {
+			headers: { "Upgrade": "websocket" },
+		});
+		ws.accept();
+
+		const { sessions: [connectedSession] } = await env.MYBROWSER.fetch("https://localhost/v1/sessions").then(res => res.json());
+		ws.close();
+
+		await waitForClosedConnection(ws);
+
+		const { sessions: [disconnectedSession] } = await env.MYBROWSER.fetch("https://localhost/v1/sessions").then(res => res.json());
+
+		return Response.json({ connectedSession, disconnectedSession });
+	}
+};
+`;
 
 	test(
 		"gets sessions while connecting and disconnecting session",
 		BROWSER_RENDERING_RETRY,
 		async ({ expect }) => {
+			const opts: MiniflareOptions = {
+				name: "worker",
+				compatibilityDate: "2024-11-20",
+				modules: true,
+				script: GET_SESSIONS_AFTER_DISCONNECT_SCRIPT,
+				browserRendering: { binding: "MYBROWSER" },
+			};
+			const mf = new Miniflare(opts);
+			useDispose(mf);
+
 			const { connectedSession, disconnectedSession } = (await mf
-				.dispatchFetch("https://localhost/get-sessions-disconnect")
+				.dispatchFetch("https://localhost")
 				.then((res) => res.json())) as any;
 			expect(connectedSession.sessionId).toBe(disconnectedSession.sessionId);
 			expect(
@@ -709,7 +486,18 @@ describe.sequential("browser rendering", { timeout: 120_000 }, () => {
 	);
 
 	test("returns limits", async ({ expect }) => {
-		const res = await mf.dispatchFetch("https://localhost/limits");
+		const mf = new Miniflare({
+			name: "worker",
+			compatibilityDate: "2024-11-20",
+			modules: true,
+			script: `export default { async fetch(req, env) {
+				return env.MYBROWSER.fetch("https://localhost/v1/limits");
+			} }`,
+			browserRendering: { binding: "MYBROWSER" },
+		});
+		useDispose(mf);
+
+		const res = await mf.dispatchFetch("https://localhost");
 		const body = (await res.json()) as any;
 		expect(res.status).toBe(200);
 		expect(typeof body.maxConcurrentSessions).toBe("number");
@@ -718,34 +506,98 @@ describe.sequential("browser rendering", { timeout: 120_000 }, () => {
 	});
 
 	test("returns empty history", async ({ expect }) => {
-		const res = await mf.dispatchFetch("https://localhost/history");
+		const mf = new Miniflare({
+			name: "worker",
+			compatibilityDate: "2024-11-20",
+			modules: true,
+			script: `export default { async fetch(req, env) {
+				return env.MYBROWSER.fetch("https://localhost/v1/history");
+			} }`,
+			browserRendering: { binding: "MYBROWSER" },
+		});
+		useDispose(mf);
+
+		const res = await mf.dispatchFetch("https://localhost");
 		const body = await res.json();
 		expect(res.status).toBe(200);
 		expect(body).toEqual([]);
 	});
 
+	const DEVTOOLS_SESSION_SCRIPT = `
+export default {
+	async fetch(request, env) {
+		const emptyList = await env.MYBROWSER.fetch("https://localhost/v1/devtools/session").then(r => r.json());
+		const { sessionId } = await env.MYBROWSER.fetch("https://localhost/v1/acquire").then(r => r.json());
+		const list = await env.MYBROWSER.fetch("https://localhost/v1/devtools/session").then(r => r.json());
+		const detail = await env.MYBROWSER.fetch(\`https://localhost/v1/devtools/session/\${sessionId}\`).then(r => r.json());
+		const missing = await env.MYBROWSER.fetch("https://localhost/v1/devtools/session/does-not-exist");
+		return Response.json({ emptyList, list, detail, missingStatus: missing.status });
+	}
+};
+`;
+
 	test(
 		"devtools session list and detail endpoints",
 		BROWSER_RENDERING_RETRY,
 		async ({ expect }) => {
-			const { newCount, ourSession, detail, missingStatus } = (await mf
-				.dispatchFetch("https://localhost/devtools-session")
+			const mf = new Miniflare({
+				name: "worker",
+				compatibilityDate: "2024-11-20",
+				modules: true,
+				script: DEVTOOLS_SESSION_SCRIPT,
+				browserRendering: { binding: "MYBROWSER" },
+			});
+			useDispose(mf);
+
+			const { emptyList, list, detail, missingStatus } = (await mf
+				.dispatchFetch("https://localhost")
 				.then((r) => r.json())) as any;
 
-			// Exactly one new session should appear after acquire
-			expect(newCount).toBe(1);
-			expect(typeof ourSession.sessionId).toBe("string");
-			expect(detail.sessionId).toBe(ourSession.sessionId);
+			expect(emptyList).toEqual([]);
+			expect(list.length).toBe(1);
+			expect(typeof list[0].sessionId).toBe("string");
+			expect(detail.sessionId).toBe(list[0].sessionId);
 			expect(missingStatus).toBe(404);
 		}
 	);
+
+	const DEVTOOLS_JSON_SCRIPT = `
+export default {
+	async fetch(request, env) {
+		const { sessionId } = await env.MYBROWSER.fetch("https://localhost/v1/acquire").then(r => r.json());
+
+		const version = await env.MYBROWSER.fetch(
+			\`https://localhost/v1/devtools/browser/\${sessionId}/json/version\`
+		).then(r => r.json());
+
+		const list = await env.MYBROWSER.fetch(
+			\`https://localhost/v1/devtools/browser/\${sessionId}/json/list\`
+		).then(r => r.json());
+
+		const listAlias = await env.MYBROWSER.fetch(
+			\`https://localhost/v1/devtools/browser/\${sessionId}/json\`
+		).then(r => r.json());
+
+		return Response.json({ version, list, listAlias });
+	}
+};
+`;
 
 	test(
 		"devtools json/version, json/list, json endpoints",
 		BROWSER_RENDERING_RETRY,
 		async ({ expect }) => {
+			const mf = new Miniflare({
+				name: "worker",
+				compatibilityDate: "2024-11-20",
+				modules: true,
+				script: DEVTOOLS_JSON_SCRIPT,
+				browserRendering: { binding: "MYBROWSER" },
+			});
+			useDispose(mf);
+
 			const { version, list, listAlias } = (await mf
-				.dispatchFetch("https://localhost/devtools-json")
+				.dispatchFetch("https://localhost")
 				.then((r) => r.json())) as any;
 
 			expect(typeof version.Browser).toBe("string");
@@ -760,12 +612,52 @@ describe.sequential("browser rendering", { timeout: 120_000 }, () => {
 		}
 	);
 
+	const DEVTOOLS_DELETE_SCRIPT = `
+${waitForClosedConnection.toString()}
+
+export default {
+	async fetch(request, env) {
+		const { sessionId } = await env.MYBROWSER.fetch("https://localhost/v1/acquire").then(r => r.json());
+		const { webSocket: ws } = await env.MYBROWSER.fetch(
+			\`https://localhost/v1/devtools/browser/\${sessionId}\`,
+			{ headers: { Upgrade: "websocket" } }
+		);
+		ws.accept();
+		const deleteResp = await env.MYBROWSER.fetch(
+			\`https://localhost/v1/devtools/browser/\${sessionId}\`,
+			{ method: "DELETE" }
+		);
+		const deleteBody = await deleteResp.json();
+		// Verify the session is gone after DELETE
+		const { sessions } = await env.MYBROWSER.fetch(\`https://localhost/v1/sessions?sessionId=\${sessionId}\`).then(r => r.json());
+		const sessionGone = sessions.length === 0;
+		await waitForClosedConnection(ws);
+		const wsClosed = ws.readyState === WebSocket.CLOSED;
+		return Response.json({
+			deleteStatus: deleteResp.status,
+			deleteBody,
+			sessionGone,
+			wsClosed,
+		});
+	}
+};
+`;
+
 	test(
 		"DELETE /v1/devtools/browser/:session_id closes browser",
 		BROWSER_RENDERING_RETRY,
 		async ({ expect }) => {
+			const mf = new Miniflare({
+				name: "worker",
+				compatibilityDate: "2024-11-20",
+				modules: true,
+				script: DEVTOOLS_DELETE_SCRIPT,
+				browserRendering: { binding: "MYBROWSER" },
+			});
+			useDispose(mf);
+
 			const { deleteStatus, deleteBody, sessionGone, wsClosed } = (await mf
-				.dispatchFetch("https://localhost/devtools-delete")
+				.dispatchFetch("https://localhost")
 				.then((r) => r.json())) as any;
 
 			expect(deleteStatus).toBe(200);
@@ -775,10 +667,53 @@ describe.sequential("browser rendering", { timeout: 120_000 }, () => {
 		}
 	);
 
+	const DEVTOOLS_BROWSER_WS_SCRIPT = `
+export default {
+	async fetch(request, env) {
+		const postResp = await env.MYBROWSER.fetch("https://localhost/v1/devtools/browser", {
+			method: "POST",
+		});
+		const { sessionId } = await postResp.json();
+
+		await new Promise(resolve => setTimeout(resolve, 200));
+
+		const getResp = await env.MYBROWSER.fetch(
+			\`https://localhost/v1/devtools/browser/\${sessionId}\`,
+			{ headers: { Upgrade: "websocket" } }
+		);
+		const sessionIdFromGet = getResp.headers.get("cf-browser-session-id");
+		const ws = getResp.webSocket;
+		ws.accept();
+		const browserVersion = await new Promise((resolve) => {
+			ws.addEventListener("message", (m) => resolve(JSON.parse(m.data)));
+			ws.send(JSON.stringify({ id: 1, method: "Browser.getVersion" }));
+		});
+		ws.close();
+
+		return Response.json({
+			postStatus: postResp.status,
+			sessionId,
+			getStatus: getResp.status,
+			sessionIdFromGet,
+			browserProduct: browserVersion.result?.product,
+		});
+	}
+};
+`;
+
 	test(
 		"POST /v1/devtools/browser acquires session, GET /v1/devtools/browser/:id connects and returns cf-browser-session-id",
 		BROWSER_RENDERING_RETRY,
 		async ({ expect }) => {
+			const mf = new Miniflare({
+				name: "worker",
+				compatibilityDate: "2024-11-20",
+				modules: true,
+				script: DEVTOOLS_BROWSER_WS_SCRIPT,
+				browserRendering: { binding: "MYBROWSER" },
+			});
+			useDispose(mf);
+
 			const {
 				postStatus,
 				sessionId,
@@ -786,7 +721,7 @@ describe.sequential("browser rendering", { timeout: 120_000 }, () => {
 				sessionIdFromGet,
 				browserProduct,
 			} = (await mf
-				.dispatchFetch("https://localhost/devtools-browser-ws")
+				.dispatchFetch("https://localhost")
 				.then((r) => r.json())) as any;
 
 			expect(postStatus).toBe(200);
@@ -802,8 +737,32 @@ describe.sequential("browser rendering", { timeout: 120_000 }, () => {
 		"GET /v1/devtools/browser acquires and connects",
 		BROWSER_RENDERING_RETRY,
 		async ({ expect }) => {
+			const mf = new Miniflare({
+				name: "worker",
+				compatibilityDate: "2024-11-20",
+				modules: true,
+				script: `export default {
+	async fetch(request, env) {
+		const resp = await env.MYBROWSER.fetch("https://localhost/v1/devtools/browser", {
+			headers: { Upgrade: "websocket" },
+		});
+		const sessionId = resp.headers.get("cf-browser-session-id");
+		const ws = resp.webSocket;
+		ws.accept();
+		const browserVersion = await new Promise((resolve) => {
+			ws.addEventListener("message", (m) => resolve(JSON.parse(m.data)));
+			ws.send(JSON.stringify({ id: 1, method: "Browser.getVersion" }));
+		});
+		ws.close();
+		return Response.json({ status: resp.status, sessionId, browserProduct: browserVersion.result?.product });
+	}
+};`,
+				browserRendering: { binding: "MYBROWSER" },
+			});
+			useDispose(mf);
+
 			const { status, sessionId, browserProduct } = (await mf
-				.dispatchFetch("https://localhost/devtools-browser-get")
+				.dispatchFetch("https://localhost")
 				.then((r) => r.json())) as any;
 
 			expect(status).toBe(101);
@@ -813,24 +772,77 @@ describe.sequential("browser rendering", { timeout: 120_000 }, () => {
 		}
 	);
 
+	const DEVTOOLS_JSON_PROTOCOL_SCRIPT = `
+export default {
+	async fetch(request, env) {
+		const { sessionId } = await env.MYBROWSER.fetch("https://localhost/v1/acquire").then(r => r.json());
+		const protocol = await env.MYBROWSER.fetch(
+			\`https://localhost/v1/devtools/browser/\${sessionId}/json/protocol\`
+		).then(r => r.json());
+		return Response.json({ hasDomains: Array.isArray(protocol.domains) });
+	}
+};
+`;
+
 	test(
 		"devtools json/protocol endpoint",
 		BROWSER_RENDERING_RETRY,
 		async ({ expect }) => {
+			const mf = new Miniflare({
+				name: "worker",
+				compatibilityDate: "2024-11-20",
+				modules: true,
+				script: DEVTOOLS_JSON_PROTOCOL_SCRIPT,
+				browserRendering: { binding: "MYBROWSER" },
+			});
+			useDispose(mf);
+
 			const { hasDomains } = (await mf
-				.dispatchFetch("https://localhost/devtools-protocol")
+				.dispatchFetch("https://localhost")
 				.then((r) => r.json())) as any;
 
 			expect(hasDomains).toBe(true);
 		}
 	);
 
+	const DEVTOOLS_JSON_NEW_ACTIVATE_CLOSE_SCRIPT = `
+export default {
+	async fetch(request, env) {
+		const { sessionId } = await env.MYBROWSER.fetch("https://localhost/v1/acquire").then(r => r.json());
+		const newTarget = await env.MYBROWSER.fetch(
+			\`https://localhost/v1/devtools/browser/\${sessionId}/json/new?url=about:blank\`,
+			{ method: "PUT" }
+		).then(r => r.json());
+		const activateResp = await env.MYBROWSER.fetch(
+			\`https://localhost/v1/devtools/browser/\${sessionId}/json/activate/\${newTarget.id}\`
+		);
+		const closeResp = await env.MYBROWSER.fetch(
+			\`https://localhost/v1/devtools/browser/\${sessionId}/json/close/\${newTarget.id}\`
+		);
+		return Response.json({
+			targetType: newTarget.type,
+			activateStatus: activateResp.status,
+			closeStatus: closeResp.status,
+		});
+	}
+};
+`;
+
 	test(
 		"devtools json/new, json/activate, json/close endpoints",
 		BROWSER_RENDERING_RETRY,
 		async ({ expect }) => {
+			const mf = new Miniflare({
+				name: "worker",
+				compatibilityDate: "2024-11-20",
+				modules: true,
+				script: DEVTOOLS_JSON_NEW_ACTIVATE_CLOSE_SCRIPT,
+				browserRendering: { binding: "MYBROWSER" },
+			});
+			useDispose(mf);
+
 			const { targetType, activateStatus, closeStatus } = (await mf
-				.dispatchFetch("https://localhost/devtools-new-activate-close")
+				.dispatchFetch("https://localhost")
 				.then((r) => r.json())) as any;
 
 			expect(targetType).toBe("page");
@@ -839,12 +851,44 @@ describe.sequential("browser rendering", { timeout: 120_000 }, () => {
 		}
 	);
 
+	const DEVTOOLS_PAGE_WS_SCRIPT = `
+export default {
+	async fetch(request, env) {
+		const { sessionId } = await env.MYBROWSER.fetch("https://localhost/v1/acquire").then(r => r.json());
+		const targets = await env.MYBROWSER.fetch(
+			\`https://localhost/v1/devtools/browser/\${sessionId}/json/list\`
+		).then(r => r.json());
+		const targetId = targets[0].id;
+		const { webSocket: ws } = await env.MYBROWSER.fetch(
+			\`https://localhost/v1/devtools/browser/\${sessionId}/page/\${targetId}\`,
+			{ headers: { Upgrade: "websocket" } }
+		);
+		ws.accept();
+		const result = await new Promise((resolve) => {
+			ws.addEventListener("message", (m) => resolve(JSON.parse(m.data)));
+			ws.send(JSON.stringify({ id: 1, method: "Runtime.evaluate", params: { expression: "1+1" } }));
+		});
+		ws.close();
+		return Response.json({ resultValue: result.result?.result?.value });
+	}
+};
+`;
+
 	test(
 		"devtools page/:target_id WebSocket endpoint",
 		BROWSER_RENDERING_RETRY,
 		async ({ expect }) => {
+			const mf = new Miniflare({
+				name: "worker",
+				compatibilityDate: "2024-11-20",
+				modules: true,
+				script: DEVTOOLS_PAGE_WS_SCRIPT,
+				browserRendering: { binding: "MYBROWSER" },
+			});
+			useDispose(mf);
+
 			const { resultValue } = (await mf
-				.dispatchFetch("https://localhost/devtools-page-ws")
+				.dispatchFetch("https://localhost")
 				.then((r) => r.json())) as any;
 
 			expect(resultValue).toBe(2);
@@ -855,8 +899,32 @@ describe.sequential("browser rendering", { timeout: 120_000 }, () => {
 		"DELETE without prior WebSocket connection",
 		BROWSER_RENDERING_RETRY,
 		async ({ expect }) => {
+			const mf = new Miniflare({
+				name: "worker",
+				compatibilityDate: "2024-11-20",
+				modules: true,
+				script: `export default {
+	async fetch(request, env) {
+		const { sessionId } = await env.MYBROWSER.fetch("https://localhost/v1/acquire").then(r => r.json());
+		const deleteResp = await env.MYBROWSER.fetch(
+			\`https://localhost/v1/devtools/browser/\${sessionId}\`,
+			{ method: "DELETE" }
+		);
+		const deleteBody = await deleteResp.json();
+		const { sessions } = await env.MYBROWSER.fetch("https://localhost/v1/sessions").then(r => r.json());
+		return Response.json({
+			deleteStatus: deleteResp.status,
+			deleteBody,
+			sessionGone: sessions.length === 0,
+		});
+	}
+};`,
+				browserRendering: { binding: "MYBROWSER" },
+			});
+			useDispose(mf);
+
 			const { deleteStatus, deleteBody, sessionGone } = (await mf
-				.dispatchFetch("https://localhost/devtools-delete-no-ws")
+				.dispatchFetch("https://localhost")
 				.then((r) => r.json())) as any;
 
 			expect(deleteStatus).toBe(200);
@@ -865,13 +933,68 @@ describe.sequential("browser rendering", { timeout: 120_000 }, () => {
 		}
 	);
 
+	const DEVTOOLS_DELETE_ALL_WS_SCRIPT = `
+${waitForClosedConnection.toString()}
+
+export default {
+	async fetch(request, env) {
+		const { sessionId } = await env.MYBROWSER.fetch("https://localhost/v1/acquire").then(r => r.json());
+
+		// Connect browser-level WebSocket
+		const { webSocket: browserWs } = await env.MYBROWSER.fetch(
+			\`https://localhost/v1/devtools/browser/\${sessionId}\`,
+			{ headers: { Upgrade: "websocket" } }
+		);
+		browserWs.accept();
+
+		// Connect page-level WebSocket
+		const targets = await env.MYBROWSER.fetch(
+			\`https://localhost/v1/devtools/browser/\${sessionId}/json/list\`
+		).then(r => r.json());
+		const { webSocket: pageWs } = await env.MYBROWSER.fetch(
+			\`https://localhost/v1/devtools/browser/\${sessionId}/page/\${targets[0].id}\`,
+			{ headers: { Upgrade: "websocket" } }
+		);
+		pageWs.accept();
+
+		// DELETE should close everything
+		const deleteResp = await env.MYBROWSER.fetch(
+			\`https://localhost/v1/devtools/browser/\${sessionId}\`,
+			{ method: "DELETE" }
+		);
+		const deleteBody = await deleteResp.json();
+
+		await Promise.all([
+			waitForClosedConnection(browserWs),
+			waitForClosedConnection(pageWs),
+		]);
+
+		return Response.json({
+			deleteStatus: deleteResp.status,
+			deleteBody,
+			browserWsClosed: browserWs.readyState === WebSocket.CLOSED,
+			pageWsClosed: pageWs.readyState === WebSocket.CLOSED,
+		});
+	}
+};
+`;
+
 	test(
 		"DELETE closes all WebSocket connections (browser + page)",
 		BROWSER_RENDERING_RETRY,
 		async ({ expect }) => {
+			const mf = new Miniflare({
+				name: "worker",
+				compatibilityDate: "2024-11-20",
+				modules: true,
+				script: DEVTOOLS_DELETE_ALL_WS_SCRIPT,
+				browserRendering: { binding: "MYBROWSER" },
+			});
+			useDispose(mf);
+
 			const { deleteStatus, deleteBody, browserWsClosed, pageWsClosed } =
 				(await mf
-					.dispatchFetch("https://localhost/devtools-delete-all-ws")
+					.dispatchFetch("https://localhost")
 					.then((r) => r.json())) as any;
 
 			expect(deleteStatus).toBe(200);
@@ -885,8 +1008,53 @@ describe.sequential("browser rendering", { timeout: 120_000 }, () => {
 		"multiple concurrent raw WebSocket connections to same session",
 		BROWSER_RENDERING_RETRY,
 		async ({ expect }) => {
+			const mf = new Miniflare({
+				name: "worker",
+				compatibilityDate: "2024-11-20",
+				modules: true,
+				script: `export default {
+	async fetch(request, env) {
+		const { sessionId } = await env.MYBROWSER.fetch("https://localhost/v1/acquire").then(r => r.json());
+
+		// Open two raw WebSocket connections to the same browser session
+		const { webSocket: ws1 } = await env.MYBROWSER.fetch(
+			\`https://localhost/v1/devtools/browser/\${sessionId}\`,
+			{ headers: { Upgrade: "websocket" } }
+		);
+		ws1.accept();
+
+		const { webSocket: ws2 } = await env.MYBROWSER.fetch(
+			\`https://localhost/v1/devtools/browser/\${sessionId}\`,
+			{ headers: { Upgrade: "websocket" } }
+		);
+		ws2.accept();
+
+		// Send Browser.getVersion on both and verify responses
+		const v1 = new Promise((resolve) => {
+			ws1.addEventListener("message", (m) => resolve(JSON.parse(m.data)));
+			ws1.send(JSON.stringify({ id: 1, method: "Browser.getVersion" }));
+		});
+		const v2 = new Promise((resolve) => {
+			ws2.addEventListener("message", (m) => resolve(JSON.parse(m.data)));
+			ws2.send(JSON.stringify({ id: 2, method: "Browser.getVersion" }));
+		});
+
+		const [r1, r2] = await Promise.all([v1, v2]);
+		ws1.close();
+		ws2.close();
+
+		return Response.json({
+			product1: r1.result?.product,
+			product2: r2.result?.product,
+		});
+	}
+};`,
+				browserRendering: { binding: "MYBROWSER" },
+			});
+			useDispose(mf);
+
 			const { product1, product2 } = (await mf
-				.dispatchFetch("https://localhost/devtools-concurrent-ws")
+				.dispatchFetch("https://localhost")
 				.then((r) => r.json())) as any;
 
 			expect(typeof product1).toBe("string");

--- a/packages/miniflare/test/plugins/browser/index.spec.ts
+++ b/packages/miniflare/test/plugins/browser/index.spec.ts
@@ -1,17 +1,25 @@
 import { Miniflare } from "miniflare";
 import {
+	afterAll,
 	afterEach,
+	beforeAll,
 	beforeEach,
 	describe,
 	test,
 	type TestOptions,
 	vi,
 } from "vitest";
-import { useDispose } from "../../test-shared";
-import type { MiniflareOptions } from "miniflare";
+import { disposeWithRetry, useDispose } from "../../test-shared";
 
+/**
+ * Send a chunked-framing message over a WebSocket.
+ *
+ * Adapted from https://github.com/cloudflare/puppeteer/blob/b4984452165437e26dd1c8e516581cec2a02b4cd/packages/puppeteer-core/src/cloudflare/chunking.ts#L6-L30
+ *
+ * @param ws - The WebSocket to send the message on.
+ * @param message - The message payload to JSON-serialize and send.
+ */
 async function sendMessage(ws: WebSocket, message: unknown) {
-	// adapted from https://github.com/cloudflare/puppeteer/blob/b4984452165437e26dd1c8e516581cec2a02b4cd/packages/puppeteer-core/src/cloudflare/chunking.ts#L6-L30
 	const messageToChunks = (data: string): Uint8Array[] => {
 		const HEADER_SIZE = 4; // Uint32
 		const MAX_MESSAGE_SIZE = 1048575; // Workers size is < 1MB
@@ -48,6 +56,12 @@ async function sendMessage(ws: WebSocket, message: unknown) {
 	}
 }
 
+/**
+ * Wait for a WebSocket connection to be fully closed.
+ *
+ * @param ws - The WebSocket to wait on.
+ * @returns A promise that resolves when the connection is closed.
+ */
 async function waitForClosedConnection(ws: WebSocket): Promise<void> {
 	if (ws.readyState === ws.CLOSED) {
 		return;
@@ -62,6 +76,40 @@ async function waitForClosedConnection(ws: WebSocket): Promise<void> {
 	});
 }
 
+/**
+ * Wait for a single chunked-framing message from a WebSocket.
+ *
+ * Reassembles multi-chunk messages using the 4-byte little-endian length
+ * header in the first chunk.
+ *
+ * @param ws - The WebSocket to listen on.
+ * @returns A promise that resolves with the parsed JSON message.
+ */
+async function waitForMessage(ws: WebSocket): Promise<unknown> {
+	const chunks: { data: Uint8Array; totalLength: number }[] = [];
+	return new Promise((resolve) => {
+		ws.addEventListener("message", function handler(event) {
+			const data = new Uint8Array(event.data as ArrayBuffer);
+			if (chunks.length === 0) {
+				// First chunk contains a 4-byte little-endian length header
+				const view = new DataView(data.buffer);
+				const totalLength = view.getUint32(0, true);
+				chunks.push({ data: data.slice(4), totalLength });
+			} else {
+				chunks[0].data = new Uint8Array([...chunks[0].data, ...data]);
+			}
+			const accumulated = chunks[0];
+			if (accumulated.data.length >= accumulated.totalLength) {
+				ws.removeEventListener("message", handler);
+				const text = new TextDecoder().decode(
+					accumulated.data.slice(0, accumulated.totalLength)
+				);
+				resolve(JSON.parse(text));
+			}
+		});
+	});
+}
+
 const BROWSER_RENDERING_RETRY = {
 	retry: {
 		condition:
@@ -71,12 +119,438 @@ const BROWSER_RENDERING_RETRY = {
 	},
 } satisfies TestOptions;
 
-const BROWSER_WORKER_SCRIPT = () => `
+/**
+ * A single "mega-worker" script that handles all browser rendering test
+ * scenarios via URL path routing.  Each test dispatches a fetch to a unique
+ * path (e.g. `/session`, `/close`, `/reuse`) and the worker runs the
+ * corresponding browser rendering logic.  This allows the entire test suite
+ * to share one Miniflare (and therefore one workerd) instance, eliminating
+ * ~16 workerd start/stop cycles and the associated cleanup races that cause
+ * flakiness on Windows CI runners.
+ *
+ * Helper functions (`sendMessage`, `waitForClosedConnection`,
+ * `waitForMessage`) are embedded via `.toString()` so they are available
+ * inside the worker script string.
+ */
+const MEGA_WORKER_SCRIPT = `
+${sendMessage.toString()}
+${waitForClosedConnection.toString()}
+${waitForMessage.toString()}
+
 export default {
 	async fetch(request, env) {
-		if (request.url.endsWith("session")) {
-			const newBrowserSession = await env.MYBROWSER.fetch("https://localhost/v1/acquire")
-			return new Response(await newBrowserSession.text())
+		const url = new URL(request.url);
+		switch (url.pathname) {
+
+			// --- /session: acquire a browser session ---
+			case "/session": {
+				const resp = await env.MYBROWSER.fetch("https://localhost/v1/acquire");
+				return new Response(await resp.text());
+			}
+
+			// --- /close: acquire, connect via legacy WS, send Browser.close ---
+			case "/close": {
+				const acquireResponse = await env.MYBROWSER.fetch("https://localhost/v1/acquire");
+				const { sessionId } = await acquireResponse.json();
+				const { webSocket: ws } = await env.MYBROWSER.fetch(
+					\`https://localhost/v1/connectDevtools?browser_session=\${sessionId}\`,
+					{ headers: { "Upgrade": "websocket" } }
+				);
+				ws.accept();
+				sendMessage(ws, { method: "Browser.close", id: -1 });
+				await waitForClosedConnection(ws);
+				return new Response("Browser closed");
+			}
+
+			// --- /reuse: acquire, connect, disconnect, reconnect ---
+			case "/reuse": {
+				const acquireResponse = await env.MYBROWSER.fetch("https://localhost/v1/acquire");
+				const { sessionId } = await acquireResponse.json();
+				const { webSocket: ws } = await env.MYBROWSER.fetch(
+					\`https://localhost/v1/connectDevtools?browser_session=\${sessionId}\`,
+					{ headers: { "Upgrade": "websocket" } }
+				);
+				ws.accept();
+				ws.close();
+				await waitForClosedConnection(ws);
+
+				// Reuse the same session by connecting to it again
+				const { webSocket: ws2 } = await env.MYBROWSER.fetch(
+					\`https://localhost/v1/connectDevtools?browser_session=\${sessionId}\`,
+					{ headers: { "Upgrade": "websocket" } }
+				);
+				ws2.accept();
+				ws2.close();
+				return new Response("Browser session reused");
+			}
+
+			// --- /reconnect: disconnect and reconnect, sending CDP commands ---
+			case "/reconnect": {
+				const acquireResponse = await env.MYBROWSER.fetch("https://localhost/v1/acquire");
+				const { sessionId } = await acquireResponse.json();
+
+				// First connection
+				const { webSocket: ws } = await env.MYBROWSER.fetch(
+					\`https://localhost/v1/connectDevtools?browser_session=\${sessionId}\`,
+					{ headers: { "Upgrade": "websocket" } }
+				);
+				ws.accept();
+
+				// Send a CDP command and verify we get a response
+				sendMessage(ws, { method: "Target.getTargets", id: 1 });
+				const msg1 = await waitForMessage(ws);
+				if (!msg1 || !msg1.result) {
+					return new Response("First CDP command failed: " + JSON.stringify(msg1));
+				}
+
+				// Disconnect
+				ws.close();
+				await waitForClosedConnection(ws);
+
+				// Reconnect with the same sessionId
+				const resp2 = await env.MYBROWSER.fetch(
+					\`https://localhost/v1/connectDevtools?browser_session=\${sessionId}\`,
+					{ headers: { "Upgrade": "websocket" } }
+				);
+				if (!resp2.webSocket) {
+					return new Response("Reconnect failed with status: " + resp2.status);
+				}
+				const ws2 = resp2.webSocket;
+				ws2.accept();
+
+				// Send a CDP command on the reconnected socket
+				sendMessage(ws2, { method: "Target.getTargets", id: 2 });
+				const msg2 = await waitForMessage(ws2);
+				if (!msg2 || !msg2.result) {
+					return new Response("Second CDP command failed: " + JSON.stringify(msg2));
+				}
+
+				ws2.close();
+				return new Response("Reconnect successful");
+			}
+
+			// --- /already-used: try to open two legacy WS connections ---
+			case "/already-used": {
+				const acquireResponse = await env.MYBROWSER.fetch("https://localhost/v1/acquire");
+				const { sessionId } = await acquireResponse.json();
+				const { webSocket: ws } = await env.MYBROWSER.fetch(
+					\`https://localhost/v1/connectDevtools?browser_session=\${sessionId}\`,
+					{ headers: { "Upgrade": "websocket" } }
+				);
+				ws.accept();
+
+				await new Promise(resolve => setTimeout(resolve, 100));
+
+				// try to open new connection for the same session
+				const resp2 = await env.MYBROWSER.fetch(
+					\`https://localhost/v1/connectDevtools?browser_session=\${sessionId}\`,
+					{ headers: { "Upgrade": "websocket" } }
+				);
+				if (resp2.status === 409) {
+					return new Response("Failed to connect to browser session");
+				}
+				return new Response("Should not reach here");
+			}
+
+			// --- /get-sessions: acquire, connect, close, check sessions ---
+			case "/get-sessions": {
+				const { sessions: beforeSessions } = await env.MYBROWSER.fetch("https://localhost/v1/sessions").then(r => r.json());
+				const baselineCount = beforeSessions.length;
+				const { sessionId } = await env.MYBROWSER.fetch("https://localhost/v1/acquire").then(r => r.json());
+				const { sessions: allAfterAcquire } = await env.MYBROWSER.fetch("https://localhost/v1/sessions").then(r => r.json());
+				// Filter to only our session to avoid interference from other tests
+				const ourSession = allAfterAcquire.find(s => s.sessionId === sessionId);
+				const newCount = allAfterAcquire.length - baselineCount;
+
+				const { webSocket: ws } = await env.MYBROWSER.fetch(
+					\`https://localhost/v1/connectDevtools?browser_session=\${sessionId}\`,
+					{ headers: { "Upgrade": "websocket" } }
+				);
+				ws.accept();
+
+				// send a close message to the browser
+				sendMessage(ws, { method: "Browser.close", id: -1 });
+				await waitForClosedConnection(ws);
+				await new Promise((resolve) => setTimeout(resolve, 1000));
+
+				const { sessions: afterClosedSessions } = await env.MYBROWSER.fetch("https://localhost/v1/sessions").then(r => r.json());
+				const sessionStillPresent = afterClosedSessions.some(s => s.sessionId === sessionId);
+				return Response.json({ baselineCount, ourSession, newCount, sessionStillPresent });
+			}
+
+			// --- /get-sessions-disconnect: acquire, connect, disconnect, check sessions ---
+			case "/get-sessions-disconnect": {
+				const { sessionId } = await env.MYBROWSER.fetch("https://localhost/v1/acquire").then(r => r.json());
+				const { webSocket: ws } = await env.MYBROWSER.fetch(
+					\`https://localhost/v1/connectDevtools?browser_session=\${sessionId}\`,
+					{ headers: { "Upgrade": "websocket" } }
+				);
+				ws.accept();
+
+				const { sessions: allConnected } = await env.MYBROWSER.fetch("https://localhost/v1/sessions").then(r => r.json());
+				const connectedSession = allConnected.find(s => s.sessionId === sessionId);
+				ws.close();
+				await waitForClosedConnection(ws);
+
+				const { sessions: allDisconnected } = await env.MYBROWSER.fetch("https://localhost/v1/sessions").then(r => r.json());
+				const disconnectedSession = allDisconnected.find(s => s.sessionId === sessionId);
+				return Response.json({ connectedSession, disconnectedSession });
+			}
+
+			// --- /limits: proxy to limits endpoint ---
+			case "/limits": {
+				return env.MYBROWSER.fetch("https://localhost/v1/limits");
+			}
+
+			// --- /history: proxy to history endpoint ---
+			case "/history": {
+				return env.MYBROWSER.fetch("https://localhost/v1/history");
+			}
+
+			// --- /devtools-session: list and detail endpoints ---
+			case "/devtools-session": {
+				const beforeList = await env.MYBROWSER.fetch("https://localhost/v1/devtools/session").then(r => r.json());
+				const baselineCount = beforeList.length;
+				const { sessionId } = await env.MYBROWSER.fetch("https://localhost/v1/acquire").then(r => r.json());
+				const afterList = await env.MYBROWSER.fetch("https://localhost/v1/devtools/session").then(r => r.json());
+				const newCount = afterList.length - baselineCount;
+				const ourSession = afterList.find(s => s.sessionId === sessionId);
+				const detail = await env.MYBROWSER.fetch(\`https://localhost/v1/devtools/session/\${sessionId}\`).then(r => r.json());
+				const missing = await env.MYBROWSER.fetch("https://localhost/v1/devtools/session/does-not-exist");
+				return Response.json({ baselineCount, newCount, ourSession, detail, missingStatus: missing.status });
+			}
+
+			// --- /devtools-json: json/version, json/list, json endpoints ---
+			case "/devtools-json": {
+				const { sessionId } = await env.MYBROWSER.fetch("https://localhost/v1/acquire").then(r => r.json());
+				const version = await env.MYBROWSER.fetch(
+					\`https://localhost/v1/devtools/browser/\${sessionId}/json/version\`
+				).then(r => r.json());
+				const list = await env.MYBROWSER.fetch(
+					\`https://localhost/v1/devtools/browser/\${sessionId}/json/list\`
+				).then(r => r.json());
+				const listAlias = await env.MYBROWSER.fetch(
+					\`https://localhost/v1/devtools/browser/\${sessionId}/json\`
+				).then(r => r.json());
+				return Response.json({ version, list, listAlias });
+			}
+
+			// --- /devtools-delete: DELETE closes browser session ---
+			case "/devtools-delete": {
+				const { sessionId } = await env.MYBROWSER.fetch("https://localhost/v1/acquire").then(r => r.json());
+				const { webSocket: ws } = await env.MYBROWSER.fetch(
+					\`https://localhost/v1/devtools/browser/\${sessionId}\`,
+					{ headers: { Upgrade: "websocket" } }
+				);
+				ws.accept();
+				const deleteResp = await env.MYBROWSER.fetch(
+					\`https://localhost/v1/devtools/browser/\${sessionId}\`,
+					{ method: "DELETE" }
+				);
+				const deleteBody = await deleteResp.json();
+				// Verify our session is gone after DELETE (filter by sessionId)
+				const { sessions } = await env.MYBROWSER.fetch("https://localhost/v1/sessions").then(r => r.json());
+				const sessionGone = !sessions.some(s => s.sessionId === sessionId);
+				await waitForClosedConnection(ws);
+				const wsClosed = ws.readyState === WebSocket.CLOSED;
+				return Response.json({ deleteStatus: deleteResp.status, deleteBody, sessionGone, wsClosed });
+			}
+
+			// --- /devtools-browser-ws: POST acquires, GET connects via WS ---
+			case "/devtools-browser-ws": {
+				const postResp = await env.MYBROWSER.fetch("https://localhost/v1/devtools/browser", {
+					method: "POST",
+				});
+				const { sessionId } = await postResp.json();
+
+				await new Promise(resolve => setTimeout(resolve, 200));
+
+				const getResp = await env.MYBROWSER.fetch(
+					\`https://localhost/v1/devtools/browser/\${sessionId}\`,
+					{ headers: { Upgrade: "websocket" } }
+				);
+				const sessionIdFromGet = getResp.headers.get("cf-browser-session-id");
+				const ws = getResp.webSocket;
+				ws.accept();
+				const browserVersion = await new Promise((resolve) => {
+					ws.addEventListener("message", (m) => resolve(JSON.parse(m.data)));
+					ws.send(JSON.stringify({ id: 1, method: "Browser.getVersion" }));
+				});
+				ws.close();
+				return Response.json({
+					postStatus: postResp.status,
+					sessionId,
+					getStatus: getResp.status,
+					sessionIdFromGet,
+					browserProduct: browserVersion.result?.product,
+				});
+			}
+
+			// --- /devtools-browser-get: GET acquires and connects in one step ---
+			case "/devtools-browser-get": {
+				const resp = await env.MYBROWSER.fetch("https://localhost/v1/devtools/browser", {
+					headers: { Upgrade: "websocket" },
+				});
+				const sessionId = resp.headers.get("cf-browser-session-id");
+				const ws = resp.webSocket;
+				ws.accept();
+				const browserVersion = await new Promise((resolve) => {
+					ws.addEventListener("message", (m) => resolve(JSON.parse(m.data)));
+					ws.send(JSON.stringify({ id: 1, method: "Browser.getVersion" }));
+				});
+				ws.close();
+				return Response.json({
+					status: resp.status,
+					sessionId,
+					browserProduct: browserVersion.result?.product,
+				});
+			}
+
+			// --- /devtools-protocol: json/protocol endpoint ---
+			case "/devtools-protocol": {
+				const { sessionId } = await env.MYBROWSER.fetch("https://localhost/v1/acquire").then(r => r.json());
+				const protocol = await env.MYBROWSER.fetch(
+					\`https://localhost/v1/devtools/browser/\${sessionId}/json/protocol\`
+				).then(r => r.json());
+				return Response.json({ hasDomains: Array.isArray(protocol.domains) });
+			}
+
+			// --- /devtools-new-activate-close: json/new, json/activate, json/close ---
+			case "/devtools-new-activate-close": {
+				const { sessionId } = await env.MYBROWSER.fetch("https://localhost/v1/acquire").then(r => r.json());
+				const newTarget = await env.MYBROWSER.fetch(
+					\`https://localhost/v1/devtools/browser/\${sessionId}/json/new?url=about:blank\`,
+					{ method: "PUT" }
+				).then(r => r.json());
+				const activateResp = await env.MYBROWSER.fetch(
+					\`https://localhost/v1/devtools/browser/\${sessionId}/json/activate/\${newTarget.id}\`
+				);
+				const closeResp = await env.MYBROWSER.fetch(
+					\`https://localhost/v1/devtools/browser/\${sessionId}/json/close/\${newTarget.id}\`
+				);
+				return Response.json({
+					targetType: newTarget.type,
+					activateStatus: activateResp.status,
+					closeStatus: closeResp.status,
+				});
+			}
+
+			// --- /devtools-page-ws: page-level WebSocket endpoint ---
+			case "/devtools-page-ws": {
+				const { sessionId } = await env.MYBROWSER.fetch("https://localhost/v1/acquire").then(r => r.json());
+				const targets = await env.MYBROWSER.fetch(
+					\`https://localhost/v1/devtools/browser/\${sessionId}/json/list\`
+				).then(r => r.json());
+				const targetId = targets[0].id;
+				const { webSocket: ws } = await env.MYBROWSER.fetch(
+					\`https://localhost/v1/devtools/browser/\${sessionId}/page/\${targetId}\`,
+					{ headers: { Upgrade: "websocket" } }
+				);
+				ws.accept();
+				const result = await new Promise((resolve) => {
+					ws.addEventListener("message", (m) => resolve(JSON.parse(m.data)));
+					ws.send(JSON.stringify({ id: 1, method: "Runtime.evaluate", params: { expression: "1+1" } }));
+				});
+				ws.close();
+				return Response.json({ resultValue: result.result?.result?.value });
+			}
+
+			// --- /devtools-delete-no-ws: DELETE without prior WebSocket ---
+			case "/devtools-delete-no-ws": {
+				const { sessionId } = await env.MYBROWSER.fetch("https://localhost/v1/acquire").then(r => r.json());
+				const deleteResp = await env.MYBROWSER.fetch(
+					\`https://localhost/v1/devtools/browser/\${sessionId}\`,
+					{ method: "DELETE" }
+				);
+				const deleteBody = await deleteResp.json();
+				const { sessions } = await env.MYBROWSER.fetch("https://localhost/v1/sessions").then(r => r.json());
+				return Response.json({
+					deleteStatus: deleteResp.status,
+					deleteBody,
+					sessionGone: !sessions.some(s => s.sessionId === sessionId),
+				});
+			}
+
+			// --- /devtools-delete-all-ws: DELETE closes browser + page WebSockets ---
+			case "/devtools-delete-all-ws": {
+				const { sessionId } = await env.MYBROWSER.fetch("https://localhost/v1/acquire").then(r => r.json());
+
+				// Connect browser-level WebSocket
+				const { webSocket: browserWs } = await env.MYBROWSER.fetch(
+					\`https://localhost/v1/devtools/browser/\${sessionId}\`,
+					{ headers: { Upgrade: "websocket" } }
+				);
+				browserWs.accept();
+
+				// Connect page-level WebSocket
+				const targets = await env.MYBROWSER.fetch(
+					\`https://localhost/v1/devtools/browser/\${sessionId}/json/list\`
+				).then(r => r.json());
+				const { webSocket: pageWs } = await env.MYBROWSER.fetch(
+					\`https://localhost/v1/devtools/browser/\${sessionId}/page/\${targets[0].id}\`,
+					{ headers: { Upgrade: "websocket" } }
+				);
+				pageWs.accept();
+
+				// DELETE should close everything
+				const deleteResp = await env.MYBROWSER.fetch(
+					\`https://localhost/v1/devtools/browser/\${sessionId}\`,
+					{ method: "DELETE" }
+				);
+				const deleteBody = await deleteResp.json();
+
+				await Promise.all([
+					waitForClosedConnection(browserWs),
+					waitForClosedConnection(pageWs),
+				]);
+
+				return Response.json({
+					deleteStatus: deleteResp.status,
+					deleteBody,
+					browserWsClosed: browserWs.readyState === WebSocket.CLOSED,
+					pageWsClosed: pageWs.readyState === WebSocket.CLOSED,
+				});
+			}
+
+			// --- /devtools-concurrent-ws: multiple raw WS connections ---
+			case "/devtools-concurrent-ws": {
+				const { sessionId } = await env.MYBROWSER.fetch("https://localhost/v1/acquire").then(r => r.json());
+
+				// Open two raw WebSocket connections to the same browser session
+				const { webSocket: ws1 } = await env.MYBROWSER.fetch(
+					\`https://localhost/v1/devtools/browser/\${sessionId}\`,
+					{ headers: { Upgrade: "websocket" } }
+				);
+				ws1.accept();
+
+				const { webSocket: ws2 } = await env.MYBROWSER.fetch(
+					\`https://localhost/v1/devtools/browser/\${sessionId}\`,
+					{ headers: { Upgrade: "websocket" } }
+				);
+				ws2.accept();
+
+				// Send Browser.getVersion on both and verify responses
+				const v1 = new Promise((resolve) => {
+					ws1.addEventListener("message", (m) => resolve(JSON.parse(m.data)));
+					ws1.send(JSON.stringify({ id: 1, method: "Browser.getVersion" }));
+				});
+				const v2 = new Promise((resolve) => {
+					ws2.addEventListener("message", (m) => resolve(JSON.parse(m.data)));
+					ws2.send(JSON.stringify({ id: 2, method: "Browser.getVersion" }));
+				});
+
+				const [r1, r2] = await Promise.all([v1, v2]);
+				ws1.close();
+				ws2.close();
+
+				return Response.json({
+					product1: r1.result?.product,
+					product2: r2.result?.product,
+				});
+			}
+
+			default:
+				return new Response("Unknown route: " + url.pathname, { status: 404 });
 		}
 	}
 };
@@ -85,6 +559,23 @@ export default {
 // We need to run browser rendering tests in a serial manner to avoid a race condition installing the browser.
 // We set the timeout quite high here as one of these tests will need to download the Chrome headless browser.
 describe.sequential("browser rendering", { timeout: 120_000 }, () => {
+	// Shared Miniflare instance for all tests except the multi-binding test.
+	// A single workerd process is reused across all tests, eliminating ~16
+	// start/stop cycles and their associated cleanup races.
+	let mf: Miniflare;
+
+	beforeAll(async () => {
+		mf = new Miniflare({
+			name: "worker",
+			compatibilityDate: "2024-11-20",
+			modules: true,
+			script: MEGA_WORKER_SCRIPT,
+			browserRendering: { binding: "MYBROWSER" },
+		});
+	});
+
+	afterAll(() => disposeWithRetry(mf));
+
 	// The CLI spinner outputs to stdout, so we mute it during tests
 	beforeEach(() => {
 		vi.spyOn(process.stdout, "write").mockImplementation(() => true);
@@ -97,16 +588,6 @@ describe.sequential("browser rendering", { timeout: 120_000 }, () => {
 		"it creates a browser session",
 		BROWSER_RENDERING_RETRY,
 		async ({ expect }) => {
-			const opts: MiniflareOptions = {
-				name: "worker",
-				compatibilityDate: "2024-11-20",
-				modules: true,
-				script: BROWSER_WORKER_SCRIPT(),
-				browserRendering: { binding: "MYBROWSER" },
-			};
-			const mf = new Miniflare(opts);
-			useDispose(mf);
-
 			const res = await mf.dispatchFetch("https://localhost/session");
 			const text = await res.text();
 			expect(text.includes("sessionId")).toBe(true);
@@ -127,7 +608,7 @@ describe.sequential("browser rendering", { timeout: 120_000 }, () => {
 				}
 			};
 			`;
-			const mf = new Miniflare({
+			const multiMf = new Miniflare({
 				workers: [
 					{
 						name: "worker-a",
@@ -145,333 +626,75 @@ describe.sequential("browser rendering", { timeout: 120_000 }, () => {
 					},
 				],
 			});
-			useDispose(mf);
+			useDispose(multiMf);
 
-			const res = await mf.dispatchFetch("https://localhost/session");
+			const res = await multiMf.dispatchFetch("https://localhost/session");
 			const text = await res.text();
 			expect(text.includes("sessionId")).toBe(true);
 		}
 	);
 
-	const BROWSER_WORKER_CLOSE_SCRIPT = `
-${sendMessage.toString()}
-${waitForClosedConnection.toString()}
-
-export default {
-	async fetch(request, env) {
-		const acquireResponse = await env.MYBROWSER.fetch("https://localhost/v1/acquire");
-		const { sessionId } = await acquireResponse.json();
-		const { webSocket: ws } = await env.MYBROWSER.fetch(\`https://localhost/v1/connectDevtools?browser_session=\${sessionId}\`, {
-			headers: { "Upgrade": "websocket" },
-		});
-		ws.accept();
-
-		sendMessage(ws, { method: "Browser.close", id: -1 });
-		await waitForClosedConnection(ws);
-
-		return new Response("Browser closed");
-	}
-};
-`;
-
 	test(
 		"it closes a browser session",
 		BROWSER_RENDERING_RETRY,
 		async ({ expect }) => {
-			const opts: MiniflareOptions = {
-				name: "worker",
-				compatibilityDate: "2024-11-20",
-				modules: true,
-				script: BROWSER_WORKER_CLOSE_SCRIPT,
-				browserRendering: { binding: "MYBROWSER" },
-			};
-			const mf = new Miniflare(opts);
-			useDispose(mf);
-
 			const res = await mf.dispatchFetch("https://localhost/close");
 			expect(await res.text()).toBe("Browser closed");
 		}
 	);
 
-	const BROWSER_WORKER_REUSE_SCRIPT = `
-${sendMessage.toString()}
-${waitForClosedConnection.toString()}
-
-export default {
-	async fetch(request, env) {
-		const acquireResponse = await env.MYBROWSER.fetch("https://localhost/v1/acquire");
-		const { sessionId } = await acquireResponse.json();
-		const { webSocket: ws } = await env.MYBROWSER.fetch(\`https://localhost/v1/connectDevtools?browser_session=\${sessionId}\`, {
-			headers: { "Upgrade": "websocket" },
-		});
-		ws.accept();
-		ws.close();
-
-		await waitForClosedConnection(ws);
-
-		// Reuse the same session by connecting to it again
-		const { webSocket: ws2 } = await env.MYBROWSER.fetch(\`https://localhost/v1/connectDevtools?browser_session=\${sessionId}\`, {
-			headers: { "Upgrade": "websocket" },
-		});
-		ws2.accept();
-		ws2.close();
-
-		return new Response("Browser session reused");
-	}
-};
-`;
-
 	test(
 		"it reuses a browser session",
 		BROWSER_RENDERING_RETRY,
 		async ({ expect }) => {
-			const opts: MiniflareOptions = {
-				name: "worker",
-				compatibilityDate: "2024-11-20",
-				modules: true,
-				script: BROWSER_WORKER_REUSE_SCRIPT,
-				browserRendering: { binding: "MYBROWSER" },
-			};
-			const mf = new Miniflare(opts);
-			useDispose(mf);
-
-			const res = await mf.dispatchFetch("https://localhost");
+			const res = await mf.dispatchFetch("https://localhost/reuse");
 			expect(await res.text()).toBe("Browser session reused");
 		}
 	);
-
-	const BROWSER_WORKER_RECONNECT_SCRIPT = `
-${sendMessage.toString()}
-${waitForClosedConnection.toString()}
-
-async function waitForMessage(ws) {
-	const chunks = [];
-	return new Promise((resolve) => {
-		ws.addEventListener("message", function handler(event) {
-			const data = new Uint8Array(event.data);
-			if (chunks.length === 0) {
-				// First chunk contains a 4-byte little-endian length header
-				const view = new DataView(data.buffer);
-				const totalLength = view.getUint32(0, true);
-				chunks.push({ data: data.slice(4), totalLength });
-			} else {
-				chunks[0].data = new Uint8Array([...chunks[0].data, ...data]);
-			}
-			const accumulated = chunks[0];
-			if (accumulated.data.length >= accumulated.totalLength) {
-				ws.removeEventListener("message", handler);
-				const text = new TextDecoder().decode(accumulated.data.slice(0, accumulated.totalLength));
-				resolve(JSON.parse(text));
-			}
-		});
-	});
-}
-
-export default {
-	async fetch(request, env) {
-		const acquireResponse = await env.MYBROWSER.fetch("https://localhost/v1/acquire");
-		const { sessionId } = await acquireResponse.json();
-
-		// First connection
-		const { webSocket: ws } = await env.MYBROWSER.fetch(\`https://localhost/v1/connectDevtools?browser_session=\${sessionId}\`, {
-			headers: { "Upgrade": "websocket" },
-		});
-		ws.accept();
-
-		// Send a CDP command and verify we get a response
-		sendMessage(ws, { method: "Target.getTargets", id: 1 });
-		const msg1 = await waitForMessage(ws);
-		if (!msg1 || !msg1.result) {
-			return new Response("First CDP command failed: " + JSON.stringify(msg1));
-		}
-
-		// Disconnect
-		ws.close();
-		await waitForClosedConnection(ws);
-
-		// Reconnect with the same sessionId
-		const resp2 = await env.MYBROWSER.fetch(\`https://localhost/v1/connectDevtools?browser_session=\${sessionId}\`, {
-			headers: { "Upgrade": "websocket" },
-		});
-		if (!resp2.webSocket) {
-			return new Response("Reconnect failed with status: " + resp2.status);
-		}
-		const ws2 = resp2.webSocket;
-		ws2.accept();
-
-		// Send a CDP command on the reconnected socket
-		sendMessage(ws2, { method: "Target.getTargets", id: 2 });
-		const msg2 = await waitForMessage(ws2);
-		if (!msg2 || !msg2.result) {
-			return new Response("Second CDP command failed: " + JSON.stringify(msg2));
-		}
-
-		ws2.close();
-		return new Response("Reconnect successful");
-	}
-};
-`;
 
 	test(
 		"it reconnects and sends CDP commands after disconnect",
 		BROWSER_RENDERING_RETRY,
 		async ({ expect }) => {
-			const opts: MiniflareOptions = {
-				name: "worker",
-				compatibilityDate: "2024-11-20",
-				modules: true,
-				script: BROWSER_WORKER_RECONNECT_SCRIPT,
-				browserRendering: { binding: "MYBROWSER" },
-			};
-			const mf = new Miniflare(opts);
-			useDispose(mf);
-
-			const res = await mf.dispatchFetch("https://localhost");
+			const res = await mf.dispatchFetch("https://localhost/reconnect");
 			expect(await res.text()).toBe("Reconnect successful");
 		}
 	);
-
-	const BROWSER_WORKER_ALREADY_USED_SCRIPT = `
-export default {
-	async fetch(request, env) {
-		const acquireResponse = await env.MYBROWSER.fetch("https://localhost/v1/acquire");
-		const { sessionId } = await acquireResponse.json();
-		const { webSocket: ws } = await env.MYBROWSER.fetch(\`https://localhost/v1/connectDevtools?browser_session=\${sessionId}\`, {
-			headers: { "Upgrade": "websocket" },
-		});
-		ws.accept();
-
-		await new Promise(resolve => setTimeout(resolve, 100));
-
-		// try to open new connection for the same session
-		const resp2 = await env.MYBROWSER.fetch(\`https://localhost/v1/connectDevtools?browser_session=\${sessionId}\`, {
-			headers: { "Upgrade": "websocket" },
-		});
-		if (resp2.status === 409) {
-			return new Response("Failed to connect to browser session");
-		}
-
-		return new Response("Should not reach here");
-	}
-};
-`;
 
 	test.skipIf(process.platform === "win32")(
 		"fails if browser session already in use",
 		BROWSER_RENDERING_RETRY,
 		async ({ expect }) => {
-			const opts: MiniflareOptions = {
-				name: "worker",
-				compatibilityDate: "2024-11-20",
-				modules: true,
-				script: BROWSER_WORKER_ALREADY_USED_SCRIPT,
-				browserRendering: { binding: "MYBROWSER" },
-			};
-			const mf = new Miniflare(opts);
-			useDispose(mf);
-
-			const res = await mf.dispatchFetch("https://localhost");
+			const res = await mf.dispatchFetch("https://localhost/already-used");
 			expect(await res.text()).toBe("Failed to connect to browser session");
 		}
 	);
-
-	const GET_SESSIONS_SCRIPT = `
-${sendMessage.toString()}
-${waitForClosedConnection.toString()}
-
-export default {
-	async fetch(request, env) {
-		const { sessions: emptySessions } = await env.MYBROWSER.fetch("https://localhost/v1/sessions").then(res => res.json());
-		const { sessionId } = await env.MYBROWSER.fetch("https://localhost/v1/acquire").then(res => res.json());
-		const { sessions: acquiredSessions } = await env.MYBROWSER.fetch("https://localhost/v1/sessions").then(res => res.json());
-
-		const { webSocket: ws } = await env.MYBROWSER.fetch(\`https://localhost/v1/connectDevtools?browser_session=\${sessionId}\`, {
-			headers: { "Upgrade": "websocket" },
-		});
-		ws.accept();
-
-		// send a close message to the browser
-		sendMessage(ws, { method: "Browser.close", id: -1 });
-
-		await waitForClosedConnection(ws);
-
-		await new Promise((resolve) => setTimeout(resolve, 1000));
-
-		const { sessions: afterClosedSessions } = await env.MYBROWSER.fetch("https://localhost/v1/sessions").then(res => res.json());
-
-		return Response.json({ emptySessions, acquiredSessions, afterClosedSessions });
-	}
-};
-`;
 
 	test(
 		"gets sessions while acquiring and closing session",
 		BROWSER_RENDERING_RETRY,
 		async ({ expect }) => {
-			const opts: MiniflareOptions = {
-				name: "worker",
-				compatibilityDate: "2024-11-20",
-				modules: true,
-				script: GET_SESSIONS_SCRIPT,
-				browserRendering: { binding: "MYBROWSER" },
-			};
-			const mf = new Miniflare(opts);
-			useDispose(mf);
-
-			const { emptySessions, acquiredSessions, afterClosedSessions } = (await mf
-				.dispatchFetch("https://localhost")
+			const { ourSession, newCount, sessionStillPresent } = (await mf
+				.dispatchFetch("https://localhost/get-sessions")
 				.then((res) => res.json())) as any;
-			expect(emptySessions.length).toBe(0);
-			expect(acquiredSessions.length).toBe(1);
+			// Exactly one new session should have been added by this test's acquire
+			expect(newCount).toBe(1);
 			expect(
-				typeof acquiredSessions[0].sessionId === "string" &&
-					typeof acquiredSessions[0].startTime === "number" &&
-					!acquiredSessions[0].connectionId &&
-					!acquiredSessions[0].connectionId
+				typeof ourSession.sessionId === "string" &&
+					typeof ourSession.startTime === "number" &&
+					!ourSession.connectionId
 			).toBe(true);
-			expect(afterClosedSessions.length).toBe(0);
+			// After Browser.close, our session should no longer be listed
+			expect(sessionStillPresent).toBe(false);
 		}
 	);
-
-	const GET_SESSIONS_AFTER_DISCONNECT_SCRIPT = `
-${waitForClosedConnection.toString()}
-
-export default {
-	async fetch(request, env) {
-		const { sessionId } = await env.MYBROWSER.fetch("https://localhost/v1/acquire").then(res => res.json());
-		const { webSocket: ws } = await env.MYBROWSER.fetch(\`https://localhost/v1/connectDevtools?browser_session=\${sessionId}\`, {
-			headers: { "Upgrade": "websocket" },
-		});
-		ws.accept();
-
-		const { sessions: [connectedSession] } = await env.MYBROWSER.fetch("https://localhost/v1/sessions").then(res => res.json());
-		ws.close();
-
-		await waitForClosedConnection(ws);
-
-		const { sessions: [disconnectedSession] } = await env.MYBROWSER.fetch("https://localhost/v1/sessions").then(res => res.json());
-
-		return Response.json({ connectedSession, disconnectedSession });
-	}
-};
-`;
 
 	test(
 		"gets sessions while connecting and disconnecting session",
 		BROWSER_RENDERING_RETRY,
 		async ({ expect }) => {
-			const opts: MiniflareOptions = {
-				name: "worker",
-				compatibilityDate: "2024-11-20",
-				modules: true,
-				script: GET_SESSIONS_AFTER_DISCONNECT_SCRIPT,
-				browserRendering: { binding: "MYBROWSER" },
-			};
-			const mf = new Miniflare(opts);
-			useDispose(mf);
-
 			const { connectedSession, disconnectedSession } = (await mf
-				.dispatchFetch("https://localhost")
+				.dispatchFetch("https://localhost/get-sessions-disconnect")
 				.then((res) => res.json())) as any;
 			expect(connectedSession.sessionId).toBe(disconnectedSession.sessionId);
 			expect(
@@ -486,18 +709,7 @@ export default {
 	);
 
 	test("returns limits", async ({ expect }) => {
-		const mf = new Miniflare({
-			name: "worker",
-			compatibilityDate: "2024-11-20",
-			modules: true,
-			script: `export default { async fetch(req, env) {
-				return env.MYBROWSER.fetch("https://localhost/v1/limits");
-			} }`,
-			browserRendering: { binding: "MYBROWSER" },
-		});
-		useDispose(mf);
-
-		const res = await mf.dispatchFetch("https://localhost");
+		const res = await mf.dispatchFetch("https://localhost/limits");
 		const body = (await res.json()) as any;
 		expect(res.status).toBe(200);
 		expect(typeof body.maxConcurrentSessions).toBe("number");
@@ -506,98 +718,34 @@ export default {
 	});
 
 	test("returns empty history", async ({ expect }) => {
-		const mf = new Miniflare({
-			name: "worker",
-			compatibilityDate: "2024-11-20",
-			modules: true,
-			script: `export default { async fetch(req, env) {
-				return env.MYBROWSER.fetch("https://localhost/v1/history");
-			} }`,
-			browserRendering: { binding: "MYBROWSER" },
-		});
-		useDispose(mf);
-
-		const res = await mf.dispatchFetch("https://localhost");
+		const res = await mf.dispatchFetch("https://localhost/history");
 		const body = await res.json();
 		expect(res.status).toBe(200);
 		expect(body).toEqual([]);
 	});
 
-	const DEVTOOLS_SESSION_SCRIPT = `
-export default {
-	async fetch(request, env) {
-		const emptyList = await env.MYBROWSER.fetch("https://localhost/v1/devtools/session").then(r => r.json());
-		const { sessionId } = await env.MYBROWSER.fetch("https://localhost/v1/acquire").then(r => r.json());
-		const list = await env.MYBROWSER.fetch("https://localhost/v1/devtools/session").then(r => r.json());
-		const detail = await env.MYBROWSER.fetch(\`https://localhost/v1/devtools/session/\${sessionId}\`).then(r => r.json());
-		const missing = await env.MYBROWSER.fetch("https://localhost/v1/devtools/session/does-not-exist");
-		return Response.json({ emptyList, list, detail, missingStatus: missing.status });
-	}
-};
-`;
-
 	test(
 		"devtools session list and detail endpoints",
 		BROWSER_RENDERING_RETRY,
 		async ({ expect }) => {
-			const mf = new Miniflare({
-				name: "worker",
-				compatibilityDate: "2024-11-20",
-				modules: true,
-				script: DEVTOOLS_SESSION_SCRIPT,
-				browserRendering: { binding: "MYBROWSER" },
-			});
-			useDispose(mf);
-
-			const { emptyList, list, detail, missingStatus } = (await mf
-				.dispatchFetch("https://localhost")
+			const { newCount, ourSession, detail, missingStatus } = (await mf
+				.dispatchFetch("https://localhost/devtools-session")
 				.then((r) => r.json())) as any;
 
-			expect(emptyList).toEqual([]);
-			expect(list.length).toBe(1);
-			expect(typeof list[0].sessionId).toBe("string");
-			expect(detail.sessionId).toBe(list[0].sessionId);
+			// Exactly one new session should appear after acquire
+			expect(newCount).toBe(1);
+			expect(typeof ourSession.sessionId).toBe("string");
+			expect(detail.sessionId).toBe(ourSession.sessionId);
 			expect(missingStatus).toBe(404);
 		}
 	);
-
-	const DEVTOOLS_JSON_SCRIPT = `
-export default {
-	async fetch(request, env) {
-		const { sessionId } = await env.MYBROWSER.fetch("https://localhost/v1/acquire").then(r => r.json());
-
-		const version = await env.MYBROWSER.fetch(
-			\`https://localhost/v1/devtools/browser/\${sessionId}/json/version\`
-		).then(r => r.json());
-
-		const list = await env.MYBROWSER.fetch(
-			\`https://localhost/v1/devtools/browser/\${sessionId}/json/list\`
-		).then(r => r.json());
-
-		const listAlias = await env.MYBROWSER.fetch(
-			\`https://localhost/v1/devtools/browser/\${sessionId}/json\`
-		).then(r => r.json());
-
-		return Response.json({ version, list, listAlias });
-	}
-};
-`;
 
 	test(
 		"devtools json/version, json/list, json endpoints",
 		BROWSER_RENDERING_RETRY,
 		async ({ expect }) => {
-			const mf = new Miniflare({
-				name: "worker",
-				compatibilityDate: "2024-11-20",
-				modules: true,
-				script: DEVTOOLS_JSON_SCRIPT,
-				browserRendering: { binding: "MYBROWSER" },
-			});
-			useDispose(mf);
-
 			const { version, list, listAlias } = (await mf
-				.dispatchFetch("https://localhost")
+				.dispatchFetch("https://localhost/devtools-json")
 				.then((r) => r.json())) as any;
 
 			expect(typeof version.Browser).toBe("string");
@@ -612,52 +760,12 @@ export default {
 		}
 	);
 
-	const DEVTOOLS_DELETE_SCRIPT = `
-${waitForClosedConnection.toString()}
-
-export default {
-	async fetch(request, env) {
-		const { sessionId } = await env.MYBROWSER.fetch("https://localhost/v1/acquire").then(r => r.json());
-		const { webSocket: ws } = await env.MYBROWSER.fetch(
-			\`https://localhost/v1/devtools/browser/\${sessionId}\`,
-			{ headers: { Upgrade: "websocket" } }
-		);
-		ws.accept();
-		const deleteResp = await env.MYBROWSER.fetch(
-			\`https://localhost/v1/devtools/browser/\${sessionId}\`,
-			{ method: "DELETE" }
-		);
-		const deleteBody = await deleteResp.json();
-		// Verify the session is gone after DELETE
-		const { sessions } = await env.MYBROWSER.fetch(\`https://localhost/v1/sessions?sessionId=\${sessionId}\`).then(r => r.json());
-		const sessionGone = sessions.length === 0;
-		await waitForClosedConnection(ws);
-		const wsClosed = ws.readyState === WebSocket.CLOSED;
-		return Response.json({
-			deleteStatus: deleteResp.status,
-			deleteBody,
-			sessionGone,
-			wsClosed,
-		});
-	}
-};
-`;
-
 	test(
 		"DELETE /v1/devtools/browser/:session_id closes browser",
 		BROWSER_RENDERING_RETRY,
 		async ({ expect }) => {
-			const mf = new Miniflare({
-				name: "worker",
-				compatibilityDate: "2024-11-20",
-				modules: true,
-				script: DEVTOOLS_DELETE_SCRIPT,
-				browserRendering: { binding: "MYBROWSER" },
-			});
-			useDispose(mf);
-
 			const { deleteStatus, deleteBody, sessionGone, wsClosed } = (await mf
-				.dispatchFetch("https://localhost")
+				.dispatchFetch("https://localhost/devtools-delete")
 				.then((r) => r.json())) as any;
 
 			expect(deleteStatus).toBe(200);
@@ -667,53 +775,10 @@ export default {
 		}
 	);
 
-	const DEVTOOLS_BROWSER_WS_SCRIPT = `
-export default {
-	async fetch(request, env) {
-		const postResp = await env.MYBROWSER.fetch("https://localhost/v1/devtools/browser", {
-			method: "POST",
-		});
-		const { sessionId } = await postResp.json();
-
-		await new Promise(resolve => setTimeout(resolve, 200));
-
-		const getResp = await env.MYBROWSER.fetch(
-			\`https://localhost/v1/devtools/browser/\${sessionId}\`,
-			{ headers: { Upgrade: "websocket" } }
-		);
-		const sessionIdFromGet = getResp.headers.get("cf-browser-session-id");
-		const ws = getResp.webSocket;
-		ws.accept();
-		const browserVersion = await new Promise((resolve) => {
-			ws.addEventListener("message", (m) => resolve(JSON.parse(m.data)));
-			ws.send(JSON.stringify({ id: 1, method: "Browser.getVersion" }));
-		});
-		ws.close();
-
-		return Response.json({
-			postStatus: postResp.status,
-			sessionId,
-			getStatus: getResp.status,
-			sessionIdFromGet,
-			browserProduct: browserVersion.result?.product,
-		});
-	}
-};
-`;
-
 	test(
 		"POST /v1/devtools/browser acquires session, GET /v1/devtools/browser/:id connects and returns cf-browser-session-id",
 		BROWSER_RENDERING_RETRY,
 		async ({ expect }) => {
-			const mf = new Miniflare({
-				name: "worker",
-				compatibilityDate: "2024-11-20",
-				modules: true,
-				script: DEVTOOLS_BROWSER_WS_SCRIPT,
-				browserRendering: { binding: "MYBROWSER" },
-			});
-			useDispose(mf);
-
 			const {
 				postStatus,
 				sessionId,
@@ -721,7 +786,7 @@ export default {
 				sessionIdFromGet,
 				browserProduct,
 			} = (await mf
-				.dispatchFetch("https://localhost")
+				.dispatchFetch("https://localhost/devtools-browser-ws")
 				.then((r) => r.json())) as any;
 
 			expect(postStatus).toBe(200);
@@ -737,32 +802,8 @@ export default {
 		"GET /v1/devtools/browser acquires and connects",
 		BROWSER_RENDERING_RETRY,
 		async ({ expect }) => {
-			const mf = new Miniflare({
-				name: "worker",
-				compatibilityDate: "2024-11-20",
-				modules: true,
-				script: `export default {
-	async fetch(request, env) {
-		const resp = await env.MYBROWSER.fetch("https://localhost/v1/devtools/browser", {
-			headers: { Upgrade: "websocket" },
-		});
-		const sessionId = resp.headers.get("cf-browser-session-id");
-		const ws = resp.webSocket;
-		ws.accept();
-		const browserVersion = await new Promise((resolve) => {
-			ws.addEventListener("message", (m) => resolve(JSON.parse(m.data)));
-			ws.send(JSON.stringify({ id: 1, method: "Browser.getVersion" }));
-		});
-		ws.close();
-		return Response.json({ status: resp.status, sessionId, browserProduct: browserVersion.result?.product });
-	}
-};`,
-				browserRendering: { binding: "MYBROWSER" },
-			});
-			useDispose(mf);
-
 			const { status, sessionId, browserProduct } = (await mf
-				.dispatchFetch("https://localhost")
+				.dispatchFetch("https://localhost/devtools-browser-get")
 				.then((r) => r.json())) as any;
 
 			expect(status).toBe(101);
@@ -772,77 +813,24 @@ export default {
 		}
 	);
 
-	const DEVTOOLS_JSON_PROTOCOL_SCRIPT = `
-export default {
-	async fetch(request, env) {
-		const { sessionId } = await env.MYBROWSER.fetch("https://localhost/v1/acquire").then(r => r.json());
-		const protocol = await env.MYBROWSER.fetch(
-			\`https://localhost/v1/devtools/browser/\${sessionId}/json/protocol\`
-		).then(r => r.json());
-		return Response.json({ hasDomains: Array.isArray(protocol.domains) });
-	}
-};
-`;
-
 	test(
 		"devtools json/protocol endpoint",
 		BROWSER_RENDERING_RETRY,
 		async ({ expect }) => {
-			const mf = new Miniflare({
-				name: "worker",
-				compatibilityDate: "2024-11-20",
-				modules: true,
-				script: DEVTOOLS_JSON_PROTOCOL_SCRIPT,
-				browserRendering: { binding: "MYBROWSER" },
-			});
-			useDispose(mf);
-
 			const { hasDomains } = (await mf
-				.dispatchFetch("https://localhost")
+				.dispatchFetch("https://localhost/devtools-protocol")
 				.then((r) => r.json())) as any;
 
 			expect(hasDomains).toBe(true);
 		}
 	);
 
-	const DEVTOOLS_JSON_NEW_ACTIVATE_CLOSE_SCRIPT = `
-export default {
-	async fetch(request, env) {
-		const { sessionId } = await env.MYBROWSER.fetch("https://localhost/v1/acquire").then(r => r.json());
-		const newTarget = await env.MYBROWSER.fetch(
-			\`https://localhost/v1/devtools/browser/\${sessionId}/json/new?url=about:blank\`,
-			{ method: "PUT" }
-		).then(r => r.json());
-		const activateResp = await env.MYBROWSER.fetch(
-			\`https://localhost/v1/devtools/browser/\${sessionId}/json/activate/\${newTarget.id}\`
-		);
-		const closeResp = await env.MYBROWSER.fetch(
-			\`https://localhost/v1/devtools/browser/\${sessionId}/json/close/\${newTarget.id}\`
-		);
-		return Response.json({
-			targetType: newTarget.type,
-			activateStatus: activateResp.status,
-			closeStatus: closeResp.status,
-		});
-	}
-};
-`;
-
 	test(
 		"devtools json/new, json/activate, json/close endpoints",
 		BROWSER_RENDERING_RETRY,
 		async ({ expect }) => {
-			const mf = new Miniflare({
-				name: "worker",
-				compatibilityDate: "2024-11-20",
-				modules: true,
-				script: DEVTOOLS_JSON_NEW_ACTIVATE_CLOSE_SCRIPT,
-				browserRendering: { binding: "MYBROWSER" },
-			});
-			useDispose(mf);
-
 			const { targetType, activateStatus, closeStatus } = (await mf
-				.dispatchFetch("https://localhost")
+				.dispatchFetch("https://localhost/devtools-new-activate-close")
 				.then((r) => r.json())) as any;
 
 			expect(targetType).toBe("page");
@@ -851,44 +839,12 @@ export default {
 		}
 	);
 
-	const DEVTOOLS_PAGE_WS_SCRIPT = `
-export default {
-	async fetch(request, env) {
-		const { sessionId } = await env.MYBROWSER.fetch("https://localhost/v1/acquire").then(r => r.json());
-		const targets = await env.MYBROWSER.fetch(
-			\`https://localhost/v1/devtools/browser/\${sessionId}/json/list\`
-		).then(r => r.json());
-		const targetId = targets[0].id;
-		const { webSocket: ws } = await env.MYBROWSER.fetch(
-			\`https://localhost/v1/devtools/browser/\${sessionId}/page/\${targetId}\`,
-			{ headers: { Upgrade: "websocket" } }
-		);
-		ws.accept();
-		const result = await new Promise((resolve) => {
-			ws.addEventListener("message", (m) => resolve(JSON.parse(m.data)));
-			ws.send(JSON.stringify({ id: 1, method: "Runtime.evaluate", params: { expression: "1+1" } }));
-		});
-		ws.close();
-		return Response.json({ resultValue: result.result?.result?.value });
-	}
-};
-`;
-
 	test(
 		"devtools page/:target_id WebSocket endpoint",
 		BROWSER_RENDERING_RETRY,
 		async ({ expect }) => {
-			const mf = new Miniflare({
-				name: "worker",
-				compatibilityDate: "2024-11-20",
-				modules: true,
-				script: DEVTOOLS_PAGE_WS_SCRIPT,
-				browserRendering: { binding: "MYBROWSER" },
-			});
-			useDispose(mf);
-
 			const { resultValue } = (await mf
-				.dispatchFetch("https://localhost")
+				.dispatchFetch("https://localhost/devtools-page-ws")
 				.then((r) => r.json())) as any;
 
 			expect(resultValue).toBe(2);
@@ -899,32 +855,8 @@ export default {
 		"DELETE without prior WebSocket connection",
 		BROWSER_RENDERING_RETRY,
 		async ({ expect }) => {
-			const mf = new Miniflare({
-				name: "worker",
-				compatibilityDate: "2024-11-20",
-				modules: true,
-				script: `export default {
-	async fetch(request, env) {
-		const { sessionId } = await env.MYBROWSER.fetch("https://localhost/v1/acquire").then(r => r.json());
-		const deleteResp = await env.MYBROWSER.fetch(
-			\`https://localhost/v1/devtools/browser/\${sessionId}\`,
-			{ method: "DELETE" }
-		);
-		const deleteBody = await deleteResp.json();
-		const { sessions } = await env.MYBROWSER.fetch("https://localhost/v1/sessions").then(r => r.json());
-		return Response.json({
-			deleteStatus: deleteResp.status,
-			deleteBody,
-			sessionGone: sessions.length === 0,
-		});
-	}
-};`,
-				browserRendering: { binding: "MYBROWSER" },
-			});
-			useDispose(mf);
-
 			const { deleteStatus, deleteBody, sessionGone } = (await mf
-				.dispatchFetch("https://localhost")
+				.dispatchFetch("https://localhost/devtools-delete-no-ws")
 				.then((r) => r.json())) as any;
 
 			expect(deleteStatus).toBe(200);
@@ -933,68 +865,13 @@ export default {
 		}
 	);
 
-	const DEVTOOLS_DELETE_ALL_WS_SCRIPT = `
-${waitForClosedConnection.toString()}
-
-export default {
-	async fetch(request, env) {
-		const { sessionId } = await env.MYBROWSER.fetch("https://localhost/v1/acquire").then(r => r.json());
-
-		// Connect browser-level WebSocket
-		const { webSocket: browserWs } = await env.MYBROWSER.fetch(
-			\`https://localhost/v1/devtools/browser/\${sessionId}\`,
-			{ headers: { Upgrade: "websocket" } }
-		);
-		browserWs.accept();
-
-		// Connect page-level WebSocket
-		const targets = await env.MYBROWSER.fetch(
-			\`https://localhost/v1/devtools/browser/\${sessionId}/json/list\`
-		).then(r => r.json());
-		const { webSocket: pageWs } = await env.MYBROWSER.fetch(
-			\`https://localhost/v1/devtools/browser/\${sessionId}/page/\${targets[0].id}\`,
-			{ headers: { Upgrade: "websocket" } }
-		);
-		pageWs.accept();
-
-		// DELETE should close everything
-		const deleteResp = await env.MYBROWSER.fetch(
-			\`https://localhost/v1/devtools/browser/\${sessionId}\`,
-			{ method: "DELETE" }
-		);
-		const deleteBody = await deleteResp.json();
-
-		await Promise.all([
-			waitForClosedConnection(browserWs),
-			waitForClosedConnection(pageWs),
-		]);
-
-		return Response.json({
-			deleteStatus: deleteResp.status,
-			deleteBody,
-			browserWsClosed: browserWs.readyState === WebSocket.CLOSED,
-			pageWsClosed: pageWs.readyState === WebSocket.CLOSED,
-		});
-	}
-};
-`;
-
 	test(
 		"DELETE closes all WebSocket connections (browser + page)",
 		BROWSER_RENDERING_RETRY,
 		async ({ expect }) => {
-			const mf = new Miniflare({
-				name: "worker",
-				compatibilityDate: "2024-11-20",
-				modules: true,
-				script: DEVTOOLS_DELETE_ALL_WS_SCRIPT,
-				browserRendering: { binding: "MYBROWSER" },
-			});
-			useDispose(mf);
-
 			const { deleteStatus, deleteBody, browserWsClosed, pageWsClosed } =
 				(await mf
-					.dispatchFetch("https://localhost")
+					.dispatchFetch("https://localhost/devtools-delete-all-ws")
 					.then((r) => r.json())) as any;
 
 			expect(deleteStatus).toBe(200);
@@ -1008,53 +885,8 @@ export default {
 		"multiple concurrent raw WebSocket connections to same session",
 		BROWSER_RENDERING_RETRY,
 		async ({ expect }) => {
-			const mf = new Miniflare({
-				name: "worker",
-				compatibilityDate: "2024-11-20",
-				modules: true,
-				script: `export default {
-	async fetch(request, env) {
-		const { sessionId } = await env.MYBROWSER.fetch("https://localhost/v1/acquire").then(r => r.json());
-
-		// Open two raw WebSocket connections to the same browser session
-		const { webSocket: ws1 } = await env.MYBROWSER.fetch(
-			\`https://localhost/v1/devtools/browser/\${sessionId}\`,
-			{ headers: { Upgrade: "websocket" } }
-		);
-		ws1.accept();
-
-		const { webSocket: ws2 } = await env.MYBROWSER.fetch(
-			\`https://localhost/v1/devtools/browser/\${sessionId}\`,
-			{ headers: { Upgrade: "websocket" } }
-		);
-		ws2.accept();
-
-		// Send Browser.getVersion on both and verify responses
-		const v1 = new Promise((resolve) => {
-			ws1.addEventListener("message", (m) => resolve(JSON.parse(m.data)));
-			ws1.send(JSON.stringify({ id: 1, method: "Browser.getVersion" }));
-		});
-		const v2 = new Promise((resolve) => {
-			ws2.addEventListener("message", (m) => resolve(JSON.parse(m.data)));
-			ws2.send(JSON.stringify({ id: 2, method: "Browser.getVersion" }));
-		});
-
-		const [r1, r2] = await Promise.all([v1, v2]);
-		ws1.close();
-		ws2.close();
-
-		return Response.json({
-			product1: r1.result?.product,
-			product2: r2.result?.product,
-		});
-	}
-};`,
-				browserRendering: { binding: "MYBROWSER" },
-			});
-			useDispose(mf);
-
 			const { product1, product2 } = (await mf
-				.dispatchFetch("https://localhost")
+				.dispatchFetch("https://localhost/devtools-concurrent-ws")
 				.then((r) => r.json())) as any;
 
 			expect(typeof product1).toBe("string");

--- a/packages/miniflare/test/plugins/browser/index.spec.ts
+++ b/packages/miniflare/test/plugins/browser/index.spec.ts
@@ -83,7 +83,7 @@ export default {
 
 // We need to run browser rendering tests in a serial manner to avoid a race condition installing the browser.
 // We set the timeout quite high here as one of these tests will need to download the Chrome headless browser.
-describe.sequential("browser rendering", { timeout: 20_000 }, () => {
+describe.sequential("browser rendering", { timeout: 120_000 }, () => {
 	// The CLI spinner outputs to stdout, so we mute it during tests
 	beforeEach(() => {
 		vi.spyOn(process.stdout, "write").mockImplementation(() => true);


### PR DESCRIPTION
The miniflare browser rendering tests have been pretty flaky lately (for example see [ci run for 14682](https://github.com/cloudflare/workers-sdk/actions/runs/29310455478/job/87012895970?pr=14682), [ci run 8734](https://github.com/cloudflare/workers-sdk/actions/runs/29412568464/job/87342872191) and [ci run 8735](https://github.com/cloudflare/workers-sdk/actions/runs/29416391407/job/87355494526)), this PR attempts to address this flakiness

The changes in this PR are:

- commit 9cb842be8e3716247feab27c00e119528db0e281

    [miniflare] Increase browser rendering test timeout to 120s
    
    The 20-second per-test timeout is too tight on Windows CI runners
    where Chrome startup can be slow under load. With 3 retries and
    exponential backoff, a single test can easily exceed 20 seconds.
    Increase to 120 seconds to give the retry mechanism room to work.

- commit 255906b0299f2bc438af24d9f9b96cc6a728748d

    [miniflare] Increase Chrome readiness probe timeout to 15s on Windows
    
    Windows CI runners are significantly slower to make Chrome's
    listening socket accept connections after the DevTools URL is
    printed. Increase the probe timeout from 5s to 15s on Windows
    to avoid spurious failures that force full test-level retries.

- commit 20efa6687e3398b75e9daca57d9ad0e1ec160fe0

    [miniflare] Broaden browser rendering test retry condition
    
    The retry regex only caught Chrome readiness probe timeouts and
    test timeouts. Transient Windows errors like ConnectEx, WSARecv,
    ECONNRESET, and EPIPE can also surface as test-level failures.
    Add these patterns so the test retries instead of failing outright.


---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: ci/tests change

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
