### PR TITLE
[wrangler] Explain authentication required by remote bindings

### DIFF
--- a/.changeset/remote-bindings-auth-context.md
+++ b/.changeset/remote-bindings-auth-context.md
@@ -2,6 +2,6 @@
 "wrangler": patch
 ---
 
-Explain why remote bindings require authentication during local development
+Handle and explain authentication failures from remote bindings during local development
 
-Wrangler now reports that bindings which need to run remotely require Cloudflare authentication even when the rest of the Worker is developed locally.
+Wrangler now recognizes authentication failures from remote preview sessions and reports that bindings which need to run remotely require Cloudflare authentication even when the rest of the Worker is developed locally.

--- a/.changeset/remote-bindings-auth-context.md
+++ b/.changeset/remote-bindings-auth-context.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Explain why remote bindings require authentication during local development
+
+Wrangler now reports that bindings which need to run remotely require Cloudflare authentication even when the rest of the Worker is developed locally.

--- a/packages/remote-bindings/src/utils/remote.test.ts
+++ b/packages/remote-bindings/src/utils/remote.test.ts
@@ -9,10 +9,10 @@ afterEach(() => {
 	vi.unstubAllEnvs();
 });
 
-function makeAuthError(code: number): APIError {
+function makeAuthError(code: number, status = 400): APIError {
 	const error = new APIError({
 		text: "A request to the Cloudflare API failed.",
-		status: 400,
+		status,
 		telemetryMessage: false,
 	});
 	error.code = code;
@@ -66,9 +66,13 @@ describe("RemoteSessionAuthenticationError", () => {
 });
 
 describe("handlePreviewSessionCreationError", () => {
-	for (const code of [9106, 10000]) {
+	for (const { code, status } of [
+		{ code: 9106, status: 400 },
+		{ code: 10000, status: 400 },
+		{ code: 10405, status: 405 },
+	]) {
 		it(`wraps API authentication error ${code}`, ({ expect }) => {
-			const cause = makeAuthError(code);
+			const cause = makeAuthError(code, status);
 			let thrown: unknown;
 
 			try {

--- a/packages/remote-bindings/src/utils/remote.test.ts
+++ b/packages/remote-bindings/src/utils/remote.test.ts
@@ -1,0 +1,87 @@
+import { APIError } from "@cloudflare/workers-utils";
+import { afterEach, describe, it, vi } from "vitest";
+import {
+	handlePreviewSessionCreationError,
+	RemoteSessionAuthenticationError,
+} from "./remote";
+
+afterEach(() => {
+	vi.unstubAllEnvs();
+});
+
+function makeAuthError(code: number): APIError {
+	const error = new APIError({
+		text: "A request to the Cloudflare API failed.",
+		status: 400,
+		telemetryMessage: false,
+	});
+	error.code = code;
+	return error;
+}
+
+describe("RemoteSessionAuthenticationError", () => {
+	it("preserves the cause and telemetry message", ({ expect }) => {
+		const cause = new Error("original API error");
+		const error = new RemoteSessionAuthenticationError(cause);
+
+		expect(error.cause).toBe(cause);
+		expect(error.telemetryMessage).toBe("remote dev authentication error");
+	});
+
+	it("explains remote bindings when authenticating with an API token", ({
+		expect,
+	}) => {
+		vi.stubEnv("CLOUDFLARE_API_TOKEN", "test-token");
+
+		const error = new RemoteSessionAuthenticationError(new Error("api error"));
+
+		expect(error.message).toMatchInlineSnapshot(`
+			"This Worker uses bindings that need to run remotely, even when developing locally, but the remote session could not be authenticated.
+			It looks like you are authenticating via a custom API token (\`CLOUDFLARE_API_TOKEN\`) set in an environment variable.
+			The token may be invalid or lack the required permissions for this operation.
+
+			To fix this, verify that your token is valid and has the correct permissions.
+			You can also run \`wrangler whoami\` to check your current authentication status."
+		`);
+	});
+
+	it("explains remote bindings when authenticating with OAuth", ({
+		expect,
+	}) => {
+		vi.stubEnv("CLOUDFLARE_API_TOKEN", "");
+		vi.stubEnv("CLOUDFLARE_API_KEY", "");
+		vi.stubEnv("CLOUDFLARE_EMAIL", "");
+
+		const error = new RemoteSessionAuthenticationError(new Error("api error"));
+
+		expect(error.message).toMatchInlineSnapshot(`
+			"This Worker uses bindings that need to run remotely, even when developing locally, but the remote session could not be authenticated.
+			Your credentials may have expired or been revoked.
+
+			To fix this, try to:
+			  - Run \`wrangler whoami\` to check your current authentication status.
+			  - Run \`wrangler logout\` and then \`wrangler login\` to re-authenticate."
+		`);
+	});
+});
+
+describe("handlePreviewSessionCreationError", () => {
+	for (const code of [9106, 10000]) {
+		it(`wraps API authentication error ${code}`, ({ expect }) => {
+			const cause = makeAuthError(code);
+			let thrown: unknown;
+
+			try {
+				handlePreviewSessionCreationError(cause, "test-account-id");
+			} catch (error) {
+				thrown = error;
+			}
+
+			expect(thrown).toBeInstanceOf(RemoteSessionAuthenticationError);
+			expect((thrown as RemoteSessionAuthenticationError).cause).toBe(cause);
+			expect((thrown as RemoteSessionAuthenticationError).message).toContain(
+				"bindings that need to run remotely, even when developing locally"
+			);
+		});
+	}
+});

--- a/packages/remote-bindings/src/utils/remote.ts
+++ b/packages/remote-bindings/src/utils/remote.ts
@@ -29,7 +29,7 @@ export class RemoteSessionAuthenticationError extends UserError {
 		const envAuth = getAuthFromEnv();
 
 		let errorMessage =
-			"Failed to establish remote session due to an authentication issue.\n";
+			"This Worker uses bindings that need to run remotely, even when developing locally, but the remote session could not be authenticated.\n";
 		if (envAuth !== undefined) {
 			// The user is authenticating via an environment variable
 			const method =

--- a/packages/remote-bindings/src/utils/remote.ts
+++ b/packages/remote-bindings/src/utils/remote.ts
@@ -23,7 +23,7 @@ import type {
 export class RemoteSessionAuthenticationError extends UserError {
 	/**
 	 * @param cause - The original error that triggered the authentication
-	 *   failure (e.g. an {@link APIError} with code 9106 or 10000).
+	 *   failure (e.g. an {@link APIError} with code 9106, 10000, or 10405).
 	 */
 	constructor(cause: unknown) {
 		const envAuth = getAuthFromEnv();
@@ -165,9 +165,10 @@ export function createRemoteWorkerInit(props: {
 function handleUserFriendlyError(error: unknown, accountId?: string) {
 	if (error instanceof APIError) {
 		switch (error.code) {
-			// code 9106 and 10000 are authentication errors
+			// codes 9106, 10000, and 10405 are authentication errors
 			case 9106:
-			case 10000: {
+			case 10000:
+			case 10405: {
 				throw new RemoteSessionAuthenticationError(error);
 			}
 


### PR DESCRIPTION
Fixes #14798.

When local development starts bindings that need to run remotely, Wrangler now explains why Cloudflare authentication is required before showing the existing API token or OAuth recovery guidance.

It also maps the `edge-preview` API's `10405` response into the same friendly remote-session authentication error. This preserves the original error cause, telemetry message, and remediation steps. Tests cover all three observed API authentication codes and snapshot the API token and OAuth messages.

Risk: error-handling/message-only. No authentication or remote-binding behavior changes.

Validation:
- `pnpm -w test:ci -F @cloudflare/remote-bindings` — 5 files and 18 tests passed
- `pnpm check` — 197 tasks passed, including build, lint, formatting, typechecks, and type tests
- `pnpm changeset status --since=upstream/main` — Wrangler patch changeset detected

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
- Public documentation
  - [x] Cloudflare docs PR(s): N/A <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: This only clarifies an existing Wrangler error message.

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->