### PR TITLE
Support `DO_NOT_TRACK=1`

### DIFF
--- a/.changeset/nine-taxis-shave.md
+++ b/.changeset/nine-taxis-shave.md
@@ -1,9 +1,7 @@
 ---
 "create-cloudflare": minor
-"@cloudflare/workers-utils": minor
-"wrangler": minor
 ---
 
-Support the `DO_NOT_TRACK` environment variable as a telemetry opt-out
+Honor `DO_NOT_TRACK=1` as a telemetry opt-out
 
-Setting `DO_NOT_TRACK=1` (see https://donottrack.sh/) disables telemetry in both Wrangler and `create-cloudflare`. The tool-specific variables `WRANGLER_SEND_METRICS` and `CREATE_CLOUDFLARE_TELEMETRY_DISABLED` still take precedence.
+Create Cloudflare now disables telemetry when `DO_NOT_TRACK=1` is set, regardless of other telemetry settings.

--- a/.changeset/nine-taxis-shave.md
+++ b/.changeset/nine-taxis-shave.md
@@ -1,0 +1,9 @@
+---
+"create-cloudflare": patch
+"@cloudflare/workers-utils": patch
+"wrangler": patch
+---
+
+Support the `DO_NOT_TRACK` environment variable as a telemetry opt-out
+
+Setting `DO_NOT_TRACK=1` (see https://donottrack.sh/) disables telemetry in both Wrangler and `create-cloudflare`. The tool-specific variables `WRANGLER_SEND_METRICS` and `CREATE_CLOUDFLARE_TELEMETRY_DISABLED` still take precedence.

--- a/.changeset/nine-taxis-shave.md
+++ b/.changeset/nine-taxis-shave.md
@@ -1,7 +1,7 @@
 ---
-"create-cloudflare": patch
-"@cloudflare/workers-utils": patch
-"wrangler": patch
+"create-cloudflare": minor
+"@cloudflare/workers-utils": minor
+"wrangler": minor
 ---
 
 Support the `DO_NOT_TRACK` environment variable as a telemetry opt-out

--- a/.changeset/workers-utils-do-not-track.md
+++ b/.changeset/workers-utils-do-not-track.md
@@ -1,0 +1,7 @@
+---
+"@cloudflare/workers-utils": minor
+---
+
+Add shared support for the `DO_NOT_TRACK` environment variable
+
+Add utilities for recognizing `DO_NOT_TRACK=1` and incorporating it when resolving Wrangler's telemetry preference.

--- a/.changeset/wrangler-do-not-track.md
+++ b/.changeset/wrangler-do-not-track.md
@@ -1,0 +1,7 @@
+---
+"wrangler": minor
+---
+
+Honor `DO_NOT_TRACK=1` as a telemetry opt-out
+
+Wrangler now disables telemetry when `DO_NOT_TRACK=1` is set, regardless of other telemetry settings.

--- a/packages/create-cloudflare/src/__tests__/metrics.test.ts
+++ b/packages/create-cloudflare/src/__tests__/metrics.test.ts
@@ -567,6 +567,8 @@ describe("runTelemetryCommand", () => {
 
 	afterEach(() => {
 		vi.useRealTimers();
+		vi.clearAllMocks();
+		vi.unstubAllEnvs();
 	});
 
 	test("run telemetry status when c3permission is disabled", async ({
@@ -602,6 +604,36 @@ describe("runTelemetryCommand", () => {
 
 		expect(normalizeOutput(std.out)).toMatchInlineSnapshot(`
 			"Status: Enabled
+
+			"
+		`);
+	});
+
+	test("run telemetry status when DO_NOT_TRACK is enabled", ({ expect }) => {
+		vi.stubEnv("DO_NOT_TRACK", "1");
+
+		runTelemetryCommand("status");
+
+		expect(readMetricsConfig).not.toHaveBeenCalled();
+		expect(writeMetricsConfig).not.toHaveBeenCalled();
+		expect(normalizeOutput(std.out)).toMatchInlineSnapshot(`
+			"Status: Disabled (set by DO_NOT_TRACK)
+
+			"
+		`);
+	});
+
+	test("run telemetry status when CREATE_CLOUDFLARE_TELEMETRY_DISABLED is enabled", ({
+		expect,
+	}) => {
+		vi.stubEnv("CREATE_CLOUDFLARE_TELEMETRY_DISABLED", "1");
+
+		runTelemetryCommand("status");
+
+		expect(readMetricsConfig).not.toHaveBeenCalled();
+		expect(writeMetricsConfig).not.toHaveBeenCalled();
+		expect(normalizeOutput(std.out)).toMatchInlineSnapshot(`
+			"Status: Disabled (set by CREATE_CLOUDFLARE_TELEMETRY_DISABLED)
 
 			"
 		`);

--- a/packages/create-cloudflare/src/__tests__/metrics.test.ts
+++ b/packages/create-cloudflare/src/__tests__/metrics.test.ts
@@ -259,6 +259,33 @@ describe("createReporter", () => {
 		expect(sendEvent).toHaveBeenCalledTimes(0);
 	});
 
+	test("sends no event if the DO_NOT_TRACK env is set to '1'", async ({
+		expect,
+	}) => {
+		vi.stubEnv("DO_NOT_TRACK", "1");
+
+		const deferred = promiseWithResolvers<string>();
+		const reporter = createReporter();
+		const operation = reporter.collectAsyncMetrics({
+			eventPrefix: "c3 session",
+			props: {
+				args: {
+					projectName: "app",
+				},
+			},
+			promise: () => deferred.promise,
+		});
+
+		expect(reporter.isEnabled).toBe(false);
+
+		expect(sendEvent).toHaveBeenCalledTimes(0);
+
+		deferred.resolve("test result");
+
+		await expect(operation).resolves.toBe("test result");
+		expect(sendEvent).toHaveBeenCalledTimes(0);
+	});
+
 	test("sends started and cancelled event to sparrow if the promise reject with a CancelError", async ({
 		expect,
 	}) => {

--- a/packages/create-cloudflare/src/__tests__/metrics.test.ts
+++ b/packages/create-cloudflare/src/__tests__/metrics.test.ts
@@ -286,6 +286,15 @@ describe("createReporter", () => {
 		expect(sendEvent).toHaveBeenCalledTimes(0);
 	});
 
+	test("DO_NOT_TRACK='1' takes precedence over CREATE_CLOUDFLARE_TELEMETRY_DISABLED='0'", ({
+		expect,
+	}) => {
+		vi.stubEnv("DO_NOT_TRACK", "1");
+		vi.stubEnv("CREATE_CLOUDFLARE_TELEMETRY_DISABLED", "0");
+
+		expect(createReporter().isEnabled).toBe(false);
+	});
+
 	test("sends started and cancelled event to sparrow if the promise reject with a CancelError", async ({
 		expect,
 	}) => {

--- a/packages/create-cloudflare/src/__tests__/metrics.test.ts
+++ b/packages/create-cloudflare/src/__tests__/metrics.test.ts
@@ -686,6 +686,58 @@ describe("runTelemetryCommand", () => {
 		`);
 	});
 
+	test("run telemetry enable when DO_NOT_TRACK is enabled", ({ expect }) => {
+		vi.stubEnv("DO_NOT_TRACK", "1");
+		vi.mocked(readMetricsConfig).mockReturnValueOnce({
+			c3permission: {
+				enabled: false,
+				date: new Date(),
+			},
+		});
+
+		runTelemetryCommand("enable");
+
+		expect(writeMetricsConfig).toHaveBeenCalledWith({
+			c3permission: {
+				enabled: true,
+				date: new Date(),
+			},
+		});
+		expect(normalizeOutput(std.out)).toMatchInlineSnapshot(`
+			"Status: Disabled (set by DO_NOT_TRACK)
+
+			Telemetry has been enabled in Create-Cloudflare's global configuration, but remains disabled while DO_NOT_TRACK is set.
+			"
+		`);
+	});
+
+	test("run telemetry enable when CREATE_CLOUDFLARE_TELEMETRY_DISABLED is enabled", ({
+		expect,
+	}) => {
+		vi.stubEnv("CREATE_CLOUDFLARE_TELEMETRY_DISABLED", "1");
+		vi.mocked(readMetricsConfig).mockReturnValueOnce({
+			c3permission: {
+				enabled: false,
+				date: new Date(),
+			},
+		});
+
+		runTelemetryCommand("enable");
+
+		expect(writeMetricsConfig).toHaveBeenCalledWith({
+			c3permission: {
+				enabled: true,
+				date: new Date(),
+			},
+		});
+		expect(normalizeOutput(std.out)).toMatchInlineSnapshot(`
+			"Status: Disabled (set by CREATE_CLOUDFLARE_TELEMETRY_DISABLED)
+
+			Telemetry has been enabled in Create-Cloudflare's global configuration, but remains disabled while CREATE_CLOUDFLARE_TELEMETRY_DISABLED is set.
+			"
+		`);
+	});
+
 	test("run telemetry disable when c3permission is enabled", async ({
 		expect,
 	}) => {

--- a/packages/create-cloudflare/src/metrics.ts
+++ b/packages/create-cloudflare/src/metrics.ts
@@ -2,6 +2,7 @@ import { AsyncLocalStorage } from "node:async_hooks";
 import { setTimeout } from "node:timers/promises";
 import { logRaw } from "@cloudflare/cli-shared-helpers";
 import { CancelError } from "@cloudflare/cli-shared-helpers/error";
+import { isDoNotTrackEnabled } from "@cloudflare/workers-utils";
 import {
 	getDeviceId,
 	readMetricsConfig,
@@ -110,7 +111,10 @@ export function createReporter() {
 	}
 
 	function isTelemetryEnabled() {
-		if (process.env.CREATE_CLOUDFLARE_TELEMETRY_DISABLED === "1" || process.env.DO_NOT_TRACK === "1") {
+		if (
+			process.env.CREATE_CLOUDFLARE_TELEMETRY_DISABLED === "1" ||
+			isDoNotTrackEnabled()
+		) {
 			return false;
 		}
 

--- a/packages/create-cloudflare/src/metrics.ts
+++ b/packages/create-cloudflare/src/metrics.ts
@@ -59,6 +59,23 @@ export function getPlatform() {
 	}
 }
 
+function resolveTelemetryStatus():
+	| { enabled: boolean; source: string }
+	| undefined {
+	if (isDoNotTrackEnabled()) {
+		return { enabled: false, source: "DO_NOT_TRACK" };
+	}
+
+	if (process.env.CREATE_CLOUDFLARE_TELEMETRY_DISABLED === "1") {
+		return {
+			enabled: false,
+			source: "CREATE_CLOUDFLARE_TELEMETRY_DISABLED",
+		};
+	}
+
+	return undefined;
+}
+
 export function createReporter() {
 	const events: Array<Promise<void>> = [];
 	const als = new AsyncLocalStorage<{
@@ -67,7 +84,9 @@ export function createReporter() {
 
 	const config = readMetricsConfig() ?? {};
 	const isFirstUsage = config.c3permission === undefined;
-	const isEnabled = isTelemetryEnabled();
+	const isEnabled =
+		resolveTelemetryStatus()?.enabled ??
+		(sparrow.hasSparrowSourceKey() && getC3Permission(config).enabled);
 	const deviceId = getDeviceId(config);
 	const packageManager = detectPackageManager();
 	const platform = getPlatform();
@@ -108,17 +127,6 @@ export function createReporter() {
 		// TODO(consider): add a timeout to avoid the process staying alive for too long
 
 		events.push(request);
-	}
-
-	function isTelemetryEnabled() {
-		if (
-			isDoNotTrackEnabled() ||
-			process.env.CREATE_CLOUDFLARE_TELEMETRY_DISABLED === "1"
-		) {
-			return false;
-		}
-
-		return sparrow.hasSparrowSourceKey() && getC3Permission(config).enabled;
 	}
 
 	async function waitForAllEventsSettled(): Promise<void> {
@@ -296,8 +304,9 @@ function updateC3Permission(enabled: boolean) {
 	writeMetricsConfig(config);
 }
 
-function logTelemetryStatus(enabled: boolean) {
-	logRaw(`Status: ${enabled ? "Enabled" : "Disabled"}`);
+function logTelemetryStatus(enabled: boolean, source?: string) {
+	const sourceMessage = source === undefined ? "" : ` (set by ${source})`;
+	logRaw(`Status: ${enabled ? "Enabled" : "Disabled"}${sourceMessage}`);
 	logRaw("");
 }
 
@@ -320,9 +329,10 @@ export const runTelemetryCommand = (
 			break;
 		}
 		case "status": {
-			const telemetry = getC3Permission();
+			const telemetry = resolveTelemetryStatus();
+			const enabled = telemetry?.enabled ?? getC3Permission().enabled;
 
-			logTelemetryStatus(telemetry.enabled);
+			logTelemetryStatus(enabled, telemetry?.source);
 			break;
 		}
 	}

--- a/packages/create-cloudflare/src/metrics.ts
+++ b/packages/create-cloudflare/src/metrics.ts
@@ -112,8 +112,8 @@ export function createReporter() {
 
 	function isTelemetryEnabled() {
 		if (
-			process.env.CREATE_CLOUDFLARE_TELEMETRY_DISABLED === "1" ||
-			isDoNotTrackEnabled()
+			isDoNotTrackEnabled() ||
+			process.env.CREATE_CLOUDFLARE_TELEMETRY_DISABLED === "1"
 		) {
 			return false;
 		}

--- a/packages/create-cloudflare/src/metrics.ts
+++ b/packages/create-cloudflare/src/metrics.ts
@@ -316,10 +316,19 @@ export const runTelemetryCommand = (
 	switch (action) {
 		case "enable": {
 			updateC3Permission(true);
-			logTelemetryStatus(true);
-			logRaw(
-				"Create-Cloudflare is now collecting telemetry about your usage. Thank you for helping us improve the experience!"
-			);
+
+			const telemetry = resolveTelemetryStatus();
+			if (telemetry === undefined) {
+				logTelemetryStatus(true);
+				logRaw(
+					"Create-Cloudflare is now collecting telemetry about your usage. Thank you for helping us improve the experience!"
+				);
+			} else {
+				logTelemetryStatus(telemetry.enabled, telemetry.source);
+				logRaw(
+					`Telemetry has been enabled in Create-Cloudflare's global configuration, but remains disabled while ${telemetry.source} is set.`
+				);
+			}
 			break;
 		}
 		case "disable": {

--- a/packages/create-cloudflare/src/metrics.ts
+++ b/packages/create-cloudflare/src/metrics.ts
@@ -110,7 +110,7 @@ export function createReporter() {
 	}
 
 	function isTelemetryEnabled() {
-		if (process.env.CREATE_CLOUDFLARE_TELEMETRY_DISABLED === "1") {
+		if (process.env.CREATE_CLOUDFLARE_TELEMETRY_DISABLED === "1" || process.env.DO_NOT_TRACK === "1") {
 			return false;
 		}
 

--- a/packages/create-cloudflare/telemetry.md
+++ b/packages/create-cloudflare/telemetry.md
@@ -82,11 +82,13 @@ Alternatively, you can set an environment variable:
 export CREATE_CLOUDFLARE_TELEMETRY_DISABLED=1
 ```
 
-Create-Cloudflare also honors [`DO_NOT_TRACK`](https://donottrack.sh/), a shared opt-out convention supported across many CLI tools. If you already have it set, telemetry is disabled with no further configuration:
+Create Cloudflare also honors the `DO_NOT_TRACK` environment variable. Set it to `1` to disable telemetry:
 
 ```sh
 export DO_NOT_TRACK=1
 ```
+
+`DO_NOT_TRACK=1` takes precedence over all other telemetry settings.
 
 If you would like to re-enable telemetry, you can run:
 

--- a/packages/create-cloudflare/telemetry.md
+++ b/packages/create-cloudflare/telemetry.md
@@ -82,6 +82,12 @@ Alternatively, you can set an environment variable:
 export CREATE_CLOUDFLARE_TELEMETRY_DISABLED=1
 ```
 
+Create-Cloudflare also honors [`DO_NOT_TRACK`](https://donottrack.sh/), a shared opt-out convention supported across many CLI tools. If you already have it set, telemetry is disabled with no further configuration:
+
+```sh
+export DO_NOT_TRACK=1
+```
+
 If you would like to re-enable telemetry, you can run:
 
 ```sh

--- a/packages/workers-utils/src/environment-variables/factory.ts
+++ b/packages/workers-utils/src/environment-variables/factory.ts
@@ -142,7 +142,7 @@ type VariableNames =
 	/** Disable config watching in ConfigController. */
 	| "WRANGLER_CI_DISABLE_CONFIG_WATCHING"
 
-	/** https://donottrack.sh/ */
+	/** Disable telemetry when set to an opt-out value. */
 	| "DO_NOT_TRACK"
 
 	// ## Docker Configuration

--- a/packages/workers-utils/src/environment-variables/factory.ts
+++ b/packages/workers-utils/src/environment-variables/factory.ts
@@ -142,6 +142,9 @@ type VariableNames =
 	/** Disable config watching in ConfigController. */
 	| "WRANGLER_CI_DISABLE_CONFIG_WATCHING"
 
+	/** https://donottrack.sh/ */
+	| "DOT_NOT_TRACK"
+
 	// ## Docker Configuration
 
 	/** Path to docker binary (default: "docker"). */

--- a/packages/workers-utils/src/environment-variables/factory.ts
+++ b/packages/workers-utils/src/environment-variables/factory.ts
@@ -143,7 +143,7 @@ type VariableNames =
 	| "WRANGLER_CI_DISABLE_CONFIG_WATCHING"
 
 	/** https://donottrack.sh/ */
-	| "DOT_NOT_TRACK"
+	| "DO_NOT_TRACK"
 
 	// ## Docker Configuration
 

--- a/packages/workers-utils/src/environment-variables/misc-variables.ts
+++ b/packages/workers-utils/src/environment-variables/misc-variables.ts
@@ -41,9 +41,7 @@ const getDoNotTrackFromEnv = getEnvironmentVariableFactory({
 	variableName: "DO_NOT_TRACK",
 });
 
-/**
- * `DO_NOT_TRACK` is a shared telemetry opt-out convention: https://donottrack.sh/
- */
+/** Whether `DO_NOT_TRACK` is set to a supported telemetry opt-out value. */
 export function isDoNotTrackEnabled(): boolean {
 	const value = getDoNotTrackFromEnv()?.toLowerCase();
 	return value === "1" || value === "true";
@@ -55,15 +53,15 @@ const getWranglerSendMetricsVariableFromEnv =
 	});
 
 /**
- * `WRANGLER_SEND_METRICS` can override whether we attempt to send metrics information to Sparrow.
- *
- * When it is unset, `DO_NOT_TRACK` opts out of sending metrics.
+ * `WRANGLER_SEND_METRICS` controls whether we attempt to send metrics information to Sparrow.
+ * `DO_NOT_TRACK` takes precedence when it is set to an opt-out value.
  */
 export function getWranglerSendMetricsFromEnv(): boolean | undefined {
-	return (
-		getWranglerSendMetricsVariableFromEnv() ??
-		(isDoNotTrackEnabled() ? false : undefined)
-	);
+	if (isDoNotTrackEnabled()) {
+		return false;
+	}
+
+	return getWranglerSendMetricsVariableFromEnv();
 }
 
 /**

--- a/packages/workers-utils/src/environment-variables/misc-variables.ts
+++ b/packages/workers-utils/src/environment-variables/misc-variables.ts
@@ -38,11 +38,14 @@ export const getC3CommandFromEnv = getEnvironmentVariableFactory({
 });
 
 /**
- * `WRANGLER_SEND_METRICS` can override whether we attempt to send metrics information to Sparrow.
+ * `WRANGLER_SEND_METRICS` and `DO_NOT_TRACK` can override whether we attempt to send
+ * metrics information to Sparrow.
  */
 export const getWranglerSendMetricsFromEnv =
 	getBooleanEnvironmentVariableFactory({
 		variableName: "WRANGLER_SEND_METRICS",
+	}) || getBooleanEnvironmentVariableFactory({
+		variableName: "DO_NOT_TRACK",
 	});
 
 /**

--- a/packages/workers-utils/src/environment-variables/misc-variables.ts
+++ b/packages/workers-utils/src/environment-variables/misc-variables.ts
@@ -37,16 +37,34 @@ export const getC3CommandFromEnv = getEnvironmentVariableFactory({
 	defaultValue: () => "create cloudflare",
 });
 
+const getDoNotTrackFromEnv = getEnvironmentVariableFactory({
+	variableName: "DO_NOT_TRACK",
+});
+
 /**
- * `WRANGLER_SEND_METRICS` and `DO_NOT_TRACK` can override whether we attempt to send
- * metrics information to Sparrow.
+ * `DO_NOT_TRACK` is a shared telemetry opt-out convention: https://donottrack.sh/
  */
-export const getWranglerSendMetricsFromEnv =
+export function isDoNotTrackEnabled(): boolean {
+	const value = getDoNotTrackFromEnv()?.toLowerCase();
+	return value === "1" || value === "true";
+}
+
+const getWranglerSendMetricsVariableFromEnv =
 	getBooleanEnvironmentVariableFactory({
 		variableName: "WRANGLER_SEND_METRICS",
-	}) || getBooleanEnvironmentVariableFactory({
-		variableName: "DO_NOT_TRACK",
 	});
+
+/**
+ * `WRANGLER_SEND_METRICS` can override whether we attempt to send metrics information to Sparrow.
+ *
+ * When it is unset, `DO_NOT_TRACK` opts out of sending metrics.
+ */
+export function getWranglerSendMetricsFromEnv(): boolean | undefined {
+	return (
+		getWranglerSendMetricsVariableFromEnv() ??
+		(isDoNotTrackEnabled() ? false : undefined)
+	);
+}
 
 /**
  * `WRANGLER_SEND_ERROR_REPORTS` controls whether we attempt to send error reports to Sentry.

--- a/packages/wrangler/src/__tests__/metrics.test.ts
+++ b/packages/wrangler/src/__tests__/metrics.test.ts
@@ -688,13 +688,13 @@ describe("metrics", () => {
 				});
 			});
 
-			it("should let the WRANGLER_SEND_METRICS environment variable override DO_NOT_TRACK", async ({
+			it("should let DO_NOT_TRACK override the WRANGLER_SEND_METRICS environment variable", async ({
 				expect,
 			}) => {
 				vi.stubEnv("DO_NOT_TRACK", "1");
 				vi.stubEnv("WRANGLER_SEND_METRICS", "true");
 				expect(await getMetricsConfig({})).toMatchObject({
-					enabled: true,
+					enabled: false,
 				});
 			});
 

--- a/packages/wrangler/src/__tests__/metrics.test.ts
+++ b/packages/wrangler/src/__tests__/metrics.test.ts
@@ -845,7 +845,7 @@ describe("metrics", () => {
 				expect(std.out).toContain("Status: Disabled");
 			});
 
-			it("shows wrangler.toml as the source with send_metrics is present", async ({
+			it("shows the wrangler config as the source when send_metrics is present", async ({
 				expect,
 			}) => {
 				writeMetricsConfig({
@@ -856,10 +856,10 @@ describe("metrics", () => {
 				});
 				writeWranglerConfig({ send_metrics: false });
 				await runWrangler(`${cmd} status`);
-				expect(std.out).toContain("Status: Disabled (set by wrangler.toml)");
+				expect(std.out).toContain("Status: Disabled (set by wrangler config)");
 			});
 
-			it("shows environment variable as the source if used", async ({
+			it("shows WRANGLER_SEND_METRICS as the source if used", async ({
 				expect,
 			}) => {
 				writeMetricsConfig({
@@ -871,7 +871,7 @@ describe("metrics", () => {
 				vi.stubEnv("WRANGLER_SEND_METRICS", "false");
 				await runWrangler(`${cmd} status`);
 				expect(std.out).toContain(
-					"Status: Disabled (set by environment variable)"
+					"Status: Disabled (set by WRANGLER_SEND_METRICS)"
 				);
 			});
 
@@ -896,7 +896,7 @@ describe("metrics", () => {
 				vi.stubEnv("WRANGLER_SEND_METRICS", "false");
 				await runWrangler(`${cmd} status`);
 				expect(std.out).toContain(
-					"Status: Disabled (set by environment variable)"
+					"Status: Disabled (set by WRANGLER_SEND_METRICS)"
 				);
 			});
 		});
@@ -965,6 +965,31 @@ Wrangler is no longer collecting telemetry about your usage.`);
 			expect(std.out).toContain(`Status: Enabled
 
 Wrangler is now collecting telemetry about your usage. Thank you for helping make Wrangler better 🧡`);
+			expect(readMetricsConfig()).toMatchObject({
+				permission: {
+					enabled: true,
+					date: new Date(2024, 11, 12),
+				},
+			});
+		});
+
+		it(`persists enabled but reports disabled when "wrangler ${cmd} enable" is run with DO_NOT_TRACK`, async ({
+			expect,
+		}) => {
+			vi.stubEnv("DO_NOT_TRACK", "1");
+			writeMetricsConfig({
+				permission: {
+					enabled: false,
+					date: new Date(2022, 6, 4),
+				},
+			});
+
+			await runWrangler(`${cmd} enable`);
+
+			expect(std.out).toContain(`Status: Disabled (set by DO_NOT_TRACK)
+
+Telemetry has been enabled in Wrangler's global configuration, but remains disabled because it is overridden by DO_NOT_TRACK.`);
+			expect(std.out).not.toContain("Wrangler is now collecting telemetry");
 			expect(readMetricsConfig()).toMatchObject({
 				permission: {
 					enabled: true,

--- a/packages/wrangler/src/__tests__/metrics.test.ts
+++ b/packages/wrangler/src/__tests__/metrics.test.ts
@@ -679,6 +679,34 @@ describe("metrics", () => {
 				});
 			});
 
+			it("should return enabled false if the DO_NOT_TRACK environment variable is set", async ({
+				expect,
+			}) => {
+				vi.stubEnv("DO_NOT_TRACK", "1");
+				expect(await getMetricsConfig({ sendMetrics: true })).toMatchObject({
+					enabled: false,
+				});
+			});
+
+			it("should let the WRANGLER_SEND_METRICS environment variable override DO_NOT_TRACK", async ({
+				expect,
+			}) => {
+				vi.stubEnv("DO_NOT_TRACK", "1");
+				vi.stubEnv("WRANGLER_SEND_METRICS", "true");
+				expect(await getMetricsConfig({})).toMatchObject({
+					enabled: true,
+				});
+			});
+
+			it("should ignore DO_NOT_TRACK if it is not set to an opt-out value", async ({
+				expect,
+			}) => {
+				vi.stubEnv("DO_NOT_TRACK", "0");
+				expect(await getMetricsConfig({ sendMetrics: true })).toMatchObject({
+					enabled: true,
+				});
+			});
+
 			it("should return the sendMetrics argument for enabled if it is defined", async ({
 				expect,
 			}) => {

--- a/packages/wrangler/src/metrics/commands.ts
+++ b/packages/wrangler/src/metrics/commands.ts
@@ -1,4 +1,7 @@
-import { getWranglerSendMetricsFromEnv } from "@cloudflare/workers-utils";
+import {
+	getWranglerSendMetricsFromEnv,
+	isDoNotTrackEnabled,
+} from "@cloudflare/workers-utils";
 import chalk from "chalk";
 import {
 	createAlias,
@@ -49,12 +52,20 @@ export const telemetryEnableCommand = createCommand({
 	behaviour: {
 		suggestSkillsAfterHandler: true,
 	},
-	async handler() {
+	async handler(_, { config }) {
 		updateMetricsPermission(true);
-		logTelemetryStatus(true);
-		logger.log(
-			"Wrangler is now collecting telemetry about your usage. Thank you for helping make Wrangler better 🧡\n"
-		);
+
+		const telemetry = resolveTelemetryStatus(config.send_metrics);
+		logTelemetryStatus(telemetry.enabled, telemetry.source);
+		if (telemetry.enabled) {
+			logger.log(
+				"Wrangler is now collecting telemetry about your usage. Thank you for helping make Wrangler better 🧡\n"
+			);
+		} else {
+			logger.log(
+				`Telemetry has been enabled in Wrangler's global configuration, but remains disabled because it is overridden by ${telemetry.source}.\n`
+			);
+		}
 	},
 });
 
@@ -68,16 +79,8 @@ export const telemetryStatusCommand = createCommand({
 		suggestSkillsAfterHandler: true,
 	},
 	async handler(_, { config }) {
-		const savedConfig = readMetricsConfig();
-		const sendMetricsEnv = getWranglerSendMetricsFromEnv();
-		if (config.send_metrics !== undefined || sendMetricsEnv !== undefined) {
-			const resolvedPermission = sendMetricsEnv ?? config.send_metrics;
-			logger.log(
-				`Status: ${resolvedPermission ? chalk.green("Enabled") : chalk.red("Disabled")} (set by ${sendMetricsEnv !== undefined ? "environment variable" : "wrangler.toml"})\n`
-			);
-		} else {
-			logTelemetryStatus(savedConfig.permission?.enabled ?? true);
-		}
+		const telemetry = resolveTelemetryStatus(config.send_metrics);
+		logTelemetryStatus(telemetry.enabled, telemetry.source);
 		logger.log(
 			"To configure telemetry globally on this machine, you can run `wrangler telemetry disable / enable`.\n" +
 				"You can override this for individual projects with the environment variable `WRANGLER_SEND_METRICS=true/false`.\n" +
@@ -86,8 +89,30 @@ export const telemetryStatusCommand = createCommand({
 	},
 });
 
-const logTelemetryStatus = (enabled: boolean) => {
+function resolveTelemetryStatus(sendMetrics: boolean | undefined): {
+	enabled: boolean;
+	source?: string;
+} {
+	if (isDoNotTrackEnabled()) {
+		return { enabled: false, source: "DO_NOT_TRACK" };
+	}
+
+	const sendMetricsEnv = getWranglerSendMetricsFromEnv();
+	if (sendMetricsEnv !== undefined) {
+		return { enabled: sendMetricsEnv, source: "WRANGLER_SEND_METRICS" };
+	}
+
+	if (sendMetrics !== undefined) {
+		return { enabled: sendMetrics, source: "wrangler config" };
+	}
+
+	const savedConfig = readMetricsConfig();
+	return { enabled: savedConfig.permission?.enabled ?? true };
+}
+
+function logTelemetryStatus(enabled: boolean, source?: string) {
+	const sourceMessage = source === undefined ? "" : ` (set by ${source})`;
 	logger.log(
-		`Status: ${enabled ? chalk.green("Enabled") : chalk.red("Disabled")}\n`
+		`Status: ${enabled ? chalk.green("Enabled") : chalk.red("Disabled")}${sourceMessage}\n`
 	);
-};
+}

--- a/packages/wrangler/telemetry.md
+++ b/packages/wrangler/telemetry.md
@@ -75,6 +75,12 @@ Alternatively, you may set an environment variable to disable telemetry.
 
 `WRANGLER_SEND_METRICS=false`
 
+Wrangler also honors [`DO_NOT_TRACK`](https://donottrack.sh/), a shared opt-out convention supported across many CLI tools. If you already have it set, telemetry is disabled with no further configuration:
+
+```sh
+export DO_NOT_TRACK=1
+```
+
 If you would like to re-enable telemetry globally, you can run:
 
 ```sh

--- a/packages/wrangler/telemetry.md
+++ b/packages/wrangler/telemetry.md
@@ -75,13 +75,13 @@ Alternatively, you may set an environment variable to disable telemetry.
 
 `WRANGLER_SEND_METRICS=false`
 
-Wrangler also honors [`DO_NOT_TRACK`](https://donottrack.sh/), a shared opt-out convention supported across many CLI tools. If you already have it set, telemetry is disabled with no further configuration:
+Wrangler also honors the `DO_NOT_TRACK` environment variable. Set it to `1` to disable telemetry:
 
 ```sh
 export DO_NOT_TRACK=1
 ```
 
-Setting `WRANGLER_SEND_METRICS` takes precedence, so `WRANGLER_SEND_METRICS=true` re-enables Wrangler telemetry even when `DO_NOT_TRACK` is set.
+`DO_NOT_TRACK=1` takes precedence over all other telemetry settings.
 
 If you would like to re-enable telemetry globally, you can run:
 

--- a/packages/wrangler/telemetry.md
+++ b/packages/wrangler/telemetry.md
@@ -81,6 +81,8 @@ Wrangler also honors [`DO_NOT_TRACK`](https://donottrack.sh/), a shared opt-out 
 export DO_NOT_TRACK=1
 ```
 
+Setting `WRANGLER_SEND_METRICS` takes precedence, so `WRANGLER_SEND_METRICS=true` re-enables Wrangler telemetry even when `DO_NOT_TRACK` is set.
+
 If you would like to re-enable telemetry globally, you can run:
 
 ```sh


### PR DESCRIPTION
Adds support for the [`DO_NOT_TRACK`](https://donottrack.sh/) environment variable in both Wrangler & `create-cloudflare` alongside their unique opt out environment variables.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: not documented previously



*A picture of a cute animal (not mandatory, but encouraged)*
<img width="256" alt="PXL_20260728_123949722" src="https://github.com/user-attachments/assets/6f4ed6cb-3b56-43ba-9aa6-af10838d4698" />
A photo of a pretty bird I saw a couple days ago (_does anyone know what bird it is?_)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14924" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->