### PR TITLE
[miniflare] Match Content-Type case-insensitively for compression

### DIFF
--- a/.changeset/fix-compressed-content-type-matching.md
+++ b/.changeset/fix-compressed-content-type-matching.md
@@ -1,0 +1,7 @@
+---
+"miniflare": patch
+---
+
+Match `Content-Type` case-insensitively when simulating Cloudflare's response compression
+
+Locally, responses were only compressed when the `Content-Type` matched the compressible media type list exactly. Because HTTP media types are case-insensitive and may carry whitespace before their parameters, headers such as `Application/JSON` or `text/html ; charset=utf-8` were treated as non-compressible, diverging from production behaviour. The media type is now trimmed and lowercased before matching.

--- a/packages/miniflare/src/shared/mime-types.ts
+++ b/packages/miniflare/src/shared/mime-types.ts
@@ -56,5 +56,7 @@ export function isCompressedByCloudflareFL(
 
 	const [contentType] = contentTypeHeader.split(";");
 
-	return compressedByCloudflareFL.has(contentType);
+	// Media types are case-insensitive and may carry whitespace before the
+	// parameter separator, e.g. `Text/HTML ; charset=utf-8`.
+	return compressedByCloudflareFL.has(contentType.trim().toLowerCase());
 }

--- a/packages/miniflare/src/shared/mime-types.ts
+++ b/packages/miniflare/src/shared/mime-types.ts
@@ -58,5 +58,7 @@ export function isCompressedByCloudflareFL(
 
 	const [contentType] = contentTypeHeader.split(";");
 
-	return compressedByCloudflareFL.has(contentType);
+	// Media types are case-insensitive and may carry whitespace before the
+	// parameter separator, e.g. `Text/HTML ; charset=utf-8`.
+	return compressedByCloudflareFL.has(contentType.trim().toLowerCase());
 }

--- a/packages/miniflare/test/shared/mime-types.spec.ts
+++ b/packages/miniflare/test/shared/mime-types.spec.ts
@@ -1,7 +1,9 @@
 import { test } from "vitest";
 import { isCompressedByCloudflareFL } from "../../src/shared/mime-types";
 
-test("isCompressedByCloudflareFL: matches known content types", ({ expect }) => {
+test("isCompressedByCloudflareFL: matches known content types", ({
+	expect,
+}) => {
 	expect(isCompressedByCloudflareFL("text/html")).toBe(true);
 	expect(isCompressedByCloudflareFL("application/json")).toBe(true);
 	expect(isCompressedByCloudflareFL("image/png")).toBe(false);

--- a/packages/miniflare/test/shared/mime-types.spec.ts
+++ b/packages/miniflare/test/shared/mime-types.spec.ts
@@ -1,0 +1,33 @@
+import { test } from "vitest";
+import { isCompressedByCloudflareFL } from "../../src/shared/mime-types";
+
+test("isCompressedByCloudflareFL: matches known content types", ({ expect }) => {
+	expect(isCompressedByCloudflareFL("text/html")).toBe(true);
+	expect(isCompressedByCloudflareFL("application/json")).toBe(true);
+	expect(isCompressedByCloudflareFL("image/png")).toBe(false);
+});
+
+test("isCompressedByCloudflareFL: ignores parameters after the media type", ({
+	expect,
+}) => {
+	expect(isCompressedByCloudflareFL("text/html;charset=utf-8")).toBe(true);
+});
+
+test("isCompressedByCloudflareFL: is case-insensitive", ({ expect }) => {
+	expect(isCompressedByCloudflareFL("Application/JSON")).toBe(true);
+	expect(isCompressedByCloudflareFL("TEXT/HTML")).toBe(true);
+});
+
+test("isCompressedByCloudflareFL: allows whitespace before the parameter separator", ({
+	expect,
+}) => {
+	expect(isCompressedByCloudflareFL("text/html ; charset=utf-8")).toBe(true);
+});
+
+test("isCompressedByCloudflareFL: treats a missing content type as compressible", ({
+	expect,
+}) => {
+	expect(isCompressedByCloudflareFL(undefined)).toBe(true);
+	expect(isCompressedByCloudflareFL(null)).toBe(true);
+	expect(isCompressedByCloudflareFL("")).toBe(true);
+});


### PR DESCRIPTION
Fixes #14828

`isCompressedByCloudflareFL` decides whether Miniflare simulates Cloudflare's response compression, but it compares the media type against an all-lowercase set without normalising it:

```js
const [contentType] = contentTypeHeader.split(";");

return compressedByCloudflareFL.has(contentType);
```

HTTP media types are case-insensitive, and optional whitespace is permitted before the parameter separator. So `Application/JSON` returns `false`, and `text/html ; charset=utf-8` (space before `;`) returns `false`, even though both should be compressed — diverging from production.

This trims and lowercases the media type before the lookup. It drives local compression in `entry.worker.ts` and `index.ts`. Added `test/shared/mime-types.spec.ts`; the case-insensitivity and whitespace cases fail before this change.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: this aligns local simulation with existing production behaviour; there is no corresponding user-facing documentation.

<!-- devin-review-badge-begin -->

---

<a href="https://cloudflare.devinenterprise.com/review/cloudflare/workers-sdk/pull/14814" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->