### PR TITLE
[wrangler] Fix grammar in container image-too-large error

### DIFF
--- a/.changeset/fix-cloudchamber-disk-error-grammar.md
+++ b/.changeset/fix-cloudchamber-disk-error-grammar.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Fix grammar in the container image-too-large error
+
+The error thrown when a container image exceeds the available disk size ended with "Your need more disk for this image." It now reads "You need more disk for this image."

--- a/packages/wrangler/src/__tests__/cloudchamber/limits.test.ts
+++ b/packages/wrangler/src/__tests__/cloudchamber/limits.test.ts
@@ -227,7 +227,7 @@ describe("ensureImageFitsLimits", () => {
 				imageTag: "docker.io/test-app:tag",
 			})
 		).rejects.toThrowErrorMatchingInlineSnapshot(
-			`[Error: Image too large: needs 3146MB, but your app is limited to images with size 2000MB. Your need more disk for this image.]`
+			`[Error: Image too large: needs 3146MB, but your app is limited to images with size 2000MB. You need more disk for this image.]`
 		);
 
 		expect(dockerImageInspect).toHaveBeenCalledExactlyOnceWith(

--- a/packages/wrangler/src/cloudchamber/limits.ts
+++ b/packages/wrangler/src/cloudchamber/limits.ts
@@ -111,7 +111,7 @@ export async function ensureImageFitsLimits(options: {
 	);
 	if (options.availableSizeInBytes < requiredSizeInBytes) {
 		throw new UserError(
-			`Image too large: needs ${Math.ceil(requiredSizeInBytes / MB)}MB, but your app is limited to images with size ${options.availableSizeInBytes / MB}MB. Your need more disk for this image.`,
+			`Image too large: needs ${Math.ceil(requiredSizeInBytes / MB)}MB, but your app is limited to images with size ${options.availableSizeInBytes / MB}MB. You need more disk for this image.`,
 			{ telemetryMessage: "cloudchamber limits image too large" }
 		);
 	}


### PR DESCRIPTION
The `UserError` thrown from `checkDiskLimit` in `cloudchamber/limits.ts` when a container image exceeds the available disk size ends with a grammatical error — "Your need more disk for this image":

```js
`Image too large: needs ${...}MB, but your app is limited to images with size ${...}MB. Your need more disk for this image.`
```

This corrects it to "You need more disk for this image." and updates the matching inline snapshot.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: this only corrects a grammatical error in a user-facing error message; there is no corresponding user-facing documentation.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14788" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->