### PR TITLE
[wrangler] Improve Email Routing plan and apply output

### DIFF
--- a/.changeset/color-email-routing-plan.md
+++ b/.changeset/color-email-routing-plan.md
@@ -1,0 +1,8 @@
+---
+"wrangler": patch
+"@cloudflare/deploy-helpers": patch
+---
+
+Color Email Routing plan change markers
+
+Wrangler now highlights additions in green, updates in yellow, and deletions and conflicts in red so Email Routing deployment plans are easier to scan before confirmation.

--- a/.changeset/fast-email-routing-zones.md
+++ b/.changeset/fast-email-routing-zones.md
@@ -1,0 +1,8 @@
+---
+"wrangler": patch
+"@cloudflare/deploy-helpers": patch
+---
+
+Apply Email Routing changes across independent zones concurrently
+
+Wrangler now limits concurrent zone updates while preserving the Email Routing plan order within each zone. Deployments that configure addresses across multiple zones complete faster without breaking delete-before-add transitions at a zone's rule limit.

--- a/packages/deploy-helpers/src/triggers/email-routing-plan.ts
+++ b/packages/deploy-helpers/src/triggers/email-routing-plan.ts
@@ -1,3 +1,5 @@
+import chalk from "chalk";
+
 /**
  * Pure plan logic for the `addresses` config field: build the plan request and
  * render the plan response. No network access.
@@ -127,11 +129,11 @@ export function planHasDestructiveChanges(
 	return plan.zones.some((zone) => zone.changes.some(isDestructiveChange));
 }
 
-const CHANGE_MARKERS: Record<PlanChangeType, string> = {
-	added: "+",
-	updated: "~",
-	deleted: "-",
-	conflict: "!",
+const CHANGE_MARKERS: Record<PlanChangeType, () => string> = {
+	added: () => chalk.green("+"),
+	updated: () => chalk.yellow("~"),
+	deleted: () => chalk.red("-"),
+	conflict: () => chalk.red("!"),
 };
 
 /** Human description of what a remote rule currently does, for conflict lines. */
