### PR TITLE
Pin `@netlify/build-info` to `10.5.1` and update pnpm patch

### DIFF
--- a/packages/autoconfig/package.json
+++ b/packages/autoconfig/package.json
@@ -35,7 +35,7 @@
 	"devDependencies": {
 		"@cloudflare/codemod": "workspace:*",
 		"@cloudflare/workers-tsconfig": "workspace:*",
-		"@netlify/build-info": "^10.5.1",
+		"@netlify/build-info": "catalog:old-node",
 		"@types/esprima": "^4.0.3",
 		"@types/node": "catalog:default",
 		"chalk": "catalog:default",

--- a/packages/autoconfig/package.json
+++ b/packages/autoconfig/package.json
@@ -36,7 +36,7 @@
 	"devDependencies": {
 		"@cloudflare/shared-ast-primitives": "workspace:*",
 		"@cloudflare/workers-tsconfig": "workspace:*",
-		"@netlify/build-info": "catalog:old-node",
+		"@netlify/build-info": "10.5.1",
 		"@types/esprima": "^4.0.3",
 		"@types/node": "catalog:default",
 		"chalk": "catalog:default",

--- a/packages/autoconfig/package.json
+++ b/packages/autoconfig/package.json
@@ -36,7 +36,7 @@
 	"devDependencies": {
 		"@cloudflare/shared-ast-primitives": "workspace:*",
 		"@cloudflare/workers-tsconfig": "workspace:*",
-		"@netlify/build-info": "^10.5.1",
+		"@netlify/build-info": "catalog:old-node",
 		"@types/esprima": "^4.0.3",
 		"@types/node": "catalog:default",
 		"chalk": "catalog:default",

--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -109,7 +109,7 @@
 		"@cloudflare/workers-utils": "workspace:*",
 		"@cloudflare/workflows-shared": "workspace:*",
 		"@cspotcode/source-map-support": "0.8.1",
-		"@netlify/build-info": "catalog:old-node",
+		"@netlify/build-info": "10.5.1",
 		"@sentry/node": "^7.86.0",
 		"@sentry/types": "^7.86.0",
 		"@sentry/utils": "^7.86.0",

--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -109,7 +109,7 @@
 		"@cloudflare/workers-utils": "workspace:*",
 		"@cloudflare/workflows-shared": "workspace:*",
 		"@cspotcode/source-map-support": "0.8.1",
-		"@netlify/build-info": "^10.5.1",
+		"@netlify/build-info": "catalog:old-node",
 		"@sentry/node": "^7.86.0",
 		"@sentry/types": "^7.86.0",
 		"@sentry/utils": "^7.86.0",

--- a/patches/@netlify__build-info@10.5.1.patch
+++ b/patches/@netlify__build-info@10.5.1.patch
@@ -20,7 +20,7 @@ diff --git a/lib/settings/get-toml-settings.js.map b/lib/settings/get-toml-setti
 deleted file mode 100644
 index cf2cc86882ac30426aef358943754e2f8712d3d0..0000000000000000000000000000000000000000
 diff --git a/package.json b/package.json
-index 62195c07c16e9405e9ec5d82baa44cd722595253..8f1e227d215cd445e9c0707089abfd7737752f66 100644
+index a8eab3be34c43ee6211237cb21007aa28f147e6c..b789969067d7b8ab0cb98f42c8fab36eb274b3ac 100644
 --- a/package.json
 +++ b/package.json
 @@ -45,7 +45,6 @@
@@ -30,4 +30,4 @@ index 62195c07c16e9405e9ec5d82baa44cd722595253..8f1e227d215cd445e9c0707089abfd77
 -    "@iarna/toml": "^2.2.5",
      "dot-prop": "^9.0.0",
      "find-up": "^7.0.0",
-     "minimatch": "^9.0.0",
+     "minimatch": "^10.2.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,6 +93,10 @@ catalogs:
     zod:
       specifier: 4.4.3
       version: 4.4.3
+  old-node:
+    '@netlify/build-info':
+      specifier: 10.5.1
+      version: 10.5.1
 
 overrides:
   '@types/react-dom@18>@types/react': ^18
@@ -106,9 +110,9 @@ patchedDependencies:
   '@cloudflare/component-listbox@1.10.6':
     hash: 67542a8abb29df36ad2c426409243d1167ca0080d2763f6ae3cce3c731c69107
     path: patches/@cloudflare__component-listbox@1.10.6.patch
-  '@netlify/build-info':
-    hash: 33ea78efb143b613c74982678a25159c8700b1677e6a009776a6c8b690c87045
-    path: patches/@netlify__build-info.patch
+  '@netlify/build-info@10.5.1':
+    hash: d4dab4e515b41a301041eaf8700001b612ab00616fa5837c8a65bcb3ce2df039
+    path: patches/@netlify__build-info@10.5.1.patch
   buffer-equal-constant-time@1.0.1:
     hash: cc16d31ed54afc06e628965b2acc54f0dbcc6d079da331da5f14040ce4d62024
     path: patches/buffer-equal-constant-time@1.0.1.patch
@@ -1700,8 +1704,8 @@ importers:
         specifier: workspace:*
         version: link:../workers-tsconfig
       '@netlify/build-info':
-        specifier: ^10.5.1
-        version: 10.5.1(patch_hash=33ea78efb143b613c74982678a25159c8700b1677e6a009776a6c8b690c87045)
+        specifier: catalog:old-node
+        version: 10.5.1(patch_hash=d4dab4e515b41a301041eaf8700001b612ab00616fa5837c8a65bcb3ce2df039)
       '@types/esprima':
         specifier: ^4.0.3
         version: 4.0.3
@@ -4601,8 +4605,8 @@ importers:
         specifier: 0.8.1
         version: 0.8.1
       '@netlify/build-info':
-        specifier: ^10.5.1
-        version: 10.5.1(patch_hash=33ea78efb143b613c74982678a25159c8700b1677e6a009776a6c8b690c87045)
+        specifier: catalog:old-node
+        version: 10.5.1(patch_hash=d4dab4e515b41a301041eaf8700001b612ab00616fa5837c8a65bcb3ce2df039)
       '@sentry/node':
         specifier: ^7.86.0
         version: 7.87.0(supports-color@9.2.2)
@@ -15480,11 +15484,6 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
-  semver@7.8.2:
-    resolution: {integrity: sha512-c8jsqUZm3omBOI66G90z1Dyw5z622G8oLG+omfsHBJf3CWQTlOcwOjvOG6wtiNfW6anKm/eA39LMwMtMez2TiQ==}
-    engines: {node: '>=10'}
-    hasBin: true
-
   semver@7.8.5:
     resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
     engines: {node: '>=10'}
@@ -20428,7 +20427,7 @@ snapshots:
       '@tybys/wasm-util': 0.10.3
     optional: true
 
-  '@netlify/build-info@10.5.1(patch_hash=33ea78efb143b613c74982678a25159c8700b1677e6a009776a6c8b690c87045)':
+  '@netlify/build-info@10.5.1(patch_hash=d4dab4e515b41a301041eaf8700001b612ab00616fa5837c8a65bcb3ce2df039)':
     dependencies:
       '@bugsnag/js': 8.6.0
       '@iarna/toml': 2.2.5
@@ -20436,7 +20435,7 @@ snapshots:
       find-up: 7.0.0
       minimatch: 10.2.5
       read-pkg: 9.0.1
-      semver: 7.7.3
+      semver: 7.8.5
       yaml: 2.8.1
       yargs: 17.7.2
 
@@ -26122,7 +26121,7 @@ snapshots:
       lodash.isstring: 4.0.1
       lodash.once: 4.1.1
       ms: 2.1.3
-      semver: 7.8.2
+      semver: 7.8.5
 
   jsprim@2.0.2:
     dependencies:
@@ -26591,7 +26590,7 @@ snapshots:
       pkg-types: 1.3.1
       postcss: 8.5.14
       postcss-nested: 7.0.2(postcss@8.5.14)
-      semver: 7.8.2
+      semver: 7.8.5
       tinyglobby: 0.2.17
     optionalDependencies:
       typescript: 5.8.3
@@ -28376,8 +28375,6 @@ snapshots:
   semver@7.7.1: {}
 
   semver@7.7.3: {}
-
-  semver@7.8.2: {}
 
   semver@7.8.5: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,6 +93,10 @@ catalogs:
     zod:
       specifier: 4.4.3
       version: 4.4.3
+  old-node:
+    '@netlify/build-info':
+      specifier: 10.5.1
+      version: 10.5.1
 
 overrides:
   '@types/react-dom@18>@types/react': ^18
@@ -106,9 +110,9 @@ patchedDependencies:
   '@cloudflare/component-listbox@1.10.6':
     hash: 67542a8abb29df36ad2c426409243d1167ca0080d2763f6ae3cce3c731c69107
     path: patches/@cloudflare__component-listbox@1.10.6.patch
-  '@netlify/build-info':
-    hash: 33ea78efb143b613c74982678a25159c8700b1677e6a009776a6c8b690c87045
-    path: patches/@netlify__build-info.patch
+  '@netlify/build-info@10.5.1':
+    hash: d4dab4e515b41a301041eaf8700001b612ab00616fa5837c8a65bcb3ce2df039
+    path: patches/@netlify__build-info@10.5.1.patch
   buffer-equal-constant-time@1.0.1:
     hash: cc16d31ed54afc06e628965b2acc54f0dbcc6d079da331da5f14040ce4d62024
     path: patches/buffer-equal-constant-time@1.0.1.patch
@@ -1706,8 +1710,8 @@ importers:
         specifier: workspace:*
         version: link:../workers-tsconfig
       '@netlify/build-info':
-        specifier: ^10.5.1
-        version: 10.5.1(patch_hash=33ea78efb143b613c74982678a25159c8700b1677e6a009776a6c8b690c87045)
+        specifier: catalog:old-node
+        version: 10.5.1(patch_hash=d4dab4e515b41a301041eaf8700001b612ab00616fa5837c8a65bcb3ce2df039)
       '@types/esprima':
         specifier: ^4.0.3
         version: 4.0.3
@@ -4634,8 +4638,8 @@ importers:
         specifier: 0.8.1
         version: 0.8.1
       '@netlify/build-info':
-        specifier: ^10.5.1
-        version: 10.5.1(patch_hash=33ea78efb143b613c74982678a25159c8700b1677e6a009776a6c8b690c87045)
+        specifier: catalog:old-node
+        version: 10.5.1(patch_hash=d4dab4e515b41a301041eaf8700001b612ab00616fa5837c8a65bcb3ce2df039)
       '@sentry/node':
         specifier: ^7.86.0
         version: 7.87.0(supports-color@9.2.2)
@@ -11884,9 +11888,6 @@ packages:
   es-errors@1.3.0:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
-
-  es-module-lexer@2.0.0:
-    resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
 
   es-module-lexer@2.3.1:
     resolution: {integrity: sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==}
@@ -20085,7 +20086,7 @@ snapshots:
       '@tybys/wasm-util': 0.10.3
     optional: true
 
-  '@netlify/build-info@10.5.1(patch_hash=33ea78efb143b613c74982678a25159c8700b1677e6a009776a6c8b690c87045)':
+  '@netlify/build-info@10.5.1(patch_hash=d4dab4e515b41a301041eaf8700001b612ab00616fa5837c8a65bcb3ce2df039)':
     dependencies:
       '@bugsnag/js': 8.6.0
       '@iarna/toml': 2.2.5
@@ -20093,8 +20094,8 @@ snapshots:
       find-up: 7.0.0
       minimatch: 10.2.5
       read-pkg: 9.0.1
-      semver: 7.7.3
-      yaml: 2.8.1
+      semver: 7.8.5
+      yaml: 2.9.0
       yargs: 17.7.2
 
   '@noble/ciphers@2.1.1': {}
@@ -24147,8 +24148,6 @@ snapshots:
   es-define-property@1.0.1: {}
 
   es-errors@1.3.0: {}
-
-  es-module-lexer@2.0.0: {}
 
   es-module-lexer@2.3.1: {}
 
@@ -29494,7 +29493,7 @@ snapshots:
       '@vitest/snapshot': 4.1.0
       '@vitest/spy': 4.1.0
       '@vitest/utils': 4.1.0
-      es-module-lexer: 2.0.0
+      es-module-lexer: 2.3.1
       expect-type: 1.3.0
       magic-string: 0.30.21
       obug: 2.1.4
@@ -29523,7 +29522,7 @@ snapshots:
       '@vitest/snapshot': 4.1.0
       '@vitest/spy': 4.1.0
       '@vitest/utils': 4.1.0
-      es-module-lexer: 2.0.0
+      es-module-lexer: 2.3.1
       expect-type: 1.3.0
       magic-string: 0.30.21
       obug: 2.1.4
@@ -29552,7 +29551,7 @@ snapshots:
       '@vitest/snapshot': 4.1.0
       '@vitest/spy': 4.1.0
       '@vitest/utils': 4.1.0
-      es-module-lexer: 2.0.0
+      es-module-lexer: 2.3.1
       expect-type: 1.3.0
       magic-string: 0.30.21
       obug: 2.1.4
@@ -29581,7 +29580,7 @@ snapshots:
       '@vitest/snapshot': 4.1.0
       '@vitest/spy': 4.1.0
       '@vitest/utils': 4.1.0
-      es-module-lexer: 2.0.0
+      es-module-lexer: 2.3.1
       expect-type: 1.3.0
       magic-string: 0.30.21
       obug: 2.1.4
@@ -29610,7 +29609,7 @@ snapshots:
       '@vitest/snapshot': 4.1.0
       '@vitest/spy': 4.1.0
       '@vitest/utils': 4.1.0
-      es-module-lexer: 2.0.0
+      es-module-lexer: 2.3.1
       expect-type: 1.3.0
       magic-string: 0.30.21
       obug: 2.1.4
@@ -29639,7 +29638,7 @@ snapshots:
       '@vitest/snapshot': 4.1.0
       '@vitest/spy': 4.1.0
       '@vitest/utils': 4.1.0
-      es-module-lexer: 2.0.0
+      es-module-lexer: 2.3.1
       expect-type: 1.3.0
       magic-string: 0.30.21
       obug: 2.1.4

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,10 +93,6 @@ catalogs:
     zod:
       specifier: 4.4.3
       version: 4.4.3
-  old-node:
-    '@netlify/build-info':
-      specifier: 10.5.1
-      version: 10.5.1
 
 overrides:
   '@types/react-dom@18>@types/react': ^18
@@ -1710,7 +1706,7 @@ importers:
         specifier: workspace:*
         version: link:../workers-tsconfig
       '@netlify/build-info':
-        specifier: catalog:old-node
+        specifier: 10.5.1
         version: 10.5.1(patch_hash=d4dab4e515b41a301041eaf8700001b612ab00616fa5837c8a65bcb3ce2df039)
       '@types/esprima':
         specifier: ^4.0.3
@@ -4638,7 +4634,7 @@ importers:
         specifier: 0.8.1
         version: 0.8.1
       '@netlify/build-info':
-        specifier: catalog:old-node
+        specifier: 10.5.1
         version: 10.5.1(patch_hash=d4dab4e515b41a301041eaf8700001b612ab00616fa5837c8a65bcb3ce2df039)
       '@sentry/node':
         specifier: ^7.86.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -149,12 +149,3 @@ catalog:
   # dependency. They therefore depend on this older published 0.x release under the old name.
   # TODO: Repoint these to "@cloudflare/vitest-plugin" once v1.0.0 is published to npm.
   "@cloudflare/vitest-pool-workers": "0.13.3"
-
-catalogs:
-  # This old-node catalog is for packages pinned to older versions because newer releases require a Node.js version higher than the minimum we support.
-  # Ideally we should try to remove packages from this catalog whenever we bump our minimum supported version.
-  old-node:
-    # @netlify/build-info >10.5.1 (11.1.0) requires a Node.js version (>=22.12.0) newer than our
-    # supported minimum (which currently is 22.0.0). Do not bump until our minimum Node.js version is raised.
-    # See: https://npmx.dev/package-code/@netlify/build-info/v/11.1.0/package.json#L69
-    "@netlify/build-info": "10.5.1"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -100,7 +100,7 @@ patchedDependencies:
   "toucan-js@4.0.0": "patches/toucan-js@4.0.0.patch"
   "postal-mime": "patches/postal-mime.patch"
   "youch@4.1.0-beta.10": "patches/youch@4.1.0-beta.10.patch"
-  "@netlify/build-info": "patches/@netlify__build-info.patch"
+  "@netlify/build-info@10.5.1": "patches/@netlify__build-info@10.5.1.patch"
   "buffer-equal-constant-time@1.0.1": "patches/buffer-equal-constant-time@1.0.1.patch"
 
 # ──────────────────────────────────────────────────────────────────────────────
@@ -149,3 +149,12 @@ catalog:
   # dependency. They therefore depend on this older published 0.x release under the old name.
   # TODO: Repoint these to "@cloudflare/vitest-plugin" once v1.0.0 is published to npm.
   "@cloudflare/vitest-pool-workers": "0.13.3"
+
+catalogs:
+  # This old-node catalog is for packages pinned to older versions because newer releases require a Node.js version higher than the minimum we support.
+  # Ideally we should try to remove packages from this catalog whenever we bump our minimum supported version.
+  old-node:
+    # @netlify/build-info >10.5.1 (11.1.0) requires a Node.js version (>=22.12.0) newer than our
+    # supported minimum (which currently is 22.0.0). Do not bump until our minimum Node.js version is raised.
+    # See: https://npmx.dev/package-code/@netlify/build-info/v/11.1.0/package.json#L69
+    "@netlify/build-info": "10.5.1"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -102,7 +102,7 @@ patchedDependencies:
   "toucan-js@4.0.0": "patches/toucan-js@4.0.0.patch"
   "postal-mime": "patches/postal-mime.patch"
   "youch@4.1.0-beta.10": "patches/youch@4.1.0-beta.10.patch"
-  "@netlify/build-info": "patches/@netlify__build-info.patch"
+  "@netlify/build-info@10.5.1": "patches/@netlify__build-info@10.5.1.patch"
   "buffer-equal-constant-time@1.0.1": "patches/buffer-equal-constant-time@1.0.1.patch"
 
 # ──────────────────────────────────────────────────────────────────────────────
@@ -147,3 +147,12 @@ catalog:
   # However, some packages (pages-shared, workers-shared, etc...) need to be tested using vitest-pool-workers but are themselves
   # ultimately included in vitest-pool-workers (through Wrangler), causing a circular dependency.
   "@cloudflare/vitest-pool-workers": "0.13.3"
+
+catalogs:
+  # This old-node catalog is for packages pinned to older versions because newer releases require a Node.js version higher than the minimum we support.
+  # Ideally we should try to remove packages from this catalog whenever we bump our minimum supported version.
+  old-node:
+    # @netlify/build-info >10.5.1 (11.1.0) requires a Node.js version (>=22.12.0) newer than our
+    # supported minimum (which currently is 22.0.0). Do not bump until our minimum Node.js version is raised.
+    # See: https://npmx.dev/package-code/@netlify/build-info/v/11.1.0/package.json#L69
+    "@netlify/build-info": "10.5.1"


### PR DESCRIPTION
The pnpm patch we currently have for `@netlify/build-info` is outdated, so this PR updates it.

It also pins the version of the package to ensure that we don't bump it and unintentionally breaking out node 22.0.0 minimum version promise.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: just pinning a package to the version we're already using
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: internal change

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://cloudflare.devinenterprise.com/review/cloudflare/workers-sdk/pull/14808" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->