### PR TITLE
[wrangler] Split cloudchamber curl headers on the first colon only

### DIFF
--- a/.changeset/fix-cloudchamber-curl-header-parsing.md
+++ b/.changeset/fix-cloudchamber-curl-header-parsing.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Fix `wrangler cloudchamber curl` mangling header values that contain a colon
+
+Header values were split on every colon and only the segment between the first and second was sent, so `--header location:https://example.com/x` arrived as `https`. Passing a header with no colon at all threw a `TypeError`. Headers are now split on the first colon only, and a header given without a value is sent with an empty one.

--- a/.changeset/fix-cloudchamber-curl-header-parsing.md
+++ b/.changeset/fix-cloudchamber-curl-header-parsing.md
@@ -4,4 +4,4 @@
 
 Fix `wrangler cloudchamber curl` mangling header values that contain a colon
 
-Header values were split on every colon and only the segment between the first and second was sent, so `--header location:https://example.com/x` arrived as `https`. Passing a header with no colon at all threw a `TypeError`. Headers are now split on the first colon only, and a header given without a value is sent with an empty one.
+Header values were split on every colon and only the segment between the first and second was sent, so `--header location:https://example.com/x` arrived as `https`. Headers are now split on the first colon only. A header that is not in the documented `--header <name>:<value>` form previously threw an unhandled `TypeError`, and now reports a clear error.

--- a/packages/wrangler/src/__tests__/cloudchamber/curl.test.ts
+++ b/packages/wrangler/src/__tests__/cloudchamber/curl.test.ts
@@ -232,6 +232,37 @@ describe("cloudchamber curl", () => {
 		`);
 	});
 
+	it("should preserve colons in header values", async ({ expect }) => {
+		setIsTTY(false);
+		setWranglerConfig({});
+		let locationHeader: string | null = null;
+		msw.use(
+			http.get("*/test", async ({ request }) => {
+				locationHeader = request.headers.get("location");
+				return HttpResponse.json(`{}`);
+			})
+		);
+		await runWrangler(
+			"cloudchamber curl /test --header location:https://example.com/a:b"
+		);
+		expect(locationHeader).toEqual("https://example.com/a:b");
+	});
+
+	it("should not throw for a header without a colon", async ({ expect }) => {
+		setIsTTY(false);
+		setWranglerConfig({});
+		let requestMade = false;
+		msw.use(
+			http.get("*/test", async () => {
+				requestMade = true;
+				return HttpResponse.json(`{}`);
+			})
+		);
+		await runWrangler("cloudchamber curl /test --header something");
+		expect(requestMade).toBe(true);
+		expect(std.out).not.toContain("TypeError");
+	});
+
 	it("works", async ({ expect }) => {
 		setIsTTY(false);
 		setWranglerConfig({});

--- a/packages/wrangler/src/__tests__/cloudchamber/curl.test.ts
+++ b/packages/wrangler/src/__tests__/cloudchamber/curl.test.ts
@@ -248,19 +248,24 @@ describe("cloudchamber curl", () => {
 		expect(locationHeader).toEqual("https://example.com/a:b");
 	});
 
-	it("should not throw for a header without a colon", async ({ expect }) => {
+	it("should error for a header without a colon", async ({ expect }) => {
 		setIsTTY(false);
 		setWranglerConfig({});
-		let requestMade = false;
-		msw.use(
-			http.get("*/test", async () => {
-				requestMade = true;
-				return HttpResponse.json(`{}`);
-			})
+		await expect(
+			runWrangler("cloudchamber curl /test --header something")
+		).rejects.toThrowErrorMatchingInlineSnapshot(
+			`[Error: Invalid header "something". Headers must be in the form of --header <name>:<value>]`
 		);
-		await runWrangler("cloudchamber curl /test --header something");
-		expect(requestMade).toBe(true);
-		expect(std.out).not.toContain("TypeError");
+	});
+
+	it("should error for a header without a name", async ({ expect }) => {
+		setIsTTY(false);
+		setWranglerConfig({});
+		await expect(
+			runWrangler("cloudchamber curl /test --header :here")
+		).rejects.toThrowErrorMatchingInlineSnapshot(
+			`[Error: Invalid header ":here". Headers must be in the form of --header <name>:<value>]`
+		);
 	});
 
 	it("works", async ({ expect }) => {

--- a/packages/wrangler/src/cloudchamber/curl.ts
+++ b/packages/wrangler/src/cloudchamber/curl.ts
@@ -96,13 +96,12 @@ async function requestFromCmd(
 	}
 	try {
 		const headers: Record<string, string> = (args.header ?? []).reduce(
-			(prev, now) => ({
-				...prev,
-				[now.toString().split(":")[0].trim()]: now
-					.toString()
-					.split(":")[1]
-					.trim(),
-			}),
+			(prev, now) => {
+				// Split on the first colon only: header values may themselves contain
+				// colons, e.g. `--header location:https://example.com/x`.
+				const [key, ...value] = now.toString().split(":");
+				return { ...prev, [key.trim()]: value.join(":").trim() };
+			},
 			{ "coordinator-request-id": requestId }
 		);
 

