### PR TITLE
fix(vite-plugin): keep Miniflare alive when a build runs during `serve`

### DIFF
--- a/.changeset/vite-plugin-bundled-dev-miniflare-dispose.md
+++ b/.changeset/vite-plugin-bundled-dev-miniflare-dispose.md
@@ -1,0 +1,9 @@
+---
+"@cloudflare/vite-plugin": patch
+---
+
+Keep Miniflare alive when a build runs during `serve` (Vite `experimental.bundledDev`)
+
+The plugin used the `buildEnd` hook as its signal that the dev server was closing, and disposed the Miniflare instance there. Vite's `experimental.bundledDev` runs a Rolldown build pass *during* `serve`, which fires `buildEnd` while the dev server is still live — so Miniflare was torn down mid-serve and the next request failed with `Expected \`miniflare\` to be defined`.
+
+During `serve`, Miniflare is now disposed from a patched `server.close` (mirroring the existing `server.restart` patch) instead of from `buildEnd`, so build passes that run while serving no longer dispose it. Behaviour is unchanged for production builds, dev-server restarts (Miniflare stays warm), and forceful exits (still covered by the existing `exit` handler).

--- a/.changeset/vite-plugin-bundled-dev-miniflare-dispose.md
+++ b/.changeset/vite-plugin-bundled-dev-miniflare-dispose.md
@@ -2,8 +2,8 @@
 "@cloudflare/vite-plugin": patch
 ---
 
-Keep Miniflare alive when a build runs during `serve` (Vite `experimental.bundledDev`)
+Fix compatibility with Vite's `experimental.bundledDev` option. Keep Miniflare, containers, and tunnels alive when a build runs in dev.
 
-The plugin used the `buildEnd` hook as its signal that the dev server was closing, and disposed the Miniflare instance there. Vite's `experimental.bundledDev` runs a Rolldown build pass *during* `serve`, which fires `buildEnd` while the dev server is still live — so Miniflare was torn down mid-serve and the next request failed with `Expected \`miniflare\` to be defined`.
+The plugin used the `buildEnd` hook as its signal that the dev server was closing, and tore down its dev resources there. Vite's `experimental.bundledDev` runs a build pass _during_ `serve`, which fires `buildEnd` while the dev server is still live — so Miniflare was disposed (the next request failed with `Expected \`miniflare\` to be defined`), locally-built container images were removed, and any active tunnel was closed, all mid-serve.
 
