### PR TITLE
fix(miniflare): KV getWithMetadata returns bare value for falsy stored values

### DIFF
--- a/packages/miniflare/src/workers/kv/namespace.worker.ts
+++ b/packages/miniflare/src/workers/kv/namespace.worker.ts
@@ -102,7 +102,7 @@ async function processKeyValue(
 			`At least one of the requested keys corresponds to a non-${type} value`
 		);
 	}
-	if (val && withMetadata) {
+	if (val !== undefined && withMetadata) {
 		return [
 			{
 				value: val,


### PR DESCRIPTION
Fixes #14770.

## Problem

`env.KV.getWithMetadata(key)` returns the bare value instead of the `{ value, metadata }` wrapper when the stored value is falsy (`""`, `0`, or `false`).

```ts
await env.KV.put('key', '');
const result = await env.KV.getWithMetadata('key', 'text');
// Expected: { value: '', metadata: null }
// Actual:   '' (bare string, no wrapper)
```

## Root cause

`packages/miniflare/src/workers/kv/namespace.worker.ts:105` had:

```ts
if (val && withMetadata)  // ❌ gates on value truthiness, not key presence
```

Empty string `""` is falsy, so this branch was never entered for empty-string values, and `getWithMetadata` silently degraded to behaving like `get`. Introduced by #8623.

## Fix

One-line change — gate on key presence instead of value truthiness:

```ts
if (val !== undefined && withMetadata)
```
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14771" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->