### PR TITLE
[create-cloudflare] Fix hello-world-workflows JS template crashing at runtime

### DIFF
--- a/.changeset/c3-workflows-js-super.md
+++ b/.changeset/c3-workflows-js-super.md
@@ -1,0 +1,7 @@
+---
+"create-cloudflare": patch
+---
+
+Fix the `hello-world-workflows` JavaScript template crashing at runtime
+
+`MyWorkflow` defined a constructor that assigned to `this` without calling `super()` first, so instantiating the Workflow threw `ReferenceError: Must call super constructor in derived class before accessing 'this'`. The constructor also took `(env)` where `WorkflowEntrypoint` is constructed with `(ctx, env)`. It was redundant in the first place — the base class already assigns `this.env` — so it has been removed, matching the TypeScript variant of the same template.

--- a/packages/create-cloudflare/templates/hello-world-workflows/js/src/index.js
+++ b/packages/create-cloudflare/templates/hello-world-workflows/js/src/index.js
@@ -23,13 +23,6 @@ import { WorkflowEntrypoint } from "cloudflare:workers";
 
 export class MyWorkflow extends WorkflowEntrypoint {
 	/**
-	 * @param {Env} env
-	 */
-	constructor(env) {
-		this.env = env;
-	}
-
-	/**
 	 * @param {WorkflowEvent<Params>} event
 	 * @param {WorkflowStep} step
 	 */


### PR DESCRIPTION
Fixes #14885.

The JavaScript variant of the `hello-world-workflows` template does not run. `MyWorkflow` assigned to `this` in its constructor without calling `super()` first, which throws in any derived class:

```
ReferenceError: Must call super constructor in derived class before accessing 'this' or returning from derived constructor
```

The constructor's signature was wrong regardless — `WorkflowEntrypoint` is constructed with `(ctx, env)`, not `(env)` — so even with a `super()` call `this.env` would have been bound to the `ctx`.

Since the base class already assigns `this.env`, the constructor was redundant. Removing it makes the JS template match the TypeScript variant of the same template, which has no constructor at all.

---

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: this is a change to a C3 template's source, which has no unit-test surface — the templates are exercised by the C3 e2e suite, which builds and runs each one. That suite covers this template and will now exercise a Workflow that actually constructs. I verified the fix directly: `node --check` passes on the template, and instantiating the old class shape throws the `ReferenceError` above while the new one constructs with `this.env` correctly populated.
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: this fixes generated template code to match its documented behaviour; no public API or documented interface changes.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14888" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->