### PR TITLE
fix: remove punycode deprecation warning (DEP0040) on every wrangler invocation

### DIFF
--- a/.changeset/fix-punycode-deprecation-warning.md
+++ b/.changeset/fix-punycode-deprecation-warning.md
@@ -5,4 +5,4 @@
 
 Remove the `punycode` module deprecation warning (`DEP0040`) logged on every Wrangler invocation.
 
-The bundled `cloudflare` API client depends on `node-fetch@2.x`, which depends on `whatwg-url@5.0.0` and its `tr46@0.0.3` dependency. Both of those directly `require("punycode")` against Node's deprecated built-in module rather than the userland `punycode` package. Patched both to require the userland package instead (same API, no behavior change), so Wrangler no longer prints `(node:...) [DEP0040] DeprecationWarning: The 'punycode' module is deprecated. Please use a userland alternative instead.` on startup.
+Wrangler no longer prints `(node:...) [DEP0040] DeprecationWarning: The "punycode" module is deprecated. Please use a userland alternative instead.` when you run a command.

--- a/.changeset/fix-punycode-deprecation-warning.md
+++ b/.changeset/fix-punycode-deprecation-warning.md
@@ -1,0 +1,8 @@
+---
+"wrangler": patch
+"@cloudflare/workers-utils": patch
+---
+
+Remove the `punycode` module deprecation warning (`DEP0040`) logged on every Wrangler invocation.
+
+The bundled `cloudflare` API client depends on `node-fetch@2.x`, which depends on `whatwg-url@5.0.0` and its `tr46@0.0.3` dependency. Both of those directly `require("punycode")` against Node's deprecated built-in module rather than the userland `punycode` package. Patched both to require the userland package instead (same API, no behavior change), so Wrangler no longer prints `(node:...) [DEP0040] DeprecationWarning: The 'punycode' module is deprecated. Please use a userland alternative instead.` on startup.

