### PR TITLE
fix(miniflare): surface D1 session commit token failures as recoverable D1 errors

### DIFF
--- a/.changeset/dev-d1-sqlite-busy-crash.md
+++ b/.changeset/dev-d1-sqlite-busy-crash.md
@@ -1,0 +1,9 @@
+---
+"miniflare": patch
+---
+
+Surface recoverable SQLite errors from local D1's session commit token lookup as catchable `D1_ERROR`s instead of crashing `wrangler dev`
+
+When another connection is writing to the same persisted local D1 database, SQLite can return a recoverable `SQLITE_BUSY` ("database is locked") error. Query failures were already surfaced to the Worker as catchable `D1_ERROR`s, but the session commit token lookup that runs after each query batch was not wrapped, so a `SQLITE_BUSY` raised there escaped as an uncaught internal error and took down the entire `wrangler dev` process (and, with multi-config dev, every hosted worker). That lookup is now wrapped in the same `D1Error` handling, so the Worker receives a normal, retryable query error and the dev server stays up.
+
+Fixes https://github.com/cloudflare/workers-sdk/issues/14916

--- a/packages/miniflare/src/workers/d1/database.worker.ts
+++ b/packages/miniflare/src/workers/d1/database.worker.ts
@@ -222,11 +222,26 @@ export class D1DatabaseObject extends MiniflareDurableObject {
 			searchParams.get("resultsFormat")
 		);
 
-		return Response.json(this.#txn(queries, resultsFormat), {
-			headers: {
-				[D1_SESSION_COMMIT_TOKEN_HTTP_HEADER]:
-					await this.state.storage.getCurrentBookmark(),
-			},
+		const results = this.#txn(queries, resultsFormat);
+
+		// `getCurrentBookmark()` can fail with a recoverable SQLite error (e.g.
+		// `SQLITE_BUSY` when another process is writing to the same persisted
+		// database), which workerd surfaces as an opaque internal error. Wrap the
+		// failure in a `D1Error` so it reaches the Worker as a normal, catchable
+		// query error instead of escaping the handler and crashing the whole
+		// `wrangler dev` process.
+		let commitToken: string;
+		try {
+			commitToken = await this.state.storage.getCurrentBookmark();
+		} catch (e) {
+			const message = e instanceof Error ? e.message : String(e);
+			throw new D1Error(
+				new Error(`Failed to get session commit token: ${message}`)
+			);
+		}
+
+		return Response.json(results, {
+			headers: { [D1_SESSION_COMMIT_TOKEN_HTTP_HEADER]: commitToken },
 		});
 	};
 

--- a/packages/miniflare/test/plugins/d1/index.spec.ts
+++ b/packages/miniflare/test/plugins/d1/index.spec.ts
@@ -1,5 +1,8 @@
+import assert from "node:assert";
 import fs from "node:fs/promises";
 import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { setTimeout } from "node:timers/promises";
 import { Miniflare } from "miniflare";
 import { test } from "vitest";
 import { FIXTURES_PATH, useDispose, useTmp } from "../../test-shared";
@@ -30,4 +33,67 @@ test("migrates database to new location", async ({ expect }) => {
 	const database = await mf.getD1Database("DATABASE");
 	const { results } = await database.prepare("SELECT * FROM entries").all();
 	expect(results).toEqual([{ key: "a", value: "1" }]);
+});
+
+// Regression test for https://github.com/cloudflare/workers-sdk/issues/14916:
+// a recoverable `SQLITE_BUSY` raised while retrieving the session commit token
+// (e.g. another process writing to the same persisted database) used to escape
+// `D1DatabaseObject#queryExecute` as an uncaught internal error, crashing the
+// whole `wrangler dev` process, instead of surfacing to the Worker as a
+// normal, catchable `D1_ERROR`.
+test("surfaces recoverable SQLite errors as catchable D1 query errors", async ({
+	expect,
+}) => {
+	const tmp = await useTmp();
+	const mf = new Miniflare({
+		modules: true,
+		script: "",
+		d1Databases: ["DATABASE"],
+		d1Persist: tmp,
+	});
+	useDispose(mf);
+
+	const db = await mf.getD1Database("DATABASE");
+	await db.prepare("CREATE TABLE entries (key TEXT PRIMARY KEY)").run();
+
+	// Find the persisted SQLite file backing the D1 database
+	const objectDir = path.join(tmp, "miniflare-D1DatabaseObject");
+	const databaseFile = (await fs.readdir(objectDir)).find(
+		(name) => name.endsWith(".sqlite") && name !== "metadata.sqlite"
+	);
+	assert(databaseFile !== undefined);
+
+	// Simulate another process holding the database's write lock
+	const external = new DatabaseSync(path.join(objectDir, databaseFile));
+	try {
+		for (let attempt = 0; ; attempt++) {
+			try {
+				external.exec("BEGIN IMMEDIATE");
+				break;
+			} catch (e) {
+				// The runtime may still be flushing its own write; retry briefly
+				if (attempt === 9) throw e;
+				await setTimeout(100);
+			}
+		}
+
+		// The read-only query itself succeeds, but retrieving the session commit
+		// token afterwards fails with `SQLITE_BUSY`. This must reach the Worker
+		// as a catchable `D1_ERROR`, not crash the process.
+		const error = await db
+			.prepare("SELECT * FROM entries")
+			.all()
+			.then(() => undefined)
+			.catch((e) => e);
+		assert(error instanceof Error);
+		expect(error.message).toMatch(
+			/^D1_ERROR: Failed to get session commit token/
+		);
+	} finally {
+		external.close();
+	}
+
+	// The database remains usable once the lock is released
+	const { results } = await db.prepare("SELECT * FROM entries").all();
+	expect(results).toEqual([]);
 });


### PR DESCRIPTION
Fixes #14916, reported by @msnelling.

In `D1DatabaseObject#queryExecute`, query execution is wrapped in `D1Error` (recoverable, catchable `D1_ERROR`), but the D1 Sessions commit-token lookup `await this.state.storage.getCurrentBookmark()` (the crash line in the report) is not. A `SQLITE_BUSY` there, e.g. another connection writing to the same persisted DB, escapes as a workerd internal error, which feeds wrangler's ProxyController fatal path and kills the whole `wrangler dev --local` process.

The fix wraps that lookup in the same recoverable-error path, so the Worker gets a normal catchable `D1_ERROR` and the dev server stays up. Reproduced deterministically in a regression test by holding a `BEGIN IMMEDIATE` lock from a second `node:sqlite` connection (Node builtin, repo engines >=22) while issuing a read-only D1 query; the reporter's exact crash signature appears without the fix.

Two honest caveats: workerd redacts the underlying SQLITE_BUSY text into "internal error; reference = ..." for this call site, so the message says that rather than "database is locked" (a message-level fix belongs in workerd); and hardening wrangler's ProxyController fatal handling more broadly is left as a maintainer design call.

Miniflare patch changeset included. D1 plugin tests: 24 passed (baseline 23); the new test fails without the fix after a rebuild. oxfmt/oxlint/tsc clean.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14921" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->