### PR TITLE
[workflows-shared] Clean up abort listeners after local workflow waits

### DIFF
--- a/.changeset/quiet-workflows-rest.md
+++ b/.changeset/quiet-workflows-rest.md
@@ -1,0 +1,7 @@
+---
+"@cloudflare/workflows-shared": patch
+---
+
+Fix local Workflows retaining abort listeners after waits complete
+
+Workflow sleeps, retry delays, dynamic delay timeouts, and event waits now remove their abort listeners when either side of the wait settles. This prevents long-running local Workflow instances from retaining a listener and its captured promise state for every completed wait until the instance is paused or evicted.

--- a/.changeset/quiet-workflows-rest.md
+++ b/.changeset/quiet-workflows-rest.md
@@ -4,4 +4,4 @@
 
 Fix local Workflows retaining abort listeners after waits complete
 
-Workflow sleeps, retry delays, dynamic delay timeouts, and event waits now remove their abort listeners when either side of the wait settles. This prevents long-running local Workflow instances from retaining a listener and its captured promise state for every completed wait until the instance is paused or evicted.
+Workflow sleeps, retry delays, and event waits now share a typed abort-aware race that removes its listener when either side settles. This prevents long-running local Workflow instances from retaining a listener and its captured promise state for every completed wait until the instance is paused or evicted.

