### PR TITLE
[wrangler] Handle null inside arrays in sortObjectRecursive

### DIFF
--- a/.changeset/fix-sort-object-recursive-null.md
+++ b/.changeset/fix-sort-object-recursive-null.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Fix a crash when diffing container configuration that contains `null` inside an array
+
+Normalizing configuration for the deployment diff threw `TypeError: Cannot convert undefined or null to object` whenever an array field contained `null`, so `wrangler containers deploy` and `wrangler cloudchamber apply` failed instead of showing the diff. `null` entries in arrays are now preserved as-is.

--- a/packages/wrangler/src/__tests__/utils/sortObjectRecursive.test.ts
+++ b/packages/wrangler/src/__tests__/utils/sortObjectRecursive.test.ts
@@ -1,0 +1,29 @@
+import { describe, it } from "vitest";
+import { sortObjectRecursive } from "../../utils/sortObjectRecursive";
+
+describe("sortObjectRecursive", () => {
+	it("should sort object keys alphabetically", ({ expect }) => {
+		expect(Object.keys(sortObjectRecursive({ b: 1, a: 2 }))).toEqual(["a", "b"]);
+	});
+
+	it("should sort nested object keys recursively", ({ expect }) => {
+		const sorted = sortObjectRecursive<{ outer: Record<string, unknown> }>({
+			outer: { b: 1, a: 2 },
+		});
+		expect(Object.keys(sorted.outer)).toEqual(["a", "b"]);
+	});
+
+	it("should preserve a null property value", ({ expect }) => {
+		expect(sortObjectRecursive({ a: null })).toEqual({ a: null });
+	});
+
+	it("should preserve null entries inside arrays", ({ expect }) => {
+		expect(sortObjectRecursive({ a: [null] })).toEqual({ a: [null] });
+	});
+
+	it("should sort objects in an array that also contains null", ({ expect }) => {
+		expect(sortObjectRecursive({ a: [{ c: 1, b: 2 }, null] })).toEqual({
+			a: [{ b: 2, c: 1 }, null],
+		});
+	});
+});

--- a/packages/wrangler/src/__tests__/utils/sortObjectRecursive.test.ts
+++ b/packages/wrangler/src/__tests__/utils/sortObjectRecursive.test.ts
@@ -3,7 +3,10 @@ import { sortObjectRecursive } from "../../utils/sortObjectRecursive";
 
 describe("sortObjectRecursive", () => {
 	it("should sort object keys alphabetically", ({ expect }) => {
-		expect(Object.keys(sortObjectRecursive({ b: 1, a: 2 }))).toEqual(["a", "b"]);
+		expect(Object.keys(sortObjectRecursive({ b: 1, a: 2 }))).toEqual([
+			"a",
+			"b",
+		]);
 	});
 
 	it("should sort nested object keys recursively", ({ expect }) => {
@@ -21,7 +24,9 @@ describe("sortObjectRecursive", () => {
 		expect(sortObjectRecursive({ a: [null] })).toEqual({ a: [null] });
 	});
 
-	it("should sort objects in an array that also contains null", ({ expect }) => {
+	it("should sort objects in an array that also contains null", ({
+		expect,
+	}) => {
 		expect(sortObjectRecursive({ a: [{ c: 1, b: 2 }, null] })).toEqual({
 			a: [{ b: 2, c: 1 }, null],
 		});

--- a/packages/wrangler/src/utils/sortObjectRecursive.ts
+++ b/packages/wrangler/src/utils/sortObjectRecursive.ts
@@ -38,7 +38,9 @@ function sortObjectKeys(unordered: Record<string | number, unknown>) {
 export function sortObjectRecursive<T = Record<string | number, unknown>>(
 	object: Record<string | number, unknown> | Record<string | number, unknown>[]
 ): T {
-	if (typeof object !== "object") {
+	// `typeof null === "object"`, so `null` must be handled before the object
+	// branches below, which would otherwise call `Object.entries(null)` and throw.
+	if (object === null || typeof object !== "object") {
 		return object;
 	}
 


### PR DESCRIPTION
`sortObjectRecursive` guards against `null` when recursing into object *properties*, but the array branch maps every element back through itself with no such guard:

```js
if (Array.isArray(object)) {
    return object.map((obj) => sortObjectRecursive(obj)) as T;
}
```

Since `typeof null === "object"`, a `null` array entry falls through to `Object.entries(null)` and throws `TypeError: Cannot convert undefined or null to object`.

This function normalizes container/Cloudchamber app configs before diffing them (`cloudchamber/apply.ts`, `containers/deploy.ts`), so a `null` in any array field crashes `wrangler containers deploy` / `wrangler cloudchamber apply` instead of rendering the diff.

Fixed by returning `null` early, alongside the existing non-object early return. Added `sortObjectRecursive.test.ts`; the two new null-in-array cases fail with the original `TypeError` before this change.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: this fixes an internal crash; there is no corresponding user-facing documentation.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14812" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->