-During `serve`, Miniflare is now disposed from a patched `server.close` (mirroring the existing `server.restart` patch) instead of from `buildEnd`, so build passes that run while serving no longer dispose it. Behaviour is unchanged for production builds, dev-server restarts (Miniflare stays warm), and forceful exits (still covered by the existing `exit` handler).
+During `serve`, these resources are now torn down from a patched `server.close`. We will replace server patching with first-class APIs when they are [added to Vite](https://github.com/vitejs/vite/issues/22913).

--- a/packages/vite-plugin-cloudflare/src/__tests__/bundled-dev-dispose.spec.ts
+++ b/packages/vite-plugin-cloudflare/src/__tests__/bundled-dev-dispose.spec.ts
@@ -1,0 +1,59 @@
+import { fileURLToPath } from "node:url";
+import { cloudflare } from "@cloudflare/vite-plugin";
+import { createServer } from "vite";
+import { afterEach, describe, test } from "vitest";
+import type { ObjectHook, Plugin, ViteDevServer } from "vite";
+
+const fixturesPath = fileURLToPath(new URL("./fixtures", import.meta.url));
+
+function callBuildEnd(plugin: Plugin): unknown {
+	const hook = plugin.buildEnd as ObjectHook<NonNullable<Plugin["buildEnd"]>>;
+	const handler = typeof hook === "function" ? hook : hook?.handler;
+	// The cloudflare hooks close over their own context, so the `this`
+	// PluginContext is unused; an empty object is sufficient to invoke them.
+	return handler?.call({} as never);
+}
+
+describe("bundled dev mode", () => {
+	let server: ViteDevServer | undefined;
+
+	afterEach(async () => {
+		await server?.close();
+		server = undefined;
+	});
+
+	// Reference: Vite's `experimental.bundledDev` runs a Rolldown build pass
+	// *during* `serve`, which fires every plugin's `buildEnd` hook while the
+	// dev server is still live. The cloudflare plugin previously treated
+	// `buildEnd` as "the dev server is closing" and disposed Miniflare, so the
+	// next request failed with `Expected \`miniflare\` to be defined`. Miniflare
+	// must survive a `buildEnd` that fires during `serve`.
+	test("Miniflare survives a buildEnd fired during serve", async ({
+		expect,
+	}) => {
+		server = await createServer({
+			root: fixturesPath,
+			logLevel: "silent",
+			plugins: [cloudflare({ inspectorPort: false, persistState: false })],
+		});
+
+		await server.listen();
+		const address = server.resolvedUrls?.local[0];
+		if (!address) {
+			throw new Error("Server address is undefined");
+		}
+
+		expect((await fetch(address)).ok).toBe(true);
+
+		// Simulate a bundledDev build pass completing mid-serve.
+		for (const plugin of server.config.plugins) {
+			if (plugin.name.startsWith("vite-plugin-cloudflare")) {
+				await callBuildEnd(plugin);
+			}
+		}
+
+		// Before the fix this request throws / 500s because Miniflare was
+		// disposed by the buildEnd above.
+		expect((await fetch(address)).ok).toBe(true);
+	});
+});

--- a/packages/vite-plugin-cloudflare/src/__tests__/bundled-dev-dispose.spec.ts
+++ b/packages/vite-plugin-cloudflare/src/__tests__/bundled-dev-dispose.spec.ts
@@ -2,12 +2,12 @@ import { fileURLToPath } from "node:url";
 import { cloudflare } from "@cloudflare/vite-plugin";
 import { createServer } from "vite";
 import { afterEach, describe, test } from "vitest";
-import type { ObjectHook, Plugin, ViteDevServer } from "vite";
+import type { Plugin, ViteDevServer } from "vite";
 
 const fixturesPath = fileURLToPath(new URL("./fixtures", import.meta.url));
 
 function callBuildEnd(plugin: Plugin): unknown {
-	const hook = plugin.buildEnd as ObjectHook<NonNullable<Plugin["buildEnd"]>>;
+	const hook = plugin.buildEnd;
 	const handler = typeof hook === "function" ? hook : hook?.handler;
 	// The cloudflare hooks close over their own context, so the `this`
 	// PluginContext is unused; an empty object is sufficient to invoke them.

--- a/packages/vite-plugin-cloudflare/src/plugins/dev.ts
+++ b/packages/vite-plugin-cloudflare/src/plugins/dev.ts
@@ -55,11 +55,26 @@ export const devPlugin = createPlugin("dev", (ctx) => {
 				cleanupContainers(dockerPath, containerImageTags);
 			}
 
+			// `buildEnd` fires both when the dev server closes AND, when Vite's
+			// `experimental.bundledDev` is enabled, at the end of every build
+			// pass that runs *during* `serve`. Disposing Miniflare here on the
+			// latter tears it down while the dev server is still live, so the
+			// next request hits `Expected \`miniflare\` to be defined`. During
+			// `serve` we therefore dispose from the patched `server.close`
+			// below (mirroring how `server.restart` is patched in index.ts)
+			// rather than from `buildEnd`.
 			debuglog(
 				"buildEnd:",
-				ctx.isRestartingDevServer ? "restarted" : "disposing"
+				ctx.resolvedViteConfig.command === "serve"
+					? "serve (dispose handled on server close)"
+					: ctx.isRestartingDevServer
+						? "restarted"
+						: "disposing"
 			);
-			if (!ctx.isRestartingDevServer) {
+			if (
+				ctx.resolvedViteConfig.command !== "serve" &&
+				!ctx.isRestartingDevServer
+			) {
 				try {
 					await ctx.disposeMiniflare();
 				} catch (error) {
@@ -74,6 +89,28 @@ export const devPlugin = createPlugin("dev", (ctx) => {
 			let containerTagToOptionsMap = initialOptions.containerTagToOptionsMap;
 
 			await ctx.startOrUpdateMiniflare(initialOptions.miniflareOptions);
+
+			// Dispose Miniflare when the dev server genuinely closes. `buildEnd`
+			// can no longer be trusted for this under `experimental.bundledDev`
+			// (see above), so patch `server.close` the same way `server.restart`
+			// is patched in index.ts. Skip disposal while restarting so Miniflare
+			// stays warm across restarts, exactly as the previous
+			// `!isRestartingDevServer` guard in `buildEnd` did. Forceful exits
+			// (ctrl+C) are still covered by the `exit` handler registered below.
+			const closeServer = viteDevServer.close.bind(viteDevServer);
+			viteDevServer.close = async () => {
+				try {
+					await closeServer();
+				} finally {
+					if (!ctx.isRestartingDevServer) {
+						try {
+							await ctx.disposeMiniflare();
+						} catch (error) {
+							debuglog("Failed to dispose Miniflare instance:", error);
+						}
+					}
+				}
+			};
 
 			// Once the HTTP server is listening, update Miniflare's publicUrl with
 			// the actual address. This ensures "Cloudflare Stream" preview URLs always reflect

--- a/packages/vite-plugin-cloudflare/src/plugins/dev.ts
+++ b/packages/vite-plugin-cloudflare/src/plugins/dev.ts
@@ -46,40 +46,16 @@ export const devPlugin = createPlugin("dev", (ctx) => {
 	let containerImageTags = new Set<string>();
 
 	return {
-		async buildEnd() {
+		buildEnd() {
+			// Server restarts are handled here.
+			// Server shutdown is handled in the patched `server.close()`.
 			if (
 				ctx.resolvedViteConfig.command === "serve" &&
+				ctx.isRestartingDevServer &&
 				containerImageTags.size
 			) {
 				const dockerPath = getDockerPath();
 				cleanupContainers(dockerPath, containerImageTags);
-			}
-
-			// `buildEnd` fires both when the dev server closes AND, when Vite's
-			// `experimental.bundledDev` is enabled, at the end of every build
-			// pass that runs *during* `serve`. Disposing Miniflare here on the
-			// latter tears it down while the dev server is still live, so the
-			// next request hits `Expected \`miniflare\` to be defined`. During
-			// `serve` we therefore dispose from the patched `server.close`
-			// below (mirroring how `server.restart` is patched in index.ts)
-			// rather than from `buildEnd`.
-			debuglog(
-				"buildEnd:",
-				ctx.resolvedViteConfig.command === "serve"
-					? "serve (dispose handled on server close)"
-					: ctx.isRestartingDevServer
-						? "restarted"
-						: "disposing"
-			);
-			if (
-				ctx.resolvedViteConfig.command !== "serve" &&
-				!ctx.isRestartingDevServer
-			) {
-				try {
-					await ctx.disposeMiniflare();
-				} catch (error) {
-					debuglog("Failed to dispose Miniflare instance:", error);
-				}
 			}
 		},
 		async configureServer(viteDevServer) {
@@ -90,19 +66,20 @@ export const devPlugin = createPlugin("dev", (ctx) => {
 
 			await ctx.startOrUpdateMiniflare(initialOptions.miniflareOptions);
 
-			// Dispose Miniflare when the dev server genuinely closes. `buildEnd`
-			// can no longer be trusted for this under `experimental.bundledDev`
-			// (see above), so patch `server.close` the same way `server.restart`
-			// is patched in index.ts. Skip disposal while restarting so Miniflare
-			// stays warm across restarts, exactly as the previous
-			// `!isRestartingDevServer` guard in `buildEnd` did. Forceful exits
-			// (ctrl+C) are still covered by the `exit` handler registered below.
+			// Dispose Miniflare and clean up containers when the dev server
+			// shuts down. `buildEnd` can't be used for this under
+			// `experimental.bundledDev`.
+			// Note Vite's `restartServer` calls `server.close()` on every restart, so we skip
+			// teardown while restarting.
 			const closeServer = viteDevServer.close.bind(viteDevServer);
 			viteDevServer.close = async () => {
 				try {
 					await closeServer();
 				} finally {
 					if (!ctx.isRestartingDevServer) {
+						if (containerImageTags.size) {
+							cleanupContainers(getDockerPath(), containerImageTags);
+						}
 						try {
 							await ctx.disposeMiniflare();
 						} catch (error) {

--- a/packages/vite-plugin-cloudflare/src/plugins/tunnel.ts
+++ b/packages/vite-plugin-cloudflare/src/plugins/tunnel.ts
@@ -627,19 +627,22 @@ export const tunnelPlugin = createPlugin("tunnel", (ctx) => {
 	}
 
 	return {
-		/**
-		 * Vite runs `buildEnd` when the dev server restarts or closes.
-		 */
-		buildEnd() {
-			if (!ctx.isRestartingDevServer) {
-				stopTunnel();
-			}
-		},
 		configureServer(server) {
 			assertIsNotPreview(ctx);
 
 			tunnelManager ??= new TunnelManager(server.config.logger);
 			patchPrintUrls(server);
+
+			const closeServer = server.close.bind(server);
+			server.close = async () => {
+				try {
+					await closeServer();
+				} finally {
+					if (!ctx.isRestartingDevServer) {
+						stopTunnel();
+					}
+				}
+			};
 
 			if (!ctx.resolvedPluginConfig.tunnel.autoStart) {
 				return;
@@ -677,12 +680,10 @@ export const tunnelPlugin = createPlugin("tunnel", (ctx) => {
 
 			const closePreviewServer = server.close.bind(server);
 			server.close = async () => {
-				const closePromise = closePreviewServer();
-
 				try {
-					stopTunnel();
+					await closePreviewServer();
 				} finally {
-					await closePromise;
+					stopTunnel();
 				}
 			};
 		},


### PR DESCRIPTION
## What / why

The plugin uses `buildEnd` as its signal that the dev server is closing, and disposes the Miniflare instance there:

https://github.com/cloudflare/workers-sdk/blob/main/packages/vite-plugin-cloudflare/src/plugins/dev.ts#L58-L69

Vite's `experimental.bundledDev` runs a Rolldown **build pass during `serve`**, so `buildEnd` fires while the dev server is still live. Miniflare gets torn down mid-serve and every subsequent request fails:

```
[vite] Internal server error: Expected `miniflare` to be defined
    at get miniflare (@cloudflare/vite-plugin/dist/index.mjs)
    at cloudflarePreMiddleware (@cloudflare/vite-plugin/dist/index.mjs)
```

With `NODE_DEBUG=@cloudflare:vite-plugin` the sequence is unambiguous:

```
Creating new Miniflare instance
Miniflare is ready
buildEnd: disposing        <-- during serve, not on close
... next request -> 500
```

Reproduces on both the currently pinned `1.37.2` and latest `1.45.1` (with matching wrangler), so it isn't version lag — the dev architecture just assumes a pure module-runner serve rather than a build-during-serve.

## Why `bundledDev` matters here (i.e. why fix this rather than avoid the flag)

Vite's unbundled dev server is optimised for the common case: the browser is on the same machine as the dev server, so one HTTP request per module is essentially free.

Our dev servers aren't local to the browser. Each runs inside a remote sandbox, and the browser reaches it through **a Cloudflare Worker and a tunnel**. Every module request is a full cross-network round trip, and the app is ~1000 modules — so a cold page load issues ~1000 sequential-ish round trips before it renders. Requests dominate; transform time is noise.

`experimental.bundledDev` is the direct fix for that shape: Rolldown bundles the graph and the dev server ships a handful of chunks instead of a thousand modules, while keeping HMR. It collapses the request count by orders of magnitude, which is exactly the axis that hurts when the dev server is behind a Worker.

This isn't a niche setup, and it's one Cloudflare users are likely to hit more, not less: remote/cloud dev environments, Codespaces-style sandboxes, and any workflow where the Vite dev server sits behind a Worker or tunnel all have the same profile. Today the combination of `@cloudflare/vite-plugin` + `experimental.bundledDev` is unusable — not slow, but 500 on every request — so the flag can't be evaluated at all by anyone using this plugin.

The fix is also small and independent of `bundledDev` itself: it just stops the plugin from conflating "a build finished" with "the dev server closed". That conflation is arguably wrong regardless of this flag — any plugin or future Vite feature that triggers a build during `serve` would hit the same teardown.

## The change

During `serve`, dispose Miniflare from a patched `server.close` instead of from `buildEnd`. This mirrors the existing `server.restart` patch in `index.ts`, so the mechanism should look familiar:

https://github.com/cloudflare/workers-sdk/blob/main/packages/vite-plugin-cloudflare/src/index.ts#L93-L105

Preserved behaviour:
- **production builds** — unchanged (`buildEnd` still disposes when `command !== "serve"`)
- **dev-server restarts** — Miniflare still stays warm (the `!isRestartingDevServer` guard moved with the disposal)
- **forceful exits (ctrl+C)** — still covered by the existing `exit` handler, which the code comments already call out as the reason `buildEnd` alone was never sufficient

## Test

`packages/vite-plugin-cloudflare/src/__tests__/bundled-dev-dispose.spec.ts` starts a real dev server, invokes the cloudflare plugins' `buildEnd` hooks (exactly what a bundledDev build pass does), and asserts the server still serves. It fails on `main` with `Expected \`miniflare\` to be defined` and passes with this change. Modeled on the existing `hmr-events.spec.ts`.

Driving the hook directly (rather than enabling `bundledDev` in the fixture) keeps the test deterministic and independent of an experimental Vite flag's internals — it pins the actual invariant: *a `buildEnd` during `serve` must not dispose Miniflare*.

## Validation beyond the unit test

Applied the equivalent change to the built plugin inside a large real app (~1000 modules, React + TanStack Router, Worker + SPA) and ran it with `experimental.bundledDev` enabled:

| | before | after |
|---|---|---|
| `GET /` | 500 `Expected \`miniflare\` to be defined` | **200**, real app HTML |
| `GET /src/main.tsx` | 500 | **200** |
| repeated requests | 500 | stable 200 |

Unrelated note in case it's useful to maintainers: with `bundledDev` there's also a separate non-fatal `TypeError: Cannot read properties of undefined (reading 'config')` from `@vitejs/plugin-react-swc`'s `transformIndexHtml` — different repo, and it doesn't block serving once this fix is in.

## Changeset

Patch for `@cloudflare/vite-plugin`.

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: bug fix