--- a/packages/wrangler/src/cloudchamber/curl.ts
+++ b/packages/wrangler/src/cloudchamber/curl.ts
@@ -8,6 +8,7 @@ import {
 } from "@cloudflare/cli-shared-helpers/colors";
 import { ApiError, OpenAPI } from "@cloudflare/containers-shared";
 import { request } from "@cloudflare/containers-shared/src/client/core/request";
+import { UserError } from "@cloudflare/workers-utils";
 import { createCommand } from "../core/create-command";
 import formatLabelledValues from "../utils/render-labelled-values";
 import { cloudchamberScope, fillOpenAPIConfiguration } from "./common";
@@ -94,17 +95,31 @@ async function requestFromCmd(
 	if (args.useStdin) {
 		args.data = await read(process.stdin);
 	}
-	try {
-		const headers: Record<string, string> = (args.header ?? []).reduce(
-			(prev, now) => {
-				// Split on the first colon only: header values may themselves contain
-				// colons, e.g. `--header location:https://example.com/x`.
-				const [key, ...value] = now.toString().split(":");
-				return { ...prev, [key.trim()]: value.join(":").trim() };
-			},
-			{ "coordinator-request-id": requestId }
-		);
+	// Parsed outside the try block below so that an invalid header surfaces as a
+	// user-facing error rather than being caught and logged as a request failure.
+	const headers: Record<string, string> = (args.header ?? []).reduce(
+		(prev, now) => {
+			const header = now.toString();
+			// Split on the first colon only: header values may themselves contain
+			// colons, e.g. `--header location:https://example.com/x`.
+			const separatorIndex = header.indexOf(":");
+			if (separatorIndex <= 0) {
+				throw new UserError(
+					`Invalid header "${header}". Headers must be in the form of --header <name>:<value>`,
+					{ telemetryMessage: "cloudchamber curl invalid header" }
+				);
+			}
+			return {
+				...prev,
+				[header.slice(0, separatorIndex).trim()]: header
+					.slice(separatorIndex + 1)
+					.trim(),
+			};
+		},
+		{ "coordinator-request-id": requestId }
+	);
 
+	try {
 		const data = args.data ?? args.dataDeprecated;
 		const res = await request(OpenAPI, {
 			url: args.path,


### PR DESCRIPTION
`wrangler cloudchamber curl` builds request headers by splitting each `--header` on **every** colon and taking only the segment between the first and second:

```js
[now.toString().split(":")[0].trim()]: now.toString().split(":")[1].trim(),
```

Two consequences:

1. A header whose value contains a colon is silently truncated — `--header location:https://example.com/x` is sent as `location: https`.
2. A header with no colon (`--header Foo`) makes `[1]` `undefined`, so `.trim()` throws a `TypeError`, which is caught and printed instead of the request being made.

This splits on the first colon only and keeps the remainder as the value, matching what `collectKeyValues.ts` already does. Added two tests; both fail before this change.

---

<!--
Please dont delete the checkboxes <3
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: this is an internal correctness fix with no corresponding user-facing documentation.
