### PR TITLE
[wrangler] Wait for workerd cleanup in port conflict E2E

### DIFF
--- a/packages/wrangler/e2e/dev.test.ts
+++ b/packages/wrangler/e2e/dev.test.ts
@@ -504,10 +504,11 @@ it.runIf(process.platform !== "win32")(
 
 		expect(exitCode).not.toBe(0);
 
-		const endProcesses = getStartedWorkerdProcesses(helper.tmpPath);
-
 		expect(beginProcesses.length).toBe(0);
-		expect(endProcesses.length).toBe(0);
+		// workerd shutdown can lag briefly after wrangler exits
+		await waitFor(() => {
+			expect(getStartedWorkerdProcesses(helper.tmpPath).length).toBe(0);
+		});
 	}
 );
 


### PR DESCRIPTION
Allow the port-conflict E2E test to account for workerd exiting shortly after Wrangler. The assertion now polls for up to five seconds instead of requiring process cleanup to be synchronous with the Wrangler process exit.

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: This only hardens test timing and does not change Wrangler behavior.

The focused port-conflict E2E test, E2E TypeScript check, type-aware lint, and formatting pass. A broader accidental E2E run also passed the changed test but hit an unrelated Python dev readiness timeout.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14730" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->