### PR TITLE
fix(miniflare): normalize Content-Type case/whitespace in isCompresse…

### DIFF
--- a/.changeset/mime-type-compression-case-whitespace.md
+++ b/.changeset/mime-type-compression-case-whitespace.md
@@ -2,7 +2,7 @@
 "miniflare": patch
 ---
 
-fix: normalize Content-Type case and whitespace when determining compression eligibility
+Normalize Content-Type case and whitespace when determining compression eligibility
 
 Responses with a `Content-Type` such as `Text/HTML` or `text/html ; charset=utf-8` are now
 compressed in local development, matching how Cloudflare's network handles them. Previously

--- a/.changeset/mime-type-compression-case-whitespace.md
+++ b/.changeset/mime-type-compression-case-whitespace.md
@@ -4,8 +4,7 @@
 
 fix: normalize Content-Type case and whitespace when determining compression eligibility
 
-`isCompressedByCloudflareFL()` compared the Content-Type header against a lowercase
-set without trimming whitespace or lowercasing the input first. Headers like
-`Text/HTML` or `text/html ; charset=utf-8` (extra space before the `;`) were
-treated as non-compressible even though Cloudflare's real edge compresses them,
-causing local dev responses to diverge from production behavior.
+Responses with a `Content-Type` such as `Text/HTML` or `text/html ; charset=utf-8` are now
+compressed in local development, matching how Cloudflare's network handles them. Previously
+differences in letter casing or extra spacing meant these responses were left uncompressed
+locally, so local behaviour diverged from production.

--- a/.changeset/mime-type-compression-case-whitespace.md
+++ b/.changeset/mime-type-compression-case-whitespace.md
@@ -4,7 +4,4 @@
 
 Normalize Content-Type case and whitespace when determining compression eligibility
 
-Responses with a `Content-Type` such as `Text/HTML` or `text/html ; charset=utf-8` are now
-compressed in local development, matching how Cloudflare's network handles them. Previously
-differences in letter casing or extra spacing meant these responses were left uncompressed
-locally, so local behaviour diverged from production.
+Responses with a `Content-Type` such as `Text/HTML` or `text/html ; charset=utf-8` are now compressed in local development, matching how Cloudflare's network handles them. Previously differences in letter casing or extra spacing meant these responses were left uncompressed locally, so local behaviour diverged from production.

--- a/.changeset/mime-type-compression-case-whitespace.md
+++ b/.changeset/mime-type-compression-case-whitespace.md
@@ -1,0 +1,11 @@
+---
+"miniflare": patch
+---
+
+fix: normalize Content-Type case and whitespace when determining compression eligibility
+
+`isCompressedByCloudflareFL()` compared the Content-Type header against a lowercase
+set without trimming whitespace or lowercasing the input first. Headers like
+`Text/HTML` or `text/html ; charset=utf-8` (extra space before the `;`) were
+treated as non-compressible even though Cloudflare's real edge compresses them,
+causing local dev responses to diverge from production behavior.

--- a/packages/miniflare/src/shared/index.ts
+++ b/packages/miniflare/src/shared/index.ts
@@ -2,6 +2,5 @@ export * from "./error";
 export * from "./event";
 export * from "./log";
 export * from "./matcher";
-export * from "./mime-types";
 export * from "./streams";
 export * from "./types";

--- a/packages/miniflare/src/shared/index.ts
+++ b/packages/miniflare/src/shared/index.ts
@@ -2,5 +2,6 @@ export * from "./error";
 export * from "./event";
 export * from "./log";
 export * from "./matcher";
+export * from "./mime-types";
 export * from "./streams";
 export * from "./types";

--- a/packages/miniflare/src/shared/mime-types.ts
+++ b/packages/miniflare/src/shared/mime-types.ts
@@ -56,5 +56,5 @@ export function isCompressedByCloudflareFL(
 
 	const [contentType] = contentTypeHeader.split(";");
 
-	return compressedByCloudflareFL.has(contentType);
+	return compressedByCloudflareFL.has(contentType.trim().toLowerCase());
 }

--- a/packages/miniflare/test/shared/mime-types.spec.ts
+++ b/packages/miniflare/test/shared/mime-types.spec.ts
@@ -1,0 +1,36 @@
+import { isCompressedByCloudflareFL } from "miniflare";
+import { test } from "vitest";
+
+test("isCompressedByCloudflareFL: matches known compressible types", ({
+	expect,
+}) => {
+	expect(isCompressedByCloudflareFL("text/html")).toBe(true);
+	expect(isCompressedByCloudflareFL("application/json")).toBe(true);
+	expect(isCompressedByCloudflareFL("image/png")).toBe(false);
+});
+
+test("isCompressedByCloudflareFL: ignores Content-Type parameters", ({
+	expect,
+}) => {
+	expect(isCompressedByCloudflareFL("text/html; charset=utf-8")).toBe(true);
+});
+
+test("isCompressedByCloudflareFL: is case-insensitive", ({ expect }) => {
+	expect(isCompressedByCloudflareFL("TEXT/HTML")).toBe(true);
+	expect(isCompressedByCloudflareFL("Application/JSON")).toBe(true);
+	expect(isCompressedByCloudflareFL("Text/Html; charset=UTF-8")).toBe(true);
+});
+
+test("isCompressedByCloudflareFL: ignores surrounding whitespace", ({
+	expect,
+}) => {
+	expect(isCompressedByCloudflareFL(" text/html ")).toBe(true);
+	expect(isCompressedByCloudflareFL("text/html ; charset=utf-8")).toBe(true);
+});
+
+test("isCompressedByCloudflareFL: treats missing Content-Type as text/plain", ({
+	expect,
+}) => {
+	expect(isCompressedByCloudflareFL(undefined)).toBe(true);
+	expect(isCompressedByCloudflareFL(null)).toBe(true);
+});

--- a/packages/miniflare/test/shared/mime-types.spec.ts
+++ b/packages/miniflare/test/shared/mime-types.spec.ts
@@ -1,5 +1,5 @@
-import { isCompressedByCloudflareFL } from "miniflare";
 import { test } from "vitest";
+import { isCompressedByCloudflareFL } from "../../src/shared/mime-types";
 
 test("isCompressedByCloudflareFL: matches known compressible types", ({
 	expect,


### PR DESCRIPTION
Fixes #14828.

`isCompressedByCloudflareFL()` compared the Content-Type header against a lowercase `Set` without trimming whitespace or lowercasing the input first. Headers like `Text/HTML` or `text/html ; charset=utf-8` (extra space before the `;`) were treated as non-compressible in local dev, even though Cloudflare's real edge compresses them — causing local dev responses to diverge from production behavior.

Fix: trim and lowercase the parsed content type before the `Set` lookup.

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: internal behavior fix, no user-facing API/docs change

> [!NOTE]
> This is a contribution from an AI agent: Claude Code, Claude Opus 4.8.