### PR TITLE
[wrangler] Fix `types --strict-vars=false` emitting invalid TypeScript for an empty array var

### DIFF
--- a/.changeset/types-empty-array-var.md
+++ b/.changeset/types-empty-array-var.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Fix `wrangler types --strict-vars=false` emitting invalid TypeScript for an empty array var
+
+A var whose value was an empty array produced `()[]`, which is a syntax error. Because this lands in the generated `worker-configuration.d.ts`, it did not just break that one line — the whole file failed to parse, so no binding types resolved at all. An empty array now generates `unknown[]`.

--- a/packages/wrangler/src/__tests__/type-generation.test.ts
+++ b/packages/wrangler/src/__tests__/type-generation.test.ts
@@ -1864,6 +1864,7 @@ describe("generate types - CLI", () => {
 					varStr: "A from wrangler toml",
 					varArrNum: [1, 2, 3],
 					varArrMix: [1, "two", 3, true],
+					varArrEmpty: [],
 					varObj: { test: true },
 				},
 			}),
@@ -1882,6 +1883,7 @@ describe("generate types - CLI", () => {
 				varStr: string;
 				varArrNum: number[];
 				varArrMix: (boolean|number|string)[];
+				varArrEmpty: unknown[];
 				varObj: object;
 			}
 			declare namespace Cloudflare {

--- a/packages/wrangler/src/__tests__/type-generation.test.ts
+++ b/packages/wrangler/src/__tests__/type-generation.test.ts
@@ -1863,6 +1863,7 @@ describe("generate types - CLI", () => {
 					varStr: "A from wrangler toml",
 					varArrNum: [1, 2, 3],
 					varArrMix: [1, "two", 3, true],
+					varArrEmpty: [],
 					varObj: { test: true },
 				},
 			}),
@@ -1881,6 +1882,7 @@ describe("generate types - CLI", () => {
 				varStr: string;
 				varArrNum: number[];
 				varArrMix: (boolean|number|string)[];
+				varArrEmpty: unknown[];
 				varObj: object;
 			}
 			declare namespace Cloudflare {

--- a/packages/wrangler/src/type-generation/index.ts
+++ b/packages/wrangler/src/type-generation/index.ts
@@ -2017,12 +2017,19 @@ function collectAllVars(
  * @returns a string representing the types of such array
  *
  * @example
+ * `[]` => `unknown[]`
  * `[1, 2, 3]` => `number[]`
  * `[1, 2, 'three']` => `(number|string)[]`
  * `['false', true]` => `(string|boolean)[]`
  */
 function typeofArray(array: unknown[]): string {
 	const typesInArray = [...new Set(array.map((item) => typeof item))].sort();
+
+	if (typesInArray.length === 0) {
+		// An empty array tells us nothing about its element type, and joining an
+		// empty list below would emit `()[]`, which is not valid TypeScript.
+		return "unknown[]";
+	}
 
 	if (typesInArray.length === 1) {
 		return `${typesInArray[0]}[]`;


### PR DESCRIPTION
Fixes #14886.

`wrangler types --strict-vars=false` emitted `()[]` for any var whose value is an empty array. `typeofArray` derives the element types from the array's contents, so an empty array yields zero types and falls through to the join branch with an empty list — the `length === 1` and `length >= 2` cases were handled, `length === 0` was not.

Because this output lands in the generated `worker-configuration.d.ts`, the impact is not limited to the one line: `()[]` is a syntax error, so the entire file fails to parse and no binding types resolve for the project.

An empty array now generates `unknown[]`. `never[]` would also be valid, but would make appends a type error for anyone who populates the var at runtime.

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: this fixes invalid output from an existing documented flag; the flag's behaviour is otherwise unchanged.

The empty-array case is covered by adding `varArrEmpty: []` to the existing `should allow opting out of strict-vars` test, which is the canonical enumeration of var shapes under `--strict-vars=false`. I confirmed it fails without the source change:

```
- 	varArrEmpty: unknown[];
+ 	varArrEmpty: ()[];
```

Full `type-generation.test.ts` suite passes (112 tests).

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14889" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->