### PR TITLE
[wrangler] Enable local observability capture by default in dev

### DIFF
--- a/.changeset/local-observability-default-on.md
+++ b/.changeset/local-observability-default-on.md
@@ -1,0 +1,8 @@
+---
+"@cloudflare/vite-plugin": minor
+"wrangler": minor
+---
+
+Enable local observability capture by default in dev
+
+`wrangler dev` and the Vite plugin now capture request traces and console logs into the Local Explorer's Observability tab out of the box — previously this was opt-in behind `X_LOCAL_OBSERVABILITY=true`. Set `X_LOCAL_OBSERVABILITY=false` to opt out (for example if the extra per-worker collector/streaming-tail services cause trouble in a multi-process dev-registry setup).

--- a/packages/workers-utils/src/environment-variables/misc-variables.ts
+++ b/packages/workers-utils/src/environment-variables/misc-variables.ts
@@ -359,18 +359,15 @@ export const getLocalExplorerEnabledFromEnv =
  * `unsafeObservability` Miniflare option, which makes core attach the trace
  * collector to each user worker.
  *
- * Temporarily defaults to `false` for release: defaulting it on attaches extra
- * per-worker services (collector + streaming tail) that destabilise the
- * multi-process dev-registry scenario on Windows (workerd socket "fetch
- * failed"). Capture is now opt-in — set `X_LOCAL_OBSERVABILITY=true`, or turn it
- * on from the Local Explorer's Observability tab (Vite dev), which reloads the
- * runtime with capture enabled. The explorer UI itself (`X_LOCAL_EXPLORER`)
- * stays on by default so the tab is always available.
+ * Defaults to `true` so the Local Explorer's Observability tab captures traces
+ * and logs out of the box. Set `X_LOCAL_OBSERVABILITY=false` to opt out — for
+ * example if the extra per-worker services (collector + streaming tail) cause
+ * trouble in a multi-process dev-registry setup.
  */
 export const getLocalObservabilityEnabledFromEnv =
 	getBooleanEnvironmentVariableFactory({
 		variableName: "X_LOCAL_OBSERVABILITY",
-		defaultValue: false,
+		defaultValue: true,
 	});
 
 /**


### PR DESCRIPTION
Turns on local observability capture by default in dev by turning the env var to true - for release

---

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: this only flips the default value of an existing env-var toggle; the capture behaviour it enables is already covered by existing miniflare observability tests, and the opt-out path (`=false`) is unchanged.
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: local dev behaviour for an internal/experimental toggle; no public API or documented surface change.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14944" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->