### PR TITLE
[workflows-shared] Prevent Windows CI worker exits in sensitive-output tests

### DIFF
--- a/packages/workflows-shared/tests/context.test.ts
+++ b/packages/workflows-shared/tests/context.test.ts
@@ -1456,13 +1456,12 @@ describe("Context - typed-array step outputs (issue #14101)", () => {
 });
 
 describe("Sensitive step output", () => {
-	// Temporary regression validation for the Windows CI worker exit.
 	it("should redact a sensitive step's output in logs while passing the real value downstream", async ({
 		expect,
 	}) => {
 		let downstreamValue: unknown;
 
-		const engineStub = await runWorkflow(
+		const engineStub = await runWorkflowAndAwait(
 			"SENSITIVE-STEP-OUTPUT",
 			async (_event, step) => {
 				const secret = await step.do(
@@ -1504,7 +1503,7 @@ describe("Sensitive step output", () => {
 	it("should redact a sensitive step's output from waitForStepResult", async ({
 		expect,
 	}) => {
-		const engineStub = await runWorkflow(
+		const engineStub = await runWorkflowAndAwait(
 			"SENSITIVE-STEP-WAIT-RESULT",
 			async (_event, step) => {
 				await step.do(
@@ -1530,16 +1529,18 @@ describe("Sensitive step output", () => {
 	});
 
 	it("should not redact a sensitive step's error", async ({ expect }) => {
-		const engineStub = await runWorkflow(
+		const engineStub = await runWorkflowAndAwait(
 			"SENSITIVE-STEP-ERROR",
 			async (_event, step) => {
-				await step.do(
-					"sensitive failing step",
-					{ sensitive: "output", retries: { limit: 0, delay: 0 } },
-					async () => {
-						throw new NonRetryableError("boom with secret context");
-					}
-				);
+				try {
+					await step.do(
+						"sensitive failing step",
+						{ sensitive: "output", retries: { limit: 0, delay: 0 } },
+						async () => {
+							throw new NonRetryableError("boom with secret context");
+						}
+					);
+				} catch {}
 			}
 		);
 
@@ -1547,7 +1548,7 @@ describe("Sensitive step output", () => {
 			async () => {
 				const logs = (await engineStub.readLogs()) as EngineLogs;
 				return logs.logs.some(
-					(val) => val.event === InstanceEvent.WORKFLOW_FAILURE
+					(val) => val.event === InstanceEvent.WORKFLOW_SUCCESS
 				);
 			},
 			{ timeout: 5000 }
@@ -1569,7 +1570,7 @@ describe("Sensitive step output", () => {
 		const payload = "streamed secret";
 		const payloadBytes = encodeUtf8(payload);
 
-		const engineStub = await runWorkflow(
+		const engineStub = await runWorkflowAndAwait(
 			"SENSITIVE-STREAM-OUTPUT",
 			async (_event, step) => {
 				const stream = await step.do(

--- a/packages/workflows-shared/tests/context.test.ts
+++ b/packages/workflows-shared/tests/context.test.ts
@@ -1461,7 +1461,7 @@ describe("Sensitive step output", () => {
 	}) => {
 		let downstreamValue: unknown;
 
-		const engineStub = await runWorkflow(
+		const engineStub = await runWorkflowAndAwait(
 			"SENSITIVE-STEP-OUTPUT",
 			async (_event, step) => {
 				const secret = await step.do(
@@ -1503,7 +1503,7 @@ describe("Sensitive step output", () => {
 	it("should redact a sensitive step's output from waitForStepResult", async ({
 		expect,
 	}) => {
-		const engineStub = await runWorkflow(
+		const engineStub = await runWorkflowAndAwait(
 			"SENSITIVE-STEP-WAIT-RESULT",
 			async (_event, step) => {
 				await step.do(
@@ -1529,16 +1529,18 @@ describe("Sensitive step output", () => {
 	});
 
 	it("should not redact a sensitive step's error", async ({ expect }) => {
-		const engineStub = await runWorkflow(
+		const engineStub = await runWorkflowAndAwait(
 			"SENSITIVE-STEP-ERROR",
 			async (_event, step) => {
-				await step.do(
-					"sensitive failing step",
-					{ sensitive: "output", retries: { limit: 0, delay: 0 } },
-					async () => {
-						throw new NonRetryableError("boom with secret context");
-					}
-				);
+				try {
+					await step.do(
+						"sensitive failing step",
+						{ sensitive: "output", retries: { limit: 0, delay: 0 } },
+						async () => {
+							throw new NonRetryableError("boom with secret context");
+						}
+					);
+				} catch {}
 			}
 		);
 
@@ -1546,7 +1548,7 @@ describe("Sensitive step output", () => {
 			async () => {
 				const logs = (await engineStub.readLogs()) as EngineLogs;
 				return logs.logs.some(
-					(val) => val.event === InstanceEvent.WORKFLOW_FAILURE
+					(val) => val.event === InstanceEvent.WORKFLOW_SUCCESS
 				);
 			},
 			{ timeout: 5000 }
@@ -1568,7 +1570,7 @@ describe("Sensitive step output", () => {
 		const payload = "streamed secret";
 		const payloadBytes = encodeUtf8(payload);
 
-		const engineStub = await runWorkflow(
+		const engineStub = await runWorkflowAndAwait(
 			"SENSITIVE-STREAM-OUTPUT",
 			async (_event, step) => {
 				const stream = await step.do(

--- a/packages/workflows-shared/tests/context.test.ts
+++ b/packages/workflows-shared/tests/context.test.ts
@@ -1456,12 +1456,13 @@ describe("Context - typed-array step outputs (issue #14101)", () => {
 });
 
 describe("Sensitive step output", () => {
+	// Temporary regression validation for the Windows CI worker exit.
 	it("should redact a sensitive step's output in logs while passing the real value downstream", async ({
 		expect,
 	}) => {
 		let downstreamValue: unknown;
 
-		const engineStub = await runWorkflowAndAwait(
+		const engineStub = await runWorkflow(
 			"SENSITIVE-STEP-OUTPUT",
 			async (_event, step) => {
 				const secret = await step.do(
@@ -1503,7 +1504,7 @@ describe("Sensitive step output", () => {
 	it("should redact a sensitive step's output from waitForStepResult", async ({
 		expect,
 	}) => {
-		const engineStub = await runWorkflowAndAwait(
+		const engineStub = await runWorkflow(
 			"SENSITIVE-STEP-WAIT-RESULT",
 			async (_event, step) => {
 				await step.do(
@@ -1529,18 +1530,16 @@ describe("Sensitive step output", () => {
 	});
 
 	it("should not redact a sensitive step's error", async ({ expect }) => {
-		const engineStub = await runWorkflowAndAwait(
+		const engineStub = await runWorkflow(
 			"SENSITIVE-STEP-ERROR",
 			async (_event, step) => {
-				try {
-					await step.do(
-						"sensitive failing step",
-						{ sensitive: "output", retries: { limit: 0, delay: 0 } },
-						async () => {
-							throw new NonRetryableError("boom with secret context");
-						}
-					);
-				} catch {}
+				await step.do(
+					"sensitive failing step",
+					{ sensitive: "output", retries: { limit: 0, delay: 0 } },
+					async () => {
+						throw new NonRetryableError("boom with secret context");
+					}
+				);
 			}
 		);
 
@@ -1548,7 +1547,7 @@ describe("Sensitive step output", () => {
 			async () => {
 				const logs = (await engineStub.readLogs()) as EngineLogs;
 				return logs.logs.some(
-					(val) => val.event === InstanceEvent.WORKFLOW_SUCCESS
+					(val) => val.event === InstanceEvent.WORKFLOW_FAILURE
 				);
 			},
 			{ timeout: 5000 }
@@ -1570,7 +1569,7 @@ describe("Sensitive step output", () => {
 		const payload = "streamed secret";
 		const payloadBytes = encodeUtf8(payload);
 
-		const engineStub = await runWorkflowAndAwait(
+		const engineStub = await runWorkflow(
 			"SENSITIVE-STREAM-OUTPUT",
 			async (_event, step) => {
 				const stream = await step.do(


### PR DESCRIPTION
Windows package tests began failing after the sensitive-output workflow tests were added. The failure was specific to the `@cloudflare/workflows-shared` suite and reported an unhandled Vitest pool error:

```text
Error: [vitest-pool]: Worker cloudflare-pool emitted error.
Caused by: Error: Worker exited unexpectedly
```

## Root cause

Four sensitive-output tests started workflows with `runWorkflow()`, then waited only for workflow logs. This allowed each test to finish while the `TestWorkflow.run` RPC was still active. In the sensitive-step error test, the intentional `NonRetryableError` also escaped through that RPC. On Windows, the outstanding RPC and unhandled rejection terminated the `cloudflare-pool` worker before the suite completed.

## Fix

- Use `runWorkflowAndAwait()` for all four sensitive-output workflows so their RPCs settle before assertions and teardown.
- Catch the intentional step failure inside the test workflow, while still asserting that its logged error is not redacted.
- Wait for `WORKFLOW_SUCCESS` in that test, confirming the workflow RPC completed cleanly after the expected step failure was handled.

## Validation

A controlled regression confirmed the cause:

- With the original fire-and-forget behavior temporarily restored, [Windows CI failed](https://github.com/cloudflare/workers-sdk/actions/runs/29818331852/job/88594809272) with 4 of 5 files and 147 of 149 tests completed, followed by the same unexpected `cloudflare-pool` worker exit.
- After restoring this fix, [Windows CI passed](https://github.com/cloudflare/workers-sdk/actions/runs/29818635075/job/88595780924), including the complete `@cloudflare/workflows-shared` suite.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: This only corrects internal test lifecycle handling.

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
