### PR TITLE
[wrangler] Wait for workers.dev propagation in E2Es

### DIFF
--- a/packages/wrangler/e2e/deployments.test.ts
+++ b/packages/wrangler/e2e/deployments.test.ts
@@ -17,8 +17,9 @@ import { generateResourceName } from "./helpers/generate-resource-name";
 import { normalizeOutput, validateAssetUploadLogs } from "./helpers/normalize";
 import { retry } from "./helpers/retry";
 import { waitForLong } from "./helpers/wait-for";
+import { waitForWorkersDev } from "./helpers/wait-for-workers-dev";
 
-const TIMEOUT = 50_000;
+const TIMEOUT = 90_000;
 
 describe.skipIf(!CLOUDFLARE_ACCOUNT_ID)(
 	"deployments",
@@ -61,13 +62,8 @@ describe.skipIf(!CLOUDFLARE_ACCOUNT_ID)(
 
 			const deployedUrl = getDeployedUrl(output);
 
-			await waitForLong(
-				async () => {
-					const response = await fetch(deployedUrl);
-					expect(await response.text()).toEqual("Hello World!");
-				},
-				{ timeout: 30_000 }
-			);
+			const response = await waitForWorkersDev(deployedUrl);
+			expect(await response.text()).toEqual("Hello World!");
 		});
 
 		it("lists 1 deployment", async ({ expect }) => {
@@ -98,13 +94,8 @@ describe.skipIf(!CLOUDFLARE_ACCOUNT_ID)(
 
 			const deployedUrl = getDeployedUrl(output);
 
-			await waitForLong(
-				async () => {
-					const response = await fetch(deployedUrl);
-					expect(await response.text()).toEqual("Updated Worker!");
-				},
-				{ timeout: 30_000 }
-			);
+			const response = await waitForWorkersDev(deployedUrl);
+			expect(await response.text()).toEqual("Updated Worker!");
 		});
 
 		it("lists 2 deployments", async ({ expect }) => {

--- a/packages/wrangler/e2e/deployments.test.ts
+++ b/packages/wrangler/e2e/deployments.test.ts
@@ -62,7 +62,10 @@ describe.skipIf(!CLOUDFLARE_ACCOUNT_ID)(
 
 			const deployedUrl = getDeployedUrl(output);
 
-			const response = await waitForWorkersDev(deployedUrl);
+			const response = await waitForWorkersDev(
+				deployedUrl,
+				async (candidate) => (await candidate.clone().text()) === "Hello World!"
+			);
 			expect(await response.text()).toEqual("Hello World!");
 		});
 
@@ -94,7 +97,11 @@ describe.skipIf(!CLOUDFLARE_ACCOUNT_ID)(
 
 			const deployedUrl = getDeployedUrl(output);
 
-			const response = await waitForWorkersDev(deployedUrl);
+			const response = await waitForWorkersDev(
+				deployedUrl,
+				async (candidate) =>
+					(await candidate.clone().text()) === "Updated Worker!"
+			);
 			expect(await response.text()).toEqual("Updated Worker!");
 		});
 

--- a/packages/wrangler/e2e/helpers/e2e-wrangler-test.ts
+++ b/packages/wrangler/e2e/helpers/e2e-wrangler-test.ts
@@ -1,7 +1,6 @@
 import assert from "node:assert";
 import crypto from "node:crypto";
 import { cp } from "node:fs/promises";
-import { setTimeout } from "node:timers/promises";
 import { fetch } from "undici";
 import { onTestFinished } from "vitest";
 import { E2E_ACCOUNT_WORKERS_DEV_DOMAIN } from "./account-id";
@@ -12,7 +11,7 @@ import {
 } from "./cert";
 import { generateResourceName } from "./generate-resource-name";
 import { makeRoot, removeFiles, seed } from "./setup";
-import { waitForLong } from "./wait-for";
+import { waitForWorkersDev } from "./wait-for-workers-dev";
 import {
 	MINIFLARE_IMPORT,
 	runWrangler,
@@ -299,13 +298,11 @@ export class WranglerE2ETestHelper {
 		await this.run(
 			`wrangler deploy ${entryPoint} --name ${workerName} ${configOption} --compatibility-date 2025-01-01`
 		);
-		await waitForLong(async () => {
-			const response = await fetch(deployedUrl);
-			assert(
-				response.status === 200,
-				`Expected status 200 but got ${response.status}`
-			);
-		});
+		const response = await waitForWorkersDev(deployedUrl);
+		assert(
+			response.status === 200,
+			`Expected status 200 but got ${response.status}`
+		);
 	}
 
 	/**
@@ -362,19 +359,6 @@ export class WranglerE2ETestHelper {
 		const deployedUrl = stdout.match(urlMatcher)?.groups?.url;
 		assert(deployedUrl, `Cannot find URL in ${JSON.stringify(stdout)}`);
 
-		// Wait a couple of seconds before we start blasting the worker with requests
-		// to allow it to complete deployment.
-		await setTimeout(2_000);
-
-		// Wait for the worker to become available
-		await waitForLong(async () => {
-			const response = await fetch(deployedUrl);
-			assert(
-				response.status === 200,
-				`Expected status 200 but got ${response.status}`
-			);
-		});
-
 		const cleanup = async () => {
 			await this.bestEffortRun(`wrangler delete --name ${workerName} --force`);
 		};
@@ -383,15 +367,30 @@ export class WranglerE2ETestHelper {
 			try {
 				this.onTeardown(cleanup, 15_000);
 			} catch (e) {
+				await cleanup();
 				throw new Error(
 					"Failed to register cleanup for worker.\nPerhaps you called this outside an `it` block?\nIf so, pass `cleanOnTestFinished: false` and then use the returned `cleanup` helper yourself",
 					{ cause: e }
 				);
 			}
-			return { deployedUrl, stdout };
-		} else {
-			return { deployedUrl, stdout, cleanup };
 		}
+
+		try {
+			const response = await waitForWorkersDev(deployedUrl);
+			assert(
+				response.status === 200,
+				`Expected status 200 but got ${response.status}`
+			);
+		} catch (error) {
+			if (!cleanOnTestFinished) {
+				await cleanup();
+			}
+			throw error;
+		}
+
+		return cleanOnTestFinished
+			? { deployedUrl, stdout }
+			: { deployedUrl, stdout, cleanup };
 	}
 
 	/** Create an AI Search instance (backed by an R2 bucket) in the default namespace and clean both up during tear-down. */

--- a/packages/wrangler/e2e/helpers/wait-for-workers-dev.test.ts
+++ b/packages/wrangler/e2e/helpers/wait-for-workers-dev.test.ts
@@ -1,0 +1,56 @@
+import assert from "node:assert";
+import { createServer } from "node:http";
+import { afterEach, it } from "vitest";
+import { waitForWorkersDev } from "./wait-for-workers-dev";
+import type { RequestListener, Server } from "node:http";
+
+let server: Server | undefined;
+
+afterEach(async () => {
+	if (server) {
+		server.closeAllConnections();
+		await new Promise<void>((resolve, reject) => {
+			server?.close((error) => (error ? reject(error) : resolve()));
+		});
+		server = undefined;
+	}
+});
+
+it("retries workers.dev 404 responses", async ({ expect }) => {
+	let requestCount = 0;
+	const url = await listen((_request, response) => {
+		requestCount++;
+		response.writeHead(requestCount === 1 ? 404 : 200).end();
+	});
+
+	const response = await waitForWorkersDev(url);
+
+	expect(response.status).toBe(200);
+	expect(requestCount).toBe(2);
+});
+
+it("returns non-404 application failures without retrying", async ({
+	expect,
+}) => {
+	let requestCount = 0;
+	const url = await listen((_request, response) => {
+		requestCount++;
+		response.writeHead(500).end();
+	});
+
+	const response = await waitForWorkersDev(url);
+
+	expect(response.status).toBe(500);
+	expect(requestCount).toBe(1);
+});
+
+async function listen(handler: RequestListener): Promise<string> {
+	server = createServer(handler);
+	await new Promise<void>((resolve, reject) => {
+		server?.once("error", reject);
+		server?.listen(0, "127.0.0.1", resolve);
+	});
+	const address = server.address();
+	assert(address && typeof address !== "string");
+	return `http://127.0.0.1:${address.port}`;
+}

--- a/packages/wrangler/e2e/helpers/wait-for-workers-dev.test.ts
+++ b/packages/wrangler/e2e/helpers/wait-for-workers-dev.test.ts
@@ -29,19 +29,48 @@ it("retries workers.dev 404 responses", async ({ expect }) => {
 	expect(requestCount).toBe(2);
 });
 
-it("returns non-404 application failures without retrying", async ({
+it("retries workers.dev 5xx responses", async ({ expect }) => {
+	let requestCount = 0;
+	const url = await listen((_request, response) => {
+		requestCount++;
+		response.writeHead(requestCount === 1 ? 503 : 200).end();
+	});
+
+	const response = await waitForWorkersDev(url);
+
+	expect(response.status).toBe(200);
+	expect(requestCount).toBe(2);
+});
+
+it("returns non-retryable application failures", async ({ expect }) => {
+	let requestCount = 0;
+	const url = await listen((_request, response) => {
+		requestCount++;
+		response.writeHead(400).end();
+	});
+
+	const response = await waitForWorkersDev(url);
+
+	expect(response.status).toBe(400);
+	expect(requestCount).toBe(1);
+});
+
+it("retries until the response satisfies the readiness predicate", async ({
 	expect,
 }) => {
 	let requestCount = 0;
 	const url = await listen((_request, response) => {
 		requestCount++;
-		response.writeHead(500).end();
+		response.end(requestCount === 1 ? "old" : "new");
 	});
 
-	const response = await waitForWorkersDev(url);
+	const response = await waitForWorkersDev(
+		url,
+		async (candidate) => (await candidate.clone().text()) === "new"
+	);
 
-	expect(response.status).toBe(500);
-	expect(requestCount).toBe(1);
+	expect(await response.text()).toBe("new");
+	expect(requestCount).toBe(2);
 });
 
 async function listen(handler: RequestListener): Promise<string> {

--- a/packages/wrangler/e2e/helpers/wait-for-workers-dev.ts
+++ b/packages/wrangler/e2e/helpers/wait-for-workers-dev.ts
@@ -1,11 +1,14 @@
 import { setTimeout } from "node:timers/promises";
-import { fetch } from "undici";
+import { fetch, type Response } from "undici";
 
 const WORKERS_DEV_PROPAGATION_TIMEOUT = 60_000;
 const INITIAL_RETRY_DELAY = 500;
 const MAX_RETRY_DELAY = 5_000;
 
-export async function waitForWorkersDev(url: string) {
+export async function waitForWorkersDev(
+	url: string,
+	isReady: (response: Response) => boolean | Promise<boolean> = () => true
+) {
 	const deadline = Date.now() + WORKERS_DEV_PROPAGATION_TIMEOUT;
 	let retryDelay = INITIAL_RETRY_DELAY;
 	let lastError: unknown;
@@ -15,11 +18,17 @@ export async function waitForWorkersDev(url: string) {
 			const response = await fetch(url, {
 				signal: AbortSignal.timeout(deadline - Date.now()),
 			});
-			if (response.status !== 404) {
+			if (
+				response.status !== 404 &&
+				response.status < 500 &&
+				(await isReady(response))
+			) {
 				return response;
 			}
 			await response.body?.cancel();
-			lastError = new Error(`Workers.dev returned 404 for ${url}`);
+			lastError = new Error(
+				`Workers.dev returned ${response.status} before it was ready for ${url}`
+			);
 		} catch (error) {
 			lastError = error;
 		}

--- a/packages/wrangler/e2e/helpers/wait-for-workers-dev.ts
+++ b/packages/wrangler/e2e/helpers/wait-for-workers-dev.ts
@@ -1,0 +1,37 @@
+import { setTimeout } from "node:timers/promises";
+import { fetch } from "undici";
+
+const WORKERS_DEV_PROPAGATION_TIMEOUT = 60_000;
+const INITIAL_RETRY_DELAY = 500;
+const MAX_RETRY_DELAY = 5_000;
+
+export async function waitForWorkersDev(url: string) {
+	const deadline = Date.now() + WORKERS_DEV_PROPAGATION_TIMEOUT;
+	let retryDelay = INITIAL_RETRY_DELAY;
+	let lastError: unknown;
+
+	while (Date.now() < deadline) {
+		try {
+			const response = await fetch(url, {
+				signal: AbortSignal.timeout(deadline - Date.now()),
+			});
+			if (response.status !== 404) {
+				return response;
+			}
+			await response.body?.cancel();
+			lastError = new Error(`Workers.dev returned 404 for ${url}`);
+		} catch (error) {
+			lastError = error;
+		}
+
+		const remaining = deadline - Date.now();
+		if (remaining > 0) {
+			await setTimeout(Math.min(retryDelay, remaining));
+			retryDelay = Math.min(retryDelay * 2, MAX_RETRY_DELAY);
+		}
+	}
+
+	throw new Error(`Timed out waiting for ${url} to propagate`, {
+		cause: lastError,
+	});
+}

--- a/packages/wrangler/e2e/provision.test.ts
+++ b/packages/wrangler/e2e/provision.test.ts
@@ -6,7 +6,7 @@ import { WranglerE2ETestHelper } from "./helpers/e2e-wrangler-test";
 import { fetchText } from "./helpers/fetch-text";
 import { generateResourceName } from "./helpers/generate-resource-name";
 import { normalizeOutput } from "./helpers/normalize";
-import { waitForLong } from "./helpers/wait-for";
+import { waitForWorkersDev } from "./helpers/wait-for-workers-dev";
 
 const TIMEOUT = 500_000;
 const normalize = (str: string) => {
@@ -122,13 +122,8 @@ describe.skipIf(!CLOUDFLARE_ACCOUNT_ID)(
 			assert(d1Match?.groups);
 			d1Id = d1Match.groups.d1;
 
-			await waitForLong(
-				async () => {
-					const response = await fetch(deployedUrl);
-					expect(await response.text()).toEqual("Hello World!");
-				},
-				{ timeout: 30_000 }
-			);
+			const response = await waitForWorkersDev(deployedUrl);
+			expect(await response.text()).toEqual("Hello World!");
 		});
 
 		it("can inherit bindings on re-deploy and won't re-provision", async ({
@@ -151,13 +146,8 @@ describe.skipIf(!CLOUDFLARE_ACCOUNT_ID)(
 				Current Version ID: 00000000-0000-0000-0000-000000000000"
 			`);
 
-			await waitForLong(
-				async () => {
-					const response = await fetch(deployedUrl);
-					expect(await response.text()).toEqual("Hello World!");
-				},
-				{ timeout: 30_000 }
-			);
+			const response = await waitForWorkersDev(deployedUrl);
+			expect(await response.text()).toEqual("Hello World!");
 		});
 		it("can inspect current bindings", async ({ expect }) => {
 			const versionsRaw = await helper.run(`wrangler versions list --json`);

--- a/packages/wrangler/e2e/provision.test.ts
+++ b/packages/wrangler/e2e/provision.test.ts
@@ -122,7 +122,10 @@ describe.skipIf(!CLOUDFLARE_ACCOUNT_ID)(
 			assert(d1Match?.groups);
 			d1Id = d1Match.groups.d1;
 
-			const response = await waitForWorkersDev(deployedUrl);
+			const response = await waitForWorkersDev(
+				deployedUrl,
+				async (candidate) => (await candidate.clone().text()) === "Hello World!"
+			);
 			expect(await response.text()).toEqual("Hello World!");
 		});
 
@@ -146,7 +149,10 @@ describe.skipIf(!CLOUDFLARE_ACCOUNT_ID)(
 				Current Version ID: 00000000-0000-0000-0000-000000000000"
 			`);
 
-			const response = await waitForWorkersDev(deployedUrl);
+			const response = await waitForWorkersDev(
+				deployedUrl,
+				async (candidate) => (await candidate.clone().text()) === "Hello World!"
+			);
 			expect(await response.text()).toEqual("Hello World!");
 		});
 		it("can inspect current bindings", async ({ expect }) => {


### PR DESCRIPTION
Centralize workers.dev propagation polling for Wrangler E2E tests. The helper retries 404 and transport failures with bounded exponential backoff, returns application failures immediately, and ensures deployed workers are registered for cleanup before readiness polling begins.

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: This only hardens E2E deployment readiness and cleanup behavior.

Focused readiness helper tests, Wrangler dependency build, E2E TypeScript checks, scoped lint, and formatting pass. An accidental broader E2E run passed the new tests but hit an unrelated Python dev readiness timeout.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14728" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->