### PR TITLE
semi-unquarantine nuxt c3 tests

### DIFF
--- a/packages/create-cloudflare/e2e/tests/frameworks/test-config.ts
+++ b/packages/create-cloudflare/e2e/tests/frameworks/test-config.ts
@@ -361,7 +361,6 @@ function getFrameworkTestConfig(pm: string): NamedFrameworkTestConfig[] {
 		},
 		{
 			name: "nuxt:pages",
-			quarantine: true,
 			promptHandlers: [
 				{
 					matcher: /Would you like to .* install .*modules\?/,
@@ -371,7 +370,9 @@ function getFrameworkTestConfig(pm: string): NamedFrameworkTestConfig[] {
 			argv: ["--platform", "pages"],
 			testCommitMessage: true,
 			timeout: LONG_TIMEOUT,
-			unsupportedPms: ["yarn"], // Currently nitro requires youch which expects Node 20+, and yarn will fail hard since we run on Node 18
+			// Currently nitro requires youch which expects Node 20+, and yarn will fail hard since we run on Node 18
+			// and the minimal template we use enforces pnpm/
+			unsupportedPms: ["yarn", "npm"],
 			unsupportedOSs: ["win32"],
 			// The Nuxt `ui` template pins `packageManager: pnpm@11.9.0`, so run
 			// it only on pnpm 11+: under pnpm 10 the cross-version self-provision
@@ -391,7 +392,6 @@ function getFrameworkTestConfig(pm: string): NamedFrameworkTestConfig[] {
 		},
 		{
 			name: "nuxt:workers",
-			quarantine: true,
 			promptHandlers: [
 				{
 					matcher: /Would you like to .* install .*modules\?/,
@@ -401,7 +401,9 @@ function getFrameworkTestConfig(pm: string): NamedFrameworkTestConfig[] {
 			argv: ["--platform", "workers"],
 			testCommitMessage: true,
 			timeout: LONG_TIMEOUT,
-			unsupportedPms: ["yarn"], // Currently nitro requires youch which expects Node 20+, and yarn will fail hard since we run on Node 18
+			// Currently nitro requires youch which expects Node 20+, and yarn will fail hard since we run on Node 18
+			// and the minimal template we use enforces pnpm/
+			unsupportedPms: ["yarn", "npm"],
 			unsupportedOSs: ["win32"],
 			// See note on nuxt:pages above.
 			unsupportedPmRanges: { pnpm: "<11.0.0" },

--- a/packages/create-cloudflare/e2e/tests/frameworks/test-config.ts
+++ b/packages/create-cloudflare/e2e/tests/frameworks/test-config.ts
@@ -371,7 +371,6 @@ function getFrameworkTestConfig(pm: string): NamedFrameworkTestConfig[] {
 			testCommitMessage: true,
 			timeout: LONG_TIMEOUT,
 			// Currently nitro requires youch which expects Node 20+, and yarn will fail hard since we run on Node 18
-			// and the minimal template we use enforces pnpm/
 			unsupportedPms: ["yarn", "npm"],
 			unsupportedOSs: ["win32"],
 			// The Nuxt `ui` template pins `packageManager: pnpm@11.9.0`, so run
@@ -402,7 +401,6 @@ function getFrameworkTestConfig(pm: string): NamedFrameworkTestConfig[] {
 			testCommitMessage: true,
 			timeout: LONG_TIMEOUT,
 			// Currently nitro requires youch which expects Node 20+, and yarn will fail hard since we run on Node 18
-			// and the minimal template we use enforces pnpm/
 			unsupportedPms: ["yarn", "npm"],
 			unsupportedOSs: ["win32"],
 			// See note on nuxt:pages above.

--- a/packages/create-cloudflare/e2e/tests/frameworks/test-config.ts
+++ b/packages/create-cloudflare/e2e/tests/frameworks/test-config.ts
@@ -370,7 +370,8 @@ function getFrameworkTestConfig(pm: string): NamedFrameworkTestConfig[] {
 			argv: ["--platform", "pages"],
 			testCommitMessage: true,
 			timeout: LONG_TIMEOUT,
-			// Currently nitro requires youch which expects Node 20+, and yarn will fail hard since we run on Node 18
+			// yarn: nitro requires youch which expects Node 20+, and yarn will fail hard since we run on Node 18.
+			// npm: nuxt project creation fails on npm with "Cannot read properties of null (reading 'edgesOut')".
 			unsupportedPms: ["yarn", "npm"],
 			unsupportedOSs: ["win32"],
 			// The Nuxt `ui` template pins `packageManager: pnpm@11.9.0`, so run

--- a/packages/create-cloudflare/e2e/tests/frameworks/test-config.ts
+++ b/packages/create-cloudflare/e2e/tests/frameworks/test-config.ts
@@ -400,7 +400,8 @@ function getFrameworkTestConfig(pm: string): NamedFrameworkTestConfig[] {
 			argv: ["--platform", "workers"],
 			testCommitMessage: true,
 			timeout: LONG_TIMEOUT,
-			// Currently nitro requires youch which expects Node 20+, and yarn will fail hard since we run on Node 18
+			// yarn: nitro requires youch which expects Node 20+, and yarn will fail hard since we run on Node 18.
+			// npm: nuxt project creation fails on npm with "Cannot read properties of null (reading 'edgesOut')".
 			unsupportedPms: ["yarn", "npm"],
 			unsupportedOSs: ["win32"],
 			// See note on nuxt:pages above.


### PR DESCRIPTION
nuxt project creation (independently of c3) was failing on npm with
`npm error Cannot read properties of null (reading 'edgesOut')`

This happens even if you use nuxi directly.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: test
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: test

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14803" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->