### PR TITLE
[wrangler] Drop "Experimental:" prefix from provisioning header

### DIFF
--- a/.changeset/drop-provisioning-experimental-header.md
+++ b/.changeset/drop-provisioning-experimental-header.md
@@ -1,0 +1,6 @@
+---
+"@cloudflare/deploy-helpers": patch
+"wrangler": patch
+---
+
+Drop the "Experimental:" prefix from the resource provisioning header now that automatic provisioning is generally available. The deploy output now reads `The following bindings need to be provisioned:`.

--- a/packages/deploy-helpers/src/deploy/helpers/print-bindings.ts
+++ b/packages/deploy-helpers/src/deploy/helpers/print-bindings.ts
@@ -824,7 +824,7 @@ export function printBindings(
 	} else {
 		let title: string;
 		if (context.provisioning) {
-			title = `${chalk.red("Experimental:")} The following bindings need to be provisioned:`;
+			title = "The following bindings need to be provisioned:";
 		} else if (context.name && isMultiWorker) {
 			title = `${chalk.blue(context.name)} has access to the following bindings:`;
 		} else {

--- a/packages/wrangler/e2e/provision.test.ts
+++ b/packages/wrangler/e2e/provision.test.ts
@@ -80,7 +80,7 @@ describe.skipIf(!CLOUDFLARE_ACCOUNT_ID)(
 			const output = await worker.output;
 			expect(normalize(output)).toMatchInlineSnapshot(`
 				"Total Upload: xx KiB / gzip: xx KiB
-				Experimental: The following bindings need to be provisioned:
+				The following bindings need to be provisioned:
 				Binding        Resource
 				env.KV         KV Namespace
 				env.D1         D1 Database
@@ -204,7 +204,7 @@ describe.skipIf(!CLOUDFLARE_ACCOUNT_ID)(
 			const output = await worker.output;
 			expect(normalize(output)).toMatchInlineSnapshot(`
 				"Total Upload: xx KiB / gzip: xx KiB
-				Experimental: The following bindings need to be provisioned:
+				The following bindings need to be provisioned:
 				Binding         Resource
 				env.KV2         KV Namespace
 				Provisioning KV2 (KV Namespace)...

--- a/packages/wrangler/src/__tests__/provision.test.ts
+++ b/packages/wrangler/src/__tests__/provision.test.ts
@@ -512,7 +512,7 @@ describe("resource provisioning", () => {
 				──────────────────
 				Total Upload: xx KiB / gzip: xx KiB
 
-				Experimental: The following bindings need to be provisioned:
+				The following bindings need to be provisioned:
 				Binding        Resource
 				env.KV         KV Namespace
 				env.D1         D1 Database
@@ -635,7 +635,7 @@ describe("resource provisioning", () => {
 				──────────────────
 				Total Upload: xx KiB / gzip: xx KiB
 
-				Experimental: The following bindings need to be provisioned:
+				The following bindings need to be provisioned:
 				Binding        Resource
 				env.KV         KV Namespace
 				env.D1         D1 Database
@@ -768,7 +768,7 @@ describe("resource provisioning", () => {
 				──────────────────
 				Total Upload: xx KiB / gzip: xx KiB
 
-				Experimental: The following bindings need to be provisioned:
+				The following bindings need to be provisioned:
 				Binding        Resource
 				env.KV         KV Namespace
 				env.D1         D1 Database
@@ -931,7 +931,7 @@ describe("resource provisioning", () => {
 				──────────────────
 				Total Upload: xx KiB / gzip: xx KiB
 
-				Experimental: The following bindings need to be provisioned:
+				The following bindings need to be provisioned:
 				Binding        Resource
 				env.KV         KV Namespace
 				env.D1         D1 Database
@@ -1081,7 +1081,7 @@ describe("resource provisioning", () => {
 				──────────────────
 				Total Upload: xx KiB / gzip: xx KiB
 
-				Experimental: The following bindings need to be provisioned:
+				The following bindings need to be provisioned:
 				Binding                 Resource
 				env.KV                  KV Namespace
 				env.PLATFORM_KV         KV Namespace
@@ -1240,7 +1240,7 @@ describe("resource provisioning", () => {
 				──────────────────
 				Total Upload: xx KiB / gzip: xx KiB
 
-				Experimental: The following bindings need to be provisioned:
+				The following bindings need to be provisioned:
 				Binding        Resource
 				env.D1         D1 Database
 
@@ -1373,7 +1373,7 @@ describe("resource provisioning", () => {
 				──────────────────
 				Total Upload: xx KiB / gzip: xx KiB
 
-				Experimental: The following bindings need to be provisioned:
+				The following bindings need to be provisioned:
 				Binding        Resource
 				env.D1         D1 Database
 
@@ -1454,7 +1454,7 @@ describe("resource provisioning", () => {
 				──────────────────
 				Total Upload: xx KiB / gzip: xx KiB
 
-				Experimental: The following bindings need to be provisioned:
+				The following bindings need to be provisioned:
 				Binding            Resource
 				env.BUCKET         R2 Bucket
 
@@ -1654,7 +1654,7 @@ describe("resource provisioning", () => {
 				──────────────────
 				Total Upload: xx KiB / gzip: xx KiB
 
-				Experimental: The following bindings need to be provisioned:
+				The following bindings need to be provisioned:
 				Binding            Resource
 				env.BUCKET         R2 Bucket
 


### PR DESCRIPTION
Now that automatic resource provisioning is generally available, the deploy output should no longer label it as `Experimental:`.

- Drop the `Experimental:` prefix from the resource provisioning header — it now reads `The following bindings need to be provisioned:`

The `--experimental-provision` flag and `experimentalAutoCreate` internals are left as-is; renaming them is a separate follow-up.

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: this only removes an "Experimental:" label from CLI output; there is no documented behaviour change.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14744" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->