### PR TITLE
docs: React Router v7 -> v8 in vite plugin README

### DIFF
--- a/packages/vite-plugin-cloudflare/README.md
+++ b/packages/vite-plugin-cloudflare/README.md
@@ -23,14 +23,14 @@ Full documentation can be found [here](https://developers.cloudflare.com/workers
 - Uses the Vite [Environment API](https://vite.dev/guide/api-environment) to integrate Vite with the Workers runtime
 - Provides direct access to [Workers runtime APIs](https://developers.cloudflare.com/workers/runtime-apis/) and [bindings](https://developers.cloudflare.com/workers/runtime-apis/bindings/)
 - Builds your front-end assets for deployment to Cloudflare, enabling you to build static sites, SPAs, and full-stack applications
-- Official support for [TanStack Start](https://tanstack.com/start/) and [React Router v7](https://reactrouter.com/) with server-side rendering
+- Official support for [TanStack Start](https://tanstack.com/start/) and [React Router v8](https://reactrouter.com/) with server-side rendering
 - Leverages Vite's hot module replacement for consistently fast updates
 - Supports `vite preview` for previewing your build output in the Workers runtime prior to deployment
 
 ## Use cases
 
 - [TanStack Start](https://tanstack.com/start/)
-- [React Router v7](https://reactrouter.com/)
+- [React Router v8](https://reactrouter.com/)
 - Support for more full-stack frameworks is coming soon
 - Static sites, such as single-page applications, with or without an integrated backend API
 - Standalone Workers


### PR DESCRIPTION
Cloudflare docs state that react router v8 is supported: https://developers.cloudflare.com/workers/framework-guides/web-apps/react-router/

But the readme still says v7!

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: this is just a readme fix
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: this is just a readme fix

<img width="480" height="640" alt="image" src="https://github.com/user-attachments/assets/b24db47f-0f87-4b17-86ee-6e2a6c22139d" />

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14757" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->