### PR TITLE
[miniflare] De-flake rate limit tests at bucket boundaries

### DIFF
--- a/fixtures/ratelimit-app/tests/index.test.ts
+++ b/fixtures/ratelimit-app/tests/index.test.ts
@@ -1,5 +1,5 @@
 import { resolve } from "path";
-import { setTimeout as sleep } from "timers/promises";
+import { setTimeout as sleep } from "node:timers/promises";
 import { afterAll, beforeAll, describe, it } from "vitest";
 import { createTestHarness } from "wrangler";
 

--- a/fixtures/ratelimit-app/tests/index.test.ts
+++ b/fixtures/ratelimit-app/tests/index.test.ts
@@ -1,4 +1,5 @@
 import { resolve } from "path";
+import { setTimeout as sleep } from "timers/promises";
 import { afterAll, beforeAll, describe, it } from "vitest";
 import { createTestHarness } from "wrangler";
 
@@ -7,6 +8,21 @@ const server = createTestHarness({
 	root: basePath,
 	workers: [{ configPath: "wrangler.jsonc" }],
 });
+
+/**
+ * Both bindings use a 60s period. Miniflare buckets requests into fixed
+ * windows aligned to the wall clock and clears every counter on rollover, so a
+ * burst that straddles a boundary has its count reset part way through and the
+ * final request is no longer rejected. Wait out the tail of the current window
+ * so each burst is guaranteed to run inside a single one.
+ */
+async function waitForFreshRateLimitWindow() {
+	const periodMs = 60 * 1000;
+	const remainingMs = periodMs - (Date.now() % periodMs);
+	if (remainingMs < 10_000) {
+		await sleep(remainingMs + 50);
+	}
+}
 
 describe("Rate limiting bindings", () => {
 	beforeAll(async () => {
@@ -18,6 +34,8 @@ describe("Rate limiting bindings", () => {
 	});
 
 	it("ratelimit binding is defined ", async ({ expect }) => {
+		await waitForFreshRateLimitWindow();
+
 		let response = await server.fetch("/");
 		let content = await response.text();
 		expect(content).toEqual("Success");
@@ -36,6 +54,8 @@ describe("Rate limiting bindings", () => {
 	});
 
 	it("ratelimit unsafe binding is defined ", async ({ expect }) => {
+		await waitForFreshRateLimitWindow();
+
 		let response = await server.fetch("/unsafe");
 		let content = await response.text();
 		expect(content).toEqual("unsafe: Success");

--- a/fixtures/ratelimit-app/tests/index.test.ts
+++ b/fixtures/ratelimit-app/tests/index.test.ts
@@ -1,5 +1,5 @@
-import { resolve } from "path";
 import { setTimeout as sleep } from "node:timers/promises";
+import { resolve } from "path";
 import { afterAll, beforeAll, describe, it } from "vitest";
 import { createTestHarness } from "wrangler";
 

--- a/packages/miniflare/test/plugins/ratelimit/index.spec.ts
+++ b/packages/miniflare/test/plugins/ratelimit/index.spec.ts
@@ -1,6 +1,28 @@
+import { setTimeout as sleep } from "node:timers/promises";
 import { Miniflare } from "miniflare";
 import { test } from "vitest";
 import { useDispose } from "../../test-shared";
+
+/**
+ * The emulated rate limiter buckets requests into fixed windows aligned to the
+ * wall clock (`Math.floor(Date.now() / (period * 1000))`, see
+ * `src/workers/ratelimit/ratelimit-object.worker.ts`) and clears every counter
+ * when the window rolls over.
+ *
+ * A burst that straddles a boundary therefore has its count reset part way
+ * through, so a test sending `limit + 1` requests and expecting the last to be
+ * rejected fails whenever the boundary lands mid-burst. Await this first: it
+ * returns immediately unless the current window is nearly over, in which case
+ * it waits for the next one so the burst runs inside a single window.
+ */
+async function waitForFreshRateLimitWindow(periodSeconds: number) {
+	const periodMs = periodSeconds * 1000;
+	const remainingMs = periodMs - (Date.now() % periodMs);
+	if (remainingMs < 10_000) {
+		// Overshoot slightly so the next request is unambiguously in the new window.
+		await sleep(remainingMs + 50);
+	}
+}
 
 test("ratelimit", async ({ expect }) => {
 	const mf = new Miniflare({
@@ -30,6 +52,8 @@ test("ratelimit", async ({ expect }) => {
 		`,
 	});
 	useDispose(mf);
+
+	await waitForFreshRateLimitWindow(60);
 
 	let res = await mf.dispatchFetch("http://localhost");
 	expect(res.status).toBe(200);
@@ -147,6 +171,8 @@ test("ratelimit counters are keyed by namespace_id", async ({ expect }) => {
 		await res.text();
 		return res.status;
 	};
+
+	await waitForFreshRateLimitWindow(60);
 
 	// RATE_A and RATE_B share the "shared" namespace, so they increment the same
 	// counter: two successes across the pair, then the third call is limited.

--- a/packages/wrangler/src/__tests__/api/startDevWorker/MultiworkerRuntimeController.test.ts
+++ b/packages/wrangler/src/__tests__/api/startDevWorker/MultiworkerRuntimeController.test.ts
@@ -1,3 +1,4 @@
+import { setTimeout as sleep } from "node:timers/promises";
 import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
 import dedent from "ts-dedent";
 import { fetch } from "undici";
@@ -46,6 +47,20 @@ function configDefaults(
 		dev: { persist: "./persist", remote: false },
 		...config,
 	};
+}
+
+/**
+ * Miniflare's rate limiter buckets requests into fixed windows aligned to the
+ * wall clock and clears every counter on rollover, so a burst that straddles a
+ * boundary has its count reset part way through. Wait out the tail of the
+ * current window so the burst below is guaranteed to run inside a single one.
+ */
+async function waitForFreshRateLimitWindow(periodSeconds: number) {
+	const periodMs = periodSeconds * 1000;
+	const remainingMs = periodMs - (Date.now() % periodMs);
+	if (remainingMs < 10_000) {
+		await sleep(remainingMs + 50);
+	}
 }
 
 describe("MultiworkerRuntimeController", () => {
@@ -186,6 +201,8 @@ describe("MultiworkerRuntimeController", () => {
 
 			const event = await bus.waitFor("reloadComplete");
 			const url = urlFromParts(event.proxyData.userWorkerUrl);
+
+			await waitForFreshRateLimitWindow(60);
 
 			// limit is 2, so the first two requests succeed and the third is
 			// rate limited — proving the secondary's binding survived the merge.


### PR DESCRIPTION
`MultiworkerRuntimeController.test.ts` has been failing intermittently in CI with `expected 200 to be 429`. Two other test files share the same latent problem.

The emulated rate limiter buckets requests into fixed windows aligned to the wall clock and clears **every** counter when the window rolls over ([`ratelimit-object.worker.ts:26-30`](https://github.com/cloudflare/workers-sdk/blob/main/packages/miniflare/src/workers/ratelimit/ratelimit-object.worker.ts#L26-L30)):

```ts
const epoch = Math.floor(Date.now() / (period * 1000));
if (epoch !== this.#epoch) {
    this.#epoch = epoch;
    this.#buckets.clear();
}
```

Every affected test sends a burst of `limit + 1` requests and asserts the last one is rejected. If the window boundary lands mid-burst the count is reset part way through, the final request succeeds, and the assertion fails. The failure probability is roughly `burstDuration / 60s` — negligible locally, but these bursts get slow enough on a loaded CI runner to show up.

Rather than change the emulation (its fixed-window behaviour is presumably deliberate, and production semantics aren't something this PR should guess at), each burst now waits out the tail of the current window first, so it is guaranteed to run inside a single one:

```ts
const remainingMs = periodMs - (Date.now() % periodMs);
if (remainingMs < 10_000) {
    await sleep(remainingMs + 50);
}
```

This is a no-op unless the window is nearly over, so the expected cost is well under a second per burst.

Applied at 5 burst sites across 3 files. The helper is defined locally in each: `fixtures/ratelimit-app` can't reach Miniflare's `test-shared`, and the two Miniflare uses are in a single file, so a shared module wouldn't buy anything.

Note the import is aliased to `sleep` deliberately — importing `setTimeout` from `node:timers/promises` shadows the global and breaks callback-style `setTimeout` usage elsewhere in the same module.

### Not addressed here

While investigating I confirmed a separate, genuine bug: because `RateLimiterObject` keeps its counters purely on the JS heap and the namespace is evictable, **any idle gap longer than workerd's ~10s eviction timer silently resets every counter**, even in the middle of a window. Verified with a probe — one `limit()` call, a 20s sleep inside a single 60s window, and the counter is back to zero.

That is a local-dev fidelity bug rather than a cause of this flake (it needs a >10s stall between two requests in a burst). It can't be fixed with `preventEviction: true`, because workerd's `deleteAllDurableObjects()` skips non-evictable namespaces, which would break `vitest-pool-workers`' `reset()` — confirmed empirically: that change makes `fixtures/vitest-pool-workers-examples/reset/test/reset.test.ts:81` fail. Filed as #14962; the likely fix is moving the counters into `state.storage`, which survives eviction and is still wiped by `reset()`.

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: this is a test-only change with no user-facing behaviour change.

> [!NOTE]
> This is a contribution from an AI agent: opencode, claude-opus-5.
