### PR TITLE
[workers-auth] Correct Apache-2.0 attribution headers

### DIFF
--- a/packages/workers-auth/src/callback-server.ts
+++ b/packages/workers-auth/src/callback-server.ts
@@ -1,17 +1,3 @@
-/* Based heavily on code from https://github.com/BitySA/oauth2-auth-code-pkce
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 import assert from "node:assert";
 import http from "node:http";
 import url from "node:url";

--- a/packages/workers-auth/src/flow.ts
+++ b/packages/workers-auth/src/flow.ts
@@ -1,17 +1,3 @@
-/* Based heavily on code from https://github.com/BitySA/oauth2-auth-code-pkce
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 import {
 	getCloudflareComplianceRegion,
 	UserError,

--- a/packages/workers-auth/src/generate-auth-url.ts
+++ b/packages/workers-auth/src/generate-auth-url.ts
@@ -1,3 +1,17 @@
+/* Based heavily on code from https://github.com/BitySA/oauth2-auth-code-pkce
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 interface GenerateAuthUrlProps {
 	authUrl: string;
 	clientId: string;

--- a/packages/workers-auth/src/generate-random-state.ts
+++ b/packages/workers-auth/src/generate-random-state.ts
@@ -1,3 +1,17 @@
+/* Based heavily on code from https://github.com/BitySA/oauth2-auth-code-pkce
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 import { webcrypto as crypto } from "node:crypto";
 import { PKCE_CHARSET } from "./pkce";
 


### PR DESCRIPTION
Corrects the `Based heavily on code from https://github.com/BitySA/oauth2-auth-code-pkce` Apache-2.0 header, which was inaccurate in **both** directions.

### Header removed (files contain no upstream code)

- `src/callback-server.ts`
- `src/flow.ts`

Both were created by the #14121 split of wrangler's `src/user/user.ts`. That single file legitimately carried the header, and the split propagated it to every resulting module regardless of whether the content that landed there was actually derived.

Upstream is a single browser-only `index.ts` implementing RFC 6749 §4.1 + RFC 7636. It has no local HTTP callback server (it redirects via `location.replace` and persists to `localStorage`) and no login/logout/refresh orchestration. Every upstream identifier these two files reference — `isReturningFromAuthServer`, `exchangeAuthCodeForAccessToken`, `ErrorOAuth2`, `exchangeRefreshTokenForAccessToken` — is an **import**, not a definition. Importing derived code does not make the importing file a derivative work.

Comparing against upstream for verbatim comment/string prose:

| File | Verbatim prose fragments | Longest common block |
| --- | --- | --- |
| `callback-server.ts` | 1 | 31 chars (an identifier) |
| `flow.ts` | 0 | 61 chars (`Content-Type: application/x-www-form-urlencoded` boilerplate) |

The single `callback-server.ts` match is `): Promise<AccessContext> {` — a type signature.

`flow.ts` has one residual echo worth naming explicitly: `isRefreshNeeded` is effectively upstream's `isAccessTokenExpired` (`Boolean(accessToken && new Date() >= new Date(accessToken.expiry))`). That is a single line, and an expiry comparison has essentially one natural expression, so it does not support an "based heavily on" claim over a 596-line orchestration file.

### Header added (files are genuinely derived)

- `src/generate-auth-url.ts` — upstream's authorize-URL builder verbatim, with only `offline_access` appended to the scopes
- `src/generate-random-state.ts` — upstream's `generateRandomState` verbatim, including the JSDoc "Generates random state to be passed for anti-csrf."

Both were extracted from `user.ts` back in #1267 and the header was never carried across.

### Unchanged

`src/pkce.ts` (17 verbatim prose fragments, 433-char common block), `src/errors.ts` (whole `ErrorOAuth2` hierarchy plus comments) and `src/token-exchange.ts` (14 fragments, including a commented-out remnant of upstream's `.catch((_) => ({ error: 'invalid_json' }))`) are genuinely derived and keep the header as-is.

`src/state.ts` shares one field *name* (`hasAuthCodeBeenExchangedForAccessToken`) and nothing else, so it is left alone.

This is a comments-only change. `package.json` ships `files: ["dist"]`, so these headers are repo-source hygiene and do not alter the published artifact; attribution for consumers is carried by the package `README.md` and `LICENSE-APACHE`.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: this is a comments-only change with no runtime or type impact. Verified with `pnpm check:lint` (0 warnings/errors), `check:type`, the full `@cloudflare/workers-auth` suite (139 passed) and wrangler's `user.test.ts` (78 passed). No lint rule enforces license headers, so nothing can regress silently.
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: `@cloudflare/workers-auth` is an internal-only package and this changes source-file license headers only. The existing statements in `README.md` and `AGENTS.md` ("Files derived from BitySA/oauth2-auth-code-pkce carry the Apache-2.0 header") remain true and become accurate for the first time.

> [!NOTE]
> This is a contribution from an AI agent: opencode, claude-opus-5.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14861" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->