### PR TITLE
[create-cloudflare] Allow fresh framework releases in E2E tests

### DIFF
--- a/packages/create-cloudflare/e2e/helpers/spawn.ts
+++ b/packages/create-cloudflare/e2e/helpers/spawn.ts
@@ -129,6 +129,8 @@ export const testEnv = {
 	YARN_ENABLE_GLOBAL_CACHE: "false",
 	PNPM_HOME: "./.pnpm",
 	npm_config_cache: "./.npm/cache",
+	// Scaffolded projects intentionally test the latest framework releases.
+	npm_config_minimum_release_age: "0",
 	// unset the VITEST env variable as this causes e2e issues with some frameworks
 	VITEST: undefined,
 };


### PR DESCRIPTION
Prevents the repository's 24-hour `minimumReleaseAge` policy from leaking into disposable projects scaffolded by C3 E2E tests.

These tests intentionally exercise the latest framework releases. The override is scoped to spawned test processes, so installs in the workers-sdk workspace retain the cooldown.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [x] Automated tests not possible - manual testing has been completed as follows: reproduced the parent `pnpm run` to disposable child install with pnpm 10.33; the inherited 1440-minute policy rejected Astro 7.1.0 and the scoped override installed it successfully.
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: this only changes C3's E2E subprocess environment.

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14722" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->