### PR TITLE
ci: increase memory for Vite plugin builds

### DIFF
--- a/.github/workflows/vite-plugin-playgrounds.yml
+++ b/.github/workflows/vite-plugin-playgrounds.yml
@@ -58,6 +58,8 @@ jobs:
         if: steps.changes.outputs.everything_but_markdown == 'true'
         run: |
           pnpm dotenv -- pnpm turbo build --filter @cloudflare/vite-plugin
+        env:
+          NODE_OPTIONS: "--max_old_space_size=8192"
       - name: Downgrade to Vite 6
         if: steps.changes.outputs.everything_but_markdown == 'true' && matrix.vite == 'vite-6'
         run: |

--- a/packages/vite-plugin-cloudflare/e2e/helpers.ts
+++ b/packages/vite-plugin-cloudflare/e2e/helpers.ts
@@ -214,7 +214,9 @@ async function updateVitePluginAndWranglerVersion(
 		// WASI binding requires @emnapi 1, causing npm's strict resolver to fail.
 		pkg.overrides = {
 			...pkg.overrides,
-			"@napi-rs/wasm-runtime": "1.1.6",
+			"@rolldown/binding-wasm32-wasi@1.1.5": {
+				"@napi-rs/wasm-runtime": "1.1.6",
+			},
 		};
 	}
 	await fs.writeFile(


### PR DESCRIPTION
Fix two unrelated failures in the Vite plugin CI workflows.

Cacheless macOS Vite playground jobs can exhaust Node's default heap while building Wrangler. Cold builds now include the standalone Pages Functions compiler in Wrangler, increasing the bundle enough for `tsup` to cross the approximately 2 GB heap limit on GitHub's macOS runner. This gives the initial plugin build the same 8 GB heap limit already used by the subsequent playground test steps.

The npm-backed Vite plugin E2E fixtures also started failing strict peer dependency resolution again after #14895. Rolldown 1.2.1 moved its WASI binding to the `@emnapi` v2 dependency family, but the global `@napi-rs/wasm-runtime@1.1.6` override from #14895 requires `@emnapi/core` v1. Scope that workaround to `@rolldown/binding-wasm32-wasi@1.1.5`, the incompatible release it was intended for, so newer bindings can resolve their compatible wasm runtime.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [x] Automated tests not possible - manual testing has been completed as follows: reproduced the OOM with a cacheless Node 22 build limited to 2 GB, then completed all 19 build tasks with the new 8 GB limit. Confirmed the Rolldown 1.1.5 and 1.2.1 dependency compatibility boundary from published npm metadata. `pnpm check`, the Vite plugin typecheck, type-aware lint, and formatting checks pass.
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: these changes only affect internal CI build and test steps.

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
