### PR TITLE
feat(vitest-pool-workers): tolerate post-stop() socket error events when configured

### DIFF
--- a/.changeset/pool-worker-tolerate-shutdown-socket-errors.md
+++ b/.changeset/pool-worker-tolerate-shutdown-socket-errors.md
@@ -1,0 +1,43 @@
+---
+"@cloudflare/vitest-pool-workers": patch
+---
+
+fix: tolerate post-`stop()` socket `error` events when configured
+
+workerd can segfault (`Received signal #11`) during shutdown on linux-x64 /
+WSL2 and macOS-arm64 (see
+[cloudflare/workerd#6763](https://github.com/cloudflare/workerd/issues/6763)).
+After all tests in a file have already reported as passing, the segfault causes
+miniflare's WebSocket to dispatch an `error` event; vitest then surfaces that
+as `[vitest-pool]: Worker cloudflare-pool emitted error` and fails the run
+with exit 1.
+
+This change adds an opt-in `tolerateWorkerShutdownErrors: boolean` option
+(default `false`) to the cloudflare-pool worker configuration. When enabled,
+`error` events received after `stop()` has begun are logged via
+`NODE_DEBUG=vitest-pool-workers` but not forwarded to vitest as fatal. Errors
+received while the pool worker is still running are still propagated
+unchanged.
+
+This change does **not** alter the behavior of `stop()` itself — for the
+dispose-side fix, see #14793 (which wraps `Miniflare#dispose()` and the
+remote-proxy session `dispose()` with `.catch()` handlers). Pairing both
+options (`tolerateWorkerShutdownErrors: true` + the dispose fix) is what
+produces a fully-shutdown-tolerant run.
+
+Scope is a test-side mitigation only — the upstream `Received signal #11`
+itself still needs to be fixed in workerd itself.
+
+Reproduction (matches
+[cloudflare/workerd#6763](https://github.com/cloudflare/workerd/issues/6763)):
+
+```
+Tests  794 passed (794)
+❌ vitest exit 1
+[vitest-pool]: Worker cloudflare-pool emitted error.
+Caused by: Worker exited unexpectedly
+```
+
+With `tolerateWorkerShutdownErrors: true`, the same suite reports `794 passed`
+and exits 0. The segfault is still printed to stderr; only the test-side exit
+suppression changes.

--- a/packages/vitest-pool-workers/src/pool/cloudflare-pool-worker.ts
+++ b/packages/vitest-pool-workers/src/pool/cloudflare-pool-worker.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert";
 import path from "node:path";
+import util from "node:util";
 import { compileModuleRules, testRegExps } from "miniflare";
 import { type ProvidedContext } from "vitest";
 import { workerdBuiltinModules } from "../shared/builtin-modules";
@@ -35,10 +36,20 @@ import type {
 
 export class CloudflarePoolWorker implements PoolWorker {
 	name = "cloudflare-pool";
+	// Used to log non-fatal socket errors (e.g. workerd shutdown segfaults —
+	// see https://github.com/cloudflare/workerd/issues/6763) without surfacing
+	// them to vitest when configured to tolerate them.
+	private readonly debug = util.debuglog("vitest-pool-workers");
 	private mf: Miniflare | undefined;
 	private socket: WebSocket | undefined;
 	private parsedPoolOptions: WorkersPoolOptionsWithDefines | undefined;
 	private main: string | undefined;
+	// Set once `stop()` begins; controls whether post-teardown `error` events
+	// from the runner socket should be suppressed (see
+	// https://github.com/cloudflare/workerd/issues/6763 and the
+	// `tolerateWorkerShutdownErrors` config option).
+	private stopping = false;
+	private tolerateWorkerShutdownErrors = false;
 	// Store wrapped listeners so off() can remove them correctly.
 	// Vitest registers at most one listener per event type.
 	private messageListener?: (event: MiniflareMessageEvent) => void;
@@ -76,6 +87,8 @@ export class CloudflarePoolWorker implements PoolWorker {
 			this.options.project,
 			resolvedPoolOptions
 		);
+		this.tolerateWorkerShutdownErrors =
+			this.parsedPoolOptions.tolerateWorkerShutdownErrors === true;
 		this.main = maybeGetResolvedMainPath(
 			this.options.project,
 			this.parsedPoolOptions
@@ -107,6 +120,14 @@ export class CloudflarePoolWorker implements PoolWorker {
 	}
 
 	async stop(): Promise<void> {
+		// Mark the worker as stopping BEFORE closing the socket so that any
+		// `error` event dispatched by the WebSocket during teardown (for
+		// example, when workerd segfaults on shutdown — see
+		// https://github.com/cloudflare/workerd/issues/6763) can be inspected
+		// in the `error` listener and, when `tolerateWorkerShutdownErrors`
+		// is enabled, suppressed instead of forwarded to vitest as a fatal
+		// error.
+		this.stopping = true;
 		this.socket?.close();
 		this.socket = undefined;
 		await this.mf?.dispose();
@@ -282,7 +303,25 @@ export class CloudflarePoolWorker implements PoolWorker {
 			this.socket.addEventListener("message", this.messageListener);
 		} else if (event === "error") {
 			this.errorListener = (e: Event) => {
-				(callback as (maybeError: unknown) => void)("error" in e ? e.error : e);
+				const errorValue = "error" in e ? e.error : e;
+				// When `tolerateWorkerShutdownErrors` is enabled and the pool
+				// worker is tearing down (or has finished tearing down),
+				// suppress socket `error` events. The workerd subprocess can
+				// segfault during teardown (see
+				// https://github.com/cloudflare/workerd/issues/6763); the
+				// resulting `error` event would otherwise be surfaced to vitest
+				// as a fatal `[vitest-pool]: Worker cloudflare-pool emitted
+				// error` and fail an otherwise-passing run with exit 1.
+				if (this.stopping && this.tolerateWorkerShutdownErrors) {
+					this.debug(
+						"ignoring socket `error` during teardown (tolerateWorkerShutdownErrors=true; see cloudflare/workerd#6763): %s",
+						errorValue instanceof Error
+							? errorValue.stack ?? errorValue.message
+							: errorValue
+					);
+					return;
+				}
+				(callback as (maybeError: unknown) => void)(errorValue);
 			};
 			this.socket.addEventListener("error", this.errorListener);
 		} else if (event === "exit") {

--- a/packages/vitest-pool-workers/src/pool/config.ts
+++ b/packages/vitest-pool-workers/src/pool/config.ts
@@ -73,6 +73,21 @@ const WorkersPoolOptionsSchema = z.object({
 	wrangler: z
 		.object({ configPath: z.ostring(), environment: z.ostring() })
 		.optional(),
+	/**
+	 * Tolerate `error` events on the runner WebSocket after the pool worker
+	 * has begun shutting down. Workerd can segfault during teardown on
+	 * linux-x64 / WSL2 and macOS-arm64 (see
+	 * https://github.com/cloudflare/workerd/issues/6763); without this flag,
+	 * those errors reach vitest as fatal `[vitest-pool]: Worker cloudflare-pool
+	 * emitted error`s, failing an otherwise-passing run with exit 1.
+	 *
+	 * Errors raised while a task is in flight are still forwarded normally;
+	 * only post-`stop()` `error` events are suppressed (and logged via
+	 * `NODE_DEBUG=vitest-pool-workers`).
+	 *
+	 * @default false
+	 */
+	tolerateWorkerShutdownErrors: z.boolean().default(false),
 });
 
 export type SourcelessWorkerOptions = Omit<


### PR DESCRIPTION
## What

When workerd segfaults during shutdown ([cloudflare/workerd#6763](https://github.com/cloudflare/workerd/issues/6763)), miniflare's WebSocket dispatches an `error` event after every test in the file has already been reported as passing. vitest then surfaces this as `[vitest-pool]: Worker cloudflare-pool emitted error` and fails the run with exit 1.

This change adds a new opt-in `tolerateWorkerShutdownErrors: boolean` option to the cloudflare-pool worker configuration. When enabled, `error` events received after `stop()` has begun are logged via `NODE_DEBUG=vitest-pool-workers` and not propagated to vitest as fatal errors. The default behavior is unchanged.

## Relationship to #14793

This PR is intentionally distinct from #14793 (which wraps Miniflare#dispose() and the remote-proxy session dispose() with .catch()). The two changes tolerate different amplifiers in the same root-cause chain:

- **#14793**: tolerates stop()'s dispose promises rejecting when workerd crashes during teardown.
- **This PR**: tolerates the WebSocket error event that miniflare emits when the workerd subprocess exits unexpectedly — which can fire *after* stop() has begun (or *during* teardown of the next test file's worker).

Both are useful. They can be enabled together or independently. Neither fixes the underlying workerd SIGSEGV — that needs to be done in workerd itself.

## Root-cause recap

The workerd SIGSEGV is the trigger; the test-side non-zero exit is three layers deep:

1. workerd subprocess dies during shutdown (upstream bug).
2. The dispose promises in CloudflarePoolWorker.stop() reject with that segfault (mitigated by #14793).
3. The WebSocket dispatches an error event AFTER stop() begins, which vitest surfaces as fatal. (mitigated by this PR)
4. tinypool's ProcessWorker.onUnexpectedExit also emits Worker exited unexpectedly for forks that exit while idle — this is mitigated by the new allowWorkerIdleExit opt-in in tinylibs/tinypool#133.

## Reproduction

```
Tests  794 passed (794)
❌ vitest exit 1
[vitest-pool]: Worker cloudflare-pool emitted error.
Caused by: Worker exited unexpectedly
```

With `tolerateWorkerShutdownErrors: true`, the same suite reports `794 passed` and exits 0. The segfault is still printed to stderr; only the test-side exit suppression changes.

## Implementation notes

- The stopping flag is set at the very start of stop() so any error event that fires after that point — including ones that fire synchronously from socket.close() — sees the same state.
- Errors raised while a task is in flight are still propagated unchanged. Only post-stop() error events are inspected.
- The debug logging uses the same util.debuglog(vitest-pool-workers) channel the rest of the package uses for diagnostic logs.
- Marks the message with the upstream issue URL so anyone seeing it during teardown can immediately find context.
- Adds a patch-level changeset.

## Related

- Partial fix (test-side amplifier #2) of cloudflare/workerd#6763.
- Complements #14793 (test-side amplifier #1).
- Cross-references the workerd comment at https://github.com/cloudflare/workerd/issues/6763#issuecomment-5033468472 and https://github.com/cloudflare/workerd/issues/6763#issuecomment-5039264484.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14794" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->