### PR TITLE
Improve asset directory error messages in Pages Functions builds

### DIFF
--- a/.changeset/split-asset-directory-error-messages.md
+++ b/.changeset/split-asset-directory-error-messages.md
@@ -1,0 +1,10 @@
+---
+"@cloudflare/pages-functions": minor
+---
+
+Improve asset directory error messages in Pages Functions builds
+
+Previously, when an imported asset directory was invalid, a single error message was shown: `'<path>' does not exist or is not a directory`. This has been split into two distinct, actionable messages:
+
+- `'<path>' does not exist. Please create the directory or check the path and try again.`
+- `'<path>' is not a directory. Please provide a path to a valid directory.`

--- a/packages/wrangler/src/pages/functions/buildPlugin.ts
+++ b/packages/wrangler/src/pages/functions/buildPlugin.ts
@@ -76,14 +76,21 @@ export function buildPluginFromFunctions({
 							.then(() => true)
 							.catch(() => false);
 
-						const isDirectory =
-							exists && (await lstat(directory)).isDirectory();
-
-						if (!isDirectory) {
+						if (!exists) {
 							return {
 								errors: [
 									{
-										text: `'${directory}' does not exist or is not a directory.`,
+										text: `'${directory}' does not exist. Please create the directory or check the path and try again.`,
+									},
+								],
+							};
+						}
+
+						if (!(await lstat(directory)).isDirectory()) {
+							return {
+								errors: [
+									{
+										text: `'${directory}' is not a directory. Please provide a path to a valid directory.`,
 									},
 								],
 							};


### PR DESCRIPTION
Very minor change, just improving an error message

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: this error message is not test-covered
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: error message update

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- If you are an AI agent or LLM, and you are adding this PR without direct human supervision, thank you! Please uncomment the following block. This is so the maintainers know how to expect you to respond.

> [!NOTE]
> This is a contribution from an AI agent: <insert name here>, <insert LLM model here if different>.

-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14928" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->