### PR TITLE
fix(workers-auth): make auth profile guidance cli agnostic

### DIFF
--- a/.changeset/curly-lions-breathe.md
+++ b/.changeset/curly-lions-breathe.md
@@ -1,0 +1,7 @@
+---
+"@cloudflare/workers-auth": patch
+---
+
+Make auth profile guidance CLI agnostic
+
+Remove Wrangler-specific wording from shared profile errors and add `cf auth create` to cf's auth descriptor.

--- a/packages/workers-auth/src/cf/index.ts
+++ b/packages/workers-auth/src/cf/index.ts
@@ -69,6 +69,7 @@ export const CF_CLI: CliDescriptor = {
 	commands: {
 		login: "cf auth login",
 		whoami: "cf auth whoami",
+		createProfile: "cf auth create",
 	},
 	keyringServiceName: CF_KEYRING_SERVICE_NAME,
 	clientId: getClientIdFromEnv,

--- a/packages/workers-auth/src/core/types.ts
+++ b/packages/workers-auth/src/core/types.ts
@@ -52,7 +52,7 @@ export interface CliDescriptor {
 	commands: {
 		login: string;
 		whoami: string;
-		createProfile?: string;
+		createProfile: string;
 	};
 
 	/**

--- a/packages/workers-auth/src/profiles.ts
+++ b/packages/workers-auth/src/profiles.ts
@@ -64,7 +64,7 @@ export function createProfileStore(args: {
 					throw new UserError(
 						`No profile is directly bound to "${formatDirectoryForUserError(normalizedDir)}". The active profile "${parentBinding.profile}" is bound at "${formatDirectoryForUserError(
 							parentBinding.dir
-						)}". Run \`wrangler auth deactivate\` from that directory instead.`,
+						)}". Run the deactivate command from that directory instead.`,
 						{ telemetryMessage: "auth deactivate wrong directory" }
 					);
 				}
@@ -151,7 +151,7 @@ export function createProfileStore(args: {
 export function validateProfileName(name: string): void {
 	if (RESERVED_PROFILE_NAMES.includes(name.toLowerCase())) {
 		throw new UserError(
-			`"${name}" is a reserved profile name. Use \`wrangler login\` and \`wrangler logout\` to manage the default profile, which applies as a global fallback.`,
+			`"${name}" is a reserved profile name. Use the login and logout commands to manage the default profile, which applies as a global fallback.`,
 			{ telemetryMessage: "auth profile reserved name" }
 		);
 	}

--- a/packages/workers-auth/tests/cf/index.test.ts
+++ b/packages/workers-auth/tests/cf/index.test.ts
@@ -44,6 +44,7 @@ describe("cf auth layer", () => {
 		expect(CF_CLI.commands).toEqual({
 			login: "cf auth login",
 			whoami: "cf auth whoami",
+			createProfile: "cf auth create",
 		});
 	});
 


### PR DESCRIPTION
Fixes n/a.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: error message change

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
