### PR TITLE
[wrangler] Preserve colons in Cloudchamber curl headers

### DIFF
--- a/.changeset/curly-cats-smile.md
+++ b/.changeset/curly-cats-smile.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Preserve colons in `wrangler cloudchamber curl` header values
+
+Header values are now split from their names at the first colon, and malformed headers produce a clear user-facing error instead of being truncated or causing a `TypeError`.

--- a/packages/wrangler/src/__tests__/cloudchamber/curl.test.ts
+++ b/packages/wrangler/src/__tests__/cloudchamber/curl.test.ts
@@ -217,19 +217,44 @@ describe("cloudchamber curl", () => {
 				// verify we are hitting the expected url
 				expect(request.url).toEqual(baseRequestUrl + "test");
 				// and that we set the expected headers
-				expect(request.headers.get("something")).toEqual("here");
-				expect(request.headers.get("other")).toEqual("thing");
+				expect(request.headers.get("location")).toEqual(
+					"https://example.com/a:b"
+				);
+				expect(request.headers.get("x-test")).toEqual("one:two:three");
+				expect(request.headers.get("x-empty")).toEqual("");
 				return HttpResponse.json(`{}`);
 			})
 		);
 		await runWrangler(
-			"cloudchamber curl /test --header something:here --header other:thing"
+			"cloudchamber curl /test --header location:https://example.com/a:b --header X-Test:one:two:three --header X-Empty:"
 		);
 		expect(std.err).toMatchInlineSnapshot(`""`);
 		expect(std.out).toMatchInlineSnapshot(`
 			""{}"
 			"
 		`);
+	});
+
+	it("rejects a header without a colon", async ({ expect }) => {
+		setIsTTY(false);
+		setWranglerConfig({});
+
+		await expect(
+			runWrangler("cloudchamber curl /test --header invalid")
+		).rejects.toThrow(
+			'Invalid header format: "invalid". Expected "name:value".'
+		);
+	});
+
+	it("rejects an empty header name", async ({ expect }) => {
+		setIsTTY(false);
+		setWranglerConfig({});
+
+		await expect(
+			runWrangler('cloudchamber curl /test --header " :value"')
+		).rejects.toThrow(
+			'Invalid header format: " :value". Header name cannot be empty.'
+		);
 	});
 
 	it("works", async ({ expect }) => {

--- a/packages/wrangler/src/cloudchamber/curl.ts
+++ b/packages/wrangler/src/cloudchamber/curl.ts
@@ -8,6 +8,7 @@ import {
 } from "@cloudflare/cli-shared-helpers/colors";
 import { ApiError, OpenAPI } from "@cloudflare/containers-shared";
 import { request } from "@cloudflare/containers-shared/src/client/core/request";
+import { UserError } from "@cloudflare/workers-utils";
 import { createCommand } from "../core/create-command";
 import formatLabelledValues from "../utils/render-labelled-values";
 import { cloudchamberScope, fillOpenAPIConfiguration } from "./common";
@@ -73,6 +74,38 @@ async function read(stream: NodeJS.ReadStream) {
 	return Buffer.concat(chunks).toString("utf8");
 }
 
+function parseHeaders(
+	headerArgs: (string | number)[] | undefined,
+	requestId: string
+): Record<string, string> {
+	const headers: Record<string, string> = {
+		"coordinator-request-id": requestId,
+	};
+
+	for (const headerArg of headerArgs ?? []) {
+		const header = headerArg.toString();
+		const separatorIndex = header.indexOf(":");
+		if (separatorIndex === -1) {
+			throw new UserError(
+				`Invalid header format: "${header}". Expected "name:value".`,
+				{ telemetryMessage: "cloudchamber curl invalid header" }
+			);
+		}
+
+		const name = header.slice(0, separatorIndex).trim();
+		if (!name) {
+			throw new UserError(
+				`Invalid header format: "${header}". Header name cannot be empty.`,
+				{ telemetryMessage: "cloudchamber curl empty header name" }
+			);
+		}
+
+		headers[name] = header.slice(separatorIndex + 1).trim();
+	}
+
+	return headers;
+}
+
 async function requestFromCmd(
 	args: {
 		path: string;
@@ -94,18 +127,9 @@ async function requestFromCmd(
 	if (args.useStdin) {
 		args.data = await read(process.stdin);
 	}
-	try {
-		const headers: Record<string, string> = (args.header ?? []).reduce(
-			(prev, now) => ({
-				...prev,
-				[now.toString().split(":")[0].trim()]: now
-					.toString()
-					.split(":")[1]
-					.trim(),
-			}),
-			{ "coordinator-request-id": requestId }
-		);
+	const headers = parseHeaders(args.header, requestId);
 
+	try {
 		const data = args.data ?? args.dataDeprecated;
 		const res = await request(OpenAPI, {
 			url: args.path,


### PR DESCRIPTION
Fixes #14827.

`cloudchamber curl` was splitting header arguments at every colon and then keeping only the first value segment. That silently truncated values such as URLs.

This changes the parser to split at the first colon only, while still trimming the name and value. Malformed headers now fail early with a clear `UserError` instead of being swallowed by the request error handler or surfacing as a `TypeError`.

The tests cover values containing multiple colons, empty values, missing separators, and empty header names.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: this fixes CLI argument parsing without changing the public interface.