### PR TITLE
fix output comparisons for e2e tests

### DIFF
--- a/packages/wrangler/e2e/remote-binding/remote-bindings-api.test.ts
+++ b/packages/wrangler/e2e/remote-binding/remote-bindings-api.test.ts
@@ -106,7 +106,7 @@ describe.skipIf(!CLOUDFLARE_ACCOUNT_ID)(
 				}
 				expect(normalizeOutput(`${error}`)).toMatchInlineSnapshot(
 					`
-					"Error: Failed to establish remote session due to an authentication issue.
+					"Error: This Worker uses bindings that need to run remotely, even when developing locally, but the remote session could not be authenticated.
 					It looks like you are authenticating via a custom API token (\`CLOUDFLARE_API_TOKEN\`) set in an environment variable.
 					The token may be invalid or lack the required permissions for this operation.
 					To fix this, verify that your token is valid and has the correct permissions.
@@ -173,7 +173,7 @@ describe.skipIf(!CLOUDFLARE_ACCOUNT_ID)(
 				}
 				expect(normalizeOutput(`${error}`)).toMatchInlineSnapshot(
 					`
-					"Error: Failed to establish remote session due to an authentication issue.
+					"Error: This Worker uses bindings that need to run remotely, even when developing locally, but the remote session could not be authenticated.
 					It looks like you are authenticating via a custom API token (\`CLOUDFLARE_API_TOKEN\`) set in an environment variable.
 					The token may be invalid or lack the required permissions for this operation.
 					To fix this, verify that your token is valid and has the correct permissions.

--- a/packages/wrangler/e2e/start-worker-auth-opts.test.ts
+++ b/packages/wrangler/e2e/start-worker-auth-opts.test.ts
@@ -190,7 +190,7 @@ describe("startWorker - auth options", { sequential: true }, () => {
 			const authErrors = emittedErrors.filter((e) =>
 				hasMatchingCauseMessage(
 					e,
-					/Failed to establish remote session due to an authentication issue/
+					/the remote session could not be authenticated./
 				)
 			);
 			expect(authErrors).toHaveLength(0);
@@ -211,7 +211,7 @@ describe("startWorker - auth options", { sequential: true }, () => {
 			const authErrors = emittedErrors.filter((e) =>
 				hasMatchingCauseMessage(
 					e,
-					/Failed to establish remote session due to an authentication issue/
+					/the remote session could not be authenticated./
 				)
 			);
 			expect(authErrors.length).toBeGreaterThan(0);


### PR DESCRIPTION
https://github.com/cloudflare/workers-sdk/pull/14806 introduced a change that broke the remote e2e tests.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: test change

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- If you are an AI agent or LLM, and you are adding this PR without direct human supervision, thank you! Please uncomment the following block. This is so the maintainers know how to expect you to respond.

> [!NOTE]
> This is a contribution from an AI agent: <insert name here>, <insert LLM model here if different>.

-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14884" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->