### PR TITLE
[vitest-pool-workers] Ignore workerd's ungraceful TLS disconnect exception logs

### DIFF
--- a/.changeset/vitest-pool-ignore-tls-disconnect.md
+++ b/.changeset/vitest-pool-ignore-tls-disconnect.md
@@ -1,0 +1,7 @@
+---
+"@cloudflare/vitest-pool-workers": patch
+---
+
+Ignore workerd's `disconnected: peer disconnected without gracefully ending TLS session` exception logs
+
+When tests make real `fetch()` calls to external TLS endpoints, servers and load balancers routinely close idle keepalive connections without sending a TLS `close_notify`. No request fails — the connection is idle — but workerd logs a `kj/compat/tls.c++` exception with a full stack trace each time, flooding otherwise green test runs. This is the TLS sibling of the `disconnected: ...` messages already in the ignore list, so filter it the same way.

--- a/packages/vitest-pool-workers/src/pool/index.ts
+++ b/packages/vitest-pool-workers/src/pool/index.ts
@@ -89,6 +89,7 @@ const ignoreMessages = [
 	"disconnected: worker_do_not_log; Request failed due to internal error",
 	"disconnected: WebSocket was aborted",
 	"disconnected: WebSocket peer disconnected",
+	"disconnected: peer disconnected without gracefully ending TLS session",
 	"CODE_MOVED for unknown code block",
 	"broken.outputGateBroken; jsg.Error: Instance dispose",
 ];


### PR DESCRIPTION
Fixes #14820.

When tests make real `fetch()` calls to external HTTPS endpoints, servers and load balancers routinely close idle keepalive connections without sending a TLS `close_notify`. No request fails — the connection is idle, and undici/Bun/Deno silently discard the same event — but workerd logs a `kj/compat/tls.c++:429: disconnected: peer disconnected without gracefully ending TLS session` exception with a full unsymbolized stack trace each time, flooding otherwise green runs ([real-world example](https://github.com/e2b-dev/E2B/actions/runs/30017080220/job/89239801004): 10+ occurrences in a passing 393-test suite).

Since the pool installs its own `handleStructuredLogs` and users can't override Miniflare's log handling from the vitest config, the only place to filter this is the pool's `ignoreMessages` list — which already suppresses the equivalent non-TLS shapes (`disconnected: operation canceled`, `disconnected: WebSocket peer disconnected`, …) as "normal operation". This PR adds the TLS variant to the same list, plus a changeset.

Note on the accompanying `stack:` line: workerd's `JsonLogger::logMessage` emits one JSON log entry per kj log call, and kj's exception stringifier includes `\nstack: …` in the same string, so the exception text and its stack trace arrive as a single structured message — the substring match filters both together, same as the existing `disconnected: …` entries.

---

- Tests
  - [ ] Tests included/updated
  - [x] Automated tests not possible - manual testing has been completed as follows: verified the exact message captured from the CI log above matches the new `ignoreMessages` entry via the existing `.includes()` filter (and that unrelated warnings/exception shapes don't); ran the E2B SDK's full 393-test workerd suite against a locally patched pool dist — all green with no change in other output. The TLS disconnect event itself is environment-dependent (triggered reliably on GitHub Actions runners, not on a local network), so an end-to-end assertion isn't practical.
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: no user-facing behavior change beyond removing non-actionable log noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)