### PR TITLE
[wrangler] Add --parse-type to ai-search create

### DIFF
--- a/.changeset/ai-search-create-parse-type.md
+++ b/.changeset/ai-search-create-parse-type.md
@@ -1,0 +1,18 @@
+---
+"wrangler": minor
+---
+
+Add `--parse-type` flag to `wrangler ai-search create`
+
+`wrangler ai-search create` now accepts `--parse-type` to control how a website data source discovers URLs. `sitemap` (the default) reads XML sitemaps; `discover` follows links recursively.
+
+Previously the parse type could only be chosen through the interactive wizard, which was skipped whenever `--source` was supplied — so it was impossible to create a `discover` instance from a script.
+
+```sh
+wrangler ai-search create my-instance \
+  --type web-crawler \
+  --source https://example.com \
+  --parse-type discover
+```
+
+The interactive wizard now offers `Discover` alongside `Sitemap`. `--parse-type` is only valid with `--type web-crawler`; passing it with `--type builtin` or `--type r2` is rejected, since the API stores the value for those source types but never reads it. When the flag is omitted in non-interactive mode the field is left unset and the API default (`sitemap`) applies.

--- a/packages/wrangler/src/__tests__/ai-search.test.ts
+++ b/packages/wrangler/src/__tests__/ai-search.test.ts
@@ -1053,6 +1053,195 @@ describe("ai-search commands", () => {
 			);
 		});
 
