### PR TITLE
docs: point vitest-pool-workers BUILD section at the tsdown config

### DIFF
--- a/packages/vitest-pool-workers/AGENTS.md
+++ b/packages/vitest-pool-workers/AGENTS.md
@@ -27,11 +27,11 @@
 
 ## BUILD
 
-`scripts/bundle.mjs` runs 3 separate esbuild builds:
+`tsdown.config.ts` defines 3 separate builds (all ESM):
 
-1. `undici` mock-agent (CJS)
-2. pool + worker (ESM)
-3. config + libs (CJS)
+1. pool — `src/pool/index.ts` → `dist/pool` (emits type declarations)
+2. worker + libs — `src/worker/index.ts` plus `src/worker/lib` and `src/worker/node` → `dist/worker`
+3. codemods — `src/codemods/vitest-v3-to-v4.ts` → `dist/codemods`
 
 Types entry `types/cloudflare-test.d.ts` is hand-written (NOT generated from source).
 


### PR DESCRIPTION
## What

`packages/vitest-pool-workers/AGENTS.md` describes the package build as:

> `scripts/bundle.mjs` runs 3 separate esbuild builds:
> 1. `undici` mock-agent (CJS)
> 2. pool + worker (ESM)
> 3. config + libs (CJS)

`scripts/bundle.mjs` is not in the tree — the build moved to `tsdown` (`"build": "tsdown"` in `package.json`), and the three builds it defines are different ones.

## The change

Updated the section to match `tsdown.config.ts`, which still exports exactly three builds, all ESM via the shared `commonOptions`:

| # | entry | outDir |
|---|---|---|
| 1 | `src/pool/index.ts` | `dist/pool` (`dts: true`) |
| 2 | `src/worker/index.ts` + `src/worker/lib` + `src/worker/node` | `dist/worker` |
| 3 | `src/codemods/vitest-v3-to-v4.ts` | `dist/codemods` |

Docs only — no code, config, or build behavior changes.

## Notes

Per CONTRIBUTING, this is a trivial change so it goes straight to a PR, and it isn't changelog-worthy so I haven't added a changeset. Happy to add one if you'd prefer.

This file is read by coding agents, so a stale build description sends them looking for a script that isn't there.

Found with [unrot](https://github.com/unrot-dev/unrot), an open-source linter for agent config files; each claim above was checked against `tsdown.config.ts` on `main`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14940" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->