### PR TITLE
[vitest-pool-workers] Support streaming tails to the main worker

### DIFF
--- a/.changeset/fuzzy-tails-listen.md
+++ b/.changeset/fuzzy-tails-listen.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/vitest-pool-workers": patch
+---
+
+Support testing Streaming Tail Workers in Vitest Pool Workers.

--- a/packages/vitest-pool-workers/src/pool/index.ts
+++ b/packages/vitest-pool-workers/src/pool/index.ts
@@ -283,6 +283,27 @@ const SELF_SERVICE_BINDING = "__VITEST_POOL_WORKERS_SELF_SERVICE";
 const LOOPBACK_SERVICE_BINDING = "__VITEST_POOL_WORKERS_LOOPBACK_SERVICE";
 const RUNNER_OBJECT_BINDING = "__VITEST_POOL_WORKERS_RUNNER_OBJECT";
 
+function rewriteStreamingTailSelfReferences(
+	worker: WorkerOptions,
+	wranglerWorkerName: string,
+	runnerWorkerName: string
+) {
+	worker.streamingTails = worker.streamingTails?.map((tail) => {
+		if (tail === wranglerWorkerName) {
+			return runnerWorkerName;
+		}
+		if (
+			typeof tail === "object" &&
+			tail !== null &&
+			"name" in tail &&
+			tail.name === wranglerWorkerName
+		) {
+			return { ...tail, name: runnerWorkerName };
+		}
+		return tail;
+	});
+}
+
 async function buildProjectWorkerOptions(
 	project: TestProject,
 	customOptions: WorkersPoolOptionsWithDefines,
@@ -585,7 +606,15 @@ async function buildProjectWorkerOptions(
 			}
 
 			// Miniflare will validate these options
-			workers.push(worker as WorkerOptions);
+			const workerOptions = worker as WorkerOptions;
+			if (wranglerWorkerName) {
+				rewriteStreamingTailSelfReferences(
+					workerOptions,
+					wranglerWorkerName,
+					runnerWorker.name
+				);
+			}
+			workers.push(workerOptions);
 		}
 		delete runnerWorker.workers;
 	}

--- a/packages/vitest-pool-workers/test/streaming-tails.test.ts
+++ b/packages/vitest-pool-workers/test/streaming-tails.test.ts
@@ -1,0 +1,84 @@
+import dedent from "ts-dedent";
+import { test, vitestConfig } from "./helpers";
+
+test(
+	"auxiliary workers can stream tails to the main worker",
+	{ timeout: 30_000 },
+	async ({ expect, seed, vitestRun }) => {
+		await seed({
+			"wrangler.jsonc": JSON.stringify({
+				name: "main-worker",
+				main: "worker.mjs",
+				compatibility_date: "2025-12-02",
+			}),
+			"worker.mjs": dedent /* javascript */ `
+				import { WorkerEntrypoint } from "cloudflare:workers";
+
+				const events = [];
+
+				export default class extends WorkerEntrypoint {
+					tailStream(onset) {
+						events.push(onset.event.type);
+						return {
+							log(event) {
+								events.push(event.event.type);
+							},
+							outcome(event) {
+								events.push(event.event.type);
+							},
+						};
+					}
+
+					getEvents() {
+						return events;
+					}
+				}
+			`,
+			"target.mjs": dedent /* javascript */ `
+				export default {
+					fetch() {
+						console.log("target log");
+						return new Response("ok");
+					},
+				};
+			`,
+			"vitest.config.mts": vitestConfig({
+				wrangler: { configPath: "wrangler.jsonc" },
+				miniflare: {
+					compatibilityDate: "2025-12-02",
+					compatibilityFlags: ["nodejs_compat"],
+					serviceBindings: { TARGET: "target" },
+					workers: [
+						{
+							name: "target",
+							modules: true,
+							scriptPath: "target.mjs",
+							streamingTails: ["main-worker"],
+						},
+					],
+				},
+			}),
+			"streaming-tails.test.ts": dedent /* javascript */ `
+				import { env, exports } from "cloudflare:workers";
+				import { expect, test, vi } from "vitest";
+
+				test("streams tails to the main worker", async () => {
+					const response = await env.TARGET.fetch("https://example.com");
+					expect(await response.text()).toBe("ok");
+
+					await vi.waitFor(async () => {
+						expect(await exports.default.getEvents()).toEqual([
+							"onset",
+							"log",
+							"outcome",
+						]);
+					});
+				});
+			`,
+		});
+
+		const result = await vitestRun();
+		expect(result.stderr).toBe("");
+		expect(await result.exitCode).toBe(0);
+	}
+);


### PR DESCRIPTION
We want to write end-to-end tests for Streaming Tail Workers using `@cloudflare/vitest-pool-workers`. Today an auxiliary Worker cannot stream tails to the main test Worker because Vitest gives the main Worker an internal name.

Rewrite the configured `streamingTails` target to that internal name. The test invokes a real auxiliary Worker and verifies the main Worker receives onset, log, and outcome events.

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: Existing `streamingTails` configuration now works in Vitest.

*A picture of a cute animal (not mandatory, but encouraged)*
<img width="1015" height="761" alt="image" src="https://github.com/user-attachments/assets/24078968-ba78-4a44-8712-b25120fd5d48" />