@@ -189,7 +191,7 @@ export function renderEmailRoutingPlan(
 
 		for (const change of zone.changes) {
 			counts[change.type]++;
-			const marker = CHANGE_MARKERS[change.type];
+			const marker = CHANGE_MARKERS[change.type]();
 			switch (change.type) {
 				case "added":
 				case "updated":

--- a/packages/deploy-helpers/src/triggers/email-routing.ts
+++ b/packages/deploy-helpers/src/triggers/email-routing.ts
@@ -4,6 +4,7 @@ import {
 	isNonInteractiveOrCI,
 	UserError,
 } from "@cloudflare/workers-utils";
+import PQueue from "p-queue";
 import { isWorkerNotFoundError } from "../deploy/helpers/worker-not-found-error";
 import { confirm, fetchResult, logger } from "../shared/context";
 import {
@@ -30,6 +31,7 @@ const PLAN_RETRY_WORKER_NOT_FOUND_CODE = 2016;
 const PLAN_RETRY_TIMEOUT_MS = 30_000;
 const PLAN_RETRY_DELAY_MS = 3_000;
 const NON_INTERACTIVE_PROGRESS_INTERVAL = 10;
+const APPLY_ZONE_CONCURRENCY = 10;
 
 function applyProgressMessage(done: number, total: number): string {
 	return `Applying Email Routing changes (${done}/${total}, ${Math.floor(
@@ -294,39 +296,49 @@ export async function applyEmailRoutingAddresses({
 		}
 	}
 
-	const failures: string[] = [];
 	const totalChanges = plan.zones.reduce(
 		(total, zone) => total + zone.changes.length,
 		0
 	);
 	const progress = startApplyProgress(totalChanges);
 	let completedChanges = 0;
+	const queue = new PQueue({ concurrency: APPLY_ZONE_CONCURRENCY });
+	const failuresByZone: string[][] = [];
+	const zonePromises: Array<Promise<void>> = [];
 
 	try {
 		for (const zone of plan.zones) {
-			for (const change of zone.changes) {
-				try {
-					await applyChange(
-						config,
-						zone.zone_id,
-						change,
-						scriptName,
-						ownerWorkerTag
-					);
-				} catch (e) {
-					failures.push(
-						`${change.target}: ${e instanceof Error ? e.message : String(e)}`
-					);
-				} finally {
-					completedChanges++;
-					progress.update(completedChanges);
-				}
-			}
+			const zoneFailures: string[] = [];
+			failuresByZone.push(zoneFailures);
+			zonePromises.push(
+				queue.add(async () => {
+					for (const change of zone.changes) {
+						try {
+							await applyChange(
+								config,
+								zone.zone_id,
+								change,
+								scriptName,
+								ownerWorkerTag
+							);
+						} catch (e) {
+							zoneFailures.push(
+								`${change.target}: ${e instanceof Error ? e.message : String(e)}`
+							);
+						} finally {
+							completedChanges++;
+							progress.update(completedChanges);
+						}
+					}
+				})
+			);
 		}
+		await Promise.all(zonePromises);
 	} finally {
 		progress.stop();
 	}
 
+	const failures = failuresByZone.flat();
 	if (failures.length > 0) {
 		for (const failure of failures) {
 			logger.error(`Email Routing change failed: ${failure}`);

--- a/packages/deploy-helpers/tests/email-routing-apply.test.ts
+++ b/packages/deploy-helpers/tests/email-routing-apply.test.ts
@@ -43,6 +43,9 @@ describe("applyEmailRoutingAddresses", () => {
 	let metadataFailures: number[];
 	let planFailures: APIError[];
 	let planBody: unknown;
+	let holdRuleWrites: boolean;
+	let ruleWriteStarts: string[];
+	let releaseRuleWrites: Array<() => void>;
 
 	beforeEach(() => {
 		plan = { zones: [] };
@@ -58,6 +61,9 @@ describe("applyEmailRoutingAddresses", () => {
 		metadataFailures = [];
 		planFailures = [];
 		planBody = undefined;
+		holdRuleWrites = false;
+		ruleWriteStarts = [];
+		releaseRuleWrites = [];
 
 		initDeployHelpersContext({
 			logger: {
@@ -111,6 +117,12 @@ describe("applyEmailRoutingAddresses", () => {
 		if (init?.method === "POST" && path.endsWith("/email/routing/rules")) {
 			const target = (body as { matchers: { value?: string }[] }).matchers[0]
 				?.value;
+			if (target) {
+				ruleWriteStarts.push(target);
+			}
+			if (holdRuleWrites) {
+				await new Promise<void>((resolve) => releaseRuleWrites.push(resolve));
+			}
 			if (target === failTarget) {
 				throw new Error("duplicate rule");
 			}
@@ -271,6 +283,85 @@ describe("applyEmailRoutingAddresses", () => {
 		]);
 		expect(writes.deletes).toEqual(["old-rule-id"]);
 		expect(confirmRequests).toBe(1);
+	});
+
+	it("applies independent zones concurrently", async ({ expect }) => {
+		holdRuleWrites = true;
+		plan = {
+			zones: [
+				{
+					zone_id: "zone1",
+					changes: [{ type: "added", target: "first@example.com" }],
+				},
+				{
+					zone_id: "zone2",
+					changes: [{ type: "added", target: "second@example.net" }],
+				},
+			],
+		};
+
+		const applying = apply(["first@example.com", "second@example.net"]);
+		await vi.waitFor(() => expect(ruleWriteStarts).toHaveLength(2));
+
+		holdRuleWrites = false;
+		for (const release of releaseRuleWrites) {
+			release();
+		}
+		await applying;
+	});
+
+	it("limits concurrent zone applies", async ({ expect }) => {
+		holdRuleWrites = true;
+		const targets = Array.from(
+			{ length: 11 },
+			(_, index) => `address-${index}@example.com`
+		);
+		plan = {
+			zones: targets.map((target, index) => ({
+				zone_id: `zone${index}`,
+				changes: [{ type: "added", target }],
+			})),
+		};
+
+		const applying = apply(targets);
+		await vi.waitFor(() => expect(ruleWriteStarts).toHaveLength(10));
+
+		holdRuleWrites = false;
+		for (const release of releaseRuleWrites) {
+			release();
+		}
+		await applying;
+		expect(ruleWriteStarts).toHaveLength(11);
+	});
+
+	it("preserves plan order within a zone", async ({ expect }) => {
+		holdRuleWrites = true;
+		plan = {
+			zones: [
+				{
+					zone_id: "zone1",
+					changes: [
+						{ type: "added", target: "first@example.com" },
+						{ type: "added", target: "second@example.com" },
+					],
+				},
+			],
+		};
+
+		const applying = apply(["first@example.com", "second@example.com"]);
+		await vi.waitFor(() =>
+			expect(ruleWriteStarts).toEqual(["first@example.com"])
+		);
+
+		holdRuleWrites = false;
+		for (const release of releaseRuleWrites) {
+			release();
+		}
+		await applying;
+		expect(ruleWriteStarts).toEqual([
+			"first@example.com",
+			"second@example.com",
+		]);
 	});
 
 	it("does not write rules when destructive changes are declined", async ({

--- a/packages/deploy-helpers/tests/email-routing-plan.test.ts
+++ b/packages/deploy-helpers/tests/email-routing-plan.test.ts
@@ -1,4 +1,5 @@
-import { describe, it } from "vitest";
+import chalk from "chalk";
+import { afterEach, beforeEach, describe, it } from "vitest";
 import {
 	buildEmailRoutingPlanRequest,
 	isDestructiveChange,
@@ -51,6 +52,16 @@ describe("buildEmailRoutingPlanRequest", () => {
 });
 
 describe("renderEmailRoutingPlan", () => {
+	const originalChalkLevel = chalk.level;
+
+	beforeEach(() => {
+		chalk.level = 0;
+	});
+
+	afterEach(() => {
+		chalk.level = originalChalkLevel;
+	});
+
 	const plan: EmailRoutingPlanResponse = {
 		zones: [
 			{
@@ -106,6 +117,30 @@ describe("renderEmailRoutingPlan", () => {
 			`  ! *@example.net -> conflict: owned by worker "other-worker" (worker other-worker)`,
 			"4 changes across 2 zones (1 added, 1 deleted, 2 conflict)",
 		]);
+	});
+
+	it("colors change markers", ({ expect }) => {
+		chalk.level = 1;
+		const lines = renderEmailRoutingPlan(
+			{
+				zones: [
+					{
+						zone_id: "zone1",
+						changes: [
+							{ type: "added", target: "add@example.com" },
+							{ type: "updated", target: "update@example.com" },
+							{ type: "deleted", target: "delete@example.com" },
+							{ type: "conflict", target: "conflict@example.com" },
+						],
+					},
+				],
+			},
+			"my-worker"
+		);
+		expect(lines[1]).toContain("\u001b[32m+\u001b[39m");
+		expect(lines[2]).toContain("\u001b[33m~\u001b[39m");
+		expect(lines[3]).toContain("\u001b[31m-\u001b[39m");
+		expect(lines[4]).toContain("\u001b[31m!\u001b[39m");
 	});
 
 	it("omits zones with no changes", ({ expect }) => {


### PR DESCRIPTION
Improve declarative Email Routing deploy output and apply performance.

- Color plan additions green, updates yellow, and deletions and conflicts red. Chalk continues to emit plain markers when color is disabled.
- Apply independent zones concurrently with a limit of 10 active zones. Changes within each zone remain serial in server-provided plan order so capacity-sensitive delete-before-add transitions remain safe.
- Keep failure reporting deterministic in plan order and count every attempted change in progress output.

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: this changes terminal presentation and apply performance without changing configuration or API behavior.