### PR TITLE
fix(workers-utils): reject null observability config instead of crashing

### DIFF
--- a/.changeset/observability-null-validation.md
+++ b/.changeset/observability-null-validation.md
@@ -1,0 +1,7 @@
+---
+"@cloudflare/workers-utils": patch
+---
+
+Return a clear error when `observability` is set to `null`
+
+`validateObservability` guarded only against `undefined`, so a `null` value (valid in JSON/JSONC config) passed the `typeof value === "object"` check and then threw `TypeError: Cannot read properties of null (reading 'enabled')` while validating the config. It now rejects `null` with the same `"observability" should be an object but got null.` diagnostic that the sibling `cache` validator already produces.

--- a/packages/workers-utils/src/config/validation.ts
+++ b/packages/workers-utils/src/config/validation.ts
@@ -6184,7 +6184,7 @@ const validateObservability: ValidatorFn = (diagnostics, field, value) => {
 		return true;
 	}
 
-	if (typeof value !== "object") {
+	if (typeof value !== "object" || value === null) {
 		diagnostics.errors.push(
 			`"${field}" should be an object but got ${JSON.stringify(value)}.`
 		);

--- a/packages/workers-utils/tests/config/validation/normalize-and-validate-config.test.ts
+++ b/packages/workers-utils/tests/config/validation/normalize-and-validate-config.test.ts
@@ -9828,6 +9828,22 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
+			it("should error if observability is null", ({ expect }) => {
+				const { diagnostics } = normalizeAndValidateConfig(
+					{ observability: null } as unknown as RawConfig,
+					undefined,
+					undefined,
+					{ env: undefined }
+				);
+
+				expect(diagnostics.hasWarnings()).toBe(false);
+				expect(diagnostics.hasErrors()).toBe(true);
+				expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
+					"Processing wrangler configuration:
+					  - "observability" should be an object but got null."
+				`);
+			});
+
 			it("should not warn on full observability config", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{


### PR DESCRIPTION
There's no existing issue for this; it's a small validation bug found while reading the config validators.

`validateObservability` guards only against `undefined`:

```ts
if (typeof value !== "object") {
```

Because `typeof null === "object"`, a `null` value falls through this check. The function then reads `val.enabled`, which throws:

```
TypeError: Cannot read properties of null (reading 'enabled')
```

`null` is reachable through real config, since Wrangler accepts JSON/JSONC where `"observability": null` is valid. Instead of a clean diagnostic, the user gets a stack trace.

The sibling `validateCache` validator already handles this correctly:

```ts
if (typeof value !== "object" || value === null) {
```

This change brings `validateObservability` in line with it, so `observability: null` now produces:

```
"observability" should be an object but got null.
```

which matches how every other object-typed field (`browser`, `durable_objects`, `cache`, ...) already reports a `null` value.

The added test fails on the current code with the `TypeError` above and passes with the fix. Verified with `pnpm test -F @cloudflare/workers-utils` (431 passed), plus `oxlint` and `oxfmt` clean.

---

- Tests
  - [x] Tests included/updated
- Public documentation
  - [x] Documentation not necessary because: this corrects an internal validation error path; no user-facing config behavior or documented field changes.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14746" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->