### PR TITLE
CC-8217 [wrangler] Apply application-level container changes when `rollout_kind` is `"none"`

### DIFF
--- a/.changeset/rollout-kind-none-app-changes.md
+++ b/.changeset/rollout-kind-none-app-changes.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Apply application-level container changes even when `rollout_kind` is `"none"`
+
+Previously, setting `rollout_kind: "none"` on a container skipped the application update entirely, so changes to application-level settings such as `max_instances`, `scheduling_policy`, or `constraints` were silently dropped (despite being shown in the deploy diff). Now the application is still updated with those changes; only the rollout is skipped, so existing instances keep running the current version until a rollout is triggered.

--- a/packages/workers-utils/src/config/environment.ts
+++ b/packages/workers-utils/src/config/environment.ts
@@ -315,7 +315,7 @@ export type ContainerApp = {
 	/**
 	 * How a rollout should be created. It supports the following modes:
 	 *  - full_auto: The container application will be rolled out fully automatically.
-	 *  - none: The container application won't have a roll out or update.
+	 *  - none: Application-level changes (e.g. `max_instances`, `scheduling_policy`) will still be applied, but no rollout will be created, so existing instances won't be updated.
 	 *  - manual: The container application will be rollout fully by manually actioning progress steps.
 	 * @optional
 	 * @default "full_auto"

--- a/packages/wrangler/src/__tests__/cloudchamber/apply.test.ts
+++ b/packages/wrangler/src/__tests__/cloudchamber/apply.test.ts
@@ -339,7 +339,7 @@ describe("cloudchamber apply", () => {
 		expect(std.stderr).toMatchInlineSnapshot(`""`);
 	});
 
-	test("can skip a simple existing application and create other", async ({
+	test("can modify an existing application without a rollout when rollout_kind is none, and create other", async ({
 		expect,
 	}) => {
 		setIsTTY(false);
@@ -385,8 +385,11 @@ describe("cloudchamber apply", () => {
 				},
 			},
 		]);
+		const applicationReqBodyPromise = mockModifyApplication(expect);
 		mockCreateApplication(expect, { id: "abc" });
 		await runWrangler("cloudchamber apply");
+		const body = await applicationReqBodyPromise;
+		expect(body.instances).toEqual(4);
 
 		expect(std.stdout).toMatchInlineSnapshot(`
 			"╭ Deploy a container application deploy changes to your application
@@ -417,6 +420,8 @@ describe("cloudchamber apply", () => {
 			│   [containers.constraints]
 			│   tier = 1
 			│
+			│
+			│  SUCCESS  Modified application my-container-app
 			│
 			│  SUCCESS  Created application my-container-app-2 (Application ID: abc)
 			│

--- a/packages/wrangler/src/__tests__/containers/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/containers/deploy.test.ts
@@ -1236,6 +1236,57 @@ describe("wrangler deploy with containers", () => {
 		).resolves.not.toThrow();
 	});
 
+	it("should apply application-level changes without creating a rollout when rollout_kind is none", async ({
+		expect,
+	}) => {
+		mockGetVersion("Galaxy-Class");
+		writeWranglerConfig({
+			...DEFAULT_DURABLE_OBJECTS,
+			containers: [
+				{ ...DEFAULT_CONTAINER_FROM_REGISTRY, rollout_kind: "none" },
+			],
+		});
+
+		mockGetApplications([
+			{
+				id: "abc",
+				name: "my-container",
+				instances: 0,
+				max_instances: 5,
+				created_at: new Date().toString(),
+				version: 1,
+				account_id: "1",
+				scheduling_policy: SchedulingPolicy.DEFAULT,
+				rollout_active_grace_period: 0,
+				configuration: {
+					image: "registry.cloudflare.com/some-account-id/hello:world",
+					disk: {
+						size: "2GB",
+						size_mb: 2000,
+					},
+					vcpu: 0.0625,
+					memory: "256MB",
+					memory_mib: 256,
+				},
+				constraints: {
+					tier: 1,
+				},
+				durable_objects: {
+					namespace_id: "1",
+				},
+			},
+		]);
+
+		// no rollout mock: creating a rollout here would hit an unhandled request error
+		mockModifyApplication(expect, { max_instances: 10 });
+
+		await runWrangler("deploy index.js");
+
+		expect(cliStd.stdout).toContain("Skipping application rollout");
+		expect(cliStd.stdout).toContain("Modified application my-container");
+		expect(std.err).toMatchInlineSnapshot(`""`);
+	});
+
 	describe("observability config resolution", () => {
 		const sharedGetApplicationResult = {
 			id: "abc",

--- a/packages/wrangler/src/cloudchamber/apply.ts
+++ b/packages/wrangler/src/cloudchamber/apply.ts
@@ -368,7 +368,7 @@ export async function apply(
 				id: ApplicationID;
 				name: ApplicationName;
 				rollout_step_percentage?: number | number[];
-				rollout_kind: CreateApplicationRolloutRequest.kind;
+				rollout_kind: CreateApplicationRolloutRequest.kind | "none";
 		  }
 	)[] = [];
 
@@ -463,25 +463,27 @@ export async function apply(
 
 			newline();
 
-			if (appConfigNoDefaults.rollout_kind !== "none") {
-				actions.push({
-					action: "modify",
-					application: createApplicationToModifyApplication(appConfig),
-					id: application.id,
-					name: application.name,
-					rollout_step_percentage:
-						application.durable_objects !== undefined
-							? (appConfigNoDefaults.rollout_step_percentage ?? 25)
-							: appConfigNoDefaults.rollout_step_percentage,
-					rollout_kind:
-						appConfigNoDefaults.rollout_kind == "full_manual"
-							? CreateApplicationRolloutRequest.kind.FULL_MANUAL
-							: CreateApplicationRolloutRequest.kind.FULL_AUTO,
-				});
-			} else {
+			if (appConfigNoDefaults.rollout_kind === "none") {
 				log("Skipping application rollout");
 				newline();
 			}
+
+			actions.push({
+				action: "modify",
+				application: createApplicationToModifyApplication(appConfig),
+				id: application.id,
+				name: application.name,
+				rollout_step_percentage:
+					application.durable_objects !== undefined
+						? (appConfigNoDefaults.rollout_step_percentage ?? 25)
+						: appConfigNoDefaults.rollout_step_percentage,
+				rollout_kind:
+					appConfigNoDefaults.rollout_kind === "none"
+						? "none"
+						: appConfigNoDefaults.rollout_kind == "full_manual"
+							? CreateApplicationRolloutRequest.kind.FULL_MANUAL
+							: CreateApplicationRolloutRequest.kind.FULL_AUTO,
+			});
 
 			continue;
 		}
@@ -636,7 +638,10 @@ export async function apply(
 				);
 			}
 
-			if (action.rollout_step_percentage !== undefined) {
+			if (
+				action.rollout_step_percentage !== undefined &&
+				action.rollout_kind !== "none"
+			) {
 				try {
 					await promiseSpinner(
 						RolloutsService.createApplicationRollout(action.id, {

--- a/packages/wrangler/src/containers/deploy.ts
+++ b/packages/wrangler/src/containers/deploy.ts
@@ -493,22 +493,24 @@ export async function apply(
 		diff.print();
 		newline();
 
-		if (containerConfig.rollout_kind !== "none") {
-			await doAction({
-				action: "modify",
-				application: modifyReq,
-				id: prevApp.id,
-				name: prevApp.name,
-				rollout_step_percentage: containerConfig.rollout_step_percentage,
-				rollout_kind:
-					containerConfig.rollout_kind == "full_manual"
-						? CreateApplicationRolloutRequest.kind.FULL_MANUAL
-						: CreateApplicationRolloutRequest.kind.FULL_AUTO,
-			});
-		} else {
+		if (containerConfig.rollout_kind === "none") {
 			log("Skipping application rollout");
 			newline();
 		}
+
+		await doAction({
+			action: "modify",
+			application: modifyReq,
+			id: prevApp.id,
+			name: prevApp.name,
+			rollout_step_percentage: containerConfig.rollout_step_percentage,
+			rollout_kind:
+				containerConfig.rollout_kind === "none"
+					? "none"
+					: containerConfig.rollout_kind == "full_manual"
+						? CreateApplicationRolloutRequest.kind.FULL_MANUAL
+						: CreateApplicationRolloutRequest.kind.FULL_AUTO,
+		});
 	} else {
 		// **************
 		// *** CREATE ***
@@ -591,7 +593,7 @@ const doAction = async (
 				id: ApplicationID;
 				name: ApplicationName;
 				rollout_step_percentage: number | number[];
-				rollout_kind: CreateApplicationRolloutRequest.kind;
+				rollout_kind: CreateApplicationRolloutRequest.kind | "none";
 		  }
 ) => {
 	if (action.action === "create") {
@@ -664,42 +666,44 @@ const doAction = async (
 			);
 		}
 
-		try {
-			await promiseSpinner(
-				RolloutsService.createApplicationRollout(action.id, {
-					description: "Progressive update",
-					strategy: CreateApplicationRolloutRequest.strategy.ROLLING,
-					target_configuration: action.application.configuration ?? {},
-					...configRolloutStepsToAPI(action.rollout_step_percentage),
-					kind: action.rollout_kind,
-				}),
-				{
-					message: `rolling out container version ${action.name}`,
+		if (action.rollout_kind !== "none") {
+			try {
+				await promiseSpinner(
+					RolloutsService.createApplicationRollout(action.id, {
+						description: "Progressive update",
+						strategy: CreateApplicationRolloutRequest.strategy.ROLLING,
+						target_configuration: action.application.configuration ?? {},
+						...configRolloutStepsToAPI(action.rollout_step_percentage),
+						kind: action.rollout_kind,
+					}),
+					{
+						message: `rolling out container version ${action.name}`,
+					}
+				);
+			} catch (err) {
+				if (!(err instanceof Error)) {
+					throw err;
 				}
-			);
-		} catch (err) {
-			if (!(err instanceof Error)) {
-				throw err;
-			}
 
-			if (!(err instanceof ApiError)) {
+				if (!(err instanceof ApiError)) {
+					throw new UserError(
+						`Unexpected error rolling out application "${action.name}":\n${err.message}`,
+						{ telemetryMessage: "containers deploy rollout unexpected error" }
+					);
+				}
+
+				if (err.status === 400) {
+					throw new UserError(
+						`Error rolling out application "${action.name}" due to a misconfiguration:\n\n\t${formatError(err)}`,
+						{ telemetryMessage: "containers deploy rollout misconfiguration" }
+					);
+				}
+
 				throw new UserError(
-					`Unexpected error rolling out application "${action.name}":\n${err.message}`,
-					{ telemetryMessage: "containers deploy rollout unexpected error" }
+					`Error rolling out application "${action.name}":\n${formatError(err)}`,
+					{ telemetryMessage: "containers deploy rollout request failed" }
 				);
 			}
-
-			if (err.status === 400) {
-				throw new UserError(
-					`Error rolling out application "${action.name}" due to a misconfiguration:\n\n\t${formatError(err)}`,
-					{ telemetryMessage: "containers deploy rollout misconfiguration" }
-				);
-			}
-
-			throw new UserError(
-				`Error rolling out application "${action.name}":\n${formatError(err)}`,
-				{ telemetryMessage: "containers deploy rollout request failed" }
-			);
 		}
 
 		success(


### PR DESCRIPTION
Previously, setting `rollout_kind: "none"` on a container skipped the application modify entirely, so application-level changes (e.g. `max_instances`, `scheduling_policy`, `constraints`) were silently dropped — despite being shown in the deploy diff. The containers team confirmed `rollout_kind` should only control rollouts.

With this change, both `wrangler deploy` and `wrangler cloudchamber apply` still call the application modify endpoint when `rollout_kind` is `"none"`; only the rollout creation is skipped, so existing instances keep running the current version until a rollout is triggered.

The `--containers-rollout=none` CLI flag is unaffected: it remains a separate escape hatch that skips the Docker build and container deploy entirely.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: `rollout_kind` is a hidden config option (`@hidden`, not in the public JSON schema); the JSDoc on the config type has been updated to describe the new semantics.

*A picture of a cute animal (not mandatory, but encouraged)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14719" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->