### PR TITLE
[miniflare] Prevent Browser Rendering teardown hangs

### DIFF
--- a/.changeset/tidy-browsers-close.md
+++ b/.changeset/tidy-browsers-close.md
@@ -1,0 +1,7 @@
+---
+"miniflare": patch
+---
+
+Prevent local Browser Rendering teardown from hanging when Chrome does not exit
+
+Miniflare now bounds graceful Chrome shutdown and forcefully terminates the browser process tree when needed, preventing disposal from waiting indefinitely.

--- a/packages/miniflare/src/index.ts
+++ b/packages/miniflare/src/index.ts
@@ -67,6 +67,7 @@ import {
 } from "./plugins";
 import { RPC_PROXY_SERVICE_NAME } from "./plugins/assets/constants";
 import { BROWSER_VERSION } from "./plugins/browser-rendering/browser-version";
+import { closeBrowserProcess } from "./plugins/browser-rendering/process";
 import {
 	CUSTOM_SERVICE_KNOWN_OUTBOUND,
 	CustomServiceKind,
@@ -987,8 +988,11 @@ export class Miniflare {
 	 */
 	#externalPlugins: Map<string, Plugin<z.ZodTypeAny>> = new Map();
 
-	// key is the browser session ID, value is the browser process
-	#browserProcesses: Map<string, Process> = new Map();
+	// key is the browser session ID, value identifies the launched browser
+	#browserProcesses: Map<
+		string,
+		{ browserProcess: Process; wsEndpoint: string }
+	> = new Map();
 
 	readonly #runtime?: Runtime;
 	readonly #removeExitHook?: () => void;
@@ -1664,22 +1668,28 @@ export class Miniflare {
 				browserProcess.nodeProcess.on("exit", () => {
 					this.#browserProcesses.delete(sessionId);
 				});
-				this.#browserProcesses.set(sessionId, browserProcess);
+				this.#browserProcesses.set(sessionId, {
+					browserProcess,
+					wsEndpoint,
+				});
 				response = Response.json({ wsEndpoint, sessionId, startTime });
 			} else if (url.pathname === "/browser/status") {
 				const sessionId = url.searchParams.get("sessionId");
 				assert(sessionId !== null, "Missing sessionId query parameter");
-				const process = this.#browserProcesses.get(sessionId);
-				response = new Response(null, { status: process ? 200 : 410 });
+				const browser = this.#browserProcesses.get(sessionId);
+				response = new Response(null, { status: browser ? 200 : 410 });
 			} else if (url.pathname === "/browser/close") {
 				const sessionId = url.searchParams.get("sessionId");
 				assert(sessionId !== null, "Missing sessionId query parameter");
-				const browserProcess = this.#browserProcesses.get(sessionId);
-				if (!browserProcess) {
+				const browser = this.#browserProcesses.get(sessionId);
+				if (!browser) {
 					response = new Response("Session not found", { status: 404 });
 				} else {
 					this.#browserProcesses.delete(sessionId);
-					await browserProcess.close().catch(() => {
+					await closeBrowserProcess(
+						browser.browserProcess,
+						browser.wsEndpoint
+					).catch(() => {
 						// oh well, process might already be dead
 					});
 					response = new Response(null, { status: 200 });
@@ -2677,14 +2687,12 @@ export class Miniflare {
 	}
 
 	async #closeBrowserProcesses() {
+		const browsers = Array.from(this.#browserProcesses.values());
+		this.#browserProcesses.clear();
 		await Promise.all(
-			Array.from(this.#browserProcesses.values()).map((process) =>
-				process.close()
+			browsers.map(({ browserProcess, wsEndpoint }) =>
+				closeBrowserProcess(browserProcess, wsEndpoint)
 			)
-		);
-		assert(
-			this.#browserProcesses.size === 0,
-			"Not all browser processes were closed"
 		);
 	}
 

--- a/packages/miniflare/src/plugins/browser-rendering/process.ts
+++ b/packages/miniflare/src/plugins/browser-rendering/process.ts
@@ -1,0 +1,67 @@
+import WebSocket from "ws";
+import type { Process } from "@puppeteer/browsers";
+
+const BROWSER_CLOSE_TIMEOUT = 5_000;
+
+type BrowserProcess = Pick<Process, "hasClosed" | "kill">;
+
+function waitForGracefulClose(
+	browserProcess: BrowserProcess,
+	wsEndpoint: string,
+	timeoutMs: number
+): Promise<boolean> {
+	return new Promise((resolve) => {
+		const socket = new WebSocket(wsEndpoint);
+		const timeout = setTimeout(() => finish(false), timeoutMs);
+		let finished = false;
+
+		function finish(closed: boolean) {
+			if (finished) return;
+			finished = true;
+			clearTimeout(timeout);
+			socket.terminate();
+			resolve(closed);
+		}
+
+		void browserProcess.hasClosed().then(
+			() => finish(true),
+			() => finish(false)
+		);
+		socket.once("open", () => {
+			socket.send(
+				JSON.stringify({ id: 1, method: "Browser.close" }),
+				(error) => {
+					if (error) finish(false);
+				}
+			);
+		});
+		socket.once("error", () => finish(false));
+	});
+}
+
+async function waitForExit(
+	browserProcess: BrowserProcess,
+	timeoutMs: number
+): Promise<void> {
+	let timeout: NodeJS.Timeout | undefined;
+	await Promise.race([
+		browserProcess.hasClosed().catch(() => {}),
+		new Promise<void>((resolve) => {
+			timeout = setTimeout(resolve, timeoutMs);
+		}),
+	]);
+	clearTimeout(timeout);
+}
+
+export async function closeBrowserProcess(
+	browserProcess: BrowserProcess,
+	wsEndpoint: string,
+	timeoutMs = BROWSER_CLOSE_TIMEOUT
+): Promise<void> {
+	if (await waitForGracefulClose(browserProcess, wsEndpoint, timeoutMs)) return;
+
+	// Process.kill() terminates the whole process tree with taskkill on Windows
+	// and SIGKILL on the detached process group on POSIX systems.
+	browserProcess.kill();
+	await waitForExit(browserProcess, timeoutMs);
+}

--- a/packages/miniflare/test/plugins/browser/process.spec.ts
+++ b/packages/miniflare/test/plugins/browser/process.spec.ts
@@ -1,0 +1,63 @@
+import { once } from "node:events";
+import { onTestFinished, test, vi } from "vitest";
+import { WebSocketServer } from "ws";
+import { closeBrowserProcess } from "../../../src/plugins/browser-rendering/process";
+
+test("gracefully closes Chrome over CDP", async ({ expect }) => {
+	const closed = Promise.withResolvers<void>();
+	const browserProcess = {
+		hasClosed: vi.fn(() => closed.promise),
+		kill: vi.fn(),
+	};
+	const server = new WebSocketServer({ port: 0 });
+	onTestFinished(
+		() => new Promise<void>((resolve) => server.close(() => resolve()))
+	);
+	await once(server, "listening");
+	const address = server.address();
+	if (typeof address === "string" || address === null) {
+		throw new Error("Expected WebSocket server to listen on a TCP port");
+	}
+	server.on("connection", (socket) => {
+		socket.once("message", (data) => {
+			expect(JSON.parse(data.toString())).toEqual({
+				id: 1,
+				method: "Browser.close",
+			});
+			closed.resolve();
+		});
+	});
+
+	await closeBrowserProcess(
+		browserProcess,
+		`ws://127.0.0.1:${address.port}`,
+		100
+	);
+
+	expect(browserProcess.kill).not.toHaveBeenCalled();
+});
+
+test("force kills Chrome when graceful close times out", async ({ expect }) => {
+	const closed = Promise.withResolvers<void>();
+	const browserProcess = {
+		hasClosed: vi.fn(() => closed.promise),
+		kill: vi.fn(),
+	};
+	const server = new WebSocketServer({ port: 0 });
+	onTestFinished(
+		() => new Promise<void>((resolve) => server.close(() => resolve()))
+	);
+	await once(server, "listening");
+	const address = server.address();
+	if (typeof address === "string" || address === null) {
+		throw new Error("Expected WebSocket server to listen on a TCP port");
+	}
+
+	await closeBrowserProcess(
+		browserProcess,
+		`ws://127.0.0.1:${address.port}`,
+		10
+	);
+
+	expect(browserProcess.kill).toHaveBeenCalledOnce();
+});


### PR DESCRIPTION
Bound Browser Rendering process shutdown so Miniflare disposal cannot wait indefinitely for Chrome. Miniflare first requests graceful shutdown over CDP, then forcefully terminates the browser process tree if Chrome does not exit within the timeout.

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: This fixes internal local Browser Rendering process cleanup without changing the public API.

Focused process-shutdown tests, Miniflare build, type checks, lint, and formatting pass. The full Browser Rendering suite could not launch Chrome locally because `child_process.spawn` returned macOS `Unknown system error -88`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14727" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->