--- a/patches/tr46@0.0.3.patch
+++ b/patches/tr46@0.0.3.patch
@@ -1,0 +1,29 @@
+diff --git a/.npmignore b/.npmignore
+deleted file mode 100644
+index 96e9161fde31e9906718f689d5cc135e507a51e1..0000000000000000000000000000000000000000
+diff --git a/index.js b/index.js
+index 9ce12ca2d026fa202f7a0d32e0a7c8526660ed78..7c3b5d7ff1624d2bfbb5b83f69a9b460e38dbeab 100644
+--- a/index.js
++++ b/index.js
+@@ -1,6 +1,6 @@
+ "use strict";
+ 
+-var punycode = require("punycode");
++var punycode = require("punycode/");
+ var mappingTable = require("./lib/mappingTable.json");
+ 
+ var PROCESSING_OPTIONS = {
+diff --git a/package.json b/package.json
+index b6826da1f7817f97ad6d307d698ad2004807c40a..f009d3c509dc412d71f87f09d77952c65f632445 100644
+--- a/package.json
++++ b/package.json
+@@ -24,6 +24,9 @@
+     "url": "https://github.com/Sebmaster/tr46.js/issues"
+   },
+   "homepage": "https://github.com/Sebmaster/tr46.js#readme",
++  "dependencies": {
++    "punycode": "^2.3.1"
++  },
+   "devDependencies": {
+     "mocha": "^2.2.5",
+     "request": "^2.57.0"

--- a/patches/whatwg-url@5.0.0.patch
+++ b/patches/whatwg-url@5.0.0.patch
@@ -1,0 +1,11 @@
+diff --git a/lib/url-state-machine.js b/lib/url-state-machine.js
+index 27d977a25f9011fc31ed28c17ba11f729b85edea..8c2d955876f2b1bec97ed84a831afedf42df8c35 100644
+--- a/lib/url-state-machine.js
++++ b/lib/url-state-machine.js
+@@ -1,5 +1,5 @@
+ "use strict";
+-const punycode = require("punycode");
++const punycode = require("punycode/");
+ const tr46 = require("tr46");
+ 
+ const specialSchemes = {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -102,6 +102,8 @@ overrides:
   '@types/node': 22.15.17
   '@types/node>undici-types': 7.29.0
 
+packageExtensionsChecksum: sha256-UxbzwzEYdCyYfQrzlOS2vSdBi/DU3m6WV596zrZlpO4=
+
 patchedDependencies:
   '@cloudflare/component-listbox@1.10.6':
     hash: 67542a8abb29df36ad2c426409243d1167ca0080d2763f6ae3cce3c731c69107
@@ -118,6 +120,12 @@ patchedDependencies:
   toucan-js@4.0.0:
     hash: 60bdb1dcdbde0a135bb56d6fa1a1027caba891b149e2cfcb48d6a5b3524e0a91
     path: patches/toucan-js@4.0.0.patch
+  tr46@0.0.3:
+    hash: 9e8c64d8e8d2799b8b2358fec99feb2efcbf1b8dc9debfc5bd86afed8f868644
+    path: patches/tr46@0.0.3.patch
+  whatwg-url@5.0.0:
+    hash: 32c763e8b3bce24c1843a53b065a050fc58536ad6918547d435ffcbf513be644
+    path: patches/whatwg-url@5.0.0.patch
   youch@4.1.0-beta.10:
     hash: 3e73fc48581841f22ea1d2cf5a3560bde280fdba04940253073fb121a70a9269
     path: patches/youch@4.1.0-beta.10.patch
@@ -15042,10 +15050,6 @@ packages:
   pumpify@1.5.1:
     resolution: {integrity: sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==}
 
-  punycode@2.1.1:
-    resolution: {integrity: sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==}
-    engines: {node: '>=6'}
-
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
@@ -26887,13 +26891,13 @@ snapshots:
 
   node-fetch@2.6.7(encoding@0.1.13):
     dependencies:
-      whatwg-url: 5.0.0
+      whatwg-url: 5.0.0(patch_hash=32c763e8b3bce24c1843a53b065a050fc58536ad6918547d435ffcbf513be644)
     optionalDependencies:
       encoding: 0.1.13
 
   node-fetch@2.7.0(encoding@0.1.13):
     dependencies:
-      whatwg-url: 5.0.0
+      whatwg-url: 5.0.0(patch_hash=32c763e8b3bce24c1843a53b065a050fc58536ad6918547d435ffcbf513be644)
     optionalDependencies:
       encoding: 0.1.13
 
@@ -27815,8 +27819,6 @@ snapshots:
       duplexify: 3.7.1
       inherits: 2.0.4
       pump: 2.0.1
-
-  punycode@2.1.1: {}
 
   punycode@2.3.1: {}
 
@@ -29250,11 +29252,13 @@ snapshots:
     dependencies:
       tldts: 7.0.19
 
-  tr46@0.0.3: {}
+  tr46@0.0.3(patch_hash=9e8c64d8e8d2799b8b2358fec99feb2efcbf1b8dc9debfc5bd86afed8f868644):
+    dependencies:
+      punycode: 2.3.1
 
   tr46@1.0.1:
     dependencies:
-      punycode: 2.1.1
+      punycode: 2.3.1
 
   tr46@5.1.1:
     dependencies:
@@ -30290,9 +30294,10 @@ snapshots:
       tr46: 5.1.1
       webidl-conversions: 7.0.0
 
-  whatwg-url@5.0.0:
+  whatwg-url@5.0.0(patch_hash=32c763e8b3bce24c1843a53b065a050fc58536ad6918547d435ffcbf513be644):
     dependencies:
-      tr46: 0.0.3
+      punycode: 2.3.1
+      tr46: 0.0.3(patch_hash=9e8c64d8e8d2799b8b2358fec99feb2efcbf1b8dc9debfc5bd86afed8f868644)
       webidl-conversions: 3.0.1
 
   whatwg-url@7.1.0:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -21,6 +21,20 @@ packages:
 
 gitChecks: false
 
+# whatwg-url@5.0.0 (pulled in by node-fetch@2.x) and its tr46@0.0.3 dependency
+# both `require("punycode")` against the deprecated Node builtin, which logs a
+# DEP0040 warning on every wrangler invocation. Our patches (patches/whatwg-url@5.0.0.patch,
+# patches/tr46@0.0.3.patch) switch them to the userland `punycode` package instead,
+# but pnpm doesn't re-resolve a patched package's dependency list, so we declare
+# the new dependency here to make sure it's actually installed and linked.
+packageExtensions:
+  "tr46@0.0.3":
+    dependencies:
+      punycode: ^2.3.1
+  "whatwg-url@5.0.0":
+    dependencies:
+      punycode: ^2.3.1
+
 # ──────────────────────────────────────────────────────────────────────────────
 # Supply chain security
 # See: https://pnpm.io/supply-chain-security
@@ -104,6 +118,8 @@ patchedDependencies:
   "youch@4.1.0-beta.10": "patches/youch@4.1.0-beta.10.patch"
   "@netlify/build-info": "patches/@netlify__build-info.patch"
   "buffer-equal-constant-time@1.0.1": "patches/buffer-equal-constant-time@1.0.1.patch"
+  "tr46@0.0.3": "patches/tr46@0.0.3.patch"
+  "whatwg-url@5.0.0": "patches/whatwg-url@5.0.0.patch"
 
 # ──────────────────────────────────────────────────────────────────────────────
 # Catalog


### PR DESCRIPTION
## Summary

Every `wrangler` invocation logs a Node deprecation warning:

```
(node:...) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
```

Root cause: the bundled `cloudflare` API client (`packages/wrangler`'s `cloudflare` devDependency, used by `@cloudflare/workers-utils` too) depends on `node-fetch@2.x`, which depends on `whatwg-url@5.0.0`. Both `whatwg-url@5.0.0` itself and its `tr46@0.0.3` dependency directly `require("punycode")` against Node's deprecated built-in module instead of the (API-identical) userland `punycode` npm package.

Note that `tr46`'s public API changed completely starting at v1.0.0 (positional-args API replaced with an options-object API, string returns replaced with `{domain, error}` objects), so bumping `tr46`/`whatwg-url`'s version isn't a safe fix for `whatwg-url@5.0.0` — it would silently change IDNA/domain-parsing behavior. Bumping the `cloudflare` SDK to v7 (which dropped `node-fetch` and this whole dependency chain in favor of native `fetch`) would fix it too, but that's a major-version bump used extensively throughout the codebase, better scoped and tested by folks who know every call site.

## Fix

Two `pnpm patch`es, both same-version (no behavior change):
- `patches/tr46@0.0.3.patch`: `require("punycode")` → `require("punycode/")`
- `patches/whatwg-url@5.0.0.patch`: same change in `lib/url-state-machine.js`

The trailing slash forces Node to resolve the userland `punycode` package instead of the deprecated builtin. Since `pnpm patch` doesn't re-resolve a patched package's declared dependencies, I added `packageExtensions` entries in `pnpm-workspace.yaml` to properly wire `punycode@^2.3.1` into both packages' dependency graphs (verified in the lockfile diff — it's a real dependency edge, not incidental hoisting).

## Test plan

- [x] `pnpm turbo build --filter=wrangler` succeeds
- [x] `grep -n 'require(.punycode' wrangler-dist/cli.js` — no matches (previously 2)
- [x] `NODE_OPTIONS='--trace-deprecation' node wrangler-dist/cli.js --version` — no warning
- [x] `pnpm test -F wrangler` — 250 test files, 4826 tests passed
- [x] `pnpm exec turbo check:type -F wrangler -F @cloudflare/workers-utils` — passes
- [x] Added changeset (patch bump for `wrangler` and `@cloudflare/workers-utils`)


- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: change covered by current tests
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: no user facing change
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14843" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->