### PR TITLE
fix(miniflare): hide workerd console window on Windows

### DIFF
--- a/.changeset/miniflare-windows-hide-workerd.md
+++ b/.changeset/miniflare-windows-hide-workerd.md
@@ -1,0 +1,5 @@
+---
+"miniflare": patch
+---
+
+Hide the workerd console window on Windows when the parent process has no console. Spawning workerd without `windowsHide: true` caused Windows Terminal to open a visible, focus-stealing window for background or detached parents (for example Astro's `astro dev --background`).

--- a/packages/miniflare/src/runtime/index.ts
+++ b/packages/miniflare/src/runtime/index.ts
@@ -247,8 +247,13 @@ export class Runtime {
 		// Default `TZ` to `UTC` to match the production Cloudflare runtime.
 		// Callers can override via `options.runtimeEnv` (e.g. for tests of
 		// timezone-dependent behaviour).
+		// `windowsHide: true` prevents a console window from popping up when the
+		// parent has no console (e.g. a detached/backgrounded Node process).
+		// Without it, Windows allocates a new console for workerd.exe, and on
+		// Windows 11 that is hosted by a visible, focus-stealing Terminal window.
 		const runtimeProcess = childProcess.spawn(command, args, {
 			stdio: ["pipe", "pipe", "pipe", "pipe"],
+			windowsHide: true,
 			env: {
 				...process.env,
 				TZ: "UTC",


### PR DESCRIPTION
Fixes #14863.

## Summary

Miniflare spawns `workerd` without `windowsHide: true`. When the parent Node process has no console (for example a detached or backgrounded process such as Astro's `astro dev --background`), Windows allocates a new console for `workerd.exe`. On Windows 11 that console is hosted by Windows Terminal, so a visible, focus-stealing window appears for the lifetime of the runtime.

- Pass `windowsHide: true` to the workerd `spawn` options. This is a no-op on macOS/Linux.

Related: withastro/astro#17516 (detached parent spawn on the Astro side).

## Checklist

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: `windowsHide` is a standard Node `spawn` option with no effect outside Windows, and verifying the console window requires a Windows 11 host with Windows Terminal as the default console host plus a console-less parent process.
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: internal spawn option with no user-facing API change.

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14864" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->