### PR TITLE
Enable `@typescript-eslint/no-deprecated` linting rule for `vite-plugin-cloudflare`

### DIFF
--- a/.oxlintrc.jsonc
+++ b/.oxlintrc.jsonc
@@ -206,12 +206,5 @@
 				"workers-sdk/no-wrangler-named-imports": "error",
 			},
 		},
-		// TODO: Remove the following override.
-		{
-			"files": ["packages/vite-plugin-cloudflare/**"],
-			"rules": {
-				"@typescript-eslint/no-deprecated": "off",
-			},
-		},
 	],
 }

--- a/packages/vite-plugin-cloudflare/playground/vitest-setup.ts
+++ b/packages/vite-plugin-cloudflare/playground/vitest-setup.ts
@@ -18,6 +18,7 @@ import type {
 	PluginOption,
 	PreviewServer,
 	ResolvedConfig,
+	Rolldown,
 	Rollup,
 	UserConfig,
 	ViteDevServer,
@@ -74,7 +75,7 @@ export let resolvedConfig: ResolvedConfig =
 export let page: Page = undefined as unknown as Page;
 export let browser: Browser = undefined as unknown as Browser;
 export let viteTestUrl: string = "";
-export const watcher: Rollup.RollupWatcher | undefined = undefined;
+export const watcher: Rolldown.RolldownWatcher | undefined = undefined;
 
 export function setViteUrl(url: string): void {
 	viteTestUrl = url;
@@ -350,10 +351,10 @@ export async function startDefaultServe(): Promise<
  * Send the rebuild complete message in build watch
  */
 export async function notifyRebuildComplete(
-	rollupWatcher: Rollup.RollupWatcher
-): Promise<Rollup.RollupWatcher> {
+	rollupWatcher: Rolldown.RolldownWatcher
+): Promise<Rolldown.RolldownWatcher> {
 	let resolveFn: undefined | (() => void);
-	const callback = (event: Rollup.RollupWatcherEvent): void => {
+	const callback = (event: Rolldown.RolldownWatcherEvent): void => {
 		if (event.code === "END") {
 			resolveFn?.();
 		}

--- a/packages/vite-plugin-cloudflare/src/build.ts
+++ b/packages/vite-plugin-cloudflare/src/build.ts
@@ -22,6 +22,9 @@ export function createBuildApp(
 		assert(clientEnvironment, `No "client" environment`);
 		const defaultHtmlPath = path.resolve(builder.config.root, "index.html");
 		const hasClientEntry =
+			/* eslint-disable-next-line @typescript-eslint/no-deprecated --
+				We use `rollupOptions` for backward compatibility with Vite 6 and 7, where `rolldownOptions` does not exist.
+				In Vite 8, `rollupOptions` is aliased to `rolldownOptions` so this works across all supported versions. */
 			clientEnvironment.config.build.rollupOptions.input ||
 			fs.existsSync(defaultHtmlPath);
 
@@ -155,6 +158,9 @@ async function fallbackBuild(
 	builder: vite.ViteBuilder,
 	environment: vite.BuildEnvironment
 ): Promise<void> {
+	/* eslint-disable-next-line @typescript-eslint/no-deprecated --
+		We use `rollupOptions` for backward compatibility with Vite 6 and 7, where `rolldownOptions` does not exist.
+		In Vite 8, `rollupOptions` is aliased to `rolldownOptions` so this works across all supported versions. */
 	environment.config.build.rollupOptions = {
 		input: VIRTUAL_CLIENT_FALLBACK_ENTRY,
 		logLevel: "silent",

--- a/packages/vite-plugin-cloudflare/src/cloudflare-environment.ts
+++ b/packages/vite-plugin-cloudflare/src/cloudflare-environment.ts
@@ -222,13 +222,13 @@ export function createCloudflareEnvironmentOptions({
 	isParentEnvironment: boolean;
 	hasNodeJsCompat: boolean;
 }): vite.EnvironmentOptions {
-	const rollupOptions: vite.Rollup.RollupOptions = isParentEnvironment
+	const rollupOptions = isParentEnvironment
 		? {
 				input: {
 					[MAIN_ENTRY_NAME]: VIRTUAL_WORKER_ENTRY,
 				},
 				// workerd checks the types of the exports so we need to ensure that additional exports are not added to the entry module
-				preserveEntrySignatures: "strict",
+				preserveEntrySignatures: "strict" as const,
 			}
 		: {};
 	const define = getProcessEnvReplacements(hasNodeJsCompat, mode);


### PR DESCRIPTION
This PR enables the `@typescript-eslint/no-deprecated` linting rule for the `vite-pluging-cloudflare` package

Followup for https://github.com/cloudflare/workers-sdk/pull/14472, https://github.com/cloudflare/workers-sdk/pull/14491, https://github.com/cloudflare/workers-sdk/pull/14509, https://github.com/cloudflare/workers-sdk/pull/14522, https://github.com/cloudflare/workers-sdk/pull/14579, https://github.com/cloudflare/workers-sdk/pull/14625 and https://github.com/cloudflare/workers-sdk/pull/14671

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: internal refactoring