### PR TITLE
[wrangler] Derive old log file age from filename timestamp

### DIFF
--- a/.changeset/spicy-mangos-cleanup.md
+++ b/.changeset/spicy-mangos-cleanup.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Speed up old debug log cleanup by reading each log file's date from its filename instead of `stat`-ing every file
+
+Wrangler periodically deletes debug log files older than 30 days from its logs directory. Previously it made a filesystem `stat` call for each file to read its modification time; it now derives the age from the timestamp already encoded in the log filename, avoiding that extra work.

--- a/packages/wrangler/src/__tests__/utils/log-file.test.ts
+++ b/packages/wrangler/src/__tests__/utils/log-file.test.ts
@@ -5,7 +5,6 @@ import {
 	readFileSync,
 	writeFileSync,
 } from "node:fs";
-import { utimes } from "node:fs/promises";
 import { join } from "node:path";
 import { removeDirSync } from "@cloudflare/workers-utils";
 import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
@@ -136,13 +135,21 @@ describe("appendToDebugLogFile", () => {
 describe("cleanupOldLogFiles", () => {
 	runInTempDir();
 
-	async function createLogFile(logsDir: string, name: string, ageDays: number) {
+	/** Builds a wrangler log filename encoding a timestamp `ageDays` in the past. */
+	function logFileNameForAge(ageDays: number) {
+		const date = new Date(Date.now() - ageDays * 24 * 60 * 60 * 1000)
+			.toISOString()
+			.replaceAll(":", "-")
+			.replace(".", "_")
+			.replace("T", "_")
+			.replace("Z", "");
+		return `wrangler-${date}.log`;
+	}
+
+	function createLogFile(logsDir: string, name: string) {
 		mkdirSync(logsDir, { recursive: true });
 		const filePath = join(logsDir, name);
 		writeFileSync(filePath, "test log content");
-		// Set the file's modification time to simulate its age
-		const mtime = new Date(Date.now() - ageDays * 24 * 60 * 60 * 1000);
-		await utimes(filePath, mtime, mtime);
 		return filePath;
 	}
 
@@ -150,15 +157,13 @@ describe("cleanupOldLogFiles", () => {
 		expect,
 	}) => {
 		const logsDir = "test-logs";
-		const oldFile = await createLogFile(
+		const oldFile = createLogFile(
 			logsDir,
-			"wrangler-old.log",
-			31 // 31 days old — should be deleted
+			logFileNameForAge(31) // 31 days old — should be deleted
 		);
-		const recentFile = await createLogFile(
+		const recentFile = createLogFile(
 			logsDir,
-			"wrangler-recent.log",
-			10 // 10 days old — should be kept
+			logFileNameForAge(10) // 10 days old — should be kept
 		);
 
 		await cleanupOldLogFiles(logsDir);
@@ -169,11 +174,22 @@ describe("cleanupOldLogFiles", () => {
 
 	it("should not delete non-wrangler log files", async ({ expect }) => {
 		const logsDir = "test-logs-other";
-		const otherFile = await createLogFile(logsDir, "other-app.log", 10);
+		const otherFile = createLogFile(logsDir, "other-app.log");
 
 		await cleanupOldLogFiles(logsDir);
 
 		expect(existsSync(otherFile)).toBe(true);
+	});
+
+	it("should keep wrangler log files whose name has no parseable timestamp", async ({
+		expect,
+	}) => {
+		const logsDir = "test-logs-unparseable";
+		const oddFile = createLogFile(logsDir, "wrangler-not-a-date.log");
+
+		await cleanupOldLogFiles(logsDir);
+
+		expect(existsSync(oddFile)).toBe(true);
 	});
 
 	it("should silently succeed if the logs directory does not exist", async ({

--- a/packages/wrangler/src/utils/log-file.ts
+++ b/packages/wrangler/src/utils/log-file.ts
@@ -59,8 +59,6 @@ function parseLogFileTimestamp(filename: string): number | undefined {
 
 /**
  * Deletes wrangler-*.log files older than 30 days from the given log directory.
- * The age is derived from the timestamp encoded in each filename, avoiding a
- * `stat` call per file.
  * Runs silently — errors are ignored so startup is never blocked by log cleanup.
  */
 export async function cleanupOldLogFiles(logsDir: string): Promise<void> {

--- a/packages/wrangler/src/utils/log-file.ts
+++ b/packages/wrangler/src/utils/log-file.ts
@@ -1,5 +1,5 @@
 import { existsSync } from "node:fs";
-import { appendFile, readdir, stat, unlink } from "node:fs/promises";
+import { appendFile, readdir, unlink } from "node:fs/promises";
 import path from "node:path";
 import { stripVTControlCharacters } from "node:util";
 import {
@@ -40,7 +40,35 @@ function getDebugFilepath() {
 }
 
 /**
+ * Parses the timestamp encoded in a wrangler log filename.
+ *
+ * Filenames are created by {@link getDebugFilepath} as `wrangler-<date>.log`,
+ * where `<date>` is an ISO 8601 timestamp with `:` replaced by `-`, `.` and `T`
+ * replaced by `_`, and the trailing `Z` removed
+ * (e.g. `wrangler-2024-01-02_03-04-05_678.log`).
+ *
+ * Returns the timestamp in milliseconds, or `undefined` if the filename does
+ * not match the expected format.
+ */
+function parseLogFileTimestamp(filename: string): number | undefined {
+	const match =
+		/^wrangler-(\d{4}-\d{2}-\d{2})_(\d{2})-(\d{2})-(\d{2})_(\d{3})\.log$/.exec(
+			filename
+		);
+	if (!match) {
+		return undefined;
+	}
+	const [, date, hours, minutes, seconds, milliseconds] = match;
+	const timestamp = Date.parse(
+		`${date}T${hours}:${minutes}:${seconds}.${milliseconds}Z`
+	);
+	return Number.isNaN(timestamp) ? undefined : timestamp;
+}
+
+/**
  * Deletes wrangler-*.log files older than 30 days from the given log directory.
+ * The age is derived from the timestamp encoded in each filename, avoiding a
+ * `stat` call per file.
  * Runs silently — errors are ignored so startup is never blocked by log cleanup.
  */
 export async function cleanupOldLogFiles(logsDir: string): Promise<void> {
@@ -53,16 +81,13 @@ export async function cleanupOldLogFiles(logsDir: string): Promise<void> {
 	try {
 		const files = await readdir(logsDir);
 		const now = Date.now();
-		for (const f of files.filter(
-			(filename) =>
-				filename.startsWith("wrangler-") && filename.endsWith(".log")
-		)) {
-			const filePath = path.join(logsDir, f);
+		for (const f of files) {
+			const timestamp = parseLogFileTimestamp(f);
+			if (timestamp === undefined || now - timestamp <= cutoffMs) {
+				continue;
+			}
 			try {
-				const fileStat = await stat(filePath);
-				if (now - fileStat.mtimeMs > cutoffMs) {
-					await unlink(filePath);
-				}
+				await unlink(path.join(logsDir, f));
 			} catch {
 				// silently ignore errors for individual files
 			}

--- a/packages/wrangler/src/utils/log-file.ts
+++ b/packages/wrangler/src/utils/log-file.ts
@@ -41,14 +41,6 @@ function getDebugFilepath() {
 
 /**
  * Parses the timestamp encoded in a wrangler log filename.
- *
- * Filenames are created by {@link getDebugFilepath} as `wrangler-<date>.log`,
- * where `<date>` is an ISO 8601 timestamp with `:` replaced by `-`, `.` and `T`
- * replaced by `_`, and the trailing `Z` removed
- * (e.g. `wrangler-2024-01-02_03-04-05_678.log`).
- *
- * Returns the timestamp in milliseconds, or `undefined` if the filename does
- * not match the expected format.
  */
 function parseLogFileTimestamp(filename: string): number | undefined {
 	const match =


### PR DESCRIPTION
Fixes #14774 

`cleanupOldLogFiles` deletes `wrangler-*.log` files older than 30 days. It previously `stat`ed every candidate file to read `mtimeMs`. Since the creation timestamp is already encoded in the filename by `getDebugFilepath` (`wrangler-<ISO>.log`, e.g. `wrangler-2024-01-02_03-04-05_678.log`), we now parse the age directly from the name and skip the per-file `stat`.

New helper `parseLogFileTimestamp(filename)` reverses the filename encoding (`:`→`-`, `.`/`T`→`_`, trailing `Z` removed) back into an ISO string and returns the ms timestamp, or `undefined` if the name doesn't match. Files that don't match (including non-`wrangler-` files and wrangler files with an unparseable name) are left untouched.

```
for (const f of files) {
  const timestamp = parseLogFileTimestamp(f);
  if (timestamp === undefined || now - timestamp <= cutoffMs) continue;
  await unlink(path.join(logsDir, f));
}
```

Devin PR requested by emily-shen@cloudflare.com

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: internal cleanup behavior with no user-facing surface change
</body>
</invoke>


Link to Devin session: https://app.devin.ai/sessions/28669df3ecf94261bf7b0cb9d21b1ab6
Requested by: @emily-shen