### PR TITLE
[wrangler] Apply Email Routing zones concurrently

### DIFF
--- a/.changeset/fast-email-routing-zones.md
+++ b/.changeset/fast-email-routing-zones.md
@@ -1,0 +1,8 @@
+---
+"wrangler": patch
+"@cloudflare/deploy-helpers": patch
+---
+
+Apply Email Routing changes across independent zones concurrently
+
+Wrangler now limits concurrent zone updates while preserving the Email Routing plan order within each zone. Deployments that configure addresses across multiple zones complete faster without breaking delete-before-add transitions at a zone's rule limit.

--- a/packages/deploy-helpers/src/triggers/email-routing.ts
+++ b/packages/deploy-helpers/src/triggers/email-routing.ts
@@ -4,6 +4,7 @@ import {
 	isNonInteractiveOrCI,
 	UserError,
 } from "@cloudflare/workers-utils";
+import PQueue from "p-queue";
 import { isWorkerNotFoundError } from "../deploy/helpers/worker-not-found-error";
 import { confirm, fetchResult, logger } from "../shared/context";
 import {
@@ -30,6 +31,7 @@ const PLAN_RETRY_WORKER_NOT_FOUND_CODE = 2016;
 const PLAN_RETRY_TIMEOUT_MS = 30_000;
 const PLAN_RETRY_DELAY_MS = 3_000;
 const NON_INTERACTIVE_PROGRESS_INTERVAL = 10;
+const APPLY_ZONE_CONCURRENCY = 10;
 
 function applyProgressMessage(done: number, total: number): string {
 	return `Applying Email Routing changes (${done}/${total}, ${Math.floor(
@@ -294,39 +296,49 @@ export async function applyEmailRoutingAddresses({
 		}
 	}
 
-	const failures: string[] = [];
 	const totalChanges = plan.zones.reduce(
 		(total, zone) => total + zone.changes.length,
 		0
 	);
 	const progress = startApplyProgress(totalChanges);
 	let completedChanges = 0;
+	const queue = new PQueue({ concurrency: APPLY_ZONE_CONCURRENCY });
+	const failuresByZone: string[][] = [];
+	const zonePromises: Array<Promise<void>> = [];
 
 	try {
 		for (const zone of plan.zones) {
-			for (const change of zone.changes) {
-				try {
-					await applyChange(
-						config,
-						zone.zone_id,
-						change,
-						scriptName,
-						ownerWorkerTag
-					);
-				} catch (e) {
-					failures.push(
-						`${change.target}: ${e instanceof Error ? e.message : String(e)}`
-					);
-				} finally {
-					completedChanges++;
-					progress.update(completedChanges);
-				}
-			}
+			const zoneFailures: string[] = [];
+			failuresByZone.push(zoneFailures);
+			zonePromises.push(
+				queue.add(async () => {
+					for (const change of zone.changes) {
+						try {
+							await applyChange(
+								config,
+								zone.zone_id,
+								change,
+								scriptName,
+								ownerWorkerTag
+							);
+						} catch (e) {
+							zoneFailures.push(
+								`${change.target}: ${e instanceof Error ? e.message : String(e)}`
+							);
+						} finally {
+							completedChanges++;
+							progress.update(completedChanges);
+						}
+					}
+				})
+			);
 		}
+		await Promise.all(zonePromises);
 	} finally {
 		progress.stop();
 	}
 
+	const failures = failuresByZone.flat();
 	if (failures.length > 0) {
 		for (const failure of failures) {
 			logger.error(`Email Routing change failed: ${failure}`);

--- a/packages/deploy-helpers/tests/email-routing-apply.test.ts
+++ b/packages/deploy-helpers/tests/email-routing-apply.test.ts
@@ -43,6 +43,9 @@ describe("applyEmailRoutingAddresses", () => {
 	let metadataFailures: number[];
 	let planFailures: APIError[];
 	let planBody: unknown;
+	let holdRuleWrites: boolean;
+	let ruleWriteStarts: string[];
+	let releaseRuleWrites: Array<() => void>;
 
 	beforeEach(() => {
 		plan = { zones: [] };
@@ -58,6 +61,9 @@ describe("applyEmailRoutingAddresses", () => {
 		metadataFailures = [];
 		planFailures = [];
 		planBody = undefined;
+		holdRuleWrites = false;
+		ruleWriteStarts = [];
+		releaseRuleWrites = [];
 
 		initDeployHelpersContext({
 			logger: {
@@ -111,6 +117,12 @@ describe("applyEmailRoutingAddresses", () => {
 		if (init?.method === "POST" && path.endsWith("/email/routing/rules")) {
 			const target = (body as { matchers: { value?: string }[] }).matchers[0]
 				?.value;
+			if (target) {
+				ruleWriteStarts.push(target);
+			}
+			if (holdRuleWrites) {
+				await new Promise<void>((resolve) => releaseRuleWrites.push(resolve));
+			}
 			if (target === failTarget) {
 				throw new Error("duplicate rule");
 			}
@@ -271,6 +283,85 @@ describe("applyEmailRoutingAddresses", () => {
 		]);
 		expect(writes.deletes).toEqual(["old-rule-id"]);
 		expect(confirmRequests).toBe(1);
+	});
+
+	it("applies independent zones concurrently", async ({ expect }) => {
+		holdRuleWrites = true;
+		plan = {
+			zones: [
+				{
+					zone_id: "zone1",
+					changes: [{ type: "added", target: "first@example.com" }],
+				},
+				{
+					zone_id: "zone2",
+					changes: [{ type: "added", target: "second@example.net" }],
+				},
+			],
+		};
+
+		const applying = apply(["first@example.com", "second@example.net"]);
+		await vi.waitFor(() => expect(ruleWriteStarts).toHaveLength(2));
+
+		holdRuleWrites = false;
+		for (const release of releaseRuleWrites) {
+			release();
+		}
+		await applying;
+	});
+
+	it("limits concurrent zone applies", async ({ expect }) => {
+		holdRuleWrites = true;
+		const targets = Array.from(
+			{ length: 11 },
+			(_, index) => `address-${index}@example.com`
+		);
+		plan = {
+			zones: targets.map((target, index) => ({
+				zone_id: `zone${index}`,
+				changes: [{ type: "added", target }],
+			})),
+		};
+
+		const applying = apply(targets);
+		await vi.waitFor(() => expect(ruleWriteStarts).toHaveLength(10));
+
+		holdRuleWrites = false;
+		for (const release of releaseRuleWrites) {
+			release();
+		}
+		await applying;
+		expect(ruleWriteStarts).toHaveLength(11);
+	});
+
+	it("preserves plan order within a zone", async ({ expect }) => {
+		holdRuleWrites = true;
+		plan = {
+			zones: [
+				{
+					zone_id: "zone1",
+					changes: [
+						{ type: "added", target: "first@example.com" },
+						{ type: "added", target: "second@example.com" },
+					],
+				},
+			],
+		};
+
+		const applying = apply(["first@example.com", "second@example.com"]);
+		await vi.waitFor(() =>
+			expect(ruleWriteStarts).toEqual(["first@example.com"])
+		);
+
+		holdRuleWrites = false;
+		for (const release of releaseRuleWrites) {
+			release();
+		}
+		await applying;
+		expect(ruleWriteStarts).toEqual([
+			"first@example.com",
+			"second@example.com",
+		]);
 	});
 
 	it("does not write rules when destructive changes are declined", async ({


### PR DESCRIPTION
Apply Email Routing changes for independent zones concurrently, with a limit of 10 active zones. Changes within each zone remain serial in the server-provided plan order so delete-before-add transitions continue to work at the per-zone rule limit.

Failure reporting remains deterministic in plan order, and progress continues to count every attempted change.

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: this only improves deploy performance and does not change configuration or API behavior.

*A picture of a cute animal (not mandatory, but encouraged)*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14834" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->