### PR TITLE
fix(vite-plugin-cloudflare): pin npm wasm runtime override

### DIFF
--- a/packages/vite-plugin-cloudflare/e2e/helpers.ts
+++ b/packages/vite-plugin-cloudflare/e2e/helpers.ts
@@ -62,7 +62,7 @@ export function seed(
 			errorOnExist: true,
 		});
 		debuglog("Fixture copied to " + projectPath);
-		await updateVitePluginAndWranglerVersion(projectPath);
+		await updateVitePluginAndWranglerVersion(projectPath, pm);
 		debuglog("Fixing up replacements in seeded files");
 		await fixupReplacements(projectPath, replacements);
 		debuglog("Updated vite-plugin version in package.json");
@@ -192,7 +192,10 @@ function wrap(proc: childProcess.ChildProcess): Process {
 	return wrappedProc;
 }
 
-async function updateVitePluginAndWranglerVersion(projectPath: string) {
+async function updateVitePluginAndWranglerVersion(
+	projectPath: string,
+	pm: "pnpm" | "yarn" | "npm"
+) {
 	const pkg = JSON.parse(
 		await fs.readFile(path.resolve(projectPath, "package.json"), "utf8")
 	);
@@ -205,6 +208,14 @@ async function updateVitePluginAndWranglerVersion(projectPath: string) {
 		if (pkg[field]?.["wrangler"] === "*") {
 			pkg[field]["wrangler"] = wranglerPackage.version;
 		}
+	}
+	if (pm === "npm") {
+		// @napi-rs/wasm-runtime 1.2.0 requires @emnapi 2, but Rolldown 1.1.5's
+		// WASI binding requires @emnapi 1, causing npm's strict resolver to fail.
+		pkg.overrides = {
+			...pkg.overrides,
+			"@napi-rs/wasm-runtime": "1.1.6",
+		};
 	}
 	await fs.writeFile(
 		path.resolve(projectPath, "package.json"),


### PR DESCRIPTION
The Vite plugin E2E npm fixtures started resolving `@napi-rs/wasm-runtime@1.2.0`, whose `@emnapi` v2 peer dependencies conflict with the `@emnapi` v1 dependencies required by Rolldown 1.1.5's WASI binding.

Pin `@napi-rs/wasm-runtime` to 1.1.6 only in npm-backed E2E fixture installs. This preserves strict peer dependency validation while avoiding the incompatible upstream release.

Validation:

- `pnpm --filter @cloudflare/vite-plugin check:type`
- `pnpm exec oxlint --deny-warnings --type-aware packages/vite-plugin-cloudflare/e2e/helpers.ts`
- Isolated `npm install --strict-peer-deps` using Vite 8.1.5 and the override

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: This only adjusts dependency resolution in the Vite plugin E2E test harness.

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- If you are an AI agent or LLM, and you are adding this PR without direct human supervision, thank you! Please uncomment the following block. This is so the maintainers know how to expect you to respond.

> [!NOTE]
> This is a contribution from an AI agent: <insert name here>, <insert LLM model here if different>.

-->
