### PR TITLE
[wrangler] Respect and surface 429 errors from HTTP requests

### DIFF
--- a/.changeset/retry-after-rate-limit.md
+++ b/.changeset/retry-after-rate-limit.md
@@ -1,0 +1,18 @@
+---
+"@cloudflare/workers-utils": minor
+"wrangler": minor
+---
+
+Respect and surface the `Retry-After` header on Cloudflare API responses
+
+Previously, if a Wrangler command (e.g. `wrangler versions upload`, `wrangler deploy`) hit the Cloudflare API's rate limit, the resulting error gave no indication of how long to wait before trying again, and 429 responses weren't retried at all (only `5xx` errors were, with a fixed linear backoff).
+
+Now:
+
+- `429 Too Many Requests` responses are automatically retried, alongside the existing `5xx` retry behaviour.
+- If a retried response includes a `Retry-After` header, Wrangler waits for that duration instead of the default backoff, and logs a message indicating how long it's waiting. To avoid blocking for an excessive amount of time, waits longer than 60 seconds fail fast instead — the surfaced `Retry-After` value lets the caller schedule its own retry.
+- If a retryable error is ultimately surfaced to the user (e.g. because retries were exhausted), the error message includes a note with the `Retry-After` duration, and the `command-failed` entry written to the Wrangler output file (`WRANGLER_OUTPUT_FILE_PATH`/`WRANGLER_OUTPUT_FILE_DIRECTORY`) gains a `retry_after_ms` field. This lets scripts and CI/CD pipelines calling Wrangler repeatedly (for example, `wrangler versions upload` on every commit) read the wait duration directly instead of regex-parsing stderr.
+
+`APIError.isRetryable()` is unchanged (still `5xx` only); `retryOnAPIFailure()` separately retries 429s. `retryAfterMs`, when present, is honoured for any retried error, not just 429s.
+
+`retryAfterMs` is also now populated on `APIError`s raised from direct R2 object requests, the Browser Rendering API, and errors surfaced from commands using the official `cloudflare` SDK client.

