### PR TITLE
[vitest-pool-workers] Make workerd verbose logging configurable

### DIFF
--- a/.changeset/quiet-taxis-listen.md
+++ b/.changeset/quiet-taxis-listen.md
@@ -1,0 +1,7 @@
+---
+"@cloudflare/vitest-pool-workers": minor
+---
+
+Add a `verbose` option to `cloudflareTest()` and `cloudflarePool()` configuration
+
+Set `verbose: false` to suppress verbose workerd runtime logs, such as caught Durable Object RPC errors. The option defaults to `true` to preserve existing output.

--- a/packages/vitest-pool-workers/src/pool/config.ts
+++ b/packages/vitest-pool-workers/src/pool/config.ts
@@ -47,6 +47,10 @@ const WorkersPoolOptionsSchema = z.object({
 	 */
 	remoteBindings: z.boolean().default(true),
 	/**
+	 * Enables verbose workerd logging. Defaults to `true`.
+	 */
+	verbose: z.boolean().optional(),
+	/**
 	 * Additional exports.
 	 * A map of module exports to be made available on the `ctx.exports`
 	 * that cannot be automatically inferred by analyzing the Worker source code.

--- a/packages/vitest-pool-workers/src/pool/index.ts
+++ b/packages/vitest-pool-workers/src/pool/index.ts
@@ -625,7 +625,6 @@ async function buildProjectWorkerOptions(
 
 const SHARED_MINIFLARE_OPTIONS: SharedOptions = {
 	log: mfLog,
-	verbose: true,
 	handleStructuredLogs,
 	unsafeStickyBlobs: true,
 } satisfies Partial<MiniflareOptions>;
@@ -696,6 +695,7 @@ async function buildProjectMiniflareOptions(
 
 	return {
 		...SHARED_MINIFLARE_OPTIONS,
+		verbose: customOptions.verbose ?? true,
 		inspectorPort,
 		unsafeModuleFallbackService: moduleFallbackService,
 		workers: [runnerWorker, ...auxiliaryWorkers],

--- a/packages/vitest-pool-workers/test/structured-logs.test.ts
+++ b/packages/vitest-pool-workers/test/structured-logs.test.ts
@@ -1,6 +1,46 @@
 import dedent from "ts-dedent";
 import { test, vitestConfig } from "./helpers";
 
+const caughtRpcError = "__CAUGHT_DURABLE_OBJECT_RPC_ERROR__";
+const durableObjectFiles = {
+	"index.ts": dedent`
+		import { DurableObject } from "cloudflare:workers";
+
+		export class ThrowingDurableObject extends DurableObject {
+			throwRpcError() {
+				throw new Error("${caughtRpcError}");
+			}
+		}
+	`,
+	"index.test.ts": dedent`
+		import { env } from "cloudflare:test";
+		import { it } from "vitest";
+
+		it("catches a Durable Object RPC error", async ({ expect }) => {
+			const stub = env.THROWER.getByName("thrower");
+			let caught;
+			try {
+				await stub.throwRpcError();
+			} catch (error) {
+				caught = error;
+			}
+			expect(caught).toBeInstanceOf(Error);
+		});
+	`,
+};
+
+function durableObjectConfig(verbose?: boolean): string {
+	return vitestConfig({
+		main: "./index.ts",
+		verbose,
+		miniflare: {
+			compatibilityDate: "2025-12-02",
+			compatibilityFlags: ["nodejs_compat"],
+			durableObjects: { THROWER: "ThrowingDurableObject" },
+		},
+	});
+}
+
 test("routes workerd structured logs to the correct output stream", async ({
 	expect,
 	seed,
@@ -32,4 +72,35 @@ test("routes workerd structured logs to the correct output stream", async ({
 	// handleStructuredLogs routes warn/error-level output to stderr
 	expect(result.stderr).toContain("__STDERR_WARN__");
 	expect(result.stderr).toContain("__STDERR_ERROR__");
+});
+
+test("enables verbose workerd logging by default", async ({
+	expect,
+	seed,
+	vitestRun,
+}) => {
+	await seed({
+		"vitest.config.mts": durableObjectConfig(),
+		...durableObjectFiles,
+	});
+
+	const result = await vitestRun();
+	expect(await result.exitCode).toBe(0);
+	expect(result.stdout).toContain(caughtRpcError);
+});
+
+test("passes verbose false to Miniflare", async ({
+	expect,
+	seed,
+	vitestRun,
+}) => {
+	await seed({
+		"vitest.config.mts": durableObjectConfig(false),
+		...durableObjectFiles,
+	});
+
+	const result = await vitestRun();
+	expect(await result.exitCode).toBe(0);
+	expect(result.stdout).not.toContain(caughtRpcError);
+	expect(result.stderr).not.toContain(caughtRpcError);
 });


### PR DESCRIPTION
Adds a narrow, typed `verbose` option to `cloudflareTest()` / `cloudflarePool()` configuration and forwards it to the shared Miniflare options. This allows users to set `verbose: false` when caught Durable Object RPC errors would otherwise produce workerd structured INFO logs on stdout.

The option defaults to `true`, preserving existing behavior. This intentionally does not expose `handleStructuredLogs` or other arbitrary shared Miniflare handlers.

Validation:
- `pnpm -w test:ci -F @cloudflare/vitest-pool-workers -- structured-logs.test.ts`
- `pnpm check --filter @cloudflare/vitest-pool-workers`
- `pnpm exec oxfmt --check packages/vitest-pool-workers/src/pool/config.ts packages/vitest-pool-workers/src/pool/index.ts packages/vitest-pool-workers/test/structured-logs.test.ts .changeset/quiet-taxis-listen.md`

The full package suite was also run, but currently fails unchanged on `main`: the temporary test installation resolves Vitest 4.1.10, whose output format no longer matches existing assertions in `console.test.ts`, `chunking.test.ts`, and `filtering.test.ts`. Running `console.test.ts` against a stashed clean `main` reproduced the same three failures.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: this repository's package README delegates the detailed configuration reference to `cloudflare-docs`; the public option includes inline typed documentation and a changeset.

*A picture of a cute animal (not mandatory, but encouraged)*

## Cute animal (Bodhi)

<img width="1536" height="2048" alt="0DEEFC05-C7B2-4D3B-9D44-5A9E0D770529_1_102_o" src="https://github.com/user-attachments/assets/951cc0ac-f9d7-4e67-9563-b0286afcc35a" />


<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

> [!NOTE]
> This is a contribution from an AI agent: Pi, GPT-5.6.