--- a/packages/workflows-shared/src/context.ts
+++ b/packages/workflows-shared/src/context.ts
@@ -7,7 +7,6 @@ import {
 	DELAY_FUNCTION_TIMEOUT_MS,
 	invokeDelayFunction,
 	raceAgainstAbort,
-	schedulerWait,
 } from "./lib/delay";
 import {
 	ABORT_REASONS,
@@ -107,6 +106,31 @@ export function toEngineStepConfig(
 		return { ...config, retries: { ...retries, delay } };
 	}
 	return { ...config, retries };
+}
+
+// Signal-aware wrapper around the global `scheduler.wait`. `scheduler.wait`
+// can't itself be cancelled, so an aborted signal resolves the returned promise
+// early and the dangling timer becomes a no-op.
+function schedulerWait(
+	durationMs: number,
+	opts?: { signal?: AbortSignal }
+): Promise<void> {
+	return new Promise<void>((resolve) => {
+		const signal = opts?.signal;
+		if (signal?.aborted) {
+			resolve();
+			return;
+		}
+		let done = false;
+		const finish = (): void => {
+			if (!done) {
+				done = true;
+				resolve();
+			}
+		};
+		void scheduler.wait(durationMs).then(finish);
+		signal?.addEventListener("abort", finish, { once: true });
+	});
 }
 
 const defaultConfig: ResolvedStepConfig = {

--- a/packages/workflows-shared/src/context.ts
+++ b/packages/workflows-shared/src/context.ts
@@ -6,6 +6,8 @@ import {
 	DEFAULT_RETRY_DELAY_MS,
 	DELAY_FUNCTION_TIMEOUT_MS,
 	invokeDelayFunction,
+	raceAgainstAbort,
+	schedulerWait,
 } from "./lib/delay";
 import {
 	ABORT_REASONS,
@@ -105,31 +107,6 @@ export function toEngineStepConfig(
 		return { ...config, retries: { ...retries, delay } };
 	}
 	return { ...config, retries };
-}
-
-// Signal-aware wrapper around the global `scheduler.wait`. `scheduler.wait`
-// can't itself be cancelled, so an aborted signal resolves the returned promise
-// early and the dangling timer becomes a no-op.
-function schedulerWait(
-	durationMs: number,
-	opts?: { signal?: AbortSignal }
-): Promise<void> {
-	return new Promise<void>((resolve) => {
-		const signal = opts?.signal;
-		if (signal?.aborted) {
-			resolve();
-			return;
-		}
-		let done = false;
-		const finish = (): void => {
-			if (!done) {
-				done = true;
-				resolve();
-			}
-		};
-		void scheduler.wait(durationMs).then(finish);
-		signal?.addEventListener("abort", finish, { once: true });
-	});
 }
 
 const defaultConfig: ResolvedStepConfig = {
@@ -1196,26 +1173,14 @@ export class Context extends RpcTarget {
 					// takes effect immediately during retries
 					{
 						const retryPauseSignal = this.#engine.pauseController.signal;
-						let pausedDuringRetry = false;
-						await Promise.race([
+						await raceAgainstAbort(
 							scheduler.wait(effectiveDuration),
-							new Promise<void>((resolve) => {
-								if (retryPauseSignal.aborted) {
-									resolve();
-									return;
-								}
-								retryPauseSignal.addEventListener("abort", () => resolve(), {
-									once: true,
-								});
-							}),
-						]);
+							retryPauseSignal
+						);
 						const retryStatus = await this.#engine.getStatus();
-						if (
+						const pausedDuringRetry =
 							retryStatus === InstanceStatus.Paused ||
-							retryStatus === InstanceStatus.WaitingForPause
-						) {
-							pausedDuringRetry = true;
-						}
+							retryStatus === InstanceStatus.WaitingForPause;
 						if (pausedDuringRetry) {
 							throw new Error(ABORT_REASONS.USER_PAUSE);
 						}
@@ -1382,28 +1347,13 @@ export class Context extends RpcTarget {
 		const pauseSignal = this.#engine.pauseController.signal;
 		const sleepDuration = disableSleep ? 0 : duration;
 
-		let pausedDuringSleep = false;
-		await Promise.race([
-			scheduler.wait(sleepDuration),
-			new Promise<void>((resolve) => {
-				if (pauseSignal.aborted) {
-					resolve();
-					return;
-				}
-				pauseSignal.addEventListener("abort", () => resolve(), {
-					once: true,
-				});
-			}),
-		]);
+		await raceAgainstAbort(scheduler.wait(sleepDuration), pauseSignal);
 
 		// Check if we were paused during the sleep
 		const statusAfterSleep = await this.#engine.getStatus();
-		if (
+		const pausedDuringSleep =
 			statusAfterSleep === InstanceStatus.Paused ||
-			statusAfterSleep === InstanceStatus.WaitingForPause
-		) {
-			pausedDuringSleep = true;
-		}
+			statusAfterSleep === InstanceStatus.WaitingForPause;
 
 		if (pausedDuringSleep) {
 			// Throw pause error
@@ -1593,26 +1543,17 @@ export class Context extends RpcTarget {
 			this.#engine.waiters.set(options.type, callbacks);
 		});
 
-		// Race event, timeout, and pause signal. The pause promise resolves
-		// when the race settles via event/timeout before the pause signal fires
+		// Race event and timeout against the pause signal.
 		const pauseSignal = this.#engine.pauseController.signal;
-		const pausePromise = new Promise<void>((resolve) => {
-			if (pauseSignal.aborted) {
-				resolve();
-				return;
-			}
-			pauseSignal.addEventListener("abort", () => resolve(), {
-				once: true,
-			});
-		});
-
-		const raceResult = await Promise.race([
-			eventPromise,
-			timeoutEntryPQ !== undefined
-				? timeoutPromise(timeoutEntryPQ.targetTimestamp - Date.now(), false)
-				: timeoutPromise(ms(options.timeout), true),
-			pausePromise,
-		]).catch(async (error) => {
+		const raceResult = await raceAgainstAbort(
+			Promise.race([
+				eventPromise,
+				timeoutEntryPQ !== undefined
+					? timeoutPromise(timeoutEntryPQ.targetTimestamp - Date.now(), false)
+					: timeoutPromise(ms(options.timeout), true),
+			]),
+			pauseSignal
+		).catch(async (error) => {
 			const callbacks = this.#engine.waiters.get(options.type);
 			if (callbacks) {
 				const idx = callbacks.findIndex(([key]) => key === cacheKey);
@@ -1632,18 +1573,19 @@ export class Context extends RpcTarget {
 		});
 
 		// Pause signal won the race — throw to stop the workflow
-		if (raceResult === undefined) {
+		if (raceResult.aborted) {
 			throw new Error(ABORT_REASONS.USER_PAUSE);
 		}
+		const event = raceResult.value;
 
 		this.#engine.writeLog(
 			InstanceEvent.WAIT_COMPLETE,
 			cacheKey,
 			waitForEventNameWithCounter,
-			raceResult as Event
+			event
 		);
-		await this.#state.storage.put(waitForEventKey, raceResult);
+		await this.#state.storage.put(waitForEventKey, event);
 
-		return raceResult as WorkflowStepEvent<T>;
+		return event as WorkflowStepEvent<T>;
 	}
 }

--- a/packages/workflows-shared/src/lib/delay.ts
+++ b/packages/workflows-shared/src/lib/delay.ts
@@ -17,6 +17,62 @@ type DelayLogger = {
 
 type Waiter = (ms: number, opts?: { signal?: AbortSignal }) => Promise<void>;
 
+type AbortRaceResult<T> = { aborted: true } | { aborted: false; value: T };
+
+export async function raceAgainstAbort<T>(
+	promise: Promise<T>,
+	signal: AbortSignal
+): Promise<AbortRaceResult<T>> {
+	const resultPromise = promise.then(
+		(value): AbortRaceResult<T> => ({
+			aborted: false,
+			value,
+		})
+	);
+	if (signal.aborted) {
+		return await Promise.race([
+			Promise.resolve<AbortRaceResult<T>>({ aborted: true }),
+			resultPromise,
+		]);
+	}
+
+	let resolveAbort: ((result: AbortRaceResult<T>) => void) | undefined;
+	const abortPromise = new Promise<AbortRaceResult<T>>((resolve) => {
+		resolveAbort = resolve;
+	});
+	const onAbort = (): void => resolveAbort?.({ aborted: true });
+	signal.addEventListener("abort", onAbort, { once: true });
+
+	if (signal.aborted) {
+		onAbort();
+	}
+
+	try {
+		return await Promise.race([resultPromise, abortPromise]);
+	} finally {
+		signal.removeEventListener("abort", onAbort);
+	}
+}
+
+// Signal-aware wrapper around the global `scheduler.wait`. `scheduler.wait`
+// can't itself be cancelled, so an aborted signal resolves the returned promise
+// early and the dangling timer becomes a no-op.
+export async function schedulerWait(
+	durationMs: number,
+	opts?: { signal?: AbortSignal }
+): Promise<void> {
+	const signal = opts?.signal;
+	if (signal?.aborted) {
+		return;
+	}
+	const waitPromise = scheduler.wait(durationMs);
+	if (signal === undefined) {
+		await waitPromise;
+		return;
+	}
+	await raceAgainstAbort(waitPromise, signal);
+}
+
 export async function invokeDelayFunction(
 	delay: WorkflowDelayFunction,
 	input: WorkflowDynamicDelayContext,

--- a/packages/workflows-shared/src/lib/delay.ts
+++ b/packages/workflows-shared/src/lib/delay.ts
@@ -30,10 +30,10 @@ export async function raceAgainstAbort<T>(
 		})
 	);
 	if (signal.aborted) {
-		return await Promise.race([
-			Promise.resolve<AbortRaceResult<T>>({ aborted: true }),
-			resultPromise,
-		]);
+		// Observe a later rejection from the losing promise so it doesn't become
+		// an unhandled rejection after returning the already-aborted result.
+		void resultPromise.catch(() => undefined);
+		return { aborted: true };
 	}
 
 	let resolveAbort: ((result: AbortRaceResult<T>) => void) | undefined;
@@ -43,34 +43,11 @@ export async function raceAgainstAbort<T>(
 	const onAbort = (): void => resolveAbort?.({ aborted: true });
 	signal.addEventListener("abort", onAbort, { once: true });
 
-	if (signal.aborted) {
-		onAbort();
-	}
-
 	try {
 		return await Promise.race([resultPromise, abortPromise]);
 	} finally {
 		signal.removeEventListener("abort", onAbort);
 	}
-}
-
-// Signal-aware wrapper around the global `scheduler.wait`. `scheduler.wait`
-// can't itself be cancelled, so an aborted signal resolves the returned promise
-// early and the dangling timer becomes a no-op.
-export async function schedulerWait(
-	durationMs: number,
-	opts?: { signal?: AbortSignal }
-): Promise<void> {
-	const signal = opts?.signal;
-	if (signal?.aborted) {
-		return;
-	}
-	const waitPromise = scheduler.wait(durationMs);
-	if (signal === undefined) {
-		await waitPromise;
-		return;
-	}
-	await raceAgainstAbort(waitPromise, signal);
 }
 
 export async function invokeDelayFunction(

--- a/packages/workflows-shared/tests/lib/delay.test.ts
+++ b/packages/workflows-shared/tests/lib/delay.test.ts
@@ -2,7 +2,7 @@ import { describe, it, vi } from "vitest";
 import {
 	DEFAULT_RETRY_DELAY_MS,
 	invokeDelayFunction,
-	schedulerWait,
+	raceAgainstAbort,
 } from "../../src/lib/delay";
 import { DelayFunctionError } from "../../src/lib/retries";
 import type { WorkflowDynamicDelayContext } from "cloudflare:workers";
@@ -22,34 +22,88 @@ const noTimeout =
 	(): ((ms: number, opts?: { signal?: AbortSignal }) => Promise<void>) => () =>
 		new Promise<void>(() => {});
 
-describe("schedulerWait", () => {
-	it("removes abort listeners after the wait completes", async ({ expect }) => {
-		const listeners = new Set<EventListenerOrEventListenerObject>();
-		const signal = {
-			aborted: false,
-			addEventListener(
-				type: string,
-				listener: EventListenerOrEventListenerObject
-			) {
-				if (type === "abort") {
-					listeners.add(listener);
-				}
-			},
-			removeEventListener(
-				type: string,
-				listener: EventListenerOrEventListenerObject
-			) {
-				if (type === "abort") {
-					listeners.delete(listener);
-				}
-			},
-		} as AbortSignal;
+describe("raceAgainstAbort", () => {
+	it("removes the abort listener when the raced promise resolves", async ({
+		expect,
+	}) => {
+		const controller = new AbortController();
+		const addEventListener = vi.spyOn(controller.signal, "addEventListener");
+		const removeEventListener = vi.spyOn(
+			controller.signal,
+			"removeEventListener"
+		);
 
-		for (let i = 0; i < 100; i++) {
-			await schedulerWait(0, { signal });
-		}
+		await expect(
+			raceAgainstAbort(Promise.resolve("done"), controller.signal)
+		).resolves.toEqual({ aborted: false, value: "done" });
 
-		expect(listeners).toHaveLength(0);
+		expect(addEventListener).toHaveBeenCalledOnce();
+		expect(removeEventListener).toHaveBeenCalledWith(
+			"abort",
+			addEventListener.mock.calls[0]?.[1]
+		);
+	});
+
+	it("removes the abort listener when the signal wins", async ({ expect }) => {
+		const controller = new AbortController();
+		const addEventListener = vi.spyOn(controller.signal, "addEventListener");
+		const removeEventListener = vi.spyOn(
+			controller.signal,
+			"removeEventListener"
+		);
+		const result = raceAgainstAbort(
+			new Promise<void>(() => {}),
+			controller.signal
+		);
+
+		controller.abort();
+
+		await expect(result).resolves.toEqual({ aborted: true });
+		expect(removeEventListener).toHaveBeenCalledWith(
+			"abort",
+			addEventListener.mock.calls[0]?.[1]
+		);
+	});
+
+	it("removes the abort listener when the raced promise rejects", async ({
+		expect,
+	}) => {
+		const controller = new AbortController();
+		const addEventListener = vi.spyOn(controller.signal, "addEventListener");
+		const removeEventListener = vi.spyOn(
+			controller.signal,
+			"removeEventListener"
+		);
+		const error = new Error("boom");
+
+		await expect(
+			raceAgainstAbort(Promise.reject(error), controller.signal)
+		).rejects.toBe(error);
+		expect(removeEventListener).toHaveBeenCalledWith(
+			"abort",
+			addEventListener.mock.calls[0]?.[1]
+		);
+	});
+
+	it("does not register a listener for an already-aborted signal", async ({
+		expect,
+	}) => {
+		const controller = new AbortController();
+		controller.abort();
+		const addEventListener = vi.spyOn(controller.signal, "addEventListener");
+		const removeEventListener = vi.spyOn(
+			controller.signal,
+			"removeEventListener"
+		);
+
+		await expect(
+			raceAgainstAbort(
+				Promise.reject(new Error("late rejection")),
+				controller.signal
+			)
+		).resolves.toEqual({ aborted: true });
+		expect(addEventListener).not.toHaveBeenCalled();
+		expect(removeEventListener).not.toHaveBeenCalled();
 	});
 });
 

--- a/packages/workflows-shared/tests/lib/delay.test.ts
+++ b/packages/workflows-shared/tests/lib/delay.test.ts
@@ -2,6 +2,7 @@ import { describe, it, vi } from "vitest";
 import {
 	DEFAULT_RETRY_DELAY_MS,
 	invokeDelayFunction,
+	schedulerWait,
 } from "../../src/lib/delay";
 import { DelayFunctionError } from "../../src/lib/retries";
 import type { WorkflowDynamicDelayContext } from "cloudflare:workers";
@@ -20,6 +21,37 @@ const makeLogger = () => ({ warn: vi.fn(), debug: vi.fn() });
 const noTimeout =
 	(): ((ms: number, opts?: { signal?: AbortSignal }) => Promise<void>) => () =>
 		new Promise<void>(() => {});
+
+describe("schedulerWait", () => {
+	it("removes abort listeners after the wait completes", async ({ expect }) => {
+		const listeners = new Set<EventListenerOrEventListenerObject>();
+		const signal = {
+			aborted: false,
+			addEventListener(
+				type: string,
+				listener: EventListenerOrEventListenerObject
+			) {
+				if (type === "abort") {
+					listeners.add(listener);
+				}
+			},
+			removeEventListener(
+				type: string,
+				listener: EventListenerOrEventListenerObject
+			) {
+				if (type === "abort") {
+					listeners.delete(listener);
+				}
+			},
+		} as AbortSignal;
+
+		for (let i = 0; i < 100; i++) {
+			await schedulerWait(0, { signal });
+		}
+
+		expect(listeners).toHaveLength(0);
+	});
+});
 
 describe("invokeDelayFunction", () => {
 	it("returns the value a synchronous delay function produces", async ({


### PR DESCRIPTION
Fixes #14839.

Local Workflow sleeps, retry delays, and event waits race their normal completion against the instance's pause signal. When the timer or event completed first, the abort listener remained attached because `{ once: true }` only removes a listener when the abort event fires. A long-running local instance could therefore retain one listener and its captured promise state per completed wait until it was paused or evicted.

This change adds a shared abort-aware race helper that removes its listener in `finally`, and uses it for all three pause-aware wait paths. It also preserves the existing behavior for already-aborted signals and observes the losing promise so a later rejection cannot become unhandled.

The regression test tracks listener registration and removal across 100 completed signal-aware waits and asserts that none remain. This affects the local Workflows runtime used by Wrangler and Miniflare; it does not change the hosted production runtime or any public API.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: this fixes listener cleanup in the local Workflows runtime without changing its public API or documented behavior.

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