--- a/packages/workers-utils/src/cfetch/index.ts
+++ b/packages/workers-utils/src/cfetch/index.ts
@@ -123,7 +123,11 @@ export async function fetchInternalBase<ResponseType>(
 	queryParams?: URLSearchParams,
 	abortSignal?: AbortSignal,
 	credentials?: ApiCredentials
-): Promise<{ response: ResponseType; status: number }> {
+): Promise<{
+	response: ResponseType;
+	status: number;
+	retryAfterMs?: number;
+}> {
 	const method = init.method ?? "GET";
 	const response = await performApiFetchBase(
 		complianceConfig,
@@ -145,6 +149,8 @@ export async function fetchInternalBase<ResponseType>(
 	logger.debugWithSanitization?.("RESPONSE:", jsonText);
 	logger.debug("-- END CF API RESPONSE");
 
+	const retryAfterMs = parseRetryAfterMs(response.headers);
+
 	if (!jsonText && (response.status === 204 || response.status === 205)) {
 		return {
 			response: {
@@ -154,6 +160,7 @@ export async function fetchInternalBase<ResponseType>(
 				messages: [],
 			} as ResponseType,
 			status: response.status,
+			retryAfterMs,
 		};
 	}
 
@@ -163,13 +170,14 @@ export async function fetchInternalBase<ResponseType>(
 			method,
 			resource,
 			response.status,
-			response.statusText
+			response.statusText,
+			retryAfterMs
 		);
 	}
 
 	try {
 		const json = parseJSON(jsonText) as ResponseType;
-		return { response: json, status: response.status };
+		return { response: json, status: response.status, retryAfterMs };
 	} catch {
 		const rayId = extractWAFBlockRayId(response.headers);
 
@@ -185,6 +193,7 @@ export async function fetchInternalBase<ResponseType>(
 				...(rayId ? [{ text: `Cloudflare Ray ID: ${rayId}` }] : []),
 			],
 			status: response.status,
+			retryAfterMs,
 			telemetryMessage: false,
 		});
 	}
@@ -200,9 +209,11 @@ export async function fetchResultBase<ResponseType>(
 	abortSignal?: AbortSignal,
 	credentials?: ApiCredentials
 ): Promise<ResponseType> {
-	const { response: json, status } = await fetchInternalBase<
-		FetchResult<ResponseType>
-	>(
+	const {
+		response: json,
+		status,
+		retryAfterMs,
+	} = await fetchInternalBase<FetchResult<ResponseType>>(
 		complianceConfig,
 		resource,
 		init,
@@ -215,7 +226,7 @@ export async function fetchResultBase<ResponseType>(
 	if (json.success) {
 		return json.result;
 	} else {
-		throwFetchError(resource, json, status);
+		throwFetchError(resource, json, status, retryAfterMs);
 	}
 }
 
@@ -236,9 +247,11 @@ export async function fetchListResultBase<ResponseType>(
 			queryParams = new URLSearchParams(queryParams);
 			queryParams.set("cursor", cursor);
 		}
-		const { response: json, status } = await fetchInternalBase<
-			FetchResult<ResponseType[]>
-		>(
+		const {
+			response: json,
+			status,
+			retryAfterMs,
+		} = await fetchInternalBase<FetchResult<ResponseType[]>>(
 			complianceConfig,
 			resource,
 			init,
@@ -256,7 +269,7 @@ export async function fetchListResultBase<ResponseType>(
 				getMoreResults = false;
 			}
 		} else {
-			throwFetchError(resource, json, status);
+			throwFetchError(resource, json, status, retryAfterMs);
 		}
 	}
 	return results;
@@ -272,6 +285,39 @@ export function truncate(text: string, maxLength: number): string {
 
 export function isWAFBlockResponse(headers: Headers): boolean {
 	return headers.get("cf-mitigated") === "challenge";
+}
+
+/**
+ * Parses a `Retry-After` header value (https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Retry-After)
+ * into milliseconds to wait before retrying, or `undefined` if absent/unparsable.
+ *
+ * Per the HTTP spec, `Retry-After` may either be a number of delay-seconds,
+ * or an HTTP-date after which the request may be retried.
+ */
+export function parseRetryAfterValue(
+	retryAfter: string | null | undefined
+): number | undefined {
+	if (!retryAfter) {
+		return undefined;
+	}
+
+	// delta-seconds, e.g. "Retry-After: 120"
+	if (/^\d+$/.test(retryAfter.trim())) {
+		return Number(retryAfter) * 1000;
+	}
+
+	// HTTP-date, e.g. "Retry-After: Fri, 31 Dec 1999 23:59:59 GMT"
+	const retryAfterDate = new Date(retryAfter);
+	if (!Number.isNaN(retryAfterDate.getTime())) {
+		return Math.max(0, retryAfterDate.getTime() - Date.now());
+	}
+
+	return undefined;
+}
+
+/** Same as {@link parseRetryAfterValue}, reading the value from a `Headers` object. */
+export function parseRetryAfterMs(headers: Headers): number | undefined {
+	return parseRetryAfterValue(headers.get("Retry-After"));
 }
 
 export function extractWAFBlockRayId(headers: Headers): string | undefined {
@@ -400,7 +446,8 @@ function escapeCharacter(character: string): string {
 export function throwFetchError(
 	resource: string,
 	response: FetchResult<unknown>,
-	status: number
+	status: number,
+	retryAfterMs?: number
 ): never {
 	const errors = response.errors ?? [];
 	for (const error of errors) {
@@ -425,11 +472,20 @@ export function throwFetchError(
 			notes.push({ text: fallbackMessage });
 		}
 	}
+	if (retryAfterMs !== undefined) {
+		notes.push({
+			text: `The API responded with a "Retry-After" header indicating you should wait ${Math.ceil(retryAfterMs / 1000)} second(s) before retrying.`,
+		});
+	}
 
 	const error = new APIError({
 		text: `A request to the Cloudflare API (${resource}) failed.`,
 		notes,
 		status,
+		// hoist the parsed `Retry-After` header (if any) so consumers such as
+		// `retryOnAPIFailure()` can back off for the amount of time the API
+		// asked us to wait, e.g. when rate limited (HTTP 429).
+		retryAfterMs,
 		telemetryMessage: false,
 	});
 	// add the first error code directly to this error
@@ -454,7 +510,8 @@ function throwWAFBlockError(
 	method: string,
 	resource: string,
 	status: number,
-	statusText: string
+	statusText: string,
+	retryAfterMs?: number
 ): never {
 	const rayId = extractWAFBlockRayId(headers);
 	throw new APIError({
@@ -474,6 +531,7 @@ function throwWAFBlockError(
 			},
 		],
 		status,
+		retryAfterMs,
 		telemetryMessage: false,
 	});
 }

--- a/packages/workers-utils/src/parse.ts
+++ b/packages/workers-utils/src/parse.ts
@@ -61,11 +61,21 @@ export class APIError extends ParseError {
 	 * endpoint-specific structured error payloads.
 	 */
 	meta?: { details?: unknown } & Record<string, unknown>;
+	/**
+	 * Optional number of milliseconds the API asked us to wait before retrying,
+	 * derived from the response's `Retry-After` header (if present).
+	 */
+	retryAfterMs?: number;
 
-	constructor({ status, ...rest }: MessageInit & { status?: number }) {
+	constructor({
+		status,
+		retryAfterMs,
+		...rest
+	}: MessageInit & { status?: number; retryAfterMs?: number }) {
 		super(rest);
 		this.name = this.constructor.name;
 		this.#status = status;
+		this.retryAfterMs = retryAfterMs;
 	}
 
 	get status(): number | undefined {

--- a/packages/workers-utils/src/retry.ts
+++ b/packages/workers-utils/src/retry.ts
@@ -4,6 +4,9 @@ import type { Logger } from "./logger";
 
 const MAX_ATTEMPTS = 3;
 
+// Cap how long we'll block on a `Retry-After` header before failing fast.
+const MAX_RETRY_AFTER_MS = 60_000;
+
 export async function retryOnAPIFailure<T>(
 	action: () => T | Promise<T>,
 	logger: Logger,
@@ -15,7 +18,9 @@ export async function retryOnAPIFailure<T>(
 		return await action();
 	} catch (err) {
 		if (err instanceof APIError) {
-			if (!err.isRetryable()) {
+			// 429 is special-cased here rather than folded into isRetryable(),
+			// since other callers rely on that meaning "5xx".
+			if (!err.isRetryable() && err.status !== 429) {
 				throw err;
 			}
 		} else if (err instanceof DOMException && err.name === "TimeoutError") {
@@ -26,14 +31,39 @@ export async function retryOnAPIFailure<T>(
 			throw err;
 		}
 
-		logger.debug(`Retrying API call after error...`);
-		logger.debug(err);
+		const retryAfterMs = err instanceof APIError ? err.retryAfterMs : undefined;
+
+		// Fail fast rather than blocking for an unreasonable amount of time.
+		if (retryAfterMs !== undefined && retryAfterMs > MAX_RETRY_AFTER_MS) {
+			throw err;
+		}
 
 		if (attempts <= 1) {
 			throw err;
 		}
 
-		await setTimeout(backoff, undefined, { signal: abortSignal });
+		// Honour `Retry-After` when present, otherwise retry immediately and
+		// 429s after a short wait
+		const jitter = Math.random() * 1000;
+
+		let wait = backoff;
+		if (retryAfterMs !== undefined) {
+			wait = retryAfterMs + jitter;
+		} else if (err instanceof APIError && err.status === 429) {
+			// never immediately retry a 429, wait at least 1s
+			wait = Math.max(backoff, 1000) + jitter;
+		}
+
+		if (retryAfterMs !== undefined) {
+			logger.info(
+				`Received a "Retry-After" header from the Cloudflare API. Waiting ${Math.ceil(retryAfterMs / 1000)} second(s) before retrying...`
+			);
+		} else {
+			logger.debug(`Retrying API call after error...`);
+			logger.debug(err);
+		}
+
+		await setTimeout(wait, undefined, { signal: abortSignal });
 		return retryOnAPIFailure(
 			action,
 			logger,

--- a/packages/workers-utils/tests/cfetch-utils.test.ts
+++ b/packages/workers-utils/tests/cfetch-utils.test.ts
@@ -1,5 +1,12 @@
 import { describe, it } from "vitest";
-import { extractAccountTag, hasMorePages } from "../src/cfetch";
+import {
+	extractAccountTag,
+	hasMorePages,
+	parseRetryAfterMs,
+	parseRetryAfterValue,
+	throwFetchError,
+} from "../src/cfetch";
+import { APIError } from "../src/parse";
 
 /**
  * hasMorePages is a function that returns a boolean based on the result_info
@@ -55,5 +62,119 @@ describe("extractAccountTag", () => {
 		expect(extractAccountTag("/accounts/foo")).toBe("foo");
 		expect(extractAccountTag("/accounts/bar/")).toBe("bar");
 		expect(extractAccountTag("/accounts/baz/more")).toBe("baz");
+	});
+});
+
+describe("parseRetryAfterMs", () => {
+	it("should return undefined when the header is absent", ({ expect }) => {
+		expect(parseRetryAfterMs(new Headers())).toBeUndefined();
+	});
+
+	it("should parse delta-seconds into milliseconds", ({ expect }) => {
+		expect(parseRetryAfterMs(new Headers({ "Retry-After": "120" }))).toBe(
+			120_000
+		);
+		expect(parseRetryAfterMs(new Headers({ "Retry-After": "0" }))).toBe(0);
+	});
+
+	it("should parse an HTTP-date into a millisecond delay", ({ expect }) => {
+		const future = new Date(Date.now() + 60_000);
+		const ms = parseRetryAfterMs(
+			new Headers({ "Retry-After": future.toUTCString() })
+		);
+		expect(ms).toBeGreaterThan(55_000);
+		expect(ms).toBeLessThanOrEqual(60_000);
+	});
+
+	it("should clamp HTTP-dates in the past to 0", ({ expect }) => {
+		const past = new Date(Date.now() - 60_000);
+		expect(
+			parseRetryAfterMs(new Headers({ "Retry-After": past.toUTCString() }))
+		).toBe(0);
+	});
+
+	it("should return undefined for an unparsable value", ({ expect }) => {
+		expect(
+			parseRetryAfterMs(new Headers({ "Retry-After": "not-a-value" }))
+		).toBeUndefined();
+	});
+});
+
+// parseRetryAfterValue is the shared parser behind parseRetryAfterMs, exposed
+// separately for clients (e.g. the official `cloudflare` SDK) whose headers
+// aren't a `Headers` object with a `.get()` method.
+describe("parseRetryAfterValue", () => {
+	it("should parse a raw delta-seconds string", ({ expect }) => {
+		expect(parseRetryAfterValue("30")).toBe(30_000);
+	});
+
+	it("should return undefined for null/undefined", ({ expect }) => {
+		expect(parseRetryAfterValue(null)).toBeUndefined();
+		expect(parseRetryAfterValue(undefined)).toBeUndefined();
+	});
+});
+
+describe("throwFetchError retryAfterMs", () => {
+	it("hoists retryAfterMs onto the thrown APIError", ({ expect }) => {
+		expect.assertions(2);
+		try {
+			throwFetchError(
+				"/some/resource",
+				{
+					success: false,
+					result: null,
+					errors: [{ code: 10013, message: "rate limited" }],
+				},
+				429,
+				30_000
+			);
+		} catch (err) {
+			expect(err).toMatchObject({ retryAfterMs: 30_000 });
+			const error = err as { notes: { text: string }[] };
+			const retryNote = error.notes.find((n) => n.text.includes("Retry-After"));
+			expect(retryNote?.text).toMatch(/30 second/);
+		}
+	});
+
+	it("leaves retryAfterMs undefined when no header was present", ({
+		expect,
+	}) => {
+		expect.assertions(1);
+		try {
+			throwFetchError(
+				"/some/resource",
+				{
+					success: false,
+					result: null,
+					errors: [{ code: 1000, message: "some error" }],
+				},
+				400
+			);
+		} catch (err) {
+			expect(err).toMatchObject({ retryAfterMs: undefined });
+		}
+	});
+});
+
+describe("APIError.isRetryable", () => {
+	// isRetryable() stays 5xx-only: a caller retrying immediately on `true`
+	// with no backoff must not see a 429 as retryable. 429 handling lives in
+	// retryOnAPIFailure() instead, which knows about retryAfterMs/backoff.
+	it("should not consider a 429 retryable", ({ expect }) => {
+		const err = new APIError({
+			status: 429,
+			text: "rate limited",
+			telemetryMessage: false,
+		});
+		expect(err.isRetryable()).toBe(false);
+	});
+
+	it("should consider 5xx retryable", ({ expect }) => {
+		const err = new APIError({
+			status: 503,
+			text: "server error",
+			telemetryMessage: false,
+		});
+		expect(err.isRetryable()).toBe(true);
 	});
 });

--- a/packages/wrangler/src/__tests__/cfetch-internal.test.ts
+++ b/packages/wrangler/src/__tests__/cfetch-internal.test.ts
@@ -6,9 +6,9 @@ import {
 } from "@cloudflare/workers-utils";
 import { http, HttpResponse } from "msw";
 import { describe, it } from "vitest";
-import { fetchGraphqlResult } from "../cfetch";
+import { fetchGraphqlResult, fetchResult } from "../cfetch";
 import { mockAccountId, mockApiToken } from "./helpers/mock-account-id";
-import { msw } from "./helpers/msw";
+import { createFetchResult, msw } from "./helpers/msw";
 
 describe("isWAFBlockResponse", () => {
 	it("should detect a WAF-mitigated response", ({ expect }) => {
@@ -250,6 +250,76 @@ describe("fetchInternal WAF block detection", () => {
 				n.text.includes("Cloudflare Ray ID:")
 			);
 			expect(rayIdNote).toBeUndefined();
+		}
+	});
+});
+
+describe("fetchResult 429 Retry-After handling", () => {
+	mockAccountId({ accountId: null });
+	mockApiToken();
+
+	it("should hoist a delta-seconds Retry-After header onto the thrown APIError", async ({
+		expect,
+	}) => {
+		msw.use(
+			http.post(
+				"*/some/resource",
+				() =>
+					HttpResponse.json(
+						createFetchResult(null, false, [
+							{ code: 10013, message: "rate limited" },
+						]),
+						{ status: 429, headers: { "Retry-After": "42" } }
+					),
+				{ once: true }
+			)
+		);
+		try {
+			await fetchResult(COMPLIANCE_REGION_CONFIG_UNKNOWN, "/some/resource", {
+				method: "POST",
+			});
+			expect.unreachable("should have thrown");
+		} catch (e) {
+			const error = e as {
+				status?: number;
+				retryAfterMs?: number;
+				notes: { text: string }[];
+			};
+			expect(error.status).toBe(429);
+			expect(error.retryAfterMs).toBe(42_000);
+			const retryNote = error.notes.find((n) => n.text.includes("Retry-After"));
+			expect(retryNote?.text).toBe(
+				'The API responded with a "Retry-After" header indicating you should wait 42 second(s) before retrying.'
+			);
+		}
+	});
+
+	it("should leave retryAfterMs undefined when no Retry-After header is present", async ({
+		expect,
+	}) => {
+		msw.use(
+			http.post(
+				"*/some/other-resource",
+				() =>
+					HttpResponse.json(
+						createFetchResult(null, false, [
+							{ code: 10013, message: "rate limited" },
+						]),
+						{ status: 429 }
+					),
+				{ once: true }
+			)
+		);
+		try {
+			await fetchResult(
+				COMPLIANCE_REGION_CONFIG_UNKNOWN,
+				"/some/other-resource",
+				{ method: "POST" }
+			);
+			expect.unreachable("should have thrown");
+		} catch (e) {
+			const error = e as { retryAfterMs?: number };
+			expect(error.retryAfterMs).toBeUndefined();
 		}
 	});
 });

--- a/packages/wrangler/src/__tests__/core/handle-errors.test.ts
+++ b/packages/wrangler/src/__tests__/core/handle-errors.test.ts
@@ -1,4 +1,5 @@
 import { APIError, ParseError } from "@cloudflare/workers-utils";
+import { Cloudflare } from "cloudflare";
 import { beforeEach, describe, it, vi } from "vitest";
 import {
 	getErrorType,
@@ -812,6 +813,39 @@ describe("handleError", () => {
 
 			expect(std.err).toContain("A file or directory could not be found");
 			expect(std.err).toContain("Missing file or directory: .wrangler");
+		});
+	});
+
+	describe("Cloudflare SDK errors", () => {
+		it("should surface the Retry-After header from a 429 SDK error", async ({
+			expect,
+		}) => {
+			const error = new Cloudflare.APIError(
+				429,
+				{ errors: [{ message: "rate limited" }] },
+				"rate limited",
+				{ "retry-after": "42" }
+			);
+
+			await handleError(error, {}, []);
+
+			expect(std.err).toContain("Retry-After");
+			expect(std.err).toContain("42 second(s)");
+		});
+
+		it("should not add a Retry-After note when the header is absent", async ({
+			expect,
+		}) => {
+			const error = new Cloudflare.APIError(
+				500,
+				{ errors: [{ message: "server error" }] },
+				"server error",
+				{}
+			);
+
+			await handleError(error, {}, []);
+
+			expect(std.err).not.toContain("Retry-After");
 		});
 	});
 });

--- a/packages/wrangler/src/__tests__/output.test.ts
+++ b/packages/wrangler/src/__tests__/output.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-empty-object-type -- Type augmentation interfaces intentionally left empty */
 import { readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
-import { FatalError } from "@cloudflare/workers-utils";
+import { APIError, FatalError } from "@cloudflare/workers-utils";
 import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
 /* eslint-disable-next-line no-restricted-imports --
  * Uses expect in MSW handlers outside test callbacks
@@ -13,9 +13,13 @@ import { mockConsoleMethods } from "./helpers/mock-console";
 import { runWrangler } from "./helpers/run-wrangler";
 import type { OutputEntry } from "../output";
 
+const { mockWhoami } = vi.hoisted(() => ({ mockWhoami: vi.fn() }));
+vi.mock("../user/whoami", () => ({ whoami: mockWhoami }));
+
 describe("writeOutput()", () => {
 	runInTempDir({ homedir: "home" });
 	afterEach(clearOutputFilePath);
+	afterEach(() => mockWhoami.mockReset());
 	mockConsoleMethods();
 
 	it("should do nothing with no env vars set", () => {
@@ -283,15 +287,11 @@ describe("writeOutput()", () => {
 	});
 
 	it("should write an error log when a handler throws an error", async () => {
-		vi.mock("../user/whoami", () => {
-			return {
-				whoami: vi.fn().mockImplementation(() => {
-					throw new FatalError("A request to the Cloudflare API failed.", {
-						code: 10211,
-						telemetryMessage: false,
-					});
-				}),
-			};
+		mockWhoami.mockImplementation(() => {
+			throw new FatalError("A request to the Cloudflare API failed.", {
+				code: 10211,
+				telemetryMessage: false,
+			});
 		});
 
 		const WRANGLER_OUTPUT_FILE_PATH = "output.json";
@@ -313,6 +313,37 @@ describe("writeOutput()", () => {
 			// excluding timestamp
 			message: "A request to the Cloudflare API failed.",
 			code: 10211,
+		});
+		expect(entries[1].retry_after_ms).toBeUndefined();
+	});
+
+	it("should include retry_after_ms in the error log when the failure carries a Retry-After duration", async () => {
+		mockWhoami.mockImplementation(() => {
+			const error = new APIError({
+				text: "A request to the Cloudflare API failed.",
+				status: 429,
+				telemetryMessage: false,
+			});
+			error.retryAfterMs = 12_345;
+			throw error;
+		});
+
+		const WRANGLER_OUTPUT_FILE_PATH = "output.json";
+		vi.stubEnv("WRANGLER_OUTPUT_FILE_DIRECTORY", "");
+		vi.stubEnv("WRANGLER_OUTPUT_FILE_PATH", WRANGLER_OUTPUT_FILE_PATH);
+
+		await expect(runWrangler("whoami")).rejects.toThrow();
+
+		const outputFile = readFileSync(WRANGLER_OUTPUT_FILE_PATH, "utf8");
+		const entries = outputFile
+			.split("\n")
+			.filter(Boolean)
+			.map((e) => JSON.parse(e));
+		expect(entries).toHaveLength(2);
+		expect(entries[1]).toMatchObject({
+			version: 1,
+			type: "command-failed",
+			retry_after_ms: 12_345,
 		});
 	});
 });

--- a/packages/wrangler/src/__tests__/utils/retry.test.ts
+++ b/packages/wrangler/src/__tests__/utils/retry.test.ts
@@ -61,10 +61,152 @@ describe("retryOnAPIFailure", () => {
 			  "APIError: 500 error",
 			  "Retrying API call after error...",
 			  "APIError: 500 error",
-			  "Retrying API call after error...",
-			  "APIError: 500 error",
 			]
 		`);
+	});
+
+	it("should retry 429 errors and succeed if the 3rd try succeeds", async ({
+		expect,
+	}) => {
+		let attempts = 0;
+
+		await retryOnAPIFailure(() => {
+			attempts++;
+			if (attempts < 3) {
+				throw new APIError({
+					status: 429,
+					text: "429 error",
+					telemetryMessage: false,
+				});
+			}
+		});
+		expect(attempts).toBe(3);
+	});
+
+	it("should wait for the duration in retryAfterMs instead of the computed backoff", async ({
+		expect,
+	}) => {
+		let attempts = 0;
+		const start = Date.now();
+
+		// Pass a large initial `backoff` (3s) so that, if `retryAfterMs` were
+		// *not* being honoured, this test would take several seconds. The
+		// thrown error's `retryAfterMs` (10ms) should take precedence.
+		await retryOnAPIFailure(
+			() => {
+				attempts++;
+				if (attempts < 2) {
+					const err = new APIError({
+						status: 429,
+						text: "429 error",
+						telemetryMessage: false,
+					});
+					err.retryAfterMs = 10;
+					throw err;
+				}
+			},
+			3000,
+			2
+		);
+
+		expect(attempts).toBe(2);
+		// Comfortably above the 10ms retryAfterMs (plus up to 1s jitter), but
+		// well below the 3s backoff that would apply if retryAfterMs were ignored.
+		expect(Date.now() - start).toBeLessThan(2000);
+	});
+
+	it("should honour Retry-After on 5xx errors too, instead of the computed backoff", async ({
+		expect,
+	}) => {
+		let attempts = 0;
+		const start = Date.now();
+
+		await retryOnAPIFailure(
+			() => {
+				attempts++;
+				if (attempts < 2) {
+					const err = new APIError({
+						status: 500,
+						text: "500 error",
+						telemetryMessage: false,
+					});
+					err.retryAfterMs = 10;
+					throw err;
+				}
+			},
+			3000,
+			2
+		);
+
+		expect(attempts).toBe(2);
+		expect(Date.now() - start).toBeLessThan(2000);
+	});
+
+	it("should fail fast without retrying when Retry-After exceeds the cap", async ({
+		expect,
+	}) => {
+		let attempts = 0;
+
+		await expect(() =>
+			retryOnAPIFailure(() => {
+				attempts++;
+				const err = new APIError({
+					status: 429,
+					text: "429 error",
+					telemetryMessage: false,
+				});
+				// Longer than MAX_RETRY_AFTER_MS (60s) — we should not block on it.
+				err.retryAfterMs = 120_000;
+				throw err;
+			})
+		).rejects.toMatchObject({ retryAfterMs: 120_000 });
+		expect(attempts).toBe(1);
+	});
+
+	it("should fail fast on a 5xx whose Retry-After exceeds the cap, rather than exhausting retries", async ({
+		expect,
+	}) => {
+		let attempts = 0;
+
+		await expect(() =>
+			retryOnAPIFailure(() => {
+				attempts++;
+				const err = new APIError({
+					status: 503,
+					text: "503 error",
+					telemetryMessage: false,
+				});
+				// Longer than MAX_RETRY_AFTER_MS (60s) — we should not block on it,
+				// even though 5xx errors are otherwise always retried.
+				err.retryAfterMs = 120_000;
+				throw err;
+			})
+		).rejects.toMatchObject({ retryAfterMs: 120_000 });
+		expect(attempts).toBe(1);
+	});
+
+	it("should log a message when waiting on a Retry-After header", async ({
+		expect,
+	}) => {
+		let attempts = 0;
+
+		await retryOnAPIFailure(() => {
+			attempts++;
+			if (attempts < 2) {
+				const err = new APIError({
+					status: 429,
+					text: "429 error",
+					telemetryMessage: false,
+				});
+				err.retryAfterMs = 0;
+				throw err;
+			}
+		});
+
+		expect(attempts).toBe(2);
+		expect(std.info).toContain(
+			'Received a "Retry-After" header from the Cloudflare API. Waiting 0 second(s) before retrying...'
+		);
 	});
 
 	it("should not retry non-5xx errors", async ({ expect }) => {
@@ -96,7 +238,6 @@ describe("retryOnAPIFailure", () => {
 		expect(attempts).toBe(3);
 		expect(getRetryAndErrorLogs(std.debug)).toMatchInlineSnapshot(`
 			[
-			  "Retrying API call after error...",
 			  "Retrying API call after error...",
 			  "Retrying API call after error...",
 			]
@@ -185,7 +326,6 @@ describe("retryOnAPIFailure", () => {
 			[
 			  "Retrying API call after error...",
 			  "Retrying API call after error...",
-			  "Retrying API call after error...",
 			]
 		`);
 	});
@@ -217,8 +357,6 @@ describe("retryOnAPIFailure", () => {
 		expect(checkedCustomIsRetryable).toBe(true);
 		expect(getRetryAndErrorLogs(std.debug)).toMatchInlineSnapshot(`
 			[
-			  "Retrying API call after error...",
-			  "CustomAPIError: 401 error",
 			  "Retrying API call after error...",
 			  "CustomAPIError: 401 error",
 			  "Retrying API call after error...",

--- a/packages/wrangler/src/__tests__/versions/versions.upload.test.ts
+++ b/packages/wrangler/src/__tests__/versions/versions.upload.test.ts
@@ -2462,8 +2462,9 @@ describe("versions upload", () => {
 							createFetchResult(null, false, [
 								{ code: 10001, message: "some other API error" },
 							]),
-							// 4xx so the upload isn't retried (retryOnAPIFailure
-							// only retries 5xx), keeping this test fast.
+							// 400 so the upload isn't retried (retryOnAPIFailure
+							// retries 5xx and 429, not other 4xx), keeping this
+							// test fast.
 							{ status: 400 }
 						),
 					{ once: true }

--- a/packages/wrangler/src/browser-rendering/utils.ts
+++ b/packages/wrangler/src/browser-rendering/utils.ts
@@ -1,4 +1,4 @@
-import { APIError } from "@cloudflare/workers-utils";
+import { APIError, parseRetryAfterMs } from "@cloudflare/workers-utils";
 import { performApiFetch } from "../cfetch";
 import type { ComplianceConfig } from "@cloudflare/workers-utils";
 
@@ -61,6 +61,7 @@ export async function fetchBrowserRendering<ResponseType>(
 			text: `Browser Run API error: ${errorMessage}`,
 			notes: [{ text: `${method} ${url} -> ${response.status}` }],
 			status: response.status,
+			retryAfterMs: parseRetryAfterMs(response.headers),
 			telemetryMessage: false,
 		});
 	}
@@ -76,6 +77,7 @@ export async function fetchBrowserRendering<ResponseType>(
 				{ text: `${method} ${url} -> ${response.status}` },
 			],
 			status: response.status,
+			retryAfterMs: parseRetryAfterMs(response.headers),
 			telemetryMessage: false,
 		});
 	}

--- a/packages/wrangler/src/cfetch/index.ts
+++ b/packages/wrangler/src/cfetch/index.ts
@@ -109,9 +109,16 @@ export async function fetchPagedListResult<ResponseType>(
 		queryParams = new URLSearchParams(queryParams);
 		queryParams.set("page", String(page));
 
-		const { response: json, status } = await fetchInternal<
-			FetchResult<ResponseType[]>
-		>(complianceConfig, resource, init, queryParams);
+		const {
+			response: json,
+			status,
+			retryAfterMs,
+		} = await fetchInternal<FetchResult<ResponseType[]>>(
+			complianceConfig,
+			resource,
+			init,
+			queryParams
+		);
 		if (json.success) {
 			results.push(...json.result);
 			if (hasMorePages(json.result_info)) {
@@ -120,7 +127,7 @@ export async function fetchPagedListResult<ResponseType>(
 				getMoreResults = false;
 			}
 		} else {
-			throwFetchError(resource, json, status);
+			throwFetchError(resource, json, status, retryAfterMs);
 		}
 	}
 	return results;
@@ -149,9 +156,16 @@ export async function fetchCursorPage<ResponseType>(
 			pageQueryParams.set("cursor", cursor);
 		}
 
-		const { response: json, status } = await fetchInternal<
-			FetchResult<ResponseType>
-		>(complianceConfig, resource, init, pageQueryParams);
+		const {
+			response: json,
+			status,
+			retryAfterMs,
+		} = await fetchInternal<FetchResult<ResponseType>>(
+			complianceConfig,
+			resource,
+			init,
+			pageQueryParams
+		);
 
 		if (json.success) {
 			if (currentPage === page) {
@@ -168,7 +182,7 @@ export async function fetchCursorPage<ResponseType>(
 				break;
 			}
 		} else {
-			throwFetchError(resource, json, status);
+			throwFetchError(resource, json, status, retryAfterMs);
 		}
 	}
 

--- a/packages/wrangler/src/cfetch/internal.ts
+++ b/packages/wrangler/src/cfetch/internal.ts
@@ -4,6 +4,7 @@ import {
 	fetchInternalBase,
 	fetchKVGetValueBase,
 	getCloudflareApiBaseUrl,
+	parseRetryAfterMs,
 	performApiFetchBase,
 	UserError,
 } from "@cloudflare/workers-utils";
@@ -127,7 +128,11 @@ export async function fetchInternal<ResponseType>(
 	queryParams?: URLSearchParams,
 	abortSignal?: AbortSignal,
 	apiToken?: ApiCredentials
-): Promise<{ response: ResponseType; status: number }> {
+): Promise<{
+	response: ResponseType;
+	status: number;
+	retryAfterMs?: number;
+}> {
 	apiToken = await resolveCredentials(complianceConfig, apiToken);
 	return fetchInternalBase(
 		complianceConfig,
@@ -288,6 +293,7 @@ export async function fetchR2Objects(
 			text: `Failed to fetch ${resource} - ${response.status}: ${response.statusText};`,
 			status: response.status,
 			notes,
+			retryAfterMs: parseRetryAfterMs(response.headers),
 			telemetryMessage: false,
 		});
 		if (errorCode !== undefined) {

--- a/packages/wrangler/src/core/handle-errors.ts
+++ b/packages/wrangler/src/core/handle-errors.ts
@@ -6,6 +6,7 @@ import {
 	COMPLIANCE_REGION_CONFIG_UNKNOWN,
 	JsonFriendlyFatalError,
 	ParseError,
+	parseRetryAfterValue,
 	renderError,
 	UserError,
 } from "@cloudflare/workers-utils";
@@ -609,15 +610,25 @@ export async function handleError(
 		mayReport = false;
 		logBuildFailure(e.cause.errors, e.cause.warnings);
 	} else if (e instanceof Cloudflare.APIError) {
-		const error = new APIError({
-			text: `A request to the Cloudflare API failed.`,
-			notes: [...e.errors.map((err) => ({ text: renderError(err) }))],
-			telemetryMessage: false,
-		});
-		error.notes.push({
+		const retryAfterMs = parseRetryAfterValue(e.headers?.["retry-after"]);
+		const notes = [...e.errors.map((err) => ({ text: renderError(err) }))];
+		if (retryAfterMs !== undefined) {
+			notes.push({
+				text: `The API responded with a "Retry-After" header indicating you should wait ${Math.ceil(retryAfterMs / 1000)} second(s) before retrying.`,
+			});
+		}
+		notes.push({
 			text: "\nIf you think this is a bug, please open an issue at: https://github.com/cloudflare/workers-sdk/issues/new/choose",
 		});
-		logger.error(error);
+		logger.error(
+			new APIError({
+				text: `A request to the Cloudflare API failed.`,
+				notes,
+				status: e.status,
+				retryAfterMs,
+				telemetryMessage: false,
+			})
+		);
 	} else {
 		if (
 			// Is this a StartDevEnv error event? If so, unwrap the cause, which is usually the user-recognisable error

--- a/packages/wrangler/src/core/register-yargs-command.ts
+++ b/packages/wrangler/src/core/register-yargs-command.ts
@@ -7,6 +7,7 @@ import {
 	getCloudflareEnv,
 	getWranglerHideBanner,
 	experimental_readRawConfig,
+	parseRetryAfterValue,
 	UserError,
 } from "@cloudflare/workers-utils";
 import { isNonInteractiveOrCI } from "@cloudflare/workers-utils";
@@ -426,9 +427,34 @@ function createHandler(def: InternalCommandDefinition, argv: string[]) {
 					version: 1,
 					code,
 					message: outputErr.message,
+					retry_after_ms: getRetryAfterMs(outputErr),
 				});
 			}
 			throw err;
 		}
 	};
+}
+
+/**
+ * Extract the number of milliseconds indicated by a `Retry-After` header (if
+ * any) associated with the given error, so it can be written to the Wrangler
+ * output file as structured JSON rather than requiring consumers to parse it
+ * out of the human-readable error message.
+ *
+ * Handles both:
+ * - `APIError`s raised internally by Wrangler's own fetch helpers, which
+ *   already have `retryAfterMs` parsed and attached directly.
+ * - Errors raised by the `cloudflare` SDK client, which expose the raw
+ *   response headers (with a lowercased `retry-after` key) instead.
+ */
+function getRetryAfterMs(err: Error): number | undefined {
+	if ("retryAfterMs" in err && typeof err.retryAfterMs === "number") {
+		return err.retryAfterMs;
+	}
+	if ("headers" in err && err.headers && typeof err.headers === "object") {
+		return parseRetryAfterValue(
+			(err.headers as Record<string, string | undefined>)["retry-after"]
+		);
+	}
+	return undefined;
 }

--- a/packages/wrangler/src/output.ts
+++ b/packages/wrangler/src/output.ts
@@ -197,4 +197,6 @@ interface OutputEntryCommandFailed extends OutputEntryBase<"command-failed"> {
 	code: number | undefined;
 	/** The message in the error. */
 	message: string | undefined;
+	/** How many milliseconds to retry the operation after if available. */
+	retry_after_ms: number | undefined;
 }


### PR DESCRIPTION
The Cloudflare API returns 429 errors with a rate limit header called https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Retry-After

This isn't always set - but in certain cases it is. When it is available we should follow it up to a certain limit to avoid waiting / blocking for too long. I set the limit to be up to a maximum of 60s for now (open to suggestions here). When reaching 60s the request will fail with the original error.

I kept the `isRetryable` returning `false` for 429 errors in case there was any existing clients as APIError is exported from the public @cloudflare/workers-utils package. If a caller was doing (err.isRetryable()) retryNow() with no backoff it would send another request immediately, making more of a mess. So I put the handling code in the one place that could handle this backoff properly.

<img width="256" height="256" alt="a robin making a pull request" src="https://github.com/user-attachments/assets/7d7a6172-57ad-45d0-b900-a5ebb5941055" />

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [X] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: Internal error handling improvements not worth documenting.


<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- If you are an AI agent or LLM, and you are adding this PR without direct human supervision, thank you! Please uncomment the following block. This is so the maintainers know how to expect you to respond.

> [!NOTE]
> This is a contribution from an AI agent: <insert name here>, <insert LLM model here if different>.

-->
