### PR TITLE
[wrangler] `useConfigRedirectIfAvailable` for "wrangler triggers deploy"

### DIFF
--- a/.changeset/tidy-pears-travel.md
+++ b/.changeset/tidy-pears-travel.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Fix `wrangler triggers deploy` to use Vite-generated redirected configuration
+
+The command now reads `.wrangler/deploy/config.json`, matching `wrangler deploy` and `wrangler versions upload`, so generated Worker names and trigger settings are applied.

--- a/packages/wrangler/src/__tests__/triggers.test.ts
+++ b/packages/wrangler/src/__tests__/triggers.test.ts
@@ -1,0 +1,31 @@
+import {
+	runInTempDir,
+	writeWranglerConfig,
+} from "@cloudflare/workers-utils/test-helpers";
+import { describe, it } from "vitest";
+import { mockConsoleMethods } from "./helpers/mock-console";
+import { runWrangler } from "./helpers/run-wrangler";
+import { writeRedirectedWranglerConfig } from "./helpers/write-wrangler-config";
+
+describe("triggers deploy", () => {
+	runInTempDir();
+	const std = mockConsoleMethods();
+
+	it("uses a redirected deploy configuration", async ({ expect }) => {
+		writeWranglerConfig({ name: undefined });
+		writeRedirectedWranglerConfig(
+			{
+				name: "generated-worker",
+				userConfigPath: "./wrangler.toml",
+			},
+			"./dist/wrangler.json"
+		);
+
+		await runWrangler("triggers deploy --dry-run");
+
+		expect(std.info).toContain(
+			'Using redirected Wrangler configuration.\n - Configuration being used: "dist/wrangler.json"'
+		);
+		expect(std.out).toContain("--dry-run: exiting now.");
+	});
+});

--- a/packages/wrangler/src/__tests__/triggers.test.ts
+++ b/packages/wrangler/src/__tests__/triggers.test.ts
@@ -1,11 +1,11 @@
 import {
 	runInTempDir,
+	writeRedirectedWranglerConfig,
 	writeWranglerConfig,
 } from "@cloudflare/workers-utils/test-helpers";
 import { describe, it } from "vitest";
 import { mockConsoleMethods } from "./helpers/mock-console";
 import { runWrangler } from "./helpers/run-wrangler";
-import { writeRedirectedWranglerConfig } from "./helpers/write-wrangler-config";
 
 describe("triggers deploy", () => {
 	runInTempDir();

--- a/packages/wrangler/src/triggers/index.ts
+++ b/packages/wrangler/src/triggers/index.ts
@@ -55,6 +55,7 @@ export const triggersDeployCommand = createCommand({
 	},
 	behaviour: {
 		supportTemporary: true,
+		useConfigRedirectIfAvailable: true,
 		warnIfMultipleEnvsConfiguredButNoneSpecified: true,
 		suggestSkillsAfterHandler: true,
 	},


### PR DESCRIPTION
`wrangler triggers deploy` did not opt into the deploy configuration redirect used by `wrangler deploy` and `wrangler versions upload`. As a result, Vite-generated, mode-specific Worker configuration in `.wrangler/deploy/config.json` was ignored, which could leave the command without the generated Worker name.

This enables the existing redirect behavior for `triggers deploy` (that already exists with `wrangler deploy` and `wrangler versions upload`) and adds focused regression coverage proving that the command loads the redirected generated config.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: This fixes an existing internal configuration redirect contract without changing the public interface.

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- If you are an AI agent or LLM, and you are adding this PR without direct human supervision, thank you! Please uncomment the following block. This is so the maintainers know how to expect you to respond.

> [!NOTE]
> This is a contribution from an AI agent: Codex, 5.6 Sol Light.

-->
