### PR TITLE
[fixtures] Update invalid account id snapshot for client-side account id validation

### DIFF
--- a/fixtures/get-platform-proxy-remote-bindings/tests/index.test.ts
+++ b/fixtures/get-platform-proxy-remote-bindings/tests/index.test.ts
@@ -6,7 +6,6 @@ import {
 	afterAll,
 	assert,
 	beforeAll,
-	beforeEach,
 	describe,
 	expect,
 	test,
@@ -30,8 +29,6 @@ const execOptions = {
 const remoteWorkerName = `preserve-e2e-get-platform-proxy-remote`;
 const remoteStagingWorkerName = `preserve-e2e-get-platform-proxy-remote-staging`;
 const remoteKvName = `tmp-e2e-kv${Date.now()}-test-remote-bindings-${randomUUID().split("-")[0]}`;
-
-const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
 if (auth) {
 	describe("getPlatformProxy - remote bindings", { timeout: 50_000 }, () => {
@@ -109,10 +106,6 @@ if (auth) {
 				});
 			} catch {}
 		}, 35_000);
-
-		beforeEach(() => {
-			errorSpy.mockReset();
-		});
 
 		describe("normal usage", () => {
 			beforeAll(async () => {


### PR DESCRIPTION
The `get-platform-proxy-remote-bindings` E2E fixture test for an invalid `account_id` is failing on `main` ([example run](https://github.com/cloudflare/workers-sdk/actions/runs/30624925610/job/91137841553)).

This is a fallout from #13746, which added client-side validation of account IDs. `validateAccountId()` now throws a `UserError` before any request is made, so:

- the thrown error message is the new validation message rather than the "A request to the Cloudflare API ... failed" message, and
- nothing is written to `console.error`, since there is no longer an API error being reported.

This PR updates the inline snapshot accordingly and drops the now-obsolete `console.error` assertions.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: this only updates a test snapshot in a private test fixture; there is no user-facing change.

*A picture of a cute animal (not mandatory, but encouraged)*

![a red panda](https://upload.wikimedia.org/wikipedia/commons/thumb/2/2c/Red_Panda_%2824986761703%29.jpg/320px-Red_Panda_%2824986761703%29.jpg)

> [!NOTE]
> This is a contribution from an AI agent: opencode, claude-opus-5.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14948" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->