### PR TITLE
[create-cloudflare] Disable pnpm self-provisioning in framework E2E

### DIFF
--- a/.github/workflows/c3-e2e.yml
+++ b/.github/workflows/c3-e2e.yml
@@ -287,6 +287,10 @@ jobs:
         run: pnpm run test:e2e:c3
         env:
           NODE_VERSION: ${{ env.NODE_VERSION }}
+          # Some framework generators write a different pnpm version to `packageManager`.
+          # By default pnpm downloads and runs it. Concurrent tests can then provision
+          # that version in the same pnpm tool store, causing recursive installs.
+          pnpm_config_manage_package_manager_versions: "false"
           E2E_EXPERIMENTAL: ${{ matrix.experimental }}
           E2E_TEST_PM: ${{ matrix.pm.name }}
           E2E_TEST_PM_VERSION: ${{ matrix.pm.version }}

--- a/packages/create-cloudflare/e2e/tests/frameworks/frameworks.test.ts
+++ b/packages/create-cloudflare/e2e/tests/frameworks/frameworks.test.ts
@@ -56,7 +56,8 @@ describe
 			// framework id + platform. getFrameworkConfig ignores it.
 			const variantLabel = testConfig.name.split(":")[2];
 			const frameworkTest = test.runIf(shouldRunTest(testConfig));
-			// Check whether concurrent pnpm version provisioning causes the Nuxt failures.
+			// Nuxt projects may provision their pinned pnpm version during installation.
+			// Keep the variants sequential so they do not mutate shared pnpm state concurrently.
 			const testToRun =
 				frameworkConfig.id === "nuxt"
 					? frameworkTest.sequential

--- a/packages/create-cloudflare/e2e/tests/frameworks/frameworks.test.ts
+++ b/packages/create-cloudflare/e2e/tests/frameworks/frameworks.test.ts
@@ -55,14 +55,7 @@ describe
 			// is a variant label that disambiguates tests sharing the same
 			// framework id + platform. getFrameworkConfig ignores it.
 			const variantLabel = testConfig.name.split(":")[2];
-			const frameworkTest = test.runIf(shouldRunTest(testConfig));
-			// Nuxt projects may provision their pinned pnpm version during installation.
-			// Keep the variants sequential so they do not mutate shared pnpm state concurrently.
-			const testToRun =
-				frameworkConfig.id === "nuxt"
-					? frameworkTest.sequential
-					: frameworkTest;
-			testToRun(
+			test.runIf(shouldRunTest(testConfig))(
 				`${frameworkConfig.id} (${frameworkConfig.platform ?? "pages"})${
 					variantLabel ? ` [${variantLabel}]` : ""
 				}`,

--- a/packages/create-cloudflare/e2e/tests/frameworks/frameworks.test.ts
+++ b/packages/create-cloudflare/e2e/tests/frameworks/frameworks.test.ts
@@ -55,7 +55,13 @@ describe
 			// is a variant label that disambiguates tests sharing the same
 			// framework id + platform. getFrameworkConfig ignores it.
 			const variantLabel = testConfig.name.split(":")[2];
-			test.runIf(shouldRunTest(testConfig))(
+			const frameworkTest = test.runIf(shouldRunTest(testConfig));
+			// Check whether concurrent pnpm version provisioning causes the Nuxt failures.
+			const testToRun =
+				frameworkConfig.id === "nuxt"
+					? frameworkTest.sequential
+					: frameworkTest;
+			testToRun(
 				`${frameworkConfig.id} (${frameworkConfig.platform ?? "pages"})${
 					variantLabel ? ` [${variantLabel}]` : ""
 				}`,

--- a/packages/create-cloudflare/turbo.json
+++ b/packages/create-cloudflare/turbo.json
@@ -28,7 +28,8 @@
 				"E2E_FRAMEWORK_TEMPLATE_TO_TEST",
 				"E2E_PROJECT_PATH",
 				"E2E_TEST_RETRIES",
-				"E2E_RUN_DEPLOY_TESTS"
+				"E2E_RUN_DEPLOY_TESTS",
+				"pnpm_config_manage_package_manager_versions"
 			],
 			"dependsOn": ["build"],
 			"inputs": ["e2e/**", "vitest-e2e.config.ts", "!e2e/README.md"],


### PR DESCRIPTION
Framework generators may write a pnpm version to their generated `packageManager` field that differs from the C3 E2E matrix version. pnpm then downloads and runs that version. When concurrent framework tests provision it through the same pnpm tool store, provisioning can recurse until Node fails with `ERANGE: uv_cwd`.

Disable automatic package-manager version provisioning only for the framework E2E run. This keeps concurrent framework coverage while avoiding shared pnpm tool-store mutation. Other C3 E2E jobs retain their existing behavior.

This addresses the failure reproduced consistently across attempts 2–6 of #14924.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: this only changes test-runner configuration and has no user-facing behavior.

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->