### PR TITLE
[Workflows] Add sensitive option to Workflows steps

### DIFF
--- a/.changeset/workflows-sensitive-step-output.md
+++ b/.changeset/workflows-sensitive-step-output.md
@@ -1,0 +1,8 @@
+---
+"wrangler": minor
+"miniflare": minor
+---
+
+Add support for redacting sensitive Workflows step output in local dev.
+
+Steps configured with `sensitive: "output"` now have their output redacted to `[REDACTED]` in step logs and step-output responses when running Workflows locally, matching production behavior. The real value is still passed to downstream steps, and step errors are never redacted.

--- a/packages/workflows-shared/src/context.ts
+++ b/packages/workflows-shared/src/context.ts
@@ -39,6 +39,7 @@ import {
 	isValidStepConfig,
 	isValidStepName,
 	MAX_STEP_NAME_LENGTH,
+	SENSITIVE_STEP_OUTPUT,
 } from "./lib/validators";
 import { MODIFIER_KEYS } from "./modifier";
 import type { Engine } from "./engine";
@@ -67,6 +68,8 @@ export type Event = {
 // execution.
 const SERIALIZABLE_DELAY_MARKER = "[dynamic]";
 type SerializableDelayMarker = typeof SERIALIZABLE_DELAY_MARKER;
+
+export const REDACTED_STEP_OUTPUT = "[REDACTED]";
 
 // The persisted, fully-merged config. A dynamic delay is stored as the marker.
 export type ResolvedStepConfig = {
@@ -1257,12 +1260,18 @@ export class Context extends RpcTarget {
 				}
 			}
 
+			const redactOutput = config.sensitive === SENSITIVE_STEP_OUTPUT;
 			this.#engine.writeLog(events.success, cacheKey, stepNameWithCounter, {
 				// TODO (WOR-86): Add limits, figure out serialization
-				result: lastStreamMeta ? undefined : result,
-				...(lastStreamMeta && {
-					streamOutput: { cacheKey, meta: lastStreamMeta },
-				}),
+				result: redactOutput
+					? REDACTED_STEP_OUTPUT
+					: lastStreamMeta
+						? undefined
+						: result,
+				...(!redactOutput &&
+					lastStreamMeta && {
+						streamOutput: { cacheKey, meta: lastStreamMeta },
+					}),
 				...(!isRollback && rollbackFn ? { hasRollback: true } : {}),
 			});
 			this.#registerRollback({

--- a/packages/workflows-shared/src/lib/validators.ts
+++ b/packages/workflows-shared/src/lib/validators.ts
@@ -1,6 +1,8 @@
 import { ms } from "itty-time";
 import { z } from "zod";
 
+export const SENSITIVE_STEP_OUTPUT = "output";
+
 export const MAX_WORKFLOW_NAME_LENGTH = 64;
 
 export const MAX_WORKFLOW_INSTANCE_ID_LENGTH = 100;
@@ -58,6 +60,7 @@ const STEP_CONFIG_SCHEMA = z
 			.strict()
 			.optional(),
 		timeout: z.number().gte(0).or(z.string()).optional(),
+		sensitive: z.literal(SENSITIVE_STEP_OUTPUT).optional(),
 	})
 	.strict();
 

--- a/packages/workflows-shared/tests/context.test.ts
+++ b/packages/workflows-shared/tests/context.test.ts
@@ -1,8 +1,10 @@
 import { runInDurableObject } from "cloudflare:test";
 import { env } from "cloudflare:workers";
+import { NonRetryableError } from "cloudflare:workflows";
 import { afterEach, describe, it, vi } from "vitest";
 import workerdUnsafe from "workerd:unsafe";
 import { InstanceEvent } from "../src";
