### PR TITLE
[vite-plugin] Fix flaky WebSocket upgrade test and harden upgrade handler

### DIFF
--- a/.changeset/fix-vite-plugin-websocket-upgrade-rejection.md
+++ b/.changeset/fix-vite-plugin-websocket-upgrade-rejection.md
@@ -1,0 +1,7 @@
+---
+"@cloudflare/vite-plugin": patch
+---
+
+Destroy the client socket instead of crashing when a WebSocket upgrade fails
+
+If `dispatchFetch` rejected while a WebSocket upgrade was still in flight (for example when Miniflare is disposed during a dev server shutdown or restart), the error escaped the `async` upgrade handler as an unhandled rejection. This could terminate the dev server process and leaked the client socket. The upgrade handler now catches such failures and tears the socket down cleanly.

--- a/packages/vite-plugin-cloudflare/src/__tests__/websockets.spec.ts
+++ b/packages/vite-plugin-cloudflare/src/__tests__/websockets.spec.ts
@@ -15,30 +15,65 @@ import type { AddressInfo } from "node:net";
 
 describe("handleWebSocket", () => {
 	let httpServer: http.Server;
-	let miniflare: Miniflare;
+	let miniflare: Miniflare | undefined;
 	let port: number;
+	const openSockets = new Set<net.Socket>();
 
-	beforeEach(async () => {
+	const DEFAULT_WORKER_SCRIPT = `export default {
+		fetch() {
+			const [client, server] = Object.values(new WebSocketPair());
+			server.accept();
+			return new Response(null, { status: 101, webSocket: client });
+		}
+	}`;
+
+	beforeEach(() => {
+		miniflare = undefined;
 		httpServer = http.createServer((_req, res) => res.end("OK"));
-		miniflare = new Miniflare({
-			modules: true,
-			script: `export default {
-				fetch() {
-					const [client, server] = Object.values(new WebSocketPair());
-					server.accept();
-					return new Response(null, { status: 101, webSocket: client });
-				}
-			}`,
-		});
 	});
 
+	/**
+	 * Creates the `Miniflare` instance used by the test. Kept out of
+	 * `beforeEach` so tests that need a custom Worker script don't have to
+	 * spawn-then-immediately-dispose a throwaway `workerd` process.
+	 */
+	function startMiniflare(script: string = DEFAULT_WORKER_SCRIPT) {
+		miniflare = new Miniflare({ modules: true, script });
+		return miniflare;
+	}
+
+	/**
+	 * Opens a tracked client socket so `afterEach` can always tear it down,
+	 * even if a test throws before its own cleanup runs.
+	 */
+	async function connect() {
+		const socket = net.connect(port, "127.0.0.1");
+		openSockets.add(socket);
+		socket.on("close", () => openSockets.delete(socket));
+		await new Promise<void>((r) => socket.on("connect", r));
+		return socket;
+	}
+
 	async function listen(entryWorkerName?: string) {
-		handleWebSocket(httpServer, miniflare, entryWorkerName);
+		const mf = miniflare ?? startMiniflare();
+		handleWebSocket(httpServer, mf, entryWorkerName);
 		await new Promise<void>((r) => httpServer.listen(0, "127.0.0.1", r));
 		port = (httpServer.address() as AddressInfo).port;
+		// Wait for `workerd` to boot here (under the generous `testTimeout`)
+		// rather than letting the cold start eat into the tight `vi.waitFor`
+		// budgets below, which caused Windows CI flakes.
+		await mf.ready;
+		return mf;
 	}
 
 	afterEach(async () => {
+		// Destroy any client sockets first so `httpServer.close()` doesn't hang
+		// waiting on live connections (which would surface as a hook timeout).
+		for (const socket of openSockets) {
+			socket.destroy();
+		}
+		openSockets.clear();
+		httpServer?.closeAllConnections();
 		await miniflare?.dispose();
 		await new Promise<void>((resolve, reject) =>
 			httpServer?.close((e) => (e ? reject(e) : resolve()))
@@ -47,15 +82,14 @@ describe("handleWebSocket", () => {
 
 	// https://github.com/cloudflare/workers-sdk/issues/12047
 	test("survives client disconnect during upgrade", async ({ expect }) => {
-		await listen();
+		const mf = await listen();
 
 		// Mock dispatchFetch to simulate a slow response - the bug occurs when
 		// the client disconnects while dispatchFetch is pending
 		const deferred = new DeferredPromise<Response>();
-		vi.spyOn(miniflare, "dispatchFetch").mockReturnValue(deferred);
+		vi.spyOn(mf, "dispatchFetch").mockReturnValue(deferred);
 
-		const socket = net.connect(port, "127.0.0.1");
-		await new Promise<void>((r) => socket.on("connect", r));
+		const socket = await connect();
 		socket.write(
 			"GET / HTTP/1.1\r\n" +
 				"Host: localhost\r\n" +
@@ -77,15 +111,14 @@ describe("handleWebSocket", () => {
 	});
 
 	test("forwards sandbox requests", async ({ expect }) => {
-		await listen();
+		const mf = await listen();
 
 		const deferred = new DeferredPromise<Response>();
 		const mockedDispatchFetch = vi
-			.spyOn(miniflare, "dispatchFetch")
+			.spyOn(mf, "dispatchFetch")
 			.mockReturnValue(deferred);
 
-		const socket = net.connect(port, "127.0.0.1");
-		await new Promise<void>((r) => socket.on("connect", r));
+		const socket = await connect();
 		socket.write(
 			"GET / HTTP/1.1\r\n" +
 				`Host: 4567-my-sandbox-sup3rs3cr3t.localhost:${port}\r\n` +
@@ -96,7 +129,7 @@ describe("handleWebSocket", () => {
 				"Sec-WebSocket-Version: 13\r\n\r\n"
 		);
 
-		await vi.waitFor(() => expect(miniflare.dispatchFetch).toHaveBeenCalled());
+		await vi.waitFor(() => expect(mf.dispatchFetch).toHaveBeenCalled());
 
 		// Resolve the mock so miniflare.dispose() doesn't hang in afterEach
 		deferred.resolve(new Response(null));
@@ -132,15 +165,15 @@ describe("handleWebSocket", () => {
 	 */
 	async function dispatchUpgrade(
 		expect: ExpectStatic,
+		mf: Miniflare,
 		headers: Record<string, string>
 	) {
 		const deferred = new DeferredPromise<Response>();
 		const mockedDispatchFetch = vi
-			.spyOn(miniflare, "dispatchFetch")
+			.spyOn(mf, "dispatchFetch")
 			.mockReturnValue(deferred);
 
-		const socket = net.connect(port, "127.0.0.1");
-		await new Promise<void>((r) => socket.on("connect", r));
+		const socket = await connect();
 
 		const headerLines = Object.entries(headers)
 			.map(([k, v]) => `${k}: ${v}`)
@@ -154,7 +187,7 @@ describe("handleWebSocket", () => {
 				"Sec-WebSocket-Version: 13\r\n\r\n"
 		);
 
-		await vi.waitFor(() => expect(miniflare.dispatchFetch).toHaveBeenCalled());
+		await vi.waitFor(() => expect(mf.dispatchFetch).toHaveBeenCalled());
 
 		// Resolve the mock so miniflare.dispose() doesn't hang in afterEach
 		deferred.resolve(new Response(null));
@@ -168,16 +201,18 @@ describe("handleWebSocket", () => {
 	test("falls back to `http://` when no `X-Forwarded-Proto` header is set", async ({
 		expect,
 	}) => {
-		await listen();
-		const url = await dispatchUpgrade(expect, { Host: `127.0.0.1:${port}` });
+		const mf = await listen();
+		const url = await dispatchUpgrade(expect, mf, {
+			Host: `127.0.0.1:${port}`,
+		});
 		expect(`${url}`).toBe(`http://127.0.0.1:${port}/`);
 	});
 
 	test("honors the `X-Forwarded-Proto` header set to `https`", async ({
 		expect,
 	}) => {
-		await listen();
-		const url = await dispatchUpgrade(expect, {
+		const mf = await listen();
+		const url = await dispatchUpgrade(expect, mf, {
 			Host: `127.0.0.1:${port}`,
 			"X-Forwarded-Proto": "https",
 		});
@@ -187,8 +222,8 @@ describe("handleWebSocket", () => {
 	test("uses the left-most value when `X-Forwarded-Proto` is a proxy chain", async ({
 		expect,
 	}) => {
-		await listen();
-		const url = await dispatchUpgrade(expect, {
+		const mf = await listen();
+		const url = await dispatchUpgrade(expect, mf, {
 			Host: `127.0.0.1:${port}`,
 			"X-Forwarded-Proto": "https, http",
 		});
@@ -198,8 +233,8 @@ describe("handleWebSocket", () => {
 	test("ignores `X-Forwarded-Proto` when it holds an unsupported value", async ({
 		expect,
 	}) => {
-		await listen();
-		const url = await dispatchUpgrade(expect, {
+		const mf = await listen();
+		const url = await dispatchUpgrade(expect, mf, {
 			Host: `127.0.0.1:${port}`,
 			"X-Forwarded-Proto": "ws",
 		});
@@ -215,30 +250,25 @@ describe("handleWebSocket", () => {
 		// Handshake headers (`Sec-WebSocket-*`, `Connection`, `Upgrade`) are
 		// rejected upstream by miniflare's own validation before reaching the
 		// forwarding code, so they're not exercised here.
-		await miniflare.dispose();
-		miniflare = new Miniflare({
-			modules: true,
-			script: `export default {
-				fetch() {
-					const [client, server] = Object.values(new WebSocketPair());
-					server.accept();
-					const headers = new Headers({
-						"X-Hello": "testing",
-						"Transfer-Encoding": "chunked",
-						"Content-Length": "42",
-					});
-					return new Response(null, {
-						status: 101,
-						webSocket: client,
-						headers,
-					});
-				}
-			}`,
-		});
+		startMiniflare(`export default {
+			fetch() {
+				const [client, server] = Object.values(new WebSocketPair());
+				server.accept();
+				const headers = new Headers({
+					"X-Hello": "testing",
+					"Transfer-Encoding": "chunked",
+					"Content-Length": "42",
+				});
+				return new Response(null, {
+					status: 101,
+					webSocket: client,
+					headers,
+				});
+			}
+		}`);
 		await listen();
 
-		const socket = net.connect(port, "127.0.0.1");
-		await new Promise<void>((r) => socket.on("connect", r));
+		const socket = await connect();
 
 		const chunks: Buffer[] = [];
 		socket.on("data", (chunk) => chunks.push(chunk));
@@ -252,11 +282,14 @@ describe("handleWebSocket", () => {
 				"Sec-WebSocket-Version: 13\r\n\r\n"
 		);
 
-		await vi.waitFor(() => {
-			const raw = Buffer.concat(chunks).toString("utf8");
-			expect(raw).toContain("HTTP/1.1 101");
-			expect(raw).toContain("\r\n\r\n");
-		});
+		await vi.waitFor(
+			() => {
+				const raw = Buffer.concat(chunks).toString("utf8");
+				expect(raw).toContain("HTTP/1.1 101");
+				expect(raw).toContain("\r\n\r\n");
+			},
+			{ timeout: 10_000 }
+		);
 
 		const raw = Buffer.concat(chunks).toString("utf8");
 		const headerBlock = raw.slice(0, raw.indexOf("\r\n\r\n"));
@@ -278,28 +311,23 @@ describe("handleWebSocket", () => {
 		// Override the default Miniflare instance with a Worker that returns
 		// custom headers (including two Set-Cookie entries) on the upgrade
 		// response.
-		await miniflare.dispose();
-		miniflare = new Miniflare({
-			modules: true,
-			script: `export default {
-				fetch() {
-					const [client, server] = Object.values(new WebSocketPair());
-					server.accept();
-					const headers = new Headers({ "X-Hello": "testing" });
-					headers.append("Set-Cookie", "session=abc; Path=/");
-					headers.append("Set-Cookie", "theme=dark; Path=/; HttpOnly");
-					return new Response(null, {
-						status: 101,
-						webSocket: client,
-						headers,
-					});
-				}
-			}`,
-		});
+		startMiniflare(`export default {
+			fetch() {
+				const [client, server] = Object.values(new WebSocketPair());
+				server.accept();
+				const headers = new Headers({ "X-Hello": "testing" });
+				headers.append("Set-Cookie", "session=abc; Path=/");
+				headers.append("Set-Cookie", "theme=dark; Path=/; HttpOnly");
+				return new Response(null, {
+					status: 101,
+					webSocket: client,
+					headers,
+				});
+			}
+		}`);
 		await listen();
 
-		const socket = net.connect(port, "127.0.0.1");
-		await new Promise<void>((r) => socket.on("connect", r));
+		const socket = await connect();
 
 		const chunks: Buffer[] = [];
 		socket.on("data", (chunk) => chunks.push(chunk));
@@ -313,11 +341,14 @@ describe("handleWebSocket", () => {
 				"Sec-WebSocket-Version: 13\r\n\r\n"
 		);
 
-		await vi.waitFor(() => {
-			const raw = Buffer.concat(chunks).toString("utf8");
-			expect(raw).toContain("HTTP/1.1 101");
-			expect(raw).toContain("\r\n\r\n");
-		});
+		await vi.waitFor(
+			() => {
+				const raw = Buffer.concat(chunks).toString("utf8");
+				expect(raw).toContain("HTTP/1.1 101");
+				expect(raw).toContain("\r\n\r\n");
+			},
+			{ timeout: 10_000 }
+		);
 
 		const raw = Buffer.concat(chunks).toString("utf8");
 		const headerBlock = raw.slice(0, raw.indexOf("\r\n\r\n"));
@@ -329,5 +360,41 @@ describe("handleWebSocket", () => {
 		expect(headerBlock).toContain("Set-Cookie: theme=dark; Path=/; HttpOnly");
 
 		socket.destroy();
+	});
+
+	test("destroys the socket without an unhandled rejection when dispatchFetch fails", async ({
+		expect,
+	}) => {
+		const mf = await listen();
+
+		// Simulate Miniflare being disposed mid-upgrade: `dispatchFetch` rejects.
+		vi.spyOn(mf, "dispatchFetch").mockRejectedValue(
+			new Error("Cannot use disposed instance")
+		);
+
+		const unhandled = vi.fn();
+		process.on("unhandledRejection", unhandled);
+
+		const socket = await connect();
+		const closed = new Promise<void>((resolve) =>
+			socket.on("close", () => resolve())
+		);
+
+		socket.write(
+			"GET / HTTP/1.1\r\n" +
+				`Host: 127.0.0.1:${port}\r\n` +
+				"Upgrade: websocket\r\n" +
+				"Connection: Upgrade\r\n" +
+				"Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n" +
+				"Sec-WebSocket-Version: 13\r\n\r\n"
+		);
+
+		// The handler catches the rejection and tears the socket down.
+		await closed;
+		// Give any (incorrectly) unhandled rejection a tick to surface.
+		await new Promise((resolve) => setTimeout(resolve, 50));
+		process.off("unhandledRejection", unhandled);
+
+		expect(unhandled).not.toHaveBeenCalled();
 	});
 });

--- a/packages/vite-plugin-cloudflare/src/__tests__/websockets.spec.ts
+++ b/packages/vite-plugin-cloudflare/src/__tests__/websockets.spec.ts
@@ -7,6 +7,7 @@ import {
 	beforeEach,
 	describe,
 	type ExpectStatic,
+	onTestFinished,
 	test,
 	vi,
 } from "vitest";
@@ -374,6 +375,9 @@ describe("handleWebSocket", () => {
 
 		const unhandled = vi.fn();
 		process.on("unhandledRejection", unhandled);
+		onTestFinished(() => {
+			process.off("unhandledRejection", unhandled);
+		});
 
 		const socket = await connect();
 		const closed = new Promise<void>((resolve) =>
@@ -393,7 +397,6 @@ describe("handleWebSocket", () => {
 		await closed;
 		// Give any (incorrectly) unhandled rejection a tick to surface.
 		await new Promise((resolve) => setTimeout(resolve, 50));
-		process.off("unhandledRejection", unhandled);
 
 		expect(unhandled).not.toHaveBeenCalled();
 	});

--- a/packages/vite-plugin-cloudflare/src/websockets.ts
+++ b/packages/vite-plugin-cloudflare/src/websockets.ts
@@ -45,59 +45,70 @@ export function handleWebSocket(
 			// Socket errors crash Node.js if unhandled
 			socket.on("error", () => socket.destroy());
 
-			const rawHost = request.headers.host ?? UNKNOWN_HOST;
-			// Honor `X-Forwarded-Proto` so that the upgrade URL reflects the
-			// protocol the original client used (e.g. behind a TLS-terminating
-			// reverse proxy or tunnel). Matches `createRequestHandler` in utils.ts.
-			const protocol = getForwardedProto(request) ?? "http:";
-			const base = /^https?:\/\//i.test(rawHost)
-				? rawHost
-				: `${protocol}//${rawHost}`;
-			const url = new URL(request.url ?? "", base);
+			try {
+				const rawHost = request.headers.host ?? UNKNOWN_HOST;
+				// Honor `X-Forwarded-Proto` so that the upgrade URL reflects the
+				// protocol the original client used (e.g. behind a TLS-terminating
+				// reverse proxy or tunnel). Matches `createRequestHandler` in utils.ts.
+				const protocol = getForwardedProto(request) ?? "http:";
+				const base = /^https?:\/\//i.test(rawHost)
+					? rawHost
+					: `${protocol}//${rawHost}`;
+				const url = new URL(request.url ?? "", base);
 
-			const isViteRequest =
-				request.headers["sec-websocket-protocol"]?.startsWith("vite");
-			const isSandboxRequest = hasSandboxOrigin(url.origin);
+				const isViteRequest =
+					request.headers["sec-websocket-protocol"]?.startsWith("vite");
+				const isSandboxRequest = hasSandboxOrigin(url.origin);
 
-			// Ignore Vite HMR WebSockets but forward on all sandbox requests.
-			if (isViteRequest && !isSandboxRequest) {
-				return;
-			}
-
-			const headers = createHeaders(request);
-
-			if (entryWorkerName) {
-				headers.set(CoreHeaders.ROUTE_OVERRIDE, entryWorkerName);
-			}
-
-			const response = await miniflare.dispatchFetch(url, {
-				headers: headers as unknown as Headers,
-				method: request.method,
-			});
-			const workerWebSocket = response.webSocket;
-
-			if (!workerWebSocket) {
-				socket.destroy();
-				return;
-			}
-
-			// Forward response headers (e.g. Set-Cookie, custom auth headers) from
-			// the Worker's 101 response onto the upgrade response sent to the
-			// client. Without this, headers set on a `new Response(null, { status:
-			// 101, webSocket, headers })` are silently dropped during `vite dev`,
-			// even though they are delivered correctly by `wrangler dev`.
-			// See cloudflare/workers-sdk#10390.
-			workerResponseHeaders.set(request, response.headers);
-
-			nodeWebSocket.handleUpgrade(
-				request,
-				socket,
-				head,
-				async (clientWebSocket) => {
-					void coupleWebSocket(clientWebSocket, workerWebSocket);
-					nodeWebSocket.emit("connection", clientWebSocket, request);
+				// Ignore Vite HMR WebSockets but forward on all sandbox requests.
+				if (isViteRequest && !isSandboxRequest) {
+					return;
 				}
-			);
+
+				const headers = createHeaders(request);
+
+				if (entryWorkerName) {
+					headers.set(CoreHeaders.ROUTE_OVERRIDE, entryWorkerName);
+				}
+
+				const response = await miniflare.dispatchFetch(url, {
+					headers: headers as unknown as Headers,
+					method: request.method,
+				});
+				const workerWebSocket = response.webSocket;
+
+				if (!workerWebSocket) {
+					socket.destroy();
+					return;
+				}
+
+				// Forward response headers (e.g. Set-Cookie, custom auth headers) from
+				// the Worker's 101 response onto the upgrade response sent to the
+				// client. Without this, headers set on a `new Response(null, { status:
+				// 101, webSocket, headers })` are silently dropped during `vite dev`,
+				// even though they are delivered correctly by `wrangler dev`.
+				// See cloudflare/workers-sdk#10390.
+				workerResponseHeaders.set(request, response.headers);
+
+				nodeWebSocket.handleUpgrade(
+					request,
+					socket,
+					head,
+					async (clientWebSocket) => {
+						void coupleWebSocket(clientWebSocket, workerWebSocket);
+						nodeWebSocket.emit("connection", clientWebSocket, request);
+					}
+				);
+			} catch {
+				// `dispatchFetch` rejects if Miniflare is disposed while an upgrade
+				// is still in flight (e.g. during dev server shutdown or restart).
+				// This listener is `async`, so an uncaught rejection here escapes as
+				// an unhandled rejection — which terminates the Node.js process on
+				// modern versions and leaks the client socket. Tear the socket down
+				// instead, mirroring the `!workerWebSocket` path above.
+				workerResponseHeaders.delete(request);
+				socket.destroy();
+			}
 		}
 	);
 }

--- a/packages/vite-plugin-cloudflare/vitest.config.ts
+++ b/packages/vite-plugin-cloudflare/vitest.config.ts
@@ -1,14 +1,16 @@
-import { defineConfig } from "vitest/config";
+import { defineConfig, mergeConfig } from "vitest/config";
+import configShared from "../../vitest.shared";
 
-export default defineConfig({
-	define: {
-		__VITE_PLUGIN_DEFAULT_COMPAT_DATE__: JSON.stringify("2024-01-01"),
-	},
-	test: {
-		reporters: ["default"],
-		include: ["**/__tests__/**/*.spec.[tj]s"],
-		exclude: ["**/node_modules/**", "**/dist/**", "./playground/**/*.*"],
-		testTimeout: 50_000,
-	},
-	publicDir: false,
-});
+export default mergeConfig(
+	configShared,
+	defineConfig({
+		define: {
+			__VITE_PLUGIN_DEFAULT_COMPAT_DATE__: JSON.stringify("2024-01-01"),
+		},
+		test: {
+			include: ["**/__tests__/**/*.spec.[tj]s"],
+			exclude: ["**/node_modules/**", "**/dist/**", "./playground/**/*.*"],
+		},
+		publicDir: false,
+	})
+);


### PR DESCRIPTION
Deflakes the `@cloudflare/vite-plugin` WebSocket upgrade test on Windows CI, and fixes a latent unhandled-rejection bug it exposed.

**Observed flake:** [Tests (Windows, packages-and-tools)](https://github.com/cloudflare/workers-sdk/actions/runs/30192637280/job/89768522836) — `handleWebSocket > does not forward framing headers from the Worker response`:
- `AssertionError: expected '' to contain 'HTTP/1.1 101'`
- `Error: Hook timed out in 10000ms` (afterEach)
- `MiniflareCoreError [ERR_DISPOSED]` unhandled rejection

**Root cause:** `listen()` never awaited `miniflare.ready`, so a cold `workerd` boot was charged against `vi.waitFor`'s 1s default timeout instead of the 50s test timeout. On the contended Windows runner the boot exceeded 1s, so no bytes arrived. The test then threw before its `socket.destroy()`, so `httpServer.close()` hung on the live socket — and because this package's vitest config didn't extend the shared one, `hookTimeout` fell back to the 10s default (and there was no `retry` safety net). Finally, `afterEach`'s `dispose()` rejected the still-pending `dispatchFetch`, and the `async` upgrade handler had no `try/catch`, surfacing the `ERR_DISPOSED` unhandled rejection.

**Changes:**
- `src/websockets.ts` (real fix): wrap the `upgrade` handler in `try/catch` and destroy the socket on failure. Without this, a rejected `dispatchFetch` during dev-server shutdown/restart escapes the `async` listener as an unhandled rejection (can terminate the process) and leaks the client socket. This path is reachable in real `vite dev`/`vite preview`, not just tests.
- `src/__tests__/websockets.spec.ts`: `listen()` awaits `miniflare.ready` (deterministic fix); Miniflare created per-test via a helper (no throwaway spawn); `afterEach` tears down tracked sockets and calls `closeAllConnections()` before closing the server so a failed assertion can't cascade into a hook timeout; explicit `{ timeout: 10_000 }` on the two real round-trip waits; added a regression test asserting no unhandled rejection when `dispatchFetch` fails.
- `vitest.config.ts`: extend `vitest.shared.ts` to inherit `retry: 1`, `hookTimeout`/`teardownTimeout`, etc.

**Verification:** `websockets.spec.ts` 9/9 pass; full package suite 179/179 across 18 files (confirms `restoreMocks: true` from the shared config regresses nothing); type-check, lint, and format clean. Removing the `try/catch` makes the new regression test hang the process, confirming it catches the bug.

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: internal test/robustness fix with no user-facing API or behavior change.

> [!NOTE]
> This is a contribution from an AI agent: OpenCode, anthropic/claude-opus-4-8.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14862" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->