### PR TITLE
[miniflare] Avoid email cleanup race

### DIFF
--- a/.changeset/tidy-cats-rest.md
+++ b/.changeset/tidy-cats-rest.md
@@ -4,4 +4,4 @@
 
 Prevent concurrent Miniflare instances from deleting each other's temporary email sessions
 
-Email session cleanup now atomically removes the shared parent directory only when it is empty, avoiding startup failures when multiple local runtimes use the same project.
+Email session cleanup now removes only the current instance's session directory and leaves the shared parent intact, avoiding startup failures when multiple local runtimes use the same project.

--- a/.changeset/tidy-cats-rest.md
+++ b/.changeset/tidy-cats-rest.md
@@ -1,0 +1,7 @@
+---
+"miniflare": patch
+---
+
+Prevent concurrent Miniflare instances from deleting each other's temporary email sessions
+
+Email session cleanup now atomically removes the shared parent directory only when it is empty, avoiding startup failures when multiple local runtimes use the same project.

--- a/packages/miniflare/src/index.ts
+++ b/packages/miniflare/src/index.ts
@@ -1164,15 +1164,13 @@ export class Miniflare {
 						`Unable to remove email session directory: ${String(e)}`
 					);
 				}
-				// Check if parent directory is now empty and remove it
+				// Only remove the shared parent if it is still empty. This must be atomic
+				// so another Miniflare instance's new session is never removed.
 				try {
-					const entries = fs.readdirSync(emailPaths.parentDir);
-					if (entries.length === 0) {
-						removeDirSync(emailPaths.parentDir);
-					}
+					fs.rmdirSync(emailPaths.parentDir);
 				} catch (e) {
 					this.#log.debug(
-						`Unable to check/remove email parent directory: ${String(e)}`
+						`Unable to remove empty email parent directory: ${String(e)}`
 					);
 				}
 			}
@@ -3439,16 +3437,13 @@ export class Miniflare {
 						`Unable to remove email session directory: ${String(e)}`
 					);
 				}
-				// Check if parent directory is now empty and remove it
+				// Only remove the shared parent if it is still empty. This must be atomic
+				// so another Miniflare instance's new session is never removed.
 				try {
-					const entries = await fs.promises.readdir(emailPaths.parentDir);
-					if (entries.length === 0) {
-						await removeDir(emailPaths.parentDir);
-					}
+					await fs.promises.rmdir(emailPaths.parentDir);
 				} catch (e) {
-					// Parent directory doesn't exist or can't be read, ignore
 					this.#log.debug(
-						`Unable to check/remove email parent directory: ${String(e)}`
+						`Unable to remove empty email parent directory: ${String(e)}`
 					);
 				}
 			}

--- a/packages/miniflare/src/index.ts
+++ b/packages/miniflare/src/index.ts
@@ -1164,15 +1164,6 @@ export class Miniflare {
 						`Unable to remove email session directory: ${String(e)}`
 					);
 				}
-				// Only remove the shared parent if it is still empty. This must be atomic
-				// so another Miniflare instance's new session is never removed.
-				try {
-					fs.rmdirSync(emailPaths.parentDir);
-				} catch (e) {
-					this.#log.debug(
-						`Unable to remove empty email parent directory: ${String(e)}`
-					);
-				}
 			}
 			// Unregister all workers from the dev registry. Note that dispose()
 			// does synchronous cleanup (unregistering workers) then returns a
@@ -3429,21 +3420,11 @@ export class Miniflare {
 				this.#tmpPath
 			);
 			if (emailPaths) {
-				// Remove session directory and wait for completion before checking parent
 				try {
 					await removeDir(emailPaths.sessionDir);
 				} catch (e) {
 					this.#log.debug(
 						`Unable to remove email session directory: ${String(e)}`
-					);
-				}
-				// Only remove the shared parent if it is still empty. This must be atomic
-				// so another Miniflare instance's new session is never removed.
-				try {
-					await fs.promises.rmdir(emailPaths.parentDir);
-				} catch (e) {
-					this.#log.debug(
-						`Unable to remove empty email parent directory: ${String(e)}`
 					);
 				}
 			}

--- a/packages/miniflare/test/plugins/email/index.spec.ts
+++ b/packages/miniflare/test/plugins/email/index.spec.ts
@@ -2100,11 +2100,13 @@ test("disposing does not remove a concurrent email session", async ({
 	);
 	await mkdir(concurrentSessionPath);
 
-	// Simulate another instance creating its session after an empty-directory check.
-	vi.spyOn(fs.promises, "readdir").mockResolvedValueOnce([]);
+	// A separate emptiness check reintroduces the race. Return a stale result so
+	// regressing to read-then-remove would delete the concurrent session.
+	const readdirSpy = vi.spyOn(fs.promises, "readdir").mockResolvedValueOnce([]);
 
 	await mf.dispose();
 
+	expect(readdirSpy).not.toHaveBeenCalled();
 	expect(existsSync(concurrentSessionPath)).toBe(true);
 });
 

--- a/packages/miniflare/test/plugins/email/index.spec.ts
+++ b/packages/miniflare/test/plugins/email/index.spec.ts
@@ -1,5 +1,5 @@
-import { existsSync } from "node:fs";
-import { readFile } from "node:fs/promises";
+import fs, { existsSync } from "node:fs";
+import { mkdir, readFile, readdir } from "node:fs/promises";
 import path from "node:path";
 import {
 	EMAIL_PLUGIN,
@@ -2071,6 +2071,41 @@ test("send_email binding is available from getBindings", async ({ expect }) => {
 	expect(result).toEqual({
 		messageId: synthesizedMessageId(expect, "sender.domain"),
 	});
+});
+
+test("disposing does not remove a concurrent email session", async ({
+	expect,
+}) => {
+	const projectTmpPath = await useProjectTmpPath();
+	const mf = new Miniflare({
+		modules: true,
+		script: "",
+		email: {
+			send_email: [{ name: "SEND_EMAIL" }],
+		},
+		defaultProjectTmpPath: projectTmpPath,
+		compatibilityDate: "2025-03-17",
+	});
+
+	await mf.getBindings();
+
+	const emailParentPath = path.join(projectTmpPath, "email");
+	const [sessionName] = await readdir(emailParentPath);
+	if (sessionName === undefined) {
+		throw new Error("Expected an email session directory");
+	}
+	const concurrentSessionPath = path.join(
+		emailParentPath,
+		"concurrent-session"
+	);
+	await mkdir(concurrentSessionPath);
+
+	// Simulate another instance creating its session after an empty-directory check.
+	vi.spyOn(fs.promises, "readdir").mockResolvedValueOnce([]);
+
+	await mf.dispose();
+
+	expect(existsSync(concurrentSessionPath)).toBe(true);
 });
 
 describe("EMAIL_PLUGIN.getServices", () => {


### PR DESCRIPTION
Prevents one Miniflare instance from deleting another instance's temporary email session when both use the same project.

Email cleanup previously checked whether the shared parent directory was empty and then recursively removed it. A concurrent instance could create its session between those operations. Both asynchronous disposal and the synchronous exit hook now use non-recursive directory removal, which atomically succeeds only while the parent remains empty.

This addresses the `Directory named "email:disk:project" not found` failures seen in parallel `getPlatformProxy` fixture tests.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: this fixes internal temporary-directory cleanup behavior.

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14723" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->