### PR TITLE
Recover from workerd crashes in Miniflare

### DIFF
--- a/.changeset/rude-lands-hug.md
+++ b/.changeset/rude-lands-hug.md
@@ -1,0 +1,10 @@
+---
+"miniflare": patch
+"@cloudflare/vite-plugin": patch
+---
+
+Recover local development after the Workers runtime crashes
+
+Previously, an unexpected workerd crash left Miniflare running but unable to serve subsequent requests. Miniflare now restarts workerd after post-startup crashes, while continuing to surface startup crashes as fatal errors.
+
+The Cloudflare Vite plugin also restarts the Vite development server after workerd recovers so its environments, hot channels, and module runners are recreated.

--- a/packages/miniflare/src/index.ts
+++ b/packages/miniflare/src/index.ts
@@ -2458,6 +2458,53 @@ export class Miniflare {
 		};
 	}
 
+	#handleWorkerdCrash(): void {
+		// A crash destroys the proxy server heap just like a config update.
+		this.#proxyClient?.poisonProxies();
+		void this.#runtimeMutex
+			.runWith(async () => {
+				try {
+					await this.#assembleAndUpdateConfig(true);
+				} catch (error) {
+					const cause =
+						error instanceof Error ? error : new Error(String(error));
+					this.#runtimeRestartError = new MiniflareCoreError(
+						"ERR_RUNTIME_FAILURE",
+						"The Workers runtime failed to restart after an unexpected crash.",
+						cause
+					);
+					throw this.#runtimeRestartError;
+				}
+			})
+			.then(
+				async () => {
+					if (this.#disposeController.signal.aborted) {
+						return;
+					}
+					try {
+						await this.#sharedOpts.core.unsafeHandleRuntimeRestart?.();
+					} catch (error) {
+						const cause =
+							error instanceof Error ? error : new Error(String(error));
+						this.#log.error(
+							new Error(
+								"The Workers runtime restarted, but the runtime restart callback failed.",
+								{ cause }
+							)
+						);
+					}
+				},
+				(error) => {
+					if (this.#disposeController.signal.aborted) {
+						return;
+					}
+					this.#log.error(
+						error instanceof Error ? error : new Error(String(error))
+					);
+				}
+			);
+	}
+
 	async #assembleAndUpdateConfig(reusePorts = false) {
 		await this.#closeBrowserProcesses();
 
@@ -2545,52 +2592,7 @@ export class Miniflare {
 			verbose: this.#sharedOpts.core.verbose,
 			handleRuntimeStdio: this.#sharedOpts.core.handleRuntimeStdio,
 			handleStructuredLogs: this.#sharedOpts.core.handleStructuredLogs,
-			onWorkerdCrashRestart: () => {
-				// A crash destroys the proxy server heap just like a config update.
-				this.#proxyClient?.poisonProxies();
-				void this.#runtimeMutex
-					.runWith(async () => {
-						try {
-							await this.#assembleAndUpdateConfig(true);
-						} catch (error) {
-							const cause =
-								error instanceof Error ? error : new Error(String(error));
-							this.#runtimeRestartError = new MiniflareCoreError(
-								"ERR_RUNTIME_FAILURE",
-								"The Workers runtime failed to restart after an unexpected crash.",
-								cause
-							);
-							throw this.#runtimeRestartError;
-						}
-					})
-					.then(
-						async () => {
-							if (this.#disposeController.signal.aborted) {
-								return;
-							}
-							try {
-								await this.#sharedOpts.core.unsafeHandleRuntimeRestart?.();
-							} catch (error) {
-								const cause =
-									error instanceof Error ? error : new Error(String(error));
-								this.#log.error(
-									new Error(
-										"The Workers runtime restarted, but the runtime restart callback failed.",
-										{ cause }
-									)
-								);
-							}
-						},
-						(error) => {
-							if (this.#disposeController.signal.aborted) {
-								return;
-							}
-							this.#log.error(
-								error instanceof Error ? error : new Error(String(error))
-							);
-						}
-					);
-			},
+			onWorkerdCrashRestart: () => this.#handleWorkerdCrash(),
 			runtimeEnv: this.#sharedOpts.core.unsafeRuntimeEnv,
 		};
 		const maybeSocketPorts = await this.#runtime.updateConfig(

--- a/packages/miniflare/src/index.ts
+++ b/packages/miniflare/src/index.ts
@@ -1001,6 +1001,7 @@ export class Miniflare {
 	#socketPorts?: SocketPorts;
 	#runtimeDispatcher?: Dispatcher;
 	#proxyClient?: ProxyClient;
+	#runtimeRestartError?: MiniflareCoreError;
 
 	#structuredWorkerdLogs: boolean;
 
@@ -1913,8 +1914,12 @@ export class Miniflare {
 		id: SocketIdentifier,
 		previousRequestedPort: number | undefined,
 		host = DEFAULT_HOST,
-		requestedPort?: number
+		requestedPort?: number,
+		reusePort = false
 	) {
+		if (reusePort) {
+			requestedPort = this.#socketPorts?.get(id) ?? requestedPort;
+		}
 		// If `port` is set to `0`, was previously set to `0`, and we previously had
 		// a port for this socket, reuse that random port
 		if (requestedPort === 0 && previousRequestedPort === 0) {
@@ -1982,7 +1987,8 @@ export class Miniflare {
 	async #assembleConfig(
 		loopbackHost: string,
 		loopbackPort: number,
-		devRegistryEnabled: boolean
+		devRegistryEnabled: boolean,
+		reusePorts: boolean
 	): Promise<Config> {
 		const allPreviousWorkerOpts = this.#previousWorkerOpts;
 		const allWorkerOpts = this.#workerOpts;
@@ -2033,12 +2039,18 @@ export class Miniflare {
 		const configuredHost = sharedOpts.core.host ?? DEFAULT_HOST;
 		if (maybeGetLocallyAccessibleHost(configuredHost) === undefined) {
 			// If we aren't able to locally access `workerd` on the configured host, configure an additional socket that's
-			// only accessible on `127.0.0.1:0`
+			// only accessible on `127.0.0.1`
 			sockets.push({
 				name: SOCKET_ENTRY_LOCAL,
 				service: { name: SERVICE_ENTRY },
 				http: {},
-				address: "127.0.0.1:0",
+				address: this.#getSocketAddress(
+					SOCKET_ENTRY_LOCAL,
+					undefined,
+					"127.0.0.1",
+					undefined,
+					reusePorts
+				),
 			});
 		}
 
@@ -2246,7 +2258,8 @@ export class Miniflare {
 					name,
 					previousDirectSocket?.port,
 					directSocket.host,
-					directSocket.port
+					directSocket.port,
+					reusePorts
 				);
 				// check if Worker with assets with default export
 				// (class or non-class based)
@@ -2445,7 +2458,7 @@ export class Miniflare {
 		};
 	}
 
-	async #assembleAndUpdateConfig() {
+	async #assembleAndUpdateConfig(reusePorts = false) {
 		await this.#closeBrowserProcesses();
 
 		// This function must be run with `#runtimeMutex` held
@@ -2464,7 +2477,8 @@ export class Miniflare {
 		const config = await this.#assembleConfig(
 			loopbackHost,
 			loopbackPort,
-			this.#devRegistry.isEnabled()
+			this.#devRegistry.isEnabled(),
+			reusePorts
 		);
 		const configBuffer = serializeConfig(config);
 
@@ -2492,7 +2506,8 @@ export class Miniflare {
 			SOCKET_ENTRY,
 			this.#previousSharedOpts?.core.port,
 			configuredHost,
-			this.#sharedOpts.core.port
+			this.#sharedOpts.core.port,
+			reusePorts
 		);
 		let runtimeInspectorAddress: string | undefined;
 		if (this.#sharedOpts.core.inspectorPort !== undefined) {
@@ -2512,7 +2527,8 @@ export class Miniflare {
 				// listen-inspector event, causing waitForPorts() to hang.
 				// See https://github.com/cloudflare/workers-sdk/issues/14077
 				"127.0.0.1",
-				runtimeInspectorPort
+				runtimeInspectorPort,
+				reusePorts
 			);
 			this.#previousRuntimeInspectorPort = runtimeInspectorPort;
 		}
@@ -2529,6 +2545,52 @@ export class Miniflare {
 			verbose: this.#sharedOpts.core.verbose,
 			handleRuntimeStdio: this.#sharedOpts.core.handleRuntimeStdio,
 			handleStructuredLogs: this.#sharedOpts.core.handleStructuredLogs,
+			onWorkerdCrashRestart: () => {
+				// A crash destroys the proxy server heap just like a config update.
+				this.#proxyClient?.poisonProxies();
+				void this.#runtimeMutex
+					.runWith(async () => {
+						try {
+							await this.#assembleAndUpdateConfig(true);
+						} catch (error) {
+							const cause =
+								error instanceof Error ? error : new Error(String(error));
+							this.#runtimeRestartError = new MiniflareCoreError(
+								"ERR_RUNTIME_FAILURE",
+								"The Workers runtime failed to restart after an unexpected crash.",
+								cause
+							);
+							throw this.#runtimeRestartError;
+						}
+					})
+					.then(
+						async () => {
+							if (this.#disposeController.signal.aborted) {
+								return;
+							}
+							try {
+								await this.#sharedOpts.core.unsafeHandleRuntimeRestart?.();
+							} catch (error) {
+								const cause =
+									error instanceof Error ? error : new Error(String(error));
+								this.#log.error(
+									new Error(
+										"The Workers runtime restarted, but the runtime restart callback failed.",
+										{ cause }
+									)
+								);
+							}
+						},
+						(error) => {
+							if (this.#disposeController.signal.aborted) {
+								return;
+							}
+							this.#log.error(
+								error instanceof Error ? error : new Error(String(error))
+							);
+						}
+					);
+			},
 			runtimeEnv: this.#sharedOpts.core.unsafeRuntimeEnv,
 		};
 		const maybeSocketPorts = await this.#runtime.updateConfig(
@@ -2673,6 +2735,7 @@ export class Miniflare {
 
 			this.#handleReload();
 		}
+		this.#runtimeRestartError = undefined;
 	}
 
 	async #closeBrowserProcesses() {
@@ -2696,6 +2759,9 @@ export class Miniflare {
 		// waiters on the mutex to avoid logging ready/updated messages to the
 		// console if there are future updates)
 		await this.#runtimeMutex.drained();
+		if (!disposing && this.#runtimeRestartError !== undefined) {
+			throw this.#runtimeRestartError;
+		}
 		// If we called `dispose()`, we may not have a `#runtimeEntryURL` if we
 		// `dispose()`d synchronously, immediately after constructing a `Miniflare`
 		// instance. In this case, return a discard URL which we'll ignore.

--- a/packages/miniflare/src/plugins/core/index.ts
+++ b/packages/miniflare/src/plugins/core/index.ts
@@ -294,6 +294,14 @@ export const CoreSharedOptionsSchema = z
 			.returns(z.void())
 			.optional(),
 
+		// Called after Miniflare has automatically restarted the `workerd`
+		// runtime following an unexpected crash. Lets embedders (e.g. the Vite
+		// plugin) re-establish any state that lived in the crashed process,
+		// such as module runners created over a separate bootstrap channel.
+		unsafeHandleRuntimeRestart: z
+			.custom<() => Awaitable<void>>((value) => typeof value === "function")
+			.optional(),
+
 		// Deliberately not `z.function()`: parsing that schema replaces the
 		// callback with a validating wrapper. When the callback is `async`
 		// (assignable to a `void` return), the wrapper calls it, rejects the

--- a/packages/miniflare/src/runtime/index.ts
+++ b/packages/miniflare/src/runtime/index.ts
@@ -44,6 +44,8 @@ export interface RuntimeOptions {
 	verbose?: boolean;
 	handleRuntimeStdio?: (stdout: Readable, stderr: Readable) => void;
 	handleStructuredLogs?: StructuredLogsHandler;
+	// Called when workerd crashes after the initial ready signal
+	onWorkerdCrashRestart?: () => void;
 	// Extra environment variables to set on the spawned `workerd` subprocess.
 	// Merged on top of `process.env` and Miniflare's own defaults
 	// (e.g. `TZ=UTC`, `FORCE_COLOR`), so callers can override those defaults.
@@ -235,7 +237,6 @@ export class Runtime {
 	): Promise<SocketPorts | undefined> {
 		// 1. Stop existing process (if any) and wait for exit
 		await this.dispose();
-		// TODO: what happens if runtime crashes?
 
 		// 2. Start new process
 		const command = getRuntimeCommand();
@@ -308,36 +309,35 @@ export class Runtime {
 			const bootloaderPath =
 				process.env.NODE_OPTIONS?.match(/--require "(.*?)"/)?.[1];
 
-			if (!bootloaderPath) {
-				return ports;
-			}
-			const watchdogPath = path.resolve(bootloaderPath, "../watchdog.js");
+			if (bootloaderPath) {
+				const watchdogPath = path.resolve(bootloaderPath, "../watchdog.js");
 
-			const info = getInspectorOptions();
+				const info = getInspectorOptions();
 
-			for (const name of workerNames) {
-				// This is copied from https://github.com/microsoft/vscode-js-debug/blob/0b5e0dade997b3c702a98e1f58989afcb30612d6/src/targets/node/bootloader.ts#L284
-				// It spawns a detached "watchdog" process for each corresponding (user) Worker in workerd which will maintain the VSCode debug connection
-				const p = spawn(process.execPath, [watchdogPath], {
-					env: {
-						NODE_INSPECTOR_INFO: JSON.stringify({
-							ipcAddress: info.inspectorIpc || "",
-							pid: String(this.#process.pid),
-							scriptName: name,
-							inspectorURL: `ws://127.0.0.1:${ports?.get(
-								kInspectorSocket
-							)}/core:user:${name}`,
-							waitForDebugger: true,
-							ownId: randomBytes(12).toString("hex"),
-							openerId: info.openerId,
-						}),
-						NODE_SKIP_PLATFORM_CHECK: process.env.NODE_SKIP_PLATFORM_CHECK,
-						ELECTRON_RUN_AS_NODE: "1",
-					},
-					stdio: "ignore",
-					detached: true,
-				});
-				p.unref();
+				for (const name of workerNames) {
+					// This is copied from https://github.com/microsoft/vscode-js-debug/blob/0b5e0dade997b3c702a98e1f58989afcb30612d6/src/targets/node/bootloader.ts#L284
+					// It spawns a detached "watchdog" process for each corresponding (user) Worker in workerd which will maintain the VSCode debug connection
+					const p = spawn(process.execPath, [watchdogPath], {
+						env: {
+							NODE_INSPECTOR_INFO: JSON.stringify({
+								ipcAddress: info.inspectorIpc || "",
+								pid: String(this.#process.pid),
+								scriptName: name,
+								inspectorURL: `ws://127.0.0.1:${ports?.get(
+									kInspectorSocket
+								)}/core:user:${name}`,
+								waitForDebugger: true,
+								ownId: randomBytes(12).toString("hex"),
+								openerId: info.openerId,
+							}),
+							NODE_SKIP_PLATFORM_CHECK: process.env.NODE_SKIP_PLATFORM_CHECK,
+							ELECTRON_RUN_AS_NODE: "1",
+						},
+						stdio: "ignore",
+						detached: true,
+					});
+					p.unref();
+				}
 			}
 		}
 
@@ -345,6 +345,23 @@ export class Runtime {
 
 		if (ports === undefined && !abortSignal.aborted) {
 			startupLogBuffer.handleStartupFailure();
+		} else {
+			// workerd is now listening. Watch for unexpected exits so we can
+			// restart.
+			const currentProcess = this.#process;
+			void processExitPromise.then(() => {
+				if (this.#process !== currentProcess) {
+					// We got here because dispose() set this.#process to
+					// undefined before sending SIGKILL
+					return;
+				}
+				if (abortSignal.aborted) {
+					return;
+				}
+				// Crash: clear stale #process and notify the caller.
+				this.#process = undefined;
+				options.onWorkerdCrashRestart?.();
+			});
 		}
 
 		return ports;

--- a/packages/miniflare/test/index.spec.ts
+++ b/packages/miniflare/test/index.spec.ts
@@ -2969,6 +2969,175 @@ unixSerialTest(
 	}
 );
 
+test("Miniflare: workerd crash during startup => ERR_RUNTIME_FAILURE", async ({
+	expect,
+	onTestFinished,
+}) => {
+	const mf = new Miniflare({
+		modules: true,
+		script: `
+			import { abortIsolate } from "cloudflare:workers";
+			abortIsolate("crash!");
+			export default {
+				fetch(request) {
+					return new Response("ok");
+				},
+			}
+		`,
+	});
+	// dispose() on a startup-failed instance propagates the same
+	// ERR_RUNTIME_FAILURE
+	onTestFinished(() => mf.dispose().catch(() => {}));
+
+	await expect(mf.ready).rejects.toMatchObject({
+		code: "ERR_RUNTIME_FAILURE",
+		message: expect.stringContaining("The Workers runtime failed to start."),
+	});
+});
+
+test("Miniflare: workerd crash in handler => restart", async ({ expect }) => {
+	const runtimeRestarted = new DeferredPromise<void>();
+	const mf = new Miniflare({
+		modules: true,
+		unsafeHandleRuntimeRestart: () => runtimeRestarted.resolve(),
+		script: `
+			import { abortIsolate } from "cloudflare:workers";
+			let counter = 1;
+			export default {
+				fetch(request) {
+					if (new URL(request.url).searchParams.get("crash")) {
+						abortIsolate("test crash");
+					}
+					return new Response(\`ok \${counter++}\`);
+				},
+			}
+		`,
+	});
+	useDispose(mf);
+
+	const ready = await mf.ready;
+	const worker = await mf.getWorker();
+	const r1 = await mf.dispatchFetch("http://placeholder/");
+	expect(await r1.text()).toBe("ok 1");
+
+	const r2 = await mf.dispatchFetch("http://placeholder/");
+	expect(await r2.text()).toBe("ok 2");
+
+	// Trigger crash
+	await expect(
+		mf.dispatchFetch("http://placeholder/?crash=1")
+	).rejects.toThrow();
+
+	await runtimeRestarted;
+	expect(await mf.ready).toEqual(ready);
+	expect(() => worker.fetch("http://placeholder/")).toThrow(/poisoned stub/);
+
+	// Starts over with counter = 1 again
+	const r3 = await fetch(ready);
+	expect(await r3.text()).toBe("ok 1");
+	const restartedWorker = await mf.getWorker();
+	const r4 = await restartedWorker.fetch("http://placeholder/");
+	expect(await r4.text()).toBe("ok 2");
+});
+
+test("Miniflare: logs workerd restart failures", async ({ expect }) => {
+	const log = new TestLog();
+	const logError = vi.spyOn(log, "error").mockImplementation(() => {});
+	const handleRuntimeRestart = vi.fn();
+	let runtimeStarts = 0;
+	const options = {
+		log,
+		modules: true,
+		handleRuntimeStdio() {
+			runtimeStarts++;
+			if (runtimeStarts === 2) {
+				throw new Error("restart failed");
+			}
+		},
+		unsafeHandleRuntimeRestart: handleRuntimeRestart,
+		script: `
+			import { abortIsolate } from "cloudflare:workers";
+			export default {
+				fetch(request) {
+					if (new URL(request.url).searchParams.get("crash")) {
+						abortIsolate("test crash");
+					}
+					return new Response("ok");
+				},
+			}
+		`,
+	} satisfies MiniflareOptions;
+	const mf = new Miniflare(options);
+	useDispose(mf);
+
+	await mf.ready;
+	await expect(
+		mf.dispatchFetch("http://placeholder/?crash=1")
+	).rejects.toThrow();
+
+	await vi.waitFor(() => {
+		expect(logError).toHaveBeenCalledWith(
+			expect.objectContaining({
+				code: "ERR_RUNTIME_FAILURE",
+				message:
+					"The Workers runtime failed to restart after an unexpected crash.",
+			})
+		);
+	});
+	expect(handleRuntimeRestart).not.toHaveBeenCalled();
+	await expect(mf.ready).rejects.toMatchObject({
+		code: "ERR_RUNTIME_FAILURE",
+		message: "The Workers runtime failed to restart after an unexpected crash.",
+	});
+
+	await mf.setOptions(options);
+	const response = await mf.dispatchFetch("http://placeholder/");
+	expect(await response.text()).toBe("ok");
+});
+
+test("Miniflare: logs post-restart callback failures", async ({ expect }) => {
+	const log = new TestLog();
+	const logError = vi.spyOn(log, "error").mockImplementation(() => {});
+	const callbackCalled = new DeferredPromise<void>();
+	const mf = new Miniflare({
+		log,
+		modules: true,
+		async unsafeHandleRuntimeRestart() {
+			callbackCalled.resolve();
+			throw new Error("callback failed");
+		},
+		script: `
+			import { abortIsolate } from "cloudflare:workers";
+			export default {
+				fetch(request) {
+					if (new URL(request.url).searchParams.get("crash")) {
+						abortIsolate("test crash");
+					}
+					return new Response("ok");
+				},
+			}
+		`,
+	});
+	useDispose(mf);
+
+	await mf.ready;
+	await expect(
+		mf.dispatchFetch("http://placeholder/?crash=1")
+	).rejects.toThrow();
+	await callbackCalled;
+
+	await vi.waitFor(() => {
+		expect(logError).toHaveBeenCalledWith(
+			expect.objectContaining({
+				message:
+					"The Workers runtime restarted, but the runtime restart callback failed.",
+			})
+		);
+	});
+	const response = await mf.dispatchFetch("http://placeholder/");
+	expect(await response.text()).toBe("ok");
+});
+
 test("Miniflare: exits cleanly", async ({ expect }) => {
 	const miniflarePath = require.resolve("miniflare");
 	const result = childProcess.spawn(

--- a/packages/vite-plugin-cloudflare/playground/config-changes/__tests__/runtime-restart.spec.ts
+++ b/packages/vite-plugin-cloudflare/playground/config-changes/__tests__/runtime-restart.spec.ts
@@ -1,0 +1,42 @@
+import { test, vi } from "vitest";
+import {
+	getTextResponse,
+	isBuild,
+	viteTestUrl,
+	WAIT_FOR_OPTIONS,
+} from "../../__test-utils__";
+
+test.runIf(!isBuild)(
+	"serves requests after workerd crashes",
+	async ({ expect }) => {
+		await vi.waitFor(
+			async () =>
+				expect(await getTextResponse()).toContain(
+					'The value of MY_VAR is "one"'
+				),
+			WAIT_FOR_OPTIONS
+		);
+		const initialRuntimeResponse = await fetch(`${viteTestUrl}/__runtime-id`);
+		expect(initialRuntimeResponse.ok).toBe(true);
+		const initialRuntimeId = await initialRuntimeResponse.text();
+
+		const crashResponse = await fetch(`${viteTestUrl}/__crash-workerd`, {
+			signal: AbortSignal.timeout(2_000),
+		}).catch(() => undefined);
+		expect(crashResponse?.ok).not.toBe(true);
+
+		await vi.waitFor(async () => {
+			const runtimeId = await fetch(`${viteTestUrl}/__runtime-id`, {
+				signal: AbortSignal.timeout(2_000),
+			}).then((response) => response.text());
+			expect(runtimeId).not.toBe(initialRuntimeId);
+
+			const response = await fetch(viteTestUrl, {
+				signal: AbortSignal.timeout(2_000),
+			});
+			expect(response.ok).toBe(true);
+			expect(await response.text()).toContain('The value of MY_VAR is "one"');
+		}, WAIT_FOR_OPTIONS);
+	},
+	20_000
+);

--- a/packages/vite-plugin-cloudflare/playground/config-changes/src/index.ts
+++ b/packages/vite-plugin-cloudflare/playground/config-changes/src/index.ts
@@ -1,10 +1,22 @@
+// @ts-expect-error -- `abortIsolate` is an internal runtime test hook.
+import { abortIsolate } from "cloudflare:workers";
+
 interface Env {
 	MY_VAR: string;
 	MY_SECRET: string;
 }
 
+const runtimeId = crypto.randomUUID();
+
 export default {
-	async fetch(_, env) {
+	async fetch(request, env) {
+		const pathname = new URL(request.url).pathname;
+		if (pathname === "/__crash-workerd") {
+			abortIsolate("Vite runtime restart test");
+		}
+		if (pathname === "/__runtime-id") {
+			return new Response(runtimeId);
+		}
 		return new Response(
 			`The value of MY_VAR is "${env.MY_VAR}" and the value of MY_SECRET is "${env.MY_SECRET}"`
 		);

--- a/packages/vite-plugin-cloudflare/src/miniflare-options.ts
+++ b/packages/vite-plugin-cloudflare/src/miniflare-options.ts
@@ -35,7 +35,11 @@ import { getInputInspectorPort } from "./debug";
 import { additionalModuleRE } from "./plugins/additional-modules";
 import { ENVIRONMENT_NAME_HEADER } from "./shared";
 import { checkForNpmUpdate } from "./update-check";
-import { satisfiesMinimumViteVersion, withTrailingSlash } from "./utils";
+import {
+	debuglog,
+	satisfiesMinimumViteVersion,
+	withTrailingSlash,
+} from "./utils";
 import type { Bundle } from "./build-output-preview";
 import type { CloudflareDevEnvironment } from "./cloudflare-environment";
 import type { ContainerTagToOptionsMap } from "./containers";
@@ -474,6 +478,18 @@ export async function getDevMiniflareOptions(
 			unsafeLocalExplorer: getLocalExplorerEnabledFromEnv(),
 			telemetry: { enabled: false },
 			handleStructuredLogs: getStructuredLogsLogger(logger),
+			async unsafeHandleRuntimeRestart() {
+				// Miniflare has restarted `workerd` after a crash, but the
+				// module runners created over our separate bootstrap channel
+				// died with the previous process. Restarting the Vite dev
+				// server re-creates the environments, hot channels, and module
+				// runners so requests are served again instead of failing with
+				// an opaque `fetch failed`.
+				debuglog(
+					"workerd restarted after a crash; restarting the Vite dev server"
+				);
+				await viteDevServer.restart();
+			},
 			defaultPersistRoot: getPersistenceRoot(
 				resolvedViteConfig.root,
 				resolvedPluginConfig.persistState


### PR DESCRIPTION
This replaces a previous attempt https://github.com/cloudflare/workers-sdk/pull/13045

When workerd crashes we can usually recover. This does so by restoring state inside Miniflare and notifying the Vite plugin (via `unsafeHandleRuntimeRestart`) so it can restart the dev server.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: No API change

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14792" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->