+		it("should forward --parse-type discover for a web-crawler instance", async ({
+			expect,
+		}) => {
+			let capturedBody: Record<string, unknown> | undefined;
+			mockListTokens([MOCK_TOKEN]);
+			mockConfirm({
+				text: "Configure custom metadata fields? (optional)",
+				result: false,
+			});
+			msw.use(
+				http.post(
+					"*/accounts/:accountId/ai-search/namespaces/:namespace/instances",
+					async ({ request }) => {
+						capturedBody = (await request.json()) as Record<string, unknown>;
+						return HttpResponse.json(
+							createFetchResult(
+								{
+									...MOCK_INSTANCE,
+									type: "web-crawler",
+									source: "https://example.com",
+								},
+								true
+							)
+						);
+					},
+					{ once: true }
+				)
+			);
+			await runWrangler(
+				"ai-search create my-instance --namespace default --type web-crawler --source https://example.com --parse-type discover"
+			);
+			expect(capturedBody).toMatchObject({
+				type: "web-crawler",
+				source: "https://example.com",
+				source_params: { web_crawler: { parse_type: "discover" } },
+			});
+		});
+
+		it("should forward --parse-type sitemap for a web-crawler instance", async ({
+			expect,
+		}) => {
+			let capturedBody: Record<string, unknown> | undefined;
+			mockListTokens([MOCK_TOKEN]);
+			mockConfirm({
+				text: "Configure custom metadata fields? (optional)",
+				result: false,
+			});
+			msw.use(
+				http.post(
+					"*/accounts/:accountId/ai-search/namespaces/:namespace/instances",
+					async ({ request }) => {
+						capturedBody = (await request.json()) as Record<string, unknown>;
+						return HttpResponse.json(
+							createFetchResult(
+								{
+									...MOCK_INSTANCE,
+									type: "web-crawler",
+									source: "https://example.com",
+								},
+								true
+							)
+						);
+					},
+					{ once: true }
+				)
+			);
+			await runWrangler(
+				"ai-search create my-instance --namespace default --type web-crawler --source https://example.com --parse-type sitemap"
+			);
+			expect(capturedBody).toMatchObject({
+				source_params: { web_crawler: { parse_type: "sitemap" } },
+			});
+		});
+
+		it("should omit web_crawler source params when --parse-type is not passed in non-interactive mode", async ({
+			expect,
+		}) => {
+			setIsTTY(false);
+			let capturedBody: Record<string, unknown> | undefined;
+			mockListTokens([MOCK_TOKEN]);
+			msw.use(
+				http.post(
+					"*/accounts/:accountId/ai-search/namespaces/:namespace/instances",
+					async ({ request }) => {
+						capturedBody = (await request.json()) as Record<string, unknown>;
+						return HttpResponse.json(
+							createFetchResult(
+								{
+									...MOCK_INSTANCE,
+									type: "web-crawler",
+									source: "https://example.com",
+								},
+								true
+							)
+						);
+					},
+					{ once: true }
+				)
+			);
+			await runWrangler(
+				"ai-search create my-instance --namespace default --type web-crawler --source https://example.com"
+			);
+			expect(capturedBody).not.toHaveProperty("source_params");
+		});
+
+		it("should interactively select the discover parse type", async ({
+			expect,
+		}) => {
+			let capturedBody: Record<string, unknown> | undefined;
+			mockListTokens([MOCK_TOKEN]);
+			mockSelect({ text: "Select the source type:", result: "web-crawler" });
+			mockSelect({
+				text: "Select the web source type:",
+				result: "discover",
+			});
+			msw.use(
+				http.get(
+					"*/zones",
+					() =>
+						HttpResponse.json(
+							createFetchResult([{ id: "zone-1", name: "example.com" }])
+						),
+					{ once: true }
+				)
+			);
+			mockSelect({ text: "Select a zone:", result: "example.com" });
+			mockConfirm({
+				text: "Configure custom metadata fields? (optional)",
+				result: false,
+			});
+			msw.use(
+				http.post(
+					"*/accounts/:accountId/ai-search/namespaces/:namespace/instances",
+					async ({ request }) => {
+						capturedBody = (await request.json()) as Record<string, unknown>;
+						return HttpResponse.json(
+							createFetchResult(
+								{
+									...MOCK_INSTANCE,
+									type: "web-crawler",
+									source: "https://example.com",
+								},
+								true
+							)
+						);
+					},
+					{ once: true }
+				)
+			);
+			await runWrangler("ai-search create my-instance --namespace default");
+			expect(capturedBody).toMatchObject({
+				source_params: { web_crawler: { parse_type: "discover" } },
+			});
+		});
+
+		it("should error when --parse-type is used with --type builtin", async ({
+			expect,
+		}) => {
+			mockListTokens([MOCK_TOKEN]);
+			await expect(
+				runWrangler(
+					"ai-search create my-instance --namespace default --type builtin --parse-type discover"
+				)
+			).rejects.toThrow(
+				/--parse-type is only supported with --type web-crawler/
+			);
+		});
+
+		it("should error when --parse-type is used with --type r2", async ({
+			expect,
+		}) => {
+			mockListTokens([MOCK_TOKEN]);
+			await expect(
+				runWrangler(
+					"ai-search create my-instance --namespace default --type r2 --source my-bucket --parse-type discover"
+				)
+			).rejects.toThrow(
+				/--parse-type is only supported with --type web-crawler/
+			);
+		});
+
+		it("should reject an invalid --parse-type value", async ({ expect }) => {
+			await expect(
+				runWrangler(
+					"ai-search create my-instance --namespace default --type web-crawler --source https://example.com --parse-type crawl"
+				)
+			).rejects.toThrow(/Invalid values/);
+		});
+
 		it("should error when name is missing", async ({ expect }) => {
 			await expect(() => runWrangler("ai-search create")).rejects.toThrow(
 				"Not enough non-option arguments"

--- a/packages/wrangler/src/ai-search/create.ts
+++ b/packages/wrangler/src/ai-search/create.ts
@@ -17,6 +17,7 @@ import {
 import type {
 	AiSearchCustomMetadata,
 	AiSearchCustomMetadataDataType,
+	AiSearchParseType,
 } from "./types";
 
 const CREATE_NEW_BUCKET = "__create_new__";
@@ -28,6 +29,11 @@ const CUSTOM_METADATA_DATA_TYPES = [
 	"boolean",
 	"datetime",
 ] as const satisfies readonly AiSearchCustomMetadataDataType[];
+
+const PARSE_TYPES = [
+	"sitemap",
+	"discover",
+] as const satisfies readonly AiSearchParseType[];
 
 // Reserved field names rejected by the AI Search backend; validated client-side
 // for fast feedback. Keep in sync with apps/config-api validation rules.
@@ -229,6 +235,14 @@ export const aiSearchCreateCommand = createCommand({
 			type: "string",
 			choices: ["builtin", "r2", "web-crawler"],
 			description: "The source type for the instance.",
+		},
+		"parse-type": {
+			type: "string",
+			choices: PARSE_TYPES,
+			description:
+				"How website URLs are discovered (--type web-crawler only). " +
+				"'sitemap' reads XML sitemaps; 'discover' follows links recursively. " +
+				"Defaults to 'sitemap'.",
 		},
 		"source-jurisdiction": {
 			type: "string",
@@ -483,10 +497,46 @@ export const aiSearchCreateCommand = createCommand({
 			);
 		}
 
-		// 2. Source selection — depends on the type
+		// --parse-type only applies to web-crawler sources. The API stores it for
+		// other types but never reads it, so reject rather than silently no-op.
+		if (instanceType !== "web-crawler" && args.parseType !== undefined) {
+			throw new UserError(
+				`--parse-type is only supported with --type web-crawler (got --type ${instanceType}).`,
+				{
+					telemetryMessage: "ai search create parse-type unsupported type",
+				}
+			);
+		}
+
+		// 2. Parse type — how a web-crawler source discovers URLs. Resolved before
+		// source selection so that it is honored even when --source is supplied.
+		let webParseType: AiSearchParseType | undefined;
+		if (instanceType === "web-crawler") {
+			if (args.parseType !== undefined) {
+				webParseType = args.parseType;
+			} else if (!isNonInteractiveOrCI() && !args.json) {
+				webParseType = await select("Select the web source type:", {
+					choices: [
+						{
+							title: "Sitemap",
+							description: "Crawl and index pages from a sitemap",
+							value: "sitemap" as const,
+						},
+						{
+							title: "Discover",
+							description: "Follow links recursively to discover pages",
+							value: "discover" as const,
+						},
+					],
+					defaultOption: 0,
+				});
+			}
+			// Non-interactive without the flag: omit it and let the API default to
+			// "sitemap", preserving behaviour for existing scripted invocations.
+		}
+
+		// 3. Source selection — depends on the type
 		let instanceSource = args.source;
-		// Track whether the user went through the web/sitemap interactive flow
-		let webParseType: string | undefined;
 		// R2 jurisdiction of the source bucket. May be supplied via flag or
 		// entered interactively; passed through to the API as-is (server-side
 		// validated) so future jurisdictions work without a Wrangler upgrade.
@@ -500,7 +550,7 @@ export const aiSearchCreateCommand = createCommand({
 					{ telemetryMessage: "ai search create missing r2 source" }
 				);
 			}
-			// 2.0 R2 jurisdiction: ask where the source bucket lives so we list
+			// 3.0 R2 jurisdiction: ask where the source bucket lives so we list
 			// (and optionally create) buckets in the matching jurisdiction.
 			if (sourceJurisdiction === undefined) {
 				sourceJurisdiction = await prompt(
@@ -508,7 +558,7 @@ export const aiSearchCreateCommand = createCommand({
 				);
 			}
 			const effectiveJurisdiction = sourceJurisdiction?.trim() || undefined;
-			// 2.1 R2: list buckets and let user pick, with "Create new" option
+			// 3.1 R2: list buckets and let user pick, with "Create new" option
 			const buckets = await listR2Buckets(
 				config,
 				accountId,
@@ -560,21 +610,7 @@ export const aiSearchCreateCommand = createCommand({
 					{ telemetryMessage: "ai search create missing web crawler source" }
 				);
 			}
-			// 2.2 Web: select source type (sitemap only for now), then list zones
-			// fallbackOption: 0 is safe — sitemap is the only available option
-			webParseType = await select("Select the web source type:", {
-				choices: [
-					{
-						title: "Sitemap",
-						description: "Crawl and index pages from a sitemap",
-						value: "sitemap" as const,
-					},
-				],
-				defaultOption: 0,
-				fallbackOption: 0,
-			});
-
-			// List all zones for the account
+			// 3.2 Web: list the account's zones so the user can pick one as the source
 			const zones = await fetchPagedListResult<{
 				id: string;
 				name: string;
@@ -612,7 +648,7 @@ export const aiSearchCreateCommand = createCommand({
 				instanceSource = `https://${selectedZone}`;
 			}
 		}
-		// 3. Custom metadata (optional). Honors --custom-metadata or
+		// 4. Custom metadata (optional). Honors --custom-metadata or
 		// --custom-metadata-schema; otherwise prompts interactively when
 		// running attached to a TTY.
 		if (

--- a/packages/wrangler/src/ai-search/types.ts
+++ b/packages/wrangler/src/ai-search/types.ts
@@ -55,6 +55,12 @@ export interface AiSearchCustomMetadata {
 	field_name: string;
 }
 
+/**
+ * How a web-crawler source discovers URLs. `sitemap` reads XML sitemaps;
+ * `discover` follows links recursively.
+ */
+export type AiSearchParseType = "sitemap" | "discover";
+
 export interface AiSearchPublicEndpointParams {
 	authorized_hosts?: string[];
 	chat_completions_endpoint?: { disabled?: boolean };
@@ -76,7 +82,7 @@ export interface AiSearchSourceParams {
 			specific_sitemaps?: string[];
 			use_browser_rendering?: boolean;
 		};
-		parse_type?: string;
+		parse_type?: AiSearchParseType;
 		store_options?: {
 			storage_id?: string;
 			r2_jurisdiction?: string;


### PR DESCRIPTION
Fixes [RAG-1541](https://jira.cfdata.org/browse/RAG-1541).

Adds a `--parse-type` flag to `wrangler ai-search create` so a website data source can be created with `parse_type` set to `discover` rather than the default `sitemap`.

The parse type could previously only be chosen through the interactive wizard, and that prompt was nested inside the "no `--source` supplied" branch — so it was unreachable whenever `--source` was passed, making `discover` impossible to set from a script. Parse-type resolution now happens in its own step, before source selection.

- New flag `--parse-type` with choices `sitemap` / `discover` (`sitemap` reads XML sitemaps; `discover` follows links recursively).
- Only valid for `--type web-crawler`; passing it with `--type builtin` or `--type r2` errors, since the API stores the value for those source types but never reads it.
- Forwarded to the API as `source_params.web_crawler.parse_type`.
- The interactive web flow now offers `Discover` alongside `Sitemap`.
- Omitted from the payload in non-interactive mode when the flag is absent, so the API default (`sitemap`) still applies and existing scripted invocations are unaffected.
- `AiSearchSourceParams.web_crawler.parse_type` was typed as a bare `string`; it is now the `AiSearchParseType` union.

Example:

`wrangler ai-search create my-instance --type web-crawler --source https://example.com --parse-type discover`

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: the `wrangler ai-search` commands are in open beta and not yet part of the published public Wrangler command docs; this flag will be documented alongside that command set. Note that the `discover` parse type is itself not yet in the public AI Search API docs either, so a docs update covering both is expected to follow separately.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14952" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->