+import { REDACTED_STEP_OUTPUT } from "../src/context";
 import { computeHash } from "../src/lib/cache";
 import {
 	InvalidStepReadableStreamError,
@@ -1450,5 +1452,160 @@ describe("Context - typed-array step outputs (issue #14101)", () => {
 		expect(
 			logs.logs.some((val) => val.event === InstanceEvent.WORKFLOW_FAILURE)
 		).toBe(false);
+	});
+});
+
+describe("Sensitive step output", () => {
+	it("should redact a sensitive step's output in logs while passing the real value downstream", async ({
+		expect,
+	}) => {
+		let downstreamValue: unknown;
+
+		const engineStub = await runWorkflow(
+			"SENSITIVE-STEP-OUTPUT",
+			async (_event, step) => {
+				const secret = await step.do(
+					"sensitive step",
+					{ sensitive: "output" },
+					async () => {
+						return { token: "super-secret" };
+					}
+				);
+				await step.do("downstream step", async () => {
+					downstreamValue = secret;
+					return "ok";
+				});
+			}
+		);
+
+		await vi.waitUntil(
+			async () => {
+				const logs = (await engineStub.readLogs()) as EngineLogs;
+				return logs.logs.some(
+					(val) => val.event === InstanceEvent.WORKFLOW_SUCCESS
+				);
+			},
+			{ timeout: 5000 }
+		);
+
+		const logs = (await engineStub.readLogs()) as EngineLogs;
+		const stepLog = logs.logs.find(
+			(val) =>
+				val.event === InstanceEvent.STEP_SUCCESS &&
+				val.target === "sensitive step-1"
+		);
+		expect(stepLog?.metadata.result).toBe(REDACTED_STEP_OUTPUT);
+
+		// The real value is still cached and handed to the running workflow.
+		expect(downstreamValue).toEqual({ token: "super-secret" });
+	});
+
+	it("should redact a sensitive step's output from waitForStepResult", async ({
+		expect,
+	}) => {
+		const engineStub = await runWorkflow(
+			"SENSITIVE-STEP-WAIT-RESULT",
+			async (_event, step) => {
+				await step.do(
+					"sensitive step",
+					{ sensitive: "output" },
+					async () => "super-secret"
+				);
+			}
+		);
+
+		await vi.waitUntil(
+			async () => {
+				const logs = (await engineStub.readLogs()) as EngineLogs;
+				return logs.logs.some(
+					(val) => val.event === InstanceEvent.WORKFLOW_SUCCESS
+				);
+			},
+			{ timeout: 5000 }
+		);
+
+		const result = await engineStub.waitForStepResult("sensitive step");
+		expect(result).toBe(REDACTED_STEP_OUTPUT);
+	});
+
+	it("should not redact a sensitive step's error", async ({ expect }) => {
+		const engineStub = await runWorkflow(
+			"SENSITIVE-STEP-ERROR",
+			async (_event, step) => {
+				await step.do(
+					"sensitive failing step",
+					{ sensitive: "output", retries: { limit: 0, delay: 0 } },
+					async () => {
+						throw new NonRetryableError("boom with secret context");
+					}
+				);
+			}
+		);
+
+		await vi.waitUntil(
+			async () => {
+				const logs = (await engineStub.readLogs()) as EngineLogs;
+				return logs.logs.some(
+					(val) => val.event === InstanceEvent.WORKFLOW_FAILURE
+				);
+			},
+			{ timeout: 5000 }
+		);
+
+		const logs = (await engineStub.readLogs()) as EngineLogs;
+		const attemptFailure = logs.logs.find(
+			(val) => val.event === InstanceEvent.ATTEMPT_FAILURE
+		);
+		const error = attemptFailure?.metadata.error as
+			| { message: string }
+			| undefined;
+		expect(error?.message).toContain("boom with secret context");
+	});
+
+	it("should redact a sensitive streaming step output in readLogs", async ({
+		expect,
+	}) => {
+		const payload = "streamed secret";
+		const payloadBytes = encodeUtf8(payload);
+
+		const engineStub = await runWorkflow(
+			"SENSITIVE-STREAM-OUTPUT",
+			async (_event, step) => {
+				const stream = await step.do(
+					"sensitive stream step",
+					{ sensitive: "output" },
+					async () => {
+						return new ReadableStream<Uint8Array>({
+							start(controller) {
+								controller.enqueue(payloadBytes);
+								controller.close();
+							},
+						});
+					}
+				);
+				const bytes = await readStreamBytes(
+					stream as ReadableStream<Uint8Array>
+				);
+				return decodeUtf8(bytes);
+			}
+		);
+
+		await vi.waitUntil(
+			async () => {
+				const logs = (await engineStub.readLogs()) as EngineLogs;
+				return logs.logs.some(
+					(val) => val.event === InstanceEvent.WORKFLOW_SUCCESS
+				);
+			},
+			{ timeout: 5000 }
+		);
+
+		const logs = (await engineStub.readLogs()) as EngineLogs;
+		const stepLog = logs.logs.find(
+			(val) =>
+				val.event === InstanceEvent.STEP_SUCCESS &&
+				val.target === "sensitive stream step-1"
+		);
+		expect(stepLog?.metadata.result).toBe(REDACTED_STEP_OUTPUT);
 	});
 });

--- a/packages/workflows-shared/tests/validators.test.ts
+++ b/packages/workflows-shared/tests/validators.test.ts
@@ -96,6 +96,8 @@ describe("Workflow step config validation", () => {
 			retries: { limit: 3, delay: 10, backoff: "constant" },
 			timeout: 0,
 		},
+		{ timeout: "5 minutes", sensitive: "all" },
+		{ timeout: "5 minutes", sensitive: true },
 	])("should reject invalid step configs", (value, { expect }) => {
 		expect(isValidStepConfig(value)).toBe(false);
 	});
@@ -116,6 +118,11 @@ describe("Workflow step config validation", () => {
 		{
 			retries: { limit: 5, delay: 0, backoff: "constant" },
 			timeout: "2 minutes",
+		},
+		{
+			retries: { limit: 3, delay: 10, backoff: "constant" },
+			timeout: "2 minutes",
+			sensitive: "output",
 		},
 	])("should accept valid step configs", (value, { expect }) => {
 		expect(isValidStepConfig(value)).toBe(true);


### PR DESCRIPTION
Fixes WOR-1485.

Adds `sensitive: output` to step outputs, matching prod behavior.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: it's already documented

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14742" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->