### PR TITLE
[wrangler] Add SQL example to the agent-facing observability query hint

### DIFF
--- a/.changeset/local-explorer-query-hint-example.md
+++ b/.changeset/local-explorer-query-hint-example.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Improve the agent-facing Local Explorer hint for the observability query endpoint
+
+When a `wrangler dev` session is detected as running inside an AI agent, the hint for `POST /local/observability/query` now explains that the endpoint takes a read-only SQL query (SELECT/WITH only) over the captured `spans` and `logs` tables, notes that `attributes` is JSON (read via `json(attributes)`), and includes a copy-pasteable `curl` example. The full OpenAPI schema is demoted to a last-resort footer so agents reach for the small, actionable example first instead of fetching the large schema.

--- a/packages/wrangler/src/__tests__/dev/start-dev.test.ts
+++ b/packages/wrangler/src/__tests__/dev/start-dev.test.ts
@@ -114,7 +114,7 @@ describe("startDev", () => {
 		);
 		// The query route ships a copy-pasteable example that also documents the request body shape.
 		expect(std.out).toContain(
-			`curl -X POST http://127.0.0.1:8787/cdn-cgi/explorer/api/local/observability/query -d '{"sql":"SELECT service, name, outcome, duration_ms FROM spans WHERE parent_id IS NULL LIMIT 20"}'`
+			`curl -X POST http://127.0.0.1:8787/cdn-cgi/explorer/api/local/observability/query -H 'Content-Type: application/json' -d '{"sql":"SELECT service, name, outcome, duration_ms FROM spans WHERE parent_id IS NULL LIMIT 20"}'`
 		);
 		// The OpenAPI schema is demoted to a last-resort footer after the functional routes.
 		expect(std.out).toContain(

--- a/packages/wrangler/src/__tests__/dev/start-dev.test.ts
+++ b/packages/wrangler/src/__tests__/dev/start-dev.test.ts
@@ -110,7 +110,15 @@ describe("startDev", () => {
 			"GET http://127.0.0.1:8787/cdn-cgi/explorer/api/local/workers - local Workers and bindings"
 		);
 		expect(std.out).toContain(
-			"POST http://127.0.0.1:8787/cdn-cgi/explorer/api/local/observability/query - query request traces and console logs"
+			"POST http://127.0.0.1:8787/cdn-cgi/explorer/api/local/observability/query - run a read-only SQL query (SELECT/WITH only) over captured request traces and console logs. Tables: spans, logs (read attributes via json(attributes)). Example:"
+		);
+		// The query route ships a copy-pasteable example that also documents the request body shape.
+		expect(std.out).toContain(
+			`curl -X POST http://127.0.0.1:8787/cdn-cgi/explorer/api/local/observability/query -d '{"sql":"SELECT service, name, outcome, duration_ms FROM spans WHERE parent_id IS NULL LIMIT 20"}'`
+		);
+		// The OpenAPI schema is demoted to a last-resort footer after the functional routes.
+		expect(std.out).toContain(
+			"fetch the full OpenAPI schema (large - use only as a last resort):"
 		);
 	});
 

--- a/packages/wrangler/src/dev/start-dev.ts
+++ b/packages/wrangler/src/dev/start-dev.ts
@@ -382,7 +382,7 @@ function printLocalExplorerAgentHint(url: URL): void {
 		  GET ${explorerApiUrl}/workers/durable_objects/namespaces - Durable Object namespaces
 		  GET ${explorerApiUrl}/workflows - Workflows
 		  POST ${explorerApiUrl}/local/observability/query - run a read-only SQL query (SELECT/WITH only) over captured request traces and console logs. Tables: spans, logs (read attributes via json(attributes)). Example:
-		    curl -X POST ${explorerApiUrl}/local/observability/query -d '{"sql":"SELECT service, name, outcome, duration_ms FROM spans WHERE parent_id IS NULL LIMIT 20"}'
+		    curl -X POST ${explorerApiUrl}/local/observability/query -H 'Content-Type: application/json' -d '{"sql":"SELECT service, name, outcome, duration_ms FROM spans WHERE parent_id IS NULL LIMIT 20"}'
 		If the routes above don't cover what you need, fetch the full OpenAPI schema (large - use only as a last resort):
 		  GET ${explorerApiUrl} - OpenAPI schema`);
 }

--- a/packages/wrangler/src/dev/start-dev.ts
+++ b/packages/wrangler/src/dev/start-dev.ts
@@ -375,14 +375,16 @@ function printLocalExplorerAgentHint(url: URL): void {
 		Wrangler detected this dev session is running in an AI agent.
 		The Local Explorer API is available at ${explorerApiUrl}
 		Useful routes:
-		  GET ${explorerApiUrl} - OpenAPI schema
-		  GET ${explorerApiUrl}/d1/database - D1 databases
 		  GET ${explorerApiUrl}/local/workers - local Workers and bindings
-		  GET ${explorerApiUrl}/r2/buckets - R2 buckets
 		  GET ${explorerApiUrl}/storage/kv/namespaces - KV namespaces
+		  GET ${explorerApiUrl}/d1/database - D1 databases
+		  GET ${explorerApiUrl}/r2/buckets - R2 buckets
 		  GET ${explorerApiUrl}/workers/durable_objects/namespaces - Durable Object namespaces
 		  GET ${explorerApiUrl}/workflows - Workflows
-		  POST ${explorerApiUrl}/local/observability/query - query request traces and console logs`);
+		  POST ${explorerApiUrl}/local/observability/query - run a read-only SQL query (SELECT/WITH only) over captured request traces and console logs. Tables: spans, logs (read attributes via json(attributes)). Example:
+		    curl -X POST ${explorerApiUrl}/local/observability/query -d '{"sql":"SELECT service, name, outcome, duration_ms FROM spans WHERE parent_id IS NULL LIMIT 20"}'
+		If the routes above don't cover what you need, fetch the full OpenAPI schema (large - use only as a last resort):
+		  GET ${explorerApiUrl} - OpenAPI schema`);
 }
 
 export function formatHostname(hostname: string): string {


### PR DESCRIPTION
When a `wrangler dev` session is detected as running inside an AI agent, Wrangler prints a hint pointing at the Local Explorer API. This improves the line for the observability query endpoint (`POST /local/observability/query`), which previously just said "query request traces and console logs" — giving an agent no idea how to actually call it.

The hint now:
- explains the endpoint takes a **read-only SQL query** (SELECT/WITH only) over the captured `spans` and `logs` tables,
- notes that `attributes` is JSON (read via `json(attributes)`), which agents can't infer from column names alone,
- includes a copy-pasteable `curl` **example** that also documents the `{"sql": "..."}` request body shape,
- demotes the full OpenAPI schema to a last-resort footer, so agents reach for the small, actionable example first instead of fetching the large (~23k token) schema.

The example conveys the endpoint usage, request envelope, table names, and the root-span filter (`parent_id IS NULL`) far more succinctly than embedding the whole schema.

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: this only changes local dev CLI output (an agent-facing hint); there is no public API or documented surface change.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14918" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->