### PR TITLE
[miniflare] Fix flaky sites.spec.ts by bundling kv-asset-handler from source

### DIFF
--- a/packages/miniflare/test/plugins/kv/sites.spec.ts
+++ b/packages/miniflare/test/plugins/kv/sites.spec.ts
@@ -20,6 +20,19 @@ const ctx: Context = {
 	modulesPath: "",
 };
 
+// The fixtures below import `@cloudflare/kv-asset-handler`. By default esbuild
+// resolves that bare specifier through the pnpm symlink to the sibling
+// workspace package's built `dist/`, coupling this suite to that package having
+// been built and its output being readable at bundle time. That coupling has
+// caused CI failures ("Could not resolve @cloudflare/kv-asset-handler") from
+// this `beforeAll`, taking down the whole suite. Alias the specifier to the
+// package source instead so fixture bundling is self-contained and never
+// depends on the sibling package's build output.
+const KV_ASSET_HANDLER_SOURCE = path.resolve(
+	FIXTURES_PATH,
+	"../../../../kv-asset-handler/src/index.ts"
+);
+
 beforeAll(async () => {
 	// Build fixtures
 	const tmp = await useTmp();
@@ -27,6 +40,9 @@ beforeAll(async () => {
 		entryPoints: [SERVICE_WORKER_ENTRY_PATH, MODULES_ENTRY_PATH],
 		format: "esm",
 		external: ["__STATIC_CONTENT_MANIFEST"],
+		alias: {
+			"@cloudflare/kv-asset-handler": KV_ASSET_HANDLER_SOURCE,
+		},
 		bundle: true,
 		sourcemap: true,
 		outdir: tmp,


### PR DESCRIPTION
Fixes a CI flake in `packages/miniflare/test/plugins/kv/sites.spec.ts`.

The Workers Sites test fixtures (`test/fixtures/sites/{service-worker,modules}.ts`) import `@cloudflare/kv-asset-handler`. The suite's `beforeAll` bundles them with esbuild, which resolved that bare specifier through the pnpm symlink to the sibling package's built `dist/`. This coupled the fixture build to the sibling package's build output being present and readable at bundle time, and intermittently failed in CI with:

```
Could not resolve "@cloudflare/kv-asset-handler"
```

Because the failure happens in `beforeAll`, it takes down the whole suite, and Vitest's test-level `retry` does not re-run `beforeAll`.

Investigation confirmed the error is deterministic w.r.t. the built artifact's presence (passes with `dist/` present, fails identically when `dist/` is absent), that Turbo already orders `kv-asset-handler#build` before `miniflare#test:ci`, and that nothing cleans the sibling `dist/` mid-run — so the coupling itself is the fragility.

This change aliases the specifier to the package **source** in the esbuild build so fixture bundling is self-contained and no longer depends on the sibling package's build output. Verified the suite passes both with and without `kv-asset-handler`'s `dist/` present.

Note: no existing CI test (including wrangler e2e) exercises the built `@cloudflare/kv-asset-handler` artifact; this test only used it incidentally as a fixture helper, so no build-output coverage is lost that was intentional.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: this is a test-only reliability fix with no user-facing or behavioral change.

> [!NOTE]
> This is a contribution from an AI agent: opencode (anthropic/claude-opus-4).

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14844" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->