### PR TITLE
Fix nested D1 migration loading in vitest pool

### DIFF
--- a/.changeset/read-nested-d1-migrations.md
+++ b/.changeset/read-nested-d1-migrations.md
@@ -1,0 +1,7 @@
+---
+"@cloudflare/vitest-pool-workers": patch
+---
+
+Read nested D1 migration layouts in Workers Vitest tests
+
+`readD1Migrations()` now discovers `.sql` files below the migrations directory, including Drizzle-style `0001_name/migration.sql` layouts supported by Wrangler's `migrations_pattern`, so `applyD1Migrations()` can apply the same migrations during tests.

--- a/packages/vitest-pool-workers/src/pool/d1.ts
+++ b/packages/vitest-pool-workers/src/pool/d1.ts
@@ -2,6 +2,11 @@ import fs from "node:fs";
 import path from "node:path";
 import type { D1Migration } from "../shared/d1";
 
+type MigrationFile = {
+	name: string;
+	filePath: string;
+};
+
 /**
  * Reads all migrations in `migrationsPath`, ordered by migration number.
  * Each migration will have its contents split into an array of SQL queries.
@@ -17,20 +22,87 @@ export async function readD1Migrations(
 	}
 
 	const { unstable_splitSqlQuery } = await import("wrangler"); // (lazy)
-	const names = fs
-		.readdirSync(migrationsPath)
-		.filter((name) => name.endsWith(".sql"));
-	names.sort((a, b) => {
-		const aNumber = parseInt(a.split("_")[0]);
-		const bNumber = parseInt(b.split("_")[0]);
-		return aNumber - bNumber;
-	});
-	return names.map((name) => {
-		const migrationPath = path.join(migrationsPath, name);
-		const migration = fs.readFileSync(migrationPath, "utf8");
+	const migrations = listSqlMigrations(migrationsPath);
+	return migrations.map(({ name, filePath }) => {
+		const migration = fs.readFileSync(filePath, "utf8");
 		const queries = unstable_splitSqlQuery(migration);
 		return { name, queries };
 	});
+}
+
+function listSqlMigrations(migrationsPath: string): MigrationFile[] {
+	const migrations: MigrationFile[] = [];
+	const stack: Array<{ directoryPath: string; relativePath: string }> = [
+		{ directoryPath: migrationsPath, relativePath: "" },
+	];
+
+	while (stack.length > 0) {
+		const current = stack.pop();
+		if (current === undefined) {
+			continue;
+		}
+
+		const entries = fs.readdirSync(current.directoryPath, {
+			withFileTypes: true,
+		});
+		for (const entry of entries) {
+			const entryPath = path.join(current.directoryPath, entry.name);
+			const name =
+				current.relativePath === ""
+					? entry.name
+					: `${current.relativePath}/${entry.name}`;
+
+			if (entry.isDirectory()) {
+				stack.push({ directoryPath: entryPath, relativePath: name });
+			} else if (entry.isFile() && entry.name.endsWith(".sql")) {
+				migrations.push({ name, filePath: entryPath });
+			}
+		}
+	}
+
+	return migrations.sort((a, b) => compareMigrationPaths(a.name, b.name));
+}
+
+function compareMigrationPaths(a: string, b: string): number {
+	const aSegments = a.split("/");
+	const bSegments = b.split("/");
+	const shared = Math.min(aSegments.length, bSegments.length);
+	for (let i = 0; i < shared; i++) {
+		const cmp = compareSegments(aSegments[i], bSegments[i]);
+		if (cmp !== 0) {
+			return cmp;
+		}
+	}
+	return aSegments.length - bSegments.length;
+}
+
+function compareSegments(a: string, b: string): number {
+	const aNum = leadingMigrationNumber(a);
+	const bNum = leadingMigrationNumber(b);
+	if (aNum !== bNum) {
+		if (Number.isFinite(aNum) && Number.isFinite(bNum)) {
+			return aNum - bNum;
+		}
+		if (Number.isFinite(aNum)) {
+			return -1;
+		}
+		if (Number.isFinite(bNum)) {
+			return 1;
+		}
+	}
+
+	if (a < b) {
+		return -1;
+	}
+	if (a > b) {
+		return 1;
+	}
+	return 0;
+}
+
+function leadingMigrationNumber(relativePath: string): number {
+	const firstSegment = relativePath.split("/")[0];
+	return parseInt(firstSegment.split("_")[0], 10);
 }
 
 export type { D1Migration };

--- a/packages/vitest-pool-workers/test/d1.test.ts
+++ b/packages/vitest-pool-workers/test/d1.test.ts
@@ -1,0 +1,82 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, it, vi } from "vitest";
+import { readD1Migrations } from "../src/pool/d1";
+
+vi.mock("wrangler", () => ({
+	unstable_splitSqlQuery: (sql: string) => [sql.trim()],
+}));
+
+const tmpDirs: string[] = [];
+
+afterEach(() => {
+	for (const tmpDir of tmpDirs.splice(0)) {
+		fs.rmSync(tmpDir, { recursive: true, force: true });
+	}
+});
+
+function createMigrationsDir(files: Record<string, string>): string {
+	const migrationsPath = fs.mkdtempSync(
+		path.join(os.tmpdir(), "d1-migrations-")
+	);
+	tmpDirs.push(migrationsPath);
+
+	for (const [name, contents] of Object.entries(files)) {
+		const filePath = path.join(migrationsPath, ...name.split("/"));
+		fs.mkdirSync(path.dirname(filePath), { recursive: true });
+		fs.writeFileSync(filePath, contents);
+	}
+
+	return migrationsPath;
+}
+
+describe("readD1Migrations", () => {
+	it("reads flat migrations in migration number order", async ({ expect }) => {
+		const migrationsPath = createMigrationsDir({
+			"10_seed.sql": "CREATE TABLE seed (id INTEGER);",
+			"2_add_users.sql": "CREATE TABLE users (id INTEGER);",
+		});
+
+		const migrations = await readD1Migrations(migrationsPath);
+
+		expect(migrations).toEqual([
+			{
+				name: "2_add_users.sql",
+				queries: ["CREATE TABLE users (id INTEGER);"],
+			},
+			{
+				name: "10_seed.sql",
+				queries: ["CREATE TABLE seed (id INTEGER);"],
+			},
+		]);
+	});
+
+	it("reads nested D1 migrations in migration number order", async ({
+		expect,
+	}) => {
+		const migrationsPath = createMigrationsDir({
+			"10_seed/migration.sql": "CREATE TABLE seed (id INTEGER);",
+			"2_add_users/migration.sql": "CREATE TABLE users (id INTEGER);",
+			"init/migration.sql": "CREATE TABLE init (id INTEGER);",
+			"3_ignored/snapshot.json": "{}",
+		});
+
+		const migrations = await readD1Migrations(migrationsPath);
+
+		expect(migrations).toEqual([
+			{
+				name: "2_add_users/migration.sql",
+				queries: ["CREATE TABLE users (id INTEGER);"],
+			},
+			{
+				name: "10_seed/migration.sql",
+				queries: ["CREATE TABLE seed (id INTEGER);"],
+			},
+			{
+				name: "init/migration.sql",
+				queries: ["CREATE TABLE init (id INTEGER);"],
+			},
+		]);
+	});
+});


### PR DESCRIPTION
Fixes #14866.

Read D1 migration files recursively so `readD1Migrations()` supports the nested layout that `migrations_pattern` can match, such as `0001_init/migration.sql`. The returned migration names preserve forward-slash relative paths and are sorted by migration prefix.

---

- Tests
  - [x] Tests included/updated
  - [x] Automated tests not possible - manual testing has been completed as follows: N/A
  - [x] Additional testing not necessary because: N/A
- Public documentation
  - [x] Documentation not necessary because: this fixes runtime/test helper behavior without changing public docs

> [!NOTE]
> This is a contribution from an AI agent: Hermes Agent, gpt-5.5.

Validation:
- `pnpm --filter @cloudflare/vitest-pool-workers test d1.test.ts`
- `pnpm --filter @cloudflare/vitest-pool-workers check:type`
- `pnpm --filter @cloudflare/vitest-pool-workers build`
- `oxfmt --check packages/vitest-pool-workers/src/pool/d1.ts packages/vitest-pool-workers/test/d1.test.ts .changeset/read-nested-d1-migrations.md`
- `git diff --check`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14870" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->