### PR TITLE
[wrangler] Support Artifacts Queue event sources

### DIFF
--- a/.changeset/fuzzy-dogs-listen.md
+++ b/.changeset/fuzzy-dogs-listen.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Support Artifacts sources when creating Queue event subscriptions
+
+`wrangler queues subscription create` now accepts the `artifacts` and `artifacts.repo` source types supported by the Cloudflare API.

--- a/.changeset/fuzzy-dogs-listen.md
+++ b/.changeset/fuzzy-dogs-listen.md
@@ -1,5 +1,5 @@
 ---
-"wrangler": patch
+"wrangler": minor
 ---
 
 Support Artifacts sources when creating Queue event subscriptions

--- a/packages/wrangler/src/__tests__/queues/queues-subscription.test.ts
+++ b/packages/wrangler/src/__tests__/queues/queues-subscription.test.ts
@@ -84,7 +84,7 @@ describe("queues subscription", () => {
 				  -v, --version         Show version number  [boolean]
 
 				OPTIONS
-				      --source         The event source type  [string] [required] [choices: "images", "kv", "r2", "superSlurper", "vectorize", "workersAi.model", "workersBuilds.worker", "workflows.workflow"]
+				      --source         The event source type  [string] [required] [choices: "artifacts", "artifacts.repo", "images", "kv", "r2", "superSlurper", "vectorize", "workersAi.model", "workersBuilds.worker", "workflows.workflow"]
 				      --events         Comma-separated list of event types to subscribe to  [string] [required]
 				      --name           Name for the subscription (auto-generated if not provided)  [string]
 				      --enabled        Whether the subscription should be active  [boolean] [default: true]
@@ -187,6 +187,76 @@ describe("queues subscription", () => {
 			`);
 		});
 
+		it("should create a subscription for an Artifacts account source", async ({
+			expect,
+		}) => {
+			const queueNameResolveRequest = mockGetQueueByNameRequest(
+				expectedQueueName,
+				{
+					queue_id: expectedQueueId,
+					queue_name: expectedQueueName,
+					created_on: "",
+					producers: [],
+					consumers: [],
+					producers_total_count: 0,
+					consumers_total_count: 0,
+					modified_on: "",
+				}
+			);
+
+			const createRequest = mockCreateSubscriptionRequest(
+				{
+					name: "testQueue artifacts",
+					enabled: true,
+					source: { type: EventSourceType.ARTIFACTS },
+					events: ["repo.created"],
+				},
+				expectedQueueId
+			);
+
+			await runWrangler(
+				"queues subscription create testQueue --source artifacts --events repo.created"
+			);
+
+			expect(queueNameResolveRequest.count).toEqual(1);
+			expect(createRequest.count).toEqual(1);
+		});
+
+		it("should create a subscription for an Artifacts repository source", async ({
+			expect,
+		}) => {
+			const queueNameResolveRequest = mockGetQueueByNameRequest(
+				expectedQueueName,
+				{
+					queue_id: expectedQueueId,
+					queue_name: expectedQueueName,
+					created_on: "",
+					producers: [],
+					consumers: [],
+					producers_total_count: 0,
+					consumers_total_count: 0,
+					modified_on: "",
+				}
+			);
+
+			const createRequest = mockCreateSubscriptionRequest(
+				{
+					name: "testQueue artifacts.repo",
+					enabled: true,
+					source: { type: EventSourceType.ARTIFACTS_REPO },
+					events: ["pushed"],
+				},
+				expectedQueueId
+			);
+
+			await runWrangler(
+				"queues subscription create testQueue --source artifacts.repo --events pushed"
+			);
+
+			expect(queueNameResolveRequest.count).toEqual(1);
+			expect(createRequest.count).toEqual(1);
+		});
+
 		it("should create subscription with custom name and disabled state", async ({
 			expect,
 		}) => {
@@ -254,7 +324,7 @@ describe("queues subscription", () => {
 				)
 			).rejects.toThrowErrorMatchingInlineSnapshot(`
 				[Error: Invalid values:
-				  Argument: source, Given: "invalid", Choices: "images", "kv", "r2", "superSlurper", "vectorize", "workersAi.model", "workersBuilds.worker", "workflows.workflow"]
+				  Argument: source, Given: "invalid", Choices: "artifacts", "artifacts.repo", "images", "kv", "r2", "superSlurper", "vectorize", "workersAi.model", "workersBuilds.worker", "workflows.workflow"]
 			`);
 		});
 

--- a/packages/wrangler/src/queues/cli/commands/subscription/create.ts
+++ b/packages/wrangler/src/queues/cli/commands/subscription/create.ts
@@ -20,6 +20,12 @@ function parseSourceArgument(
 	}
 ): EventSource {
 	switch (source as EventSourceType) {
+		case EventSourceType.ARTIFACTS:
+			return { type: EventSourceType.ARTIFACTS };
+
+		case EventSourceType.ARTIFACTS_REPO:
+			return { type: EventSourceType.ARTIFACTS_REPO };
+
 		case EventSourceType.IMAGES:
 			return { type: EventSourceType.IMAGES };
 

--- a/packages/wrangler/src/queues/subscription-types.ts
+++ b/packages/wrangler/src/queues/subscription-types.ts
@@ -15,6 +15,8 @@ export interface EventDestination {
 }
 
 export enum EventSourceType {
+	ARTIFACTS = "artifacts",
+	ARTIFACTS_REPO = "artifacts.repo",
 	IMAGES = "images",
 	KV = "kv",
 	R2 = "r2",
@@ -28,6 +30,8 @@ export enum EventSourceType {
 export const EVENT_SOURCE_TYPES = Object.values(EventSourceType);
 
 export type EventSource =
+	| ArtifactsEventSource
+	| ArtifactsRepoEventSource
 	| ImagesEventSource
 	| KvEventSource
 	| R2EventSource
@@ -36,6 +40,14 @@ export type EventSource =
 	| WorkersAiModelEventSource
 	| WorkersBuildsWorkerEventSource
 	| WorkflowsWorkflowEventSource;
+
+export interface ArtifactsEventSource {
+	type: EventSourceType.ARTIFACTS;
+}
+
+export interface ArtifactsRepoEventSource {
+	type: EventSourceType.ARTIFACTS_REPO;
+}
 
 export interface ImagesEventSource {
 	type: EventSourceType.IMAGES;


### PR DESCRIPTION
Allow `wrangler queues subscription create` to target the existing Artifacts Event Subscription sources:

- `artifacts` for account-scoped events
- `artifacts.repo` for repository-scoped events

Previously, Wrangler rejected both values during client-side argument validation even though the Event Subscriptions API accepts them. This adds both source types to Wrangler's typed source union and parser, and verifies the generated API request bodies for each source.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: this exposes source types already supported by the platform and updates Wrangler's built-in help output.

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14721" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->