### PR TITLE
[wrangler] Return first equidistant candidate in getSuggestion

### DIFF
--- a/.changeset/fix-did-you-mean-tie-break.md
+++ b/.changeset/fix-did-you-mean-tie-break.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Improve the "Did you mean …?" suggestion for mistyped commands on ties
+
+When a mistyped command is an equal edit-distance from more than one valid command, Wrangler now suggests the first closest match in order rather than the last, giving a more predictable and sensible "Did you mean …?" hint.

--- a/packages/wrangler/src/__tests__/utils/did-you-mean.test.ts
+++ b/packages/wrangler/src/__tests__/utils/did-you-mean.test.ts
@@ -64,6 +64,15 @@ describe("getSuggestion", () => {
 		// is a 4-char candidate — the scaled threshold allows it
 		expect(getSuggestion("git", commands)).toBe("init");
 	});
+
+	it("should return the first candidate when multiple are equidistant", ({
+		expect,
+	}) => {
+		// "hella" is distance 1 from both "hello" and "hellz"; the first one in
+		// iteration order should win, regardless of ordering.
+		expect(getSuggestion("hella", ["hello", "hellz"])).toBe("hello");
+		expect(getSuggestion("hella", ["hellz", "hello"])).toBe("hellz");
+	});
 });
 
 describe("logDidYouMean", () => {

--- a/packages/wrangler/src/utils/did-you-mean.ts
+++ b/packages/wrangler/src/utils/did-you-mean.ts
@@ -36,10 +36,11 @@ export function getSuggestion(
 		// e.g. "cat" -> "ai" or "foo" -> "d1" just because they're within 3 edits.
 		const effectiveMax = Math.min(
 			maxDistance,
-			bestDistance,
 			Math.floor((Math.min(lowerInput.length, candidate.length) * 2) / 3)
 		);
-		if (distance <= effectiveMax) {
+		// Use a strict `<` against the running best so that, on ties, the first
+		// candidate in iteration order wins (as documented above).
+		if (distance <= effectiveMax && distance < bestDistance) {
 			bestDistance = distance;
 			bestMatch = candidate;
 		}


### PR DESCRIPTION
`getSuggestion` (used by the "Did you mean …?" hint on unknown commands) documents that when multiple candidates share the same Levenshtein distance, "the first one encountered (in iteration order) is returned":

```js
const effectiveMax = Math.min(
    maxDistance,
    bestDistance,
    Math.floor((Math.min(lowerInput.length, candidate.length) * 2) / 3)
);
if (distance <= effectiveMax) {
    bestDistance = distance;
    bestMatch = candidate;
}
```

But because `bestDistance` is folded into `effectiveMax` and the comparison is `<=`, an equidistant candidate encountered *later* overwrites the earlier one — so the **last** tie wins, not the first. For example, `getSuggestion("hella", ["hello", "hellz"])` returns `"hellz"` instead of `"hello"`.

This drops `bestDistance` from the per-candidate cap (the JSDoc already documents the per-candidate threshold as `min(maxDistance, floor(...))`) and adds a strict `distance < bestDistance` improvement check, so the first equidistant candidate wins as documented. Non-tie behaviour is unchanged.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: this fixes an internal helper's behaviour to match its documented contract; there is no corresponding user-facing documentation.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14787" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->