### PR TITLE
fix(vitest-pool-workers): tolerate dispose rejections in pool worker stop()

### DIFF
--- a/.changeset/pool-worker-tolerate-dispose-segfault.md
+++ b/.changeset/pool-worker-tolerate-dispose-segfault.md
@@ -2,29 +2,6 @@
 "@cloudflare/vitest-pool-workers": patch
 ---
 
-fix: tolerate `Miniflare#dispose()` rejections in `CloudflarePoolWorker.stop()`
+Prevent worker disposal errors from failing otherwise successful test runs
 
-workerd can segfault (`Received signal #11`) during shutdown on linux-x64 /
-WSL2 and macOS-arm64 (see
-[cloudflare/workerd#6763](https://github.com/cloudflare/workerd/issues/6763)).
-Previously, the rejection from `mf.dispose()` and the remote-proxy session
-`dispose()` propagated out of `stop()` and failed the vitest run with exit 1,
-even though every test body had already reported as passed.
-
-These disposes are now wrapped with `.catch()` handlers that log the rejection
-via `util.debuglog("vitest-pool-workers")` (visible with
-`NODE_DEBUG=vitest-pool-workers`) but do not propagate. The upstream workerd
-segfault still needs to be fixed in workerd itself; this change only stops the
-pool from turning that teardown crash into a test-side exit 1.
-
-Local reproduction (WSL2, @cloudflare/vitest-pool-workers 0.12.21 baseline):
-
-```
-Tests  794 passed (794)
-❌ vitest exit 1
-[vpw:debug] Disposing remote proxy sessions...
-[vite:connect] ECONNRESET  → [vitest-pool]: Worker cloudflare-pool emitted error
-```
-
-After this change, the same suite reports `794 passed` and exits 0, with the
-rejection detail available on stderr under `NODE_DEBUG=vitest-pool-workers`.
+Errors raised while disposing test Workers are now logged for diagnostics rather than overriding the test result. Set `NODE_DEBUG=vitest-pool-workers` to view these errors.

--- a/.changeset/pool-worker-tolerate-dispose-segfault.md
+++ b/.changeset/pool-worker-tolerate-dispose-segfault.md
@@ -1,0 +1,30 @@
+---
+"@cloudflare/vitest-pool-workers": patch
+---
+
+fix: tolerate `Miniflare#dispose()` rejections in `CloudflarePoolWorker.stop()`
+
+workerd can segfault (`Received signal #11`) during shutdown on linux-x64 /
+WSL2 and macOS-arm64 (see
+[cloudflare/workerd#6763](https://github.com/cloudflare/workerd/issues/6763)).
+Previously, the rejection from `mf.dispose()` and the remote-proxy session
+`dispose()` propagated out of `stop()` and failed the vitest run with exit 1,
+even though every test body had already reported as passed.
+
+These disposes are now wrapped with `.catch()` handlers that log the rejection
+via `util.debuglog("vitest-pool-workers")` (visible with
+`NODE_DEBUG=vitest-pool-workers`) but do not propagate. The upstream workerd
+segfault still needs to be fixed in workerd itself; this change only stops the
+pool from turning that teardown crash into a test-side exit 1.
+
+Local reproduction (WSL2, @cloudflare/vitest-pool-workers 0.12.21 baseline):
+
+```
+Tests  794 passed (794)
+❌ vitest exit 1
+[vpw:debug] Disposing remote proxy sessions...
+[vite:connect] ECONNRESET  → [vitest-pool]: Worker cloudflare-pool emitted error
+```
+
+After this change, the same suite reports `794 passed` and exits 0, with the
+rejection detail available on stderr under `NODE_DEBUG=vitest-pool-workers`.

--- a/packages/vitest-pool-workers/src/pool/cloudflare-pool-worker.ts
+++ b/packages/vitest-pool-workers/src/pool/cloudflare-pool-worker.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert";
 import path from "node:path";
+import util from "node:util";
 import { compileModuleRules, testRegExps } from "miniflare";
 import { type ProvidedContext } from "vitest";
 import { workerdBuiltinModules } from "../shared/builtin-modules";
@@ -35,6 +36,10 @@ import type {
 
 export class CloudflarePoolWorker implements PoolWorker {
 	name = "cloudflare-pool";
+	// Used to log non-fatal dispose errors (e.g. workerd shutdown segfaults —
+	// see https://github.com/cloudflare/workerd/issues/6763) without propagating
+	// them as unhandled rejections that fail an otherwise-passing vitest run.
+	private readonly debug = util.debuglog("vitest-pool-workers");
 	private mf: Miniflare | undefined;
 	private socket: WebSocket | undefined;
 	private parsedPoolOptions: WorkersPoolOptionsWithDefines | undefined;
@@ -109,13 +114,30 @@ export class CloudflarePoolWorker implements PoolWorker {
 	async stop(): Promise<void> {
 		this.socket?.close();
 		this.socket = undefined;
-		await this.mf?.dispose();
+		// Tolerate (but log) dispose rejections. workerd can segfault during
+		// shutdown on linux-x64 / WSL2 and macOS-arm64 (see
+		// https://github.com/cloudflare/workerd/issues/6763); without this,
+		// the rejection bubbles out of `stop()` and fails an otherwise-passing
+		// vitest run with exit 1, even though every test body reported as
+		// passed.
+		await this.mf?.dispose().catch((err) => {
+			this.debug(
+				"miniflare dispose rejected (likely workerd shutdown segfault — see cloudflare/workerd#6763): %s",
+				err instanceof Error ? err.stack ?? err.message : err
+			);
+		});
 		this.mf = undefined;
 
 		if (this.parsedPoolOptions?.wrangler?.configPath) {
-			await remoteProxySessionsDataMap
-				.get(this.parsedPoolOptions?.wrangler?.configPath)
-				?.session?.dispose?.();
+			const session = remoteProxySessionsDataMap.get(
+				this.parsedPoolOptions.wrangler.configPath
+			)?.session;
+			await session?.dispose?.()?.catch((err) => {
+				this.debug(
+					"remote proxy session dispose rejected (likely workerd shutdown segfault — see cloudflare/workerd#6763): %s",
+					err instanceof Error ? err.stack ?? err.message : err
+				);
+			});
 		}
 
 		// Decrement the active worker count. When the last worker stops, this

--- a/packages/vitest-pool-workers/src/pool/cloudflare-pool-worker.ts
+++ b/packages/vitest-pool-workers/src/pool/cloudflare-pool-worker.ts
@@ -36,9 +36,6 @@ import type {
 
 export class CloudflarePoolWorker implements PoolWorker {
 	name = "cloudflare-pool";
-	// Used to log non-fatal dispose errors (e.g. workerd shutdown segfaults —
-	// see https://github.com/cloudflare/workerd/issues/6763) without propagating
-	// them as unhandled rejections that fail an otherwise-passing vitest run.
 	private readonly debug = util.debuglog("vitest-pool-workers");
 	private mf: Miniflare | undefined;
 	private socket: WebSocket | undefined;
@@ -114,17 +111,10 @@ export class CloudflarePoolWorker implements PoolWorker {
 	async stop(): Promise<void> {
 		this.socket?.close();
 		this.socket = undefined;
-		// Tolerate (but log) dispose rejections. workerd can segfault during
-		// shutdown on linux-x64 / WSL2 and macOS-arm64 (see
-		// https://github.com/cloudflare/workerd/issues/6763); without this,
-		// the rejection bubbles out of `stop()` and fails an otherwise-passing
-		// vitest run with exit 1, even though every test body reported as
-		// passed.
+		// Disposal errors should not override the test result, but log them for
+		// diagnostics in case they indicate an underlying teardown issue.
 		await this.mf?.dispose().catch((err) => {
-			this.debug(
-				"miniflare dispose rejected (likely workerd shutdown segfault — see cloudflare/workerd#6763): %s",
-				err instanceof Error ? err.stack ?? err.message : err
-			);
+			this.debug("miniflare dispose rejected: %O", err);
 		});
 		this.mf = undefined;
 
@@ -133,10 +123,7 @@ export class CloudflarePoolWorker implements PoolWorker {
 				this.parsedPoolOptions.wrangler.configPath
 			)?.session;
 			await session?.dispose?.()?.catch((err) => {
-				this.debug(
-					"remote proxy session dispose rejected (likely workerd shutdown segfault — see cloudflare/workerd#6763): %s",
-					err instanceof Error ? err.stack ?? err.message : err
-				);
+				this.debug("remote proxy session dispose rejected: %O", err);
 			});
 		}
 


### PR DESCRIPTION
## What

`CloudflarePoolWorker.stop()` currently `await`s `mf.dispose()` and the
remote-proxy session `dispose()` directly. When workerd segfaults during
shutdown (linux-x64 / WSL2 / macOS-arm64 — see
[cloudflare/workerd#6763](https://github.com/cloudflare/workerd/issues/6763)),
that rejection propagates out of `stop()` and the vitest process exits 1,
even though every test body has already reported as passed. Pre-commit gates
that key off `vitest` exit code then block unrelated work on a teardown
crash the user can't observe.

This change wraps both disposes with `.catch()` handlers that log the
rejection via `util.debuglog("vitest-pool-workers")` (visible under
`NODE_DEBUG=vitest-pool-workers`) but do not propagate. Diagnostics stay
available; the vitest run completes cleanly.

## Reproduction (matches the linked upstream issue)

```
Tests  794 passed (794)
❌ vitest exit 1
[vpw:debug] Disposing remote proxy sessions...
[vite:connect] ECONNRESET  → [vitest-pool]: Worker cloudflare-pool emitted error
```

After this change, the same suite reports `794 passed` and exits 0. The
rejection detail is logged on stderr under
`NODE_DEBUG=vitest-pool-workers`.

## Scope

This is a **defensive test-side mitigation**, not a workerd-side fix. The
upstream `Received signal #11` still needs to be fixed in workerd itself
(per #6763). This change stops the pool from turning that teardown crash
into a test-side exit 1.

Test files whose worker dies mid-teardown will still be silently dropped
from the pass counter if they have teardown assertions, because this only
absorbs the dispose rejection — anything that runs after the worker is
dead will of course still fail.

## Why not just fix the workerd segfault upstream?

The workerd-side bug is real and tracked in
[cloudflare/workerd#6763](https://github.com/cloudflare/workerd/issues/6763)
(no maintainer response yet as of 2026-07-22). This change is independent of
that fix landing and unblocks users today; both should ship.

## Implementation notes

- Uses the same `util.debuglog("vitest-pool-workers")` channel the rest of
  the package uses for diagnostic logs (see
  `packages/vitest-pool-workers/src/pool/index.ts:73`), so the message stays
  quiet by default and surfaces only with `NODE_DEBUG=vitest-pool-workers`.
- Marks the message with the upstream issue URL so anyone seeing it during
  teardown can immediately find context.
- Adds a `patch`-level changeset.

## Changeset

`.changeset/pool-worker-tolerate-dispose-segfault.md`

## Related

- Closes (test-side aspect of) cloudflare/workerd#6763 — partial fix;
  the underlying workerd SIGSEGV still needs a workerd-side patch.
- Cross-references the workerd comment at
  https://github.com/cloudflare/workerd/issues/6763#issuecomment-5033468472
  where the pool-side root cause was first described.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14793" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->