### PR TITLE
[miniflare] Report the Worker's error for HEAD requests

### DIFF
--- a/.changeset/heavy-pugs-repeat.md
+++ b/.changeset/heavy-pugs-repeat.md
@@ -1,0 +1,10 @@
+---
+"miniflare": patch
+"wrangler": patch
+---
+
+Report the Worker's error for `HEAD` requests instead of an internal JSON parse error
+
+A Worker that threw on a `HEAD` request (for example `curl -I`) logged `SyntaxError: Unexpected end of JSON input` from miniflare's internals rather than the actual error, and `dispatchFetch()` rejected with that same misleading error. `workerd` drops response bodies for `HEAD` requests, so the serialised error never reached the code that revives it.
+
+The error is now also carried in a header, which survives `HEAD`, so the original message and source-mapped stack are reported for every method. When no payload is available the reporting degrades to a plain error rather than surfacing a parse failure.

--- a/packages/miniflare/src/index.ts
+++ b/packages/miniflare/src/index.ts
@@ -111,6 +111,7 @@ import {
 	CoreBindings,
 	CoreHeaders,
 	CorePaths,
+	decodeErrorPayload,
 	LogLevel,
 	Mutex,
 	SharedHeaders,
@@ -2929,7 +2930,14 @@ export class Miniflare {
 		// If the Worker threw an uncaught exception, propagate it to the caller
 		const stack = response.headers.get(CoreHeaders.ERROR_STACK);
 		if (response.status === 500 && stack !== null) {
-			const caught = JsonErrorSchema.parse(await response.json());
+			// `workerd` drops response bodies for `HEAD` requests, so fall back to
+			// the header copy of the serialised error
+			const serialised =
+				(await response.text()) || decodeErrorPayload(response);
+			if (serialised === null) {
+				throw new Error("Worker threw an uncaught exception");
+			}
+			const caught = JsonErrorSchema.parse(JSON.parse(serialised));
 			throw reviveError(this.#workerSrcOpts, caught);
 		}
 

--- a/packages/miniflare/src/workers/core/constants.ts
+++ b/packages/miniflare/src/workers/core/constants.ts
@@ -39,6 +39,13 @@ export const CoreHeaders = {
 	PROXY_SHARED_SECRET: "MF-Proxy-Shared-Secret",
 	DISABLE_PRETTY_ERROR: "MF-Disable-Pretty-Error",
 	ERROR_STACK: "MF-Experimental-Error-Stack",
+	/**
+	 * The serialised error, URI-encoded. `workerd` drops response bodies for
+	 * `HEAD` requests, so the body alone cannot carry the error out of the user
+	 * Worker. Producers set this in addition to the body; consumers fall back to
+	 * it whenever the body is unavailable.
+	 */
+	ERROR_STACK_PAYLOAD: "MF-Experimental-Error-Stack-Payload",
 	ROUTE_OVERRIDE: "MF-Route-Override",
 	CF_BLOB: "MF-CF-Blob",
 	/** Used by the Vite plugin to pass through the original `sec-fetch-mode` header */
@@ -108,6 +115,26 @@ export const ProxyAddresses = {
 	ENV: 1, // env
 	USER_START: 2,
 } as const;
+
+/**
+ * Recovers the serialised error a Worker put in `ERROR_STACK_PAYLOAD`, for the
+ * cases where the response body carrying it has been dropped (`HEAD` requests).
+ * Returns `null` when the header is absent or malformed, so callers can fall
+ * back rather than surfacing a decoding failure as the Worker's error.
+ */
+export function decodeErrorPayload(response: {
+	headers: { get(name: string): string | null };
+}): string | null {
+	const payload = response.headers.get(CoreHeaders.ERROR_STACK_PAYLOAD);
+	if (payload === null) {
+		return null;
+	}
+	try {
+		return decodeURIComponent(payload);
+	} catch {
+		return null;
+	}
+}
 
 // ### Proxy Special Cases
 // The proxy supports serialising `Request`/`Response`s for the Cache API. It

--- a/packages/miniflare/src/workers/core/entry.worker.ts
+++ b/packages/miniflare/src/workers/core/entry.worker.ts
@@ -1,7 +1,12 @@
 import { blue, bold, green, grey, red, reset, yellow } from "kleur/colors";
 import { HttpError, LogLevel, SharedHeaders } from "miniflare:shared";
 import { isCompressedByCloudflareFL } from "../../shared/mime-types";
-import { CoreBindings, CoreHeaders, CorePaths } from "./constants";
+import {
+	CoreBindings,
+	CoreHeaders,
+	CorePaths,
+	decodeErrorPayload,
+} from "./constants";
 import { handleEmail } from "./email";
 import { STATUS_CODES } from "./http";
 import { matchRoutes } from "./routing";
@@ -269,12 +274,21 @@ function maybePrettifyError(request: Request, response: Response, env: Env) {
 		return response;
 	}
 
+	// `workerd` drops response bodies for `HEAD` requests, so fall back to the
+	// header copy of the serialised error. Without a payload there is nothing to
+	// prettify, and POSTing an empty body would surface a JSON parse error from
+	// miniflare's internals instead of the user's error.
+	const body = response.body ?? decodeErrorPayload(response);
+	if (body === null) {
+		return response;
+	}
+
 	return env[CoreBindings.SERVICE_LOOPBACK].fetch(
 		"http://localhost/core/error",
 		{
 			method: "POST",
 			headers: request.headers,
-			body: response.body,
+			body,
 			cf: { prettyErrorOriginalUrl: request.url },
 		}
 	);

--- a/packages/miniflare/test/plugins/core/errors/index.spec.ts
+++ b/packages/miniflare/test/plugins/core/errors/index.spec.ts
@@ -496,9 +496,14 @@ export default {
 		try {
 			throw new Error("Unusual oops!");
 		} catch (e) {
-			return Response.json(reduceError(e), {
+			const body = JSON.stringify(reduceError(e));
+			return new Response(body, {
 				status: 500,
-				headers: { "MF-Experimental-Error-Stack": "true" },
+				headers: {
+					"Content-Type": "application/json",
+					"MF-Experimental-Error-Stack": "true",
+					"MF-Experimental-Error-Stack-Payload": encodeURIComponent(body),
+				},
 			});
 		}
 	},
@@ -525,6 +530,77 @@ test("invokes handleUncaughtError with the revived error", async ({
 	expect(errors[0]).toBeInstanceOf(Error);
 	expect(errors[0].message).toBe("Unusual oops!");
 	expect(errors[0].stack).toMatch(/Object\.fetch/);
+});
+
+// `workerd` drops response bodies for `HEAD` requests, so the serialised error
+// cannot be recovered from the body alone — it is carried in a header too.
+test("reports the revived error for HEAD requests", async ({ expect }) => {
+	const log = new CustomLog();
+	const errors: Error[] = [];
+	const mf = new Miniflare({
+		log,
+		modules: true,
+		handleUncaughtError(error) {
+			errors.push(error);
+		},
+		script: JSON_ERROR_SCRIPT,
+	});
+	useDispose(mf);
+
+	const res = await fetch(await mf.ready, { method: "HEAD" });
+	expect(res.status).toBe(500);
+	expect(errors.length).toBe(1);
+	expect(errors[0]).toBeInstanceOf(Error);
+	expect(errors[0].message).toBe("Unusual oops!");
+	expect(errors[0].stack).toMatch(/Object\.fetch/);
+});
+
+test("rejects HEAD dispatchFetch with the user error, not a parse error", async ({
+	expect,
+}) => {
+	const mf = new Miniflare({ modules: true, script: JSON_ERROR_SCRIPT });
+	useDispose(mf);
+
+	await expect(
+		mf.dispatchFetch(await mf.ready, { method: "HEAD" })
+	).rejects.toThrow("Unusual oops!");
+});
+
+// A stack too large to fit in a header is sent without the payload copy, so a
+// `HEAD` request has no way to recover it. Reporting must still degrade to a
+// plain error rather than leaking a JSON parse failure from miniflare.
+const NO_PAYLOAD_HEADER_SCRIPT = `
+export default {
+	async fetch() {
+		return new Response(JSON.stringify({ name: "Error", message: "Unusual oops!" }), {
+			status: 500,
+			headers: {
+				"Content-Type": "application/json",
+				"MF-Experimental-Error-Stack": "true",
+			},
+		});
+	},
+}`;
+
+test("degrades without leaking a parse error when HEAD has no payload header", async ({
+	expect,
+}) => {
+	const mf = new Miniflare({
+		modules: true,
+		script: NO_PAYLOAD_HEADER_SCRIPT,
+	});
+	useDispose(mf);
+	const url = await mf.ready;
+
+	const res = await fetch(url, { method: "HEAD" });
+	expect(res.status).toBe(500);
+
+	await expect(mf.dispatchFetch(url, { method: "HEAD" })).rejects.toThrow(
+		"Worker threw an uncaught exception"
+	);
+
+	// The GET path still recovers the error from the body
+	await expect(mf.dispatchFetch(url)).rejects.toThrow("Unusual oops!");
 });
 
 // A stack frame may name a `file://` URL that `fileURLToPath` cannot convert

--- a/packages/wrangler/templates/middleware/middleware-miniflare3-json-error.ts
+++ b/packages/wrangler/templates/middleware/middleware-miniflare3-json-error.ts
@@ -22,10 +22,20 @@ const jsonError: Middleware = async (request, env, _ctx, middlewareCtx) => {
 		return await middlewareCtx.next(request, env);
 	} catch (e: any) {
 		const error = reduceError(e);
-		return Response.json(error, {
-			status: 500,
-			headers: { "MF-Experimental-Error-Stack": "true" },
-		});
+		const body = JSON.stringify(error);
+		const headers: Record<string, string> = {
+			"Content-Type": "application/json",
+			"MF-Experimental-Error-Stack": "true",
+		};
+		// `workerd` drops response bodies for `HEAD` requests, so also carry the
+		// serialised error in a header. Past roughly 16KB of encoded header the
+		// runtime drops the whole response, so stay well under that; the body
+		// remains the primary channel for every method that keeps one.
+		const encoded = encodeURIComponent(body);
+		if (encoded.length <= 8192) {
+			headers["MF-Experimental-Error-Stack-Payload"] = encoded;
+		}
+		return new Response(body, { status: 500, headers });
 	}
 };
 


### PR DESCRIPTION
Fixes #8917.

A Worker that throws while handling a `HEAD` request reports a `SyntaxError` from miniflare's internals instead of the actual error:

```
[wrangler:err] SyntaxError: Unexpected end of JSON input
    at JSON.parse (<anonymous>)
    ...
    at async handlePrettyErrorRequest (.../miniflare/dist/src/index.js:11164:40)
[wrangler:inf] HEAD / 500 Internal Server Error (3ms)
```

The same Worker on a `GET` reports the error correctly, so `curl -I` — the natural way to trigger a handler when you don't want the response body — is exactly the case that hides the error you were looking for. Reported on 4.10.0 and still reproducible on 4.53.0.

### Cause

`workerd` drops response bodies for `HEAD` requests. The json-error middleware serialises the error into the response body, so on `HEAD` that body is gone by the time miniflare tries to revive it, in two places:

- `entry.worker.ts` `maybePrettifyError()` forwarded `response.body` (now `null`) to the `/core/error` loopback, so `handlePrettyErrorRequest` called `request.json()` on an empty body.
- `Miniflare#dispatchFetch()` called `response.json()` on the same empty body, so it rejected with the parse error rather than the user's error.

### Change

The middleware now also carries the serialised error in an `MF-Experimental-Error-Stack-Payload` header, which survives `HEAD`, and both consumers fall back to it when the body is unavailable. The body remains the primary channel, so the `GET` path is unchanged.

Header size is capped: I measured that past roughly 16–20KB of encoded header `workerd` drops the whole response, so the payload is only attached below 8KB. A stack too large to fit is sent without the copy, and reporting then degrades to a plain `Worker threw an uncaught exception` rather than leaking a parse failure.

### Verification

Reproduced first as a failing test, then confirmed end-to-end with the reporter's minimal repro under `wrangler dev`. `HEAD` now matches `GET`:

```
[wrangler:error] Error: boom from the worker
    at Object.fetch (file:///.../src/index.js:3:9)
[wrangler:info] GET / 500 Internal Server Error (48ms)
[wrangler:error] Error: boom from the worker
    at Object.fetch (file:///.../src/index.js:3:9)
[wrangler:info] HEAD / 500 Internal Server Error (7ms)
```

Full `miniflare` suite (909 passing) and `wrangler` middleware tests (26 passing) are green. One pre-existing failure, `workerd subprocess defaults to TZ=UTC`, fails identically on a clean tree on my machine (local timezone) and is unrelated.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: this restores the already-documented error reporting behaviour for one HTTP method; there is no user-facing API or configuration change.

*A picture of a cute animal (not mandatory, but encouraged)*

🦔

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14766" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->