### PR TITLE
[wrangler] Use default readiness timeout in local dev E2Es

### DIFF
--- a/packages/wrangler/e2e/assets-multiworker.test.ts
+++ b/packages/wrangler/e2e/assets-multiworker.test.ts
@@ -18,12 +18,12 @@ async function startWorkersDevRegistry(
 	const workerA = helper.runLongLived(wranglerDev, {
 		cwd: regularWorkerFirst ? assetWorker : regularWorker,
 	});
-	await workerA.waitForReady(5_000);
+	await workerA.waitForReady();
 
 	const workerB = helper.runLongLived(wranglerDev, {
 		cwd: regularWorkerFirst ? regularWorker : assetWorker,
 	});
-	const { url } = await workerB.waitForReady(5_000);
+	const { url } = await workerB.waitForReady();
 
 	return url;
 }
@@ -39,7 +39,7 @@ async function startWorkersMultiworker(
 		`${wranglerDev} -c wrangler.toml -c ${regularWorkerFirst ? assetWorker : regularWorker}/wrangler.toml`,
 		{ cwd: regularWorkerFirst ? regularWorker : assetWorker }
 	);
-	const { url } = await worker.waitForReady(5_000);
+	const { url } = await worker.waitForReady();
 	return url;
 }
 

--- a/packages/wrangler/e2e/dev-registry.test.ts
+++ b/packages/wrangler/e2e/dev-registry.test.ts
@@ -141,7 +141,7 @@ describe.each([{ cmd: "wrangler dev" }])("dev registry $cmd", ({ cmd }) => {
 		it("can fetch b", async ({ expect }) => {
 			const worker = helper.runLongLived(cmd, { cwd: b });
 
-			const { url } = await worker.waitForReady(5_000);
+			const { url } = await worker.waitForReady();
 
 			await expect(fetch(url).then((r) => r.text())).resolves.toBe(
 				"hello world"
@@ -151,10 +151,10 @@ describe.each([{ cmd: "wrangler dev" }])("dev registry $cmd", ({ cmd }) => {
 		it("can fetch b through a (start b, start a)", async ({ expect }) => {
 			const workerB = helper.runLongLived(cmd, { cwd: b });
 			// We don't need b's URL, but ensure that b starts up before a
-			await workerB.waitForReady(5_000);
+			await workerB.waitForReady();
 
 			const workerA = helper.runLongLived(cmd, { cwd: a });
-			const { url } = await workerA.waitForReady(5_000);
+			const { url } = await workerA.waitForReady();
 
 			await waitForLong(() =>
 				expect(fetchText(url)).resolves.toBe("hello world")
@@ -169,10 +169,10 @@ describe.each([{ cmd: "wrangler dev" }])("dev registry $cmd", ({ cmd }) => {
 
 		it("can fetch b through a (start a, start b)", async ({ expect }) => {
 			const workerA = helper.runLongLived(cmd, { cwd: a });
-			const { url } = await workerA.waitForReady(5_000);
+			const { url } = await workerA.waitForReady();
 
 			const workerB = helper.runLongLived(cmd, { cwd: b });
-			await workerB.waitForReady(5_000);
+			await workerB.waitForReady();
 
 			await waitForLong(() =>
 				expect(fetchText(url)).resolves.toBe("hello world")
@@ -200,11 +200,11 @@ describe.each([{ cmd: "wrangler dev" }])("dev registry $cmd", ({ cmd }) => {
 		}) => {
 			const workerC = helper.runLongLived(cmd, { cwd: c });
 			// We don't need c's URL, but ensure that c starts up before a
-			await workerC.waitForReady(5_000);
+			await workerC.waitForReady();
 
 			const workerA = helper.runLongLived(cmd, { cwd: a });
 
-			const { url } = await workerA.waitForReady(5_000);
+			const { url } = await workerA.waitForReady();
 
 			await waitForLong(() =>
 				expect(fetchText(`${url}/service`)).resolves.toBe(
@@ -218,11 +218,11 @@ describe.each([{ cmd: "wrangler dev" }])("dev registry $cmd", ({ cmd }) => {
 			"can fetch service worker c through a (start a, start c)",
 			async ({ expect }) => {
 				const workerA = helper.runLongLived(cmd, { cwd: a });
-				const { url } = await workerA.waitForReady(5_000);
+				const { url } = await workerA.waitForReady();
 
 				const workerC = helper.runLongLived(cmd, { cwd: c });
 
-				await workerC.waitForReady(5_000);
+				await workerC.waitForReady();
 
 				await waitForLong(() =>
 					expect(fetchText(`${url}/service`)).resolves.toBe(
@@ -273,14 +273,14 @@ describe.each([{ cmd: "wrangler dev" }])("dev registry $cmd", ({ cmd }) => {
 
 		it("can fetch a without b running", async ({ expect }) => {
 			const workerA = helper.runLongLived(cmd, { cwd: a });
-			const { url } = await workerA.waitForReady(5_000);
+			const { url } = await workerA.waitForReady();
 
 			await expect(fetchText(`${url}`)).resolves.toBe("hello from a");
 		});
 
 		it("tail event sent to b", async ({ expect }) => {
 			const workerA = helper.runLongLived(cmd, { cwd: a });
-			const { url } = await workerA.waitForReady(5_000);
+			const { url } = await workerA.waitForReady();
 
 			const workerB = helper.runLongLived(cmd, { cwd: b });
 
@@ -321,7 +321,7 @@ describe.each([{ cmd: "wrangler dev" }])("dev registry $cmd", ({ cmd }) => {
 		it("can fetch DO through a", async ({ expect }) => {
 			const worker = helper.runLongLived(cmd, { cwd: a });
 
-			const { url } = await worker.waitForReady(5_000);
+			const { url } = await worker.waitForReady();
 
 			await expect(
 				fetchJson(`${url}/do`, {
@@ -336,11 +336,11 @@ describe.each([{ cmd: "wrangler dev" }])("dev registry $cmd", ({ cmd }) => {
 			"can fetch remote DO attached to a through b (start b, start a)",
 			async ({ expect }) => {
 				const workerB = helper.runLongLived(cmd, { cwd: b });
-				const { url } = await workerB.waitForReady(5_000);
+				const { url } = await workerB.waitForReady();
 
 				const workerA = helper.runLongLived(cmd, { cwd: a });
 
-				await workerA.waitForReady(5_000);
+				await workerA.waitForReady();
 
 				await expect(
 					fetchJson(`${url}/do`, {
@@ -356,11 +356,11 @@ describe.each([{ cmd: "wrangler dev" }])("dev registry $cmd", ({ cmd }) => {
 			expect,
 		}) => {
 			const workerA = helper.runLongLived(cmd, { cwd: a });
-			await workerA.waitForReady(5_000);
+			await workerA.waitForReady();
 
 			const workerB = helper.runLongLived(cmd, { cwd: b });
 
-			const { url } = await workerB.waitForReady(5_000);
+			const { url } = await workerB.waitForReady();
 
 			await waitForLong(() =>
 				expect(
@@ -400,7 +400,7 @@ describe.each([{ cmd: "wrangler dev" }])("dev registry $cmd", ({ cmd }) => {
 		it("can fetch b", async ({ expect }) => {
 			const worker = helper.runLongLived(cmd, { cwd: b });
 
-			const { url } = await worker.waitForReady(5_000);
+			const { url } = await worker.waitForReady();
 
 			await expect(fetch(url).then((r) => r.text())).resolves.toBe(
 				"hello world"
@@ -413,7 +413,7 @@ describe.each([{ cmd: "wrangler dev" }])("dev registry $cmd", ({ cmd }) => {
 				{ cwd: a }
 			);
 
-			const { url } = await worker.waitForReady(5_000);
+			const { url } = await worker.waitForReady();
 
 			await expect(fetch(url).then((r) => r.text())).resolves.toBe(
 				"Hello from Pages"
@@ -423,13 +423,13 @@ describe.each([{ cmd: "wrangler dev" }])("dev registry $cmd", ({ cmd }) => {
 		it("can fetch b through a (start b, start a)", async ({ expect }) => {
 			const workerB = helper.runLongLived(cmd, { cwd: b });
 			// We don't need b's URL, but ensure that b starts up before a
-			await workerB.waitForReady(5_000);
+			await workerB.waitForReady();
 
 			const workerA = helper.runLongLived(
 				`${cmd.replace("wrangler dev", "wrangler pages dev")}`,
 				{ cwd: a }
 			);
-			const { url } = await workerA.waitForReady(5_000);
+			const { url } = await workerA.waitForReady();
 
 			await waitForLong(() =>
 				expect(fetchText(`${url}/service`)).resolves.toBe("hello world")
@@ -447,10 +447,10 @@ describe.each([{ cmd: "wrangler dev" }])("dev registry $cmd", ({ cmd }) => {
 				`${cmd.replace("wrangler dev", "wrangler pages dev")}`,
 				{ cwd: a }
 			);
-			const { url } = await workerA.waitForReady(5_000);
+			const { url } = await workerA.waitForReady();
 
 			const workerB = helper.runLongLived(cmd, { cwd: b });
-			await workerB.waitForReady(5_000);
+			await workerB.waitForReady();
 
 			await waitForLong(() =>
 				expect(fetchText(`${url}/service`)).resolves.toBe("hello world")
@@ -468,10 +468,10 @@ describe.each([{ cmd: "wrangler dev" }])("dev registry $cmd", ({ cmd }) => {
 				`${cmd.replace("wrangler dev", "wrangler pages dev")} dist --service BEE=${workerName2}`,
 				{ cwd: a }
 			);
-			const { url } = await workerA.waitForReady(5_000);
+			const { url } = await workerA.waitForReady();
 
 			const workerB = helper.runLongLived(cmd, { cwd: b });
-			await workerB.waitForReady(5_000);
+			await workerB.waitForReady();
 
 			await waitForLong(() =>
 				expect(fetchText(`${url}/service`)).resolves.toBe("hello world")

--- a/packages/wrangler/e2e/multiworker-dev.test.ts
+++ b/packages/wrangler/e2e/multiworker-dev.test.ts
@@ -189,7 +189,7 @@ describe("multiworker", () => {
 		it("can fetch b", async ({ expect }) => {
 			const worker = helper.runLongLived(`wrangler dev`, { cwd: b });
 
-			const { url } = await worker.waitForReady(5_000);
+			const { url } = await worker.waitForReady();
 
 			await expect(fetch(url).then((r) => r.text())).resolves.toBe(
 				"hello world"
@@ -201,7 +201,7 @@ describe("multiworker", () => {
 				`wrangler dev -c wrangler.toml -c ${b}/wrangler.toml`,
 				{ cwd: a }
 			);
-			const { url } = await workerA.waitForReady(5_000);
+			const { url } = await workerA.waitForReady();
 
 			await waitForLong(
 				async () => await expect(fetchText(url)).resolves.toBe("hello world")
@@ -215,7 +215,7 @@ describe("multiworker", () => {
 				`wrangler dev -c wrangler.toml -c ${b}/wrangler.toml`,
 				{ cwd: a }
 			);
-			const { url } = await workerA.waitForReady(5_000);
+			const { url } = await workerA.waitForReady();
 
 			await waitForLong(
 				async () => await expect(fetchText(`${url}/count`)).resolves.toBe("6")
@@ -227,7 +227,7 @@ describe("multiworker", () => {
 				`wrangler dev -c wrangler.toml -c ${b}/wrangler.toml`,
 				{ cwd: a }
 			);
-			const { url } = await workerA.waitForReady(5_000);
+			const { url } = await workerA.waitForReady();
 
 			await waitForLong(async () => {
 				const response = await fetch(`${url}/props`);
@@ -260,7 +260,7 @@ describe("multiworker", () => {
 				{ cwd: a }
 			);
 
-			const { url } = await workerA.waitForReady(5_000);
+			const { url } = await workerA.waitForReady();
 
 			await waitForLong(
 				async () =>
@@ -291,7 +291,7 @@ describe("multiworker", () => {
 				`wrangler dev -c wrangler.toml -c ${c}/wrangler.toml`,
 				{ cwd: a }
 			);
-			const { url } = await workerA.waitForReady(5_000);
+			const { url } = await workerA.waitForReady();
 
 			await waitForLong(
 				async () =>
@@ -328,7 +328,7 @@ describe("multiworker", () => {
 		it("can fetch DO through a", async ({ expect }) => {
 			const worker = helper.runLongLived(`wrangler dev`, { cwd: a });
 
-			const { url } = await worker.waitForReady(5_000);
+			const { url } = await worker.waitForReady();
 
 			await expect(
 				fetchJson(`${url}/do`, {
@@ -344,7 +344,7 @@ describe("multiworker", () => {
 				`wrangler dev -c wrangler.toml -c ${a}/wrangler.toml`,
 				{ cwd: b }
 			);
-			const { url } = await workerB.waitForReady(5_000);
+			const { url } = await workerB.waitForReady();
 
 			await expect(
 				fetchJson(`${url}/do`, {
@@ -362,7 +362,7 @@ describe("multiworker", () => {
 				`wrangler dev -c wrangler.toml -c ${a}/wrangler.toml`,
 				{ cwd: b }
 			);
-			const { url } = await workerB.waitForReady(5_000);
+			const { url } = await workerB.waitForReady();
 
 			await waitForLong(
 				async () =>
@@ -414,7 +414,7 @@ describe("multiworker", () => {
 		it("can fetch a without b running", async ({ expect }) => {
 			const worker = helper.runLongLived(`wrangler dev`, { cwd: a });
 
-			const { url } = await worker.waitForReady(5_000);
+			const { url } = await worker.waitForReady();
 
 			await expect(fetchText(`${url}`)).resolves.toBe("hello from a");
 		});
@@ -424,7 +424,7 @@ describe("multiworker", () => {
 				`wrangler dev -c wrangler.toml -c ${b}/wrangler.toml`,
 				{ cwd: a }
 			);
-			const { url } = await worker.waitForReady(5_000);
+			const { url } = await worker.waitForReady();
 
 			await expect(fetchText(`${url}`)).resolves.toBe("hello from a");
 
@@ -484,7 +484,7 @@ describe("multiworker", () => {
 				`wrangler dev -c wrangler.toml -c ${b}/wrangler.toml`,
 				{ cwd: a }
 			);
-			const { url } = await worker.waitForReady(5_000);
+			const { url } = await worker.waitForReady();
 
 			await waitForLong(() =>
 				expect(fetchText(`${url}`)).resolves.toBe("hello from a")
@@ -528,7 +528,7 @@ describe("multiworker", () => {
 				`wrangler pages dev -c wrangler.toml -c ${b}/wrangler.toml -c ${c}/wrangler.toml`,
 				{ cwd: a }
 			);
-			const { url } = await pages.waitForReady(5_000);
+			const { url } = await pages.waitForReady();
 
 			await waitForLong(
 				async () =>
@@ -543,7 +543,7 @@ describe("multiworker", () => {
 				`wrangler pages dev -c wrangler.toml -c ${b}/wrangler.toml -c ${c}/wrangler.toml`,
 				{ cwd: a }
 			);
-			const { url } = await pages.waitForReady(5_000);
+			const { url } = await pages.waitForReady();
 
 			await waitForLong(
 				async () =>
@@ -558,7 +558,7 @@ describe("multiworker", () => {
 				`wrangler pages dev -c wrangler.toml -c ${b}/wrangler.toml -c ${c}/wrangler.toml`,
 				{ cwd: a }
 			);
-			const { url } = await pages.waitForReady(5_000);
+			const { url } = await pages.waitForReady();
 
 			await waitForLong(
 				async () =>
@@ -634,7 +634,7 @@ describe("multiworker", () => {
 				{ cwd: a }
 			);
 
-			const { url } = await worker.waitForReady(5_000);
+			const { url } = await worker.waitForReady();
 			const { hostname, port } = new URL(url);
 
 			await waitFor(() => {


### PR DESCRIPTION
Remove hard-coded five-second startup deadlines from the multiworker and dev-registry E2E suites. These tests now use the shared 15-second readiness timeout, avoiding failures when local workerd startup is slower under CI load.

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: This only adjusts E2E test timing and does not change Wrangler behavior.

The assets-multiworker, multiworker-dev, and dev-registry E2E suites pass, along with scoped build, type, lint, and formatting checks.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14729" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->