### PR TITLE
[vite-plugin] De-flake the playground tests on Windows

### DIFF
--- a/.github/workflows/vite-plugin-playgrounds.yml
+++ b/.github/workflows/vite-plugin-playgrounds.yml
@@ -17,7 +17,10 @@ env:
 
 jobs:
   test:
-    timeout-minutes: 30
+    # Windows jobs that miss the turbo cache already take 15-25 minutes, and the
+    # timeouts/retries in `playground/vitest.config.e2e.ts` give slow tests more
+    # room to finish, so leave headroom before the hard job kill.
+    timeout-minutes: 45
     name: ${{ format('Vite Plugin Playground ({0}, {1})', matrix.os, matrix.vite) }}
     strategy:
       fail-fast: false

--- a/packages/vite-plugin-cloudflare/AGENTS.md
+++ b/packages/vite-plugin-cloudflare/AGENTS.md
@@ -86,9 +86,17 @@ contract so the parent can drive either impl interchangeably.
 - E2E tests: `.test.ts` in `e2e/`, own vitest config
 - Playground tests: Playwright-based, tested across Vite 6/7/8 in CI
 - Playground request helpers (`playground/__test-utils__/responses.ts`):
-  - `getTextResponse()` / `getJsonResponse()` use plain `fetch()` with
-    browser navigation headers (`Sec-Fetch-Mode: navigate` et al), which the
-    asset and router workers branch on. Default to these.
+  - `getTextResponse()` / `getJsonResponse()` issue a request with browser
+    navigation headers (`Sec-Fetch-Mode: navigate` et al), which the asset and
+    router workers branch on. Default to these.
+  - They use `node:http` rather than `fetch()` **deliberately**. `Sec-Fetch-Mode`
+    is a forbidden header name, and Node's `fetch()` (undici) rewrites it to
+    `cors` on the way out — every other `Sec-Fetch-*` header survives, but that
+    one does not, and it is the one that decides whether the asset worker
+    applies `not_found_handling`. Do not "simplify" these back to `fetch()`;
+    `spa-with-api`'s "via `getTextResponse()`" test exists to catch exactly that
+    regression. Passing `mode: "navigate"` to `fetch()` is not an option either
+    (the `Request` constructor rejects it).
   - `getResponse()` drives a real `page.goto()` and returns a Playwright
     `Response`. Only use it when the assertion needs the browser. Anything
     routed through Playwright can outlive a timed-out test and surface as an

--- a/packages/vite-plugin-cloudflare/AGENTS.md
+++ b/packages/vite-plugin-cloudflare/AGENTS.md
@@ -89,14 +89,20 @@ contract so the parent can drive either impl interchangeably.
   - `getTextResponse()` / `getJsonResponse()` issue a request with browser
     navigation headers (`Sec-Fetch-Mode: navigate` et al), which the asset and
     router workers branch on. Default to these.
-  - They use `node:http` rather than `fetch()` **deliberately**. `Sec-Fetch-Mode`
-    is a forbidden header name, and Node's `fetch()` (undici) rewrites it to
-    `cors` on the way out — every other `Sec-Fetch-*` header survives, but that
-    one does not, and it is the one that decides whether the asset worker
-    applies `not_found_handling`. Do not "simplify" these back to `fetch()`;
-    `spa-with-api`'s "via `getTextResponse()`" test exists to catch exactly that
-    regression. Passing `mode: "navigate"` to `fetch()` is not an option either
-    (the `Request` constructor rejects it).
+  - They use undici's low-level `request()` rather than `fetch()`
+    **deliberately**. The Fetch spec requires implementations to set
+    `Sec-Fetch-Mode` from the request's `mode` ("append the Fetch metadata
+    headers"), so `fetch()` overwrites whatever the caller passed with `cors`
+    before the request leaves the process (`appendFetchMetadata` in undici).
+    `Sec-Fetch-Dest`/`-Site`/`-User` are unimplemented there, so they survive —
+    which is why only `Sec-Fetch-Mode` breaks and it is easy to miss. That one
+    decides whether the asset worker applies `not_found_handling`.
+  - This is permanent, not a bug to wait out: no Fetch-based API can send
+    `Sec-Fetch-Mode: navigate`, and `fetch(url, { mode: "navigate" })` is
+    rejected by the `Request` constructor. Do not "simplify" these back to
+    `fetch()`; `spa-with-api`'s "via `getTextResponse()`" test exists to catch
+    exactly that regression (it is the only playground whose compat date enables
+    `SEC_FETCH_MODE_NAVIGATE_HEADER_PREFERS_ASSET_SERVING`).
   - `getResponse()` drives a real `page.goto()` and returns a Playwright
     `Response`. Only use it when the assertion needs the browser. Anything
     routed through Playwright can outlive a timed-out test and surface as an

--- a/packages/vite-plugin-cloudflare/AGENTS.md
+++ b/packages/vite-plugin-cloudflare/AGENTS.md
@@ -85,3 +85,18 @@ contract so the parent can drive either impl interchangeably.
 - Unit tests: `.spec.ts` in `__tests__/`
 - E2E tests: `.test.ts` in `e2e/`, own vitest config
 - Playground tests: Playwright-based, tested across Vite 6/7/8 in CI
+- Playground request helpers (`playground/__test-utils__/responses.ts`):
+  - `getTextResponse()` / `getJsonResponse()` use plain `fetch()` with
+    browser navigation headers (`Sec-Fetch-Mode: navigate` et al), which the
+    asset and router workers branch on. Default to these.
+  - `getResponse()` drives a real `page.goto()` and returns a Playwright
+    `Response`. Only use it when the assertion needs the browser. Anything
+    routed through Playwright can outlive a timed-out test and surface as an
+    unhandled rejection, which fails the whole run rather than one test.
+  - `WAIT_FOR_OPTIONS` (`playground/__test-utils__/index.ts`) must stay
+    comfortably below the test timeout, otherwise `vi.waitFor()` never gets to
+    report the assertion that was actually failing.
+- `playground/vitest.config.e2e.ts` inherits the repo-wide timeouts and
+  `retry: 1` from the root `vitest.shared.ts`. It spreads `configShared.test`
+  rather than using `mergeConfig()`, which concatenates arrays and would
+  silently enable the shared `default` reporter alongside `dot`.

--- a/packages/vite-plugin-cloudflare/playground/__test-utils__/index.ts
+++ b/packages/vite-plugin-cloudflare/playground/__test-utils__/index.ts
@@ -6,9 +6,16 @@ export * from "../vitest-setup";
 export * from "./responses";
 export { satisfiesMinimumViteVersion } from "./vite-version";
 
-/** Common options to use with `vi.waitFor()` */
+/**
+ * Common options to use with `vi.waitFor()`.
+ *
+ * These must stay comfortably below the test timeout in `vitest.config.e2e.ts`.
+ * If `vi.waitFor()` is given as much time as the test itself, the test always
+ * dies of a bare "Test timed out" before `waitFor` gets to surface the
+ * assertion that was actually failing.
+ */
 export const WAIT_FOR_OPTIONS = {
-	timeout: isWindows ? 10_000 : 5_000,
+	timeout: isWindows ? 30_000 : 15_000,
 	interval: 500,
 };
 

--- a/packages/vite-plugin-cloudflare/playground/__test-utils__/responses.ts
+++ b/packages/vite-plugin-cloudflare/playground/__test-utils__/responses.ts
@@ -1,31 +1,51 @@
 import { page, viteTestUrl } from "./index";
 
 /**
- * Fetches JSON from the server using direct fetch (no browser).
- * Use this for tests that only need to hit API endpoints without browser interaction.
- * This avoids the race condition in `getJsonResponse` which uses Playwright's
- * `page.waitForResponse()` that can hang on Windows.
+ * Headers that a browser sends when navigating to a document.
+ *
+ * `getTextResponse()` and `getJsonResponse()` used to drive requests through
+ * Playwright's `page.goto()`, which is a real navigation. Some of the
+ * playgrounds depend on that: the asset worker only applies
+ * `not_found_handling` when `Sec-Fetch-Mode` is `navigate` (see
+ * `packages/workers-shared/asset-worker/src/handler.ts`), and the router worker
+ * branches on `Sec-Fetch-Dest`. Sending these headers keeps the plain `fetch()`
+ * requests below equivalent to a navigation.
+ *
+ * Note that undici overwrites `Sec-Fetch-Mode` with `cors` on the way into
+ * workerd, which the plugin works around by forwarding the original value in a
+ * custom header (see `packages/vite-plugin-cloudflare/src/utils.ts`).
  */
-export async function fetchJson(path = "/"): Promise<unknown> {
-	const url = `${viteTestUrl}${path}`;
-	const response = await fetch(url);
-	const text = await response.text();
-	try {
-		return JSON.parse(text);
-	} catch {
-		throw new Error("Invalid JSON response:\n" + text);
-	}
+const NAVIGATION_HEADERS = {
+	Accept:
+		"text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8",
+	"Sec-Fetch-Site": "none",
+	"Sec-Fetch-Mode": "navigate",
+	"Sec-Fetch-User": "?1",
+	"Sec-Fetch-Dest": "document",
+	"Upgrade-Insecure-Requests": "1",
+};
+
+/**
+ * Fetches a path from the Vite server as if the browser were navigating to it.
+ *
+ * Going through Playwright instead makes the request outlive the test when the
+ * server is slow, which on Windows CI surfaces as an unhandled
+ * "Target page, context or browser has been closed" rejection that fails the
+ * whole run rather than just the test.
+ */
+async function fetchNavigation(path: string): Promise<Response> {
+	return fetch(`${viteTestUrl}${path}`, { headers: NAVIGATION_HEADERS });
 }
 
 export async function getTextResponse(path = "/"): Promise<string> {
-	const response = await getResponse(path);
+	const response = await fetchNavigation(path);
 	return response.text();
 }
 
 export async function getJsonResponse(
 	path = "/"
 ): Promise<null | Record<string, unknown> | Array<unknown>> {
-	const response = await getResponse(path);
+	const response = await fetchNavigation(path);
 	const text = await response.text();
 	try {
 		return JSON.parse(text);
@@ -34,9 +54,24 @@ export async function getJsonResponse(
 	}
 }
 
+/**
+ * Navigates the browser to `path` and returns the Playwright response.
+ *
+ * Only use this when the test asserts on something that requires a real
+ * browser navigation (response status, headers, or subsequent page state).
+ * Otherwise use {@link getTextResponse} or {@link getJsonResponse}.
+ */
 export async function getResponse(path = "/") {
 	const url = `${viteTestUrl}${path}`;
-	const response = page.waitForResponse(url);
+	// `page.waitForResponse()` defaults to a 30s timeout, which can outlive the
+	// test itself. If the test times out while `page.goto()` below is still
+	// pending, this promise never gets awaited, and teardown closing the page
+	// rejects it with nothing attached. Vitest reports that as an unhandled
+	// error, which fails the whole run rather than just the test. Bound the wait
+	// and attach a handler up front so it can never escape; the `await` below
+	// still surfaces the real error to the test.
+	const response = page.waitForResponse(url, { timeout: 20_000 });
+	response.catch(() => {});
 	await page.goto(url);
 	return response;
 }

--- a/packages/vite-plugin-cloudflare/playground/__test-utils__/responses.ts
+++ b/packages/vite-plugin-cloudflare/playground/__test-utils__/responses.ts
@@ -1,5 +1,4 @@
-import http from "node:http";
-import https from "node:https";
+import { Agent, interceptors, request } from "undici";
 import { page, viteTestUrl } from "./index";
 
 /**
@@ -20,100 +19,59 @@ const NAVIGATION_HEADERS = {
 	"Upgrade-Insecure-Requests": "1",
 };
 
-/** Statuses that `Response` refuses to construct with a body. */
-const NULL_BODY_STATUSES = new Set([101, 103, 204, 205, 304]);
-
-const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
-
-/** Matches the browser's redirect limit, and what `fetch()` does by default. */
-const MAX_REDIRECTS = 20;
-
-function requestOnce(url: URL): Promise<Response> {
-	return new Promise((resolve, reject) => {
-		const transport = url.protocol === "https:" ? https : http;
-		const request = transport.request(
-			url,
-			{
-				method: "GET",
-				headers: NAVIGATION_HEADERS,
-				// The `basic-ssl` playground variants serve a self-signed certificate.
-				// The Playwright browser context ignores those too (`ignoreHTTPSErrors`
-				// in `vitest-setup.ts`).
-				rejectUnauthorized: false,
-			},
-			(response) => {
-				const chunks: Buffer[] = [];
-				response.on("data", (chunk: Buffer) => chunks.push(chunk));
-				response.on("error", reject);
-				response.on("end", () => {
-					const status = response.statusCode ?? 200;
-					const headers = new Headers();
-					for (const [name, value] of Object.entries(response.headers)) {
-						if (value === undefined) {
-							continue;
-						}
-						for (const entry of Array.isArray(value) ? value : [value]) {
-							headers.append(name, entry);
-						}
-					}
-					const body = NULL_BODY_STATUSES.has(status)
-						? null
-						: Buffer.concat(chunks);
-					resolve(
-						new Response(body, {
-							status,
-							statusText: response.statusMessage,
-							headers,
-						})
-					);
-				});
-			}
-		);
-		request.on("error", reject);
-		request.end();
-	});
-}
+const dispatcher = new Agent({
+	// The `basic-ssl` playground variants serve a self-signed certificate. The
+	// Playwright browser context ignores those too (`ignoreHTTPSErrors` in
+	// `vitest-setup.ts`).
+	connect: { rejectUnauthorized: false },
+	// Don't leave pooled sockets alive longer than a test file takes to finish,
+	// so a stray keep-alive connection can't hold the worker open at teardown.
+	keepAliveTimeout: 1_000,
+}).compose(
+	// Matches the browser's redirect limit, and what `fetch()` does by default.
+	interceptors.redirect({ maxRedirections: 20 })
+);
 
 /**
  * Requests a path from the Vite server as if the browser were navigating to it.
  *
- * This deliberately uses `node:http` rather than `fetch()`. Node's `fetch()`
- * (undici) rewrites `Sec-Fetch-Mode` to `cors` before the request leaves the
- * process — every other `Sec-Fetch-*` header survives, but that one does not,
- * and it is the one that decides whether the asset worker applies
- * `not_found_handling`. Requests made with `fetch()` are therefore genuinely
- * non-navigation requests, which `spa-with-api`'s tests rely on.
+ * This deliberately uses undici's low-level `request()` rather than `fetch()`.
+ * The Fetch spec requires implementations to set `Sec-Fetch-Mode` from the
+ * request's `mode` (the "append the Fetch metadata headers" step), so `fetch()`
+ * overwrites whatever the caller passed with `cors` before the request leaves
+ * the process — see `appendFetchMetadata` in undici. `Sec-Fetch-Dest`, `-Site`
+ * and `-User` are not implemented there, which is why only `Sec-Fetch-Mode` is
+ * affected and the breakage is easy to miss. It is also the one the asset worker
+ * branches on for `not_found_handling`.
  *
- * Going through Playwright would send the right headers, but makes the request
- * outlive the test when the server is slow, which on Windows CI surfaces as an
- * unhandled "Target page, context or browser has been closed" rejection that
- * fails the whole run rather than just the test.
+ * That makes this permanent rather than a bug to wait out: no Fetch-based API
+ * can send `Sec-Fetch-Mode: navigate`, and `fetch(url, { mode: "navigate" })` is
+ * rejected by the `Request` constructor. `request()` skips the Fetch layer
+ * entirely and sends the headers as given.
+ *
+ * Going through Playwright would also send the right headers, but makes the
+ * request outlive the test when the server is slow, which on Windows CI
+ * surfaces as an unhandled "Target page, context or browser has been closed"
+ * rejection that fails the whole run rather than just the test.
  */
-async function navigate(path: string): Promise<Response> {
-	let url = new URL(`${viteTestUrl}${path}`);
-
-	for (let redirects = 0; redirects <= MAX_REDIRECTS; redirects++) {
-		const response = await requestOnce(url);
-		const location = response.headers.get("location");
-		if (!REDIRECT_STATUSES.has(response.status) || location === null) {
-			return response;
-		}
-		url = new URL(location, url);
-	}
-
-	throw new Error(`Too many redirects while requesting "${path}"`);
+async function navigate(path: string): Promise<string> {
+	const { body } = await request(`${viteTestUrl}${path}`, {
+		headers: NAVIGATION_HEADERS,
+		dispatcher,
+	});
+	return body.text();
 }
 
 export async function getTextResponse(path = "/"): Promise<string> {
-	const response = await navigate(path);
-	return response.text();
+	return navigate(path);
 }
 
 export async function getJsonResponse(
 	path = "/"
 ): Promise<null | Record<string, unknown> | Array<unknown>> {
-	const response = await navigate(path);
-	const text = await response.text();
+	// Not `body.json()`, which reports parse failures without showing what came
+	// back. Playground responses are usually HTML when this goes wrong.
+	const text = await navigate(path);
 	try {
 		return JSON.parse(text);
 	} catch {

--- a/packages/vite-plugin-cloudflare/playground/__test-utils__/responses.ts
+++ b/packages/vite-plugin-cloudflare/playground/__test-utils__/responses.ts
@@ -1,19 +1,14 @@
+import http from "node:http";
+import https from "node:https";
 import { page, viteTestUrl } from "./index";
 
 /**
  * Headers that a browser sends when navigating to a document.
  *
- * `getTextResponse()` and `getJsonResponse()` used to drive requests through
- * Playwright's `page.goto()`, which is a real navigation. Some of the
- * playgrounds depend on that: the asset worker only applies
- * `not_found_handling` when `Sec-Fetch-Mode` is `navigate` (see
+ * `Sec-Fetch-Mode` is the one that matters: the asset worker only applies
+ * `not_found_handling` when it is `navigate` (see
  * `packages/workers-shared/asset-worker/src/handler.ts`), and the router worker
- * branches on `Sec-Fetch-Dest`. Sending these headers keeps the plain `fetch()`
- * requests below equivalent to a navigation.
- *
- * Note that undici overwrites `Sec-Fetch-Mode` with `cors` on the way into
- * workerd, which the plugin works around by forwarding the original value in a
- * custom header (see `packages/vite-plugin-cloudflare/src/utils.ts`).
+ * branches on `Sec-Fetch-Dest`.
  */
 const NAVIGATION_HEADERS = {
 	Accept:
@@ -25,27 +20,99 @@ const NAVIGATION_HEADERS = {
 	"Upgrade-Insecure-Requests": "1",
 };
 
+/** Statuses that `Response` refuses to construct with a body. */
+const NULL_BODY_STATUSES = new Set([101, 103, 204, 205, 304]);
+
+const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
+
+/** Matches the browser's redirect limit, and what `fetch()` does by default. */
+const MAX_REDIRECTS = 20;
+
+function requestOnce(url: URL): Promise<Response> {
+	return new Promise((resolve, reject) => {
+		const transport = url.protocol === "https:" ? https : http;
+		const request = transport.request(
+			url,
+			{
+				method: "GET",
+				headers: NAVIGATION_HEADERS,
+				// The `basic-ssl` playground variants serve a self-signed certificate.
+				// The Playwright browser context ignores those too (`ignoreHTTPSErrors`
+				// in `vitest-setup.ts`).
+				rejectUnauthorized: false,
+			},
+			(response) => {
+				const chunks: Buffer[] = [];
+				response.on("data", (chunk: Buffer) => chunks.push(chunk));
+				response.on("error", reject);
+				response.on("end", () => {
+					const status = response.statusCode ?? 200;
+					const headers = new Headers();
+					for (const [name, value] of Object.entries(response.headers)) {
+						if (value === undefined) {
+							continue;
+						}
+						for (const entry of Array.isArray(value) ? value : [value]) {
+							headers.append(name, entry);
+						}
+					}
+					const body = NULL_BODY_STATUSES.has(status)
+						? null
+						: Buffer.concat(chunks);
+					resolve(
+						new Response(body, {
+							status,
+							statusText: response.statusMessage,
+							headers,
+						})
+					);
+				});
+			}
+		);
+		request.on("error", reject);
+		request.end();
+	});
+}
+
 /**
- * Fetches a path from the Vite server as if the browser were navigating to it.
+ * Requests a path from the Vite server as if the browser were navigating to it.
  *
- * Going through Playwright instead makes the request outlive the test when the
- * server is slow, which on Windows CI surfaces as an unhandled
- * "Target page, context or browser has been closed" rejection that fails the
- * whole run rather than just the test.
+ * This deliberately uses `node:http` rather than `fetch()`. Node's `fetch()`
+ * (undici) rewrites `Sec-Fetch-Mode` to `cors` before the request leaves the
+ * process — every other `Sec-Fetch-*` header survives, but that one does not,
+ * and it is the one that decides whether the asset worker applies
+ * `not_found_handling`. Requests made with `fetch()` are therefore genuinely
+ * non-navigation requests, which `spa-with-api`'s tests rely on.
+ *
+ * Going through Playwright would send the right headers, but makes the request
+ * outlive the test when the server is slow, which on Windows CI surfaces as an
+ * unhandled "Target page, context or browser has been closed" rejection that
+ * fails the whole run rather than just the test.
  */
-async function fetchNavigation(path: string): Promise<Response> {
-	return fetch(`${viteTestUrl}${path}`, { headers: NAVIGATION_HEADERS });
+async function navigate(path: string): Promise<Response> {
+	let url = new URL(`${viteTestUrl}${path}`);
+
+	for (let redirects = 0; redirects <= MAX_REDIRECTS; redirects++) {
+		const response = await requestOnce(url);
+		const location = response.headers.get("location");
+		if (!REDIRECT_STATUSES.has(response.status) || location === null) {
+			return response;
+		}
+		url = new URL(location, url);
+	}
+
+	throw new Error(`Too many redirects while requesting "${path}"`);
 }
 
 export async function getTextResponse(path = "/"): Promise<string> {
-	const response = await fetchNavigation(path);
+	const response = await navigate(path);
 	return response.text();
 }
 
 export async function getJsonResponse(
 	path = "/"
 ): Promise<null | Record<string, unknown> | Array<unknown>> {
-	const response = await fetchNavigation(path);
+	const response = await navigate(path);
 	const text = await response.text();
 	try {
 		return JSON.parse(text);
@@ -57,9 +124,9 @@ export async function getJsonResponse(
 /**
  * Navigates the browser to `path` and returns the Playwright response.
  *
- * Only use this when the test asserts on something that requires a real
- * browser navigation (response status, headers, or subsequent page state).
- * Otherwise use {@link getTextResponse} or {@link getJsonResponse}.
+ * Only use this when the test asserts on something that requires the browser
+ * (subsequent page state, or Playwright's `Response` API). Otherwise use
+ * {@link getTextResponse} or {@link getJsonResponse}.
  */
 export async function getResponse(path = "/") {
 	const url = `${viteTestUrl}${path}`;

--- a/packages/vite-plugin-cloudflare/playground/config-changes/__tests__/runtime-restart.spec.ts
+++ b/packages/vite-plugin-cloudflare/playground/config-changes/__tests__/runtime-restart.spec.ts
@@ -20,23 +20,27 @@ test.runIf(!isBuild)(
 		expect(initialRuntimeResponse.ok).toBe(true);
 		const initialRuntimeId = await initialRuntimeResponse.text();
 
+		// This request is not expected to complete, since it crashes the runtime
+		// that is serving it, so keep the abort short to avoid stalling the test.
 		const crashResponse = await fetch(`${viteTestUrl}/__crash-workerd`, {
 			signal: AbortSignal.timeout(2_000),
 		}).catch(() => undefined);
 		expect(crashResponse?.ok).not.toBe(true);
 
+		// These requests race a workerd restart, which is slow on Windows CI. The
+		// aborts must be long enough for a cold runtime to answer, otherwise every
+		// `waitFor` attempt aborts and the retries can never succeed.
 		await vi.waitFor(async () => {
 			const runtimeId = await fetch(`${viteTestUrl}/__runtime-id`, {
-				signal: AbortSignal.timeout(2_000),
+				signal: AbortSignal.timeout(10_000),
 			}).then((response) => response.text());
 			expect(runtimeId).not.toBe(initialRuntimeId);
 
 			const response = await fetch(viteTestUrl, {
-				signal: AbortSignal.timeout(2_000),
+				signal: AbortSignal.timeout(10_000),
 			});
 			expect(response.ok).toBe(true);
 			expect(await response.text()).toContain('The value of MY_VAR is "one"');
 		}, WAIT_FOR_OPTIONS);
-	},
-	20_000
+	}
 );

--- a/packages/vite-plugin-cloudflare/playground/cron-triggers/__tests__/cf-worker-header.spec.ts
+++ b/packages/vite-plugin-cloudflare/playground/cron-triggers/__tests__/cf-worker-header.spec.ts
@@ -1,6 +1,6 @@
 import http from "node:http";
 import { afterAll, beforeAll, test } from "vitest";
-import { fetchJson } from "../../__test-utils__";
+import { getJsonResponse } from "../../__test-utils__";
 
 // Regression test for https://github.com/cloudflare/workers-sdk/issues/13791.
 //
@@ -47,7 +47,7 @@ afterAll(async () => {
 test("outbound subrequests use the first configured route's zone name as the `CF-Worker` header", async ({
 	expect,
 }) => {
-	const response = await fetchJson(
+	const response = await getJsonResponse(
 		`/cf-worker-header?echoUrl=${encodeURIComponent(echoUrl)}`
 	);
 	expect(response).toEqual({ cfWorker: "example.com" });

--- a/packages/vite-plugin-cloudflare/playground/external-workflows/__tests__/workflows.spec.ts
+++ b/packages/vite-plugin-cloudflare/playground/external-workflows/__tests__/workflows.spec.ts
@@ -1,13 +1,13 @@
 import { test, vi } from "vitest";
-import { fetchJson, WAIT_FOR_OPTIONS } from "../../__test-utils__";
+import { getJsonResponse, WAIT_FOR_OPTIONS } from "../../__test-utils__";
 
 test("creates a Workflow with an ID", async ({ expect }) => {
 	const instanceId = "external-workflows-test-id";
 
-	await fetchJson(`/create?id=${instanceId}`);
+	await getJsonResponse(`/create?id=${instanceId}`);
 
 	await vi.waitFor(async () => {
-		expect(await fetchJson(`/get?id=${instanceId}`)).toEqual({
+		expect(await getJsonResponse(`/get?id=${instanceId}`)).toEqual({
 			status: "complete",
 			__LOCAL_DEV_STEP_OUTPUTS: [
 				{ output: "First step result" },

--- a/packages/vite-plugin-cloudflare/playground/package.json
+++ b/packages/vite-plugin-cloudflare/playground/package.json
@@ -22,6 +22,7 @@
 		"semver": "^7.7.1",
 		"ts-dedent": "^2.2.0",
 		"typescript": "catalog:default",
+		"undici": "catalog:default",
 		"vitest": "catalog:default"
 	}
 }

--- a/packages/vite-plugin-cloudflare/playground/spa-with-api/__tests__/spa-with-api.spec.ts
+++ b/packages/vite-plugin-cloudflare/playground/spa-with-api/__tests__/spa-with-api.spec.ts
@@ -29,6 +29,22 @@ test("returns the home page for not found route on navigation request ('sec-fetc
 	expect(content).toBe("Vite + React");
 });
 
+// Regression test for the `getTextResponse()` transport. The previous test
+// covers a real browser navigation; this one asserts that the helper the rest
+// of the playgrounds use is *also* seen as a navigation by the Worker.
+//
+// It is easy to break: `Sec-Fetch-Mode` is a forbidden header name, and Node's
+// `fetch()` rewrites it to `cors` on the way out, so a `fetch()`-based helper
+// silently stops exercising `not_found_handling` while still passing every
+// other assertion in this file.
+test("returns the home page for not found route via `getTextResponse()`", async ({
+	expect,
+}) => {
+	const text = await getTextResponse("/api/");
+	expect(text).toContain("<title>Vite + React + TS</title>");
+	expect(text).not.toContain("Cloudflare");
+});
+
 test("returns the Worker API response for API route on non-navigation request ('sec-fetch-mode: navigate' header not included)", async ({
 	expect,
 }) => {

--- a/packages/vite-plugin-cloudflare/playground/spa-with-api/__tests__/spa-with-api.spec.ts
+++ b/packages/vite-plugin-cloudflare/playground/spa-with-api/__tests__/spa-with-api.spec.ts
@@ -33,8 +33,8 @@ test("returns the home page for not found route on navigation request ('sec-fetc
 // covers a real browser navigation; this one asserts that the helper the rest
 // of the playgrounds use is *also* seen as a navigation by the Worker.
 //
-// It is easy to break: `Sec-Fetch-Mode` is a forbidden header name, and Node's
-// `fetch()` rewrites it to `cors` on the way out, so a `fetch()`-based helper
+// It is easy to break: the Fetch spec makes `fetch()` overwrite
+// `Sec-Fetch-Mode` with the request's `mode`, so a `fetch()`-based helper
 // silently stops exercising `not_found_handling` while still passing every
 // other assertion in this file.
 test("returns the home page for not found route via `getTextResponse()`", async ({

--- a/packages/vite-plugin-cloudflare/playground/stream-binding/__tests__/worker.spec.ts
+++ b/packages/vite-plugin-cloudflare/playground/stream-binding/__tests__/worker.spec.ts
@@ -1,9 +1,9 @@
 import { test } from "vitest";
-import { fetchJson, viteTestUrl } from "../../__test-utils__";
+import { getJsonResponse, viteTestUrl } from "../../__test-utils__";
 import { CONFIGURED_PORT } from "./serve";
 
 test("stream upload returns a valid preview URL", async ({ expect }) => {
-	const result = (await fetchJson("/upload")) as {
+	const result = (await getJsonResponse("/upload")) as {
 		preview: string;
 		id: string;
 	};
@@ -19,7 +19,7 @@ test("stream preview URL port matches actual server port after port bump", async
 	const serverUrl = new URL(viteTestUrl);
 	expect(Number(serverUrl.port)).not.toBe(CONFIGURED_PORT);
 
-	const result = (await fetchJson("/upload")) as {
+	const result = (await getJsonResponse("/upload")) as {
 		preview: string;
 		id: string;
 	};

--- a/packages/vite-plugin-cloudflare/playground/vitest-setup.ts
+++ b/packages/vite-plugin-cloudflare/playground/vitest-setup.ts
@@ -213,7 +213,7 @@ beforeAll(async ({}, s) => {
 			await postServe();
 		}
 	};
-}, 40_000);
+});
 
 export async function loadConfig(configEnv: ConfigEnv) {
 	let config: UserConfig | null = null;

--- a/packages/vite-plugin-cloudflare/playground/vitest.config.e2e.ts
+++ b/packages/vite-plugin-cloudflare/playground/vitest.config.e2e.ts
@@ -1,10 +1,16 @@
 import util from "node:util";
 import { defineConfig } from "vitest/config";
+import configShared from "../../../vitest.shared";
 
 const debuglog = util.debuglog("@cloudflare:vite-plugin");
 
 export default defineConfig({
 	test: {
+		// Inherit the repo-wide timeout and retry policy, which is sized for the
+		// Windows CI runners. Spread rather than `mergeConfig()` because the latter
+		// concatenates arrays, which would silently enable the shared "default"
+		// reporter alongside the "dot" reporter set below.
+		...configShared.test,
 		// We run these tests one file at a time.
 		// Otherwise we occasionally get flakes where two playground variants are overwriting the same files.
 		fileParallelism: false,
@@ -13,7 +19,6 @@ export default defineConfig({
 		globalSetup: ["./vitest-global-setup.ts"],
 		reporters: "dot",
 		onConsoleLog: () => debuglog.enabled,
-		testTimeout: 10000,
 	},
 	publicDir: false,
 });

--- a/packages/vite-plugin-cloudflare/playground/workflows/__tests__/workflows.spec.ts
+++ b/packages/vite-plugin-cloudflare/playground/workflows/__tests__/workflows.spec.ts
@@ -1,13 +1,13 @@
 import { test, vi } from "vitest";
-import { fetchJson, WAIT_FOR_OPTIONS } from "../../__test-utils__";
+import { getJsonResponse, WAIT_FOR_OPTIONS } from "../../__test-utils__";
 
 test("creates a Workflow with an ID", async ({ expect }) => {
 	const instanceId = "workflows-test-id";
 
-	await fetchJson(`/create?id=${instanceId}`);
+	await getJsonResponse(`/create?id=${instanceId}`);
 
 	await vi.waitFor(async () => {
-		expect(await fetchJson(`/get?id=${instanceId}`)).toEqual({
+		expect(await getJsonResponse(`/get?id=${instanceId}`)).toEqual({
 			status: "complete",
 			__LOCAL_DEV_STEP_OUTPUTS: [
 				{ output: "First step result" },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2886,6 +2886,9 @@ importers:
       typescript:
         specifier: catalog:default
         version: 5.8.3
+      undici:
+        specifier: catalog:default
+        version: 7.28.0
       vitest:
         specifier: catalog:default
         version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@22.15.17)(@vitest/ui@4.1.0)(msw@2.12.4(@types/node@22.15.17)(typescript@5.8.3))(vite@8.1.5(@types/node@22.15.17)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.1))


### PR DESCRIPTION
The Windows Vite plugin playground job flakes constantly, and every failure looks different. It also only ever fails on forked PRs. Both of those have the same explanation.

### The Windows suite fails ~40% of the time, everywhere

Across the last 120 runs of `vite-plugin-playgrounds.yml` there were 105 Windows jobs:

|              | suite executed | turbo cache replay |
| ------------ | -------------- | ------------------ |
| **non-fork** | 1              | 55                 |
| **fork**     | 25             | 1                  |

Of the 25 fork jobs that actually ran the suite, **10 failed**. Non-fork jobs finish in ~2 minutes with `>>> FULL TURBO`; fork jobs take 15–25 minutes.

So forks aren't slower or more resource-starved — they're the only place the suite runs, because they have no turbo remote cache credentials. That is tracked separately in #14967; this PR is only about the flakiness itself.

### Every failure is a timeout

Not one assertion failure in the ten:

| Failing spec                                                              | Times | Signature                                    |
| ------------------------------------------------------------------------- | ----- | -------------------------------------------- |
| `workflows` / `external-workflows` > creates a Workflow with an ID        | 4     | `Test timed out in 10000ms`                  |
| `react-spa/experimental-headers-and-redirects`                            | 3     | `Hook timed out in 40000ms`                  |
| `durable-objects` > preserves same-type RPC call order                    | 2     | `Test timed out in 10000ms`                  |
| `config-changes`                                                          | 2     | `Test timed out in 10000ms`                  |
| `config-changes/runtime-restart` > serves requests after workerd crashes  | 2     | `TimeoutError: operation aborted due to timeout` |
| `ctx-exports`, `errors`, `prisma`, `dot-env/vars-changes`, `multi-worker` | 1 ea. | test/hook timeout                            |

Across 2027 successful server boots in those logs: median 3.0s, p90 4.7s, **p99 14.0s, max 33.7s**. Windows tail latency is ~11x its median, and the suite was configured with no headroom for that.

### What was wrong

**1. The playground opted out of the repo's timeout policy.** `playground/vitest.config.e2e.ts` did not extend the root `vitest.shared.ts`, so it ran with `testTimeout: 10000` and no retries — while every other suite in the repo gets 50s timeouts and `retry: 1`, under a comment that literally reads *"These timeouts are very large because the Windows CI jobs regularly take up to 42 secs."*

It now inherits that policy. Note it spreads `configShared.test` rather than using `mergeConfig()`: `mergeConfig` concatenates arrays, so merging would have silently enabled the shared `default` reporter alongside `dot`. The explicit `40_000` on the `beforeAll` in `vitest-setup.ts` is also removed, since it would have overridden the inherited `hookTimeout` (this is the `prisma` failure — its `serve.ts` runs three `execSync` calls inside that hook and medians 13.3s on Windows).

**2. `vi.waitFor()` was given as much time as the test itself.** `WAIT_FOR_OPTIONS.timeout` was `isWindows ? 10_000 : 5_000` against a 10s test budget, so on Windows the test always died of a bare "Test timed out" before `waitFor` could surface the assertion that was actually failing. 31 spec files use it; exactly one raised its own timeout.

**3. `getResponse()` leaked a dangling Playwright promise.** It created `page.waitForResponse(url)` (Playwright default 30s) and then awaited `page.goto(url)`. When the test timed out first, `return response` never ran, so nothing was ever attached to that promise — and teardown closing the page turned it into an unhandled rejection:

```
Unhandled Rejection
Error: page.waitForResponse: Target page, context or browser has been closed
 ❯ getResponse __test-utils__/responses.ts:39:24
```

Vitest fails the whole run on unhandled errors, so `retry: 1` alone would not have fixed this.

`getTextResponse()` / `getJsonResponse()` (199 call sites, no signature change) now issue the request through undici's low-level `request()`. `getResponse()` stays on Playwright for the 8 files that assert on `.status()` / `.headerValue()` / `.allHeaders()`, but bounds its wait and attaches a handler up front.

This also folds away `fetchJson()`, which was added in #12619 to work around exactly this hang and had become a confusing duplicate of `getJsonResponse()`.

**Why the `fetch()` calls send navigation headers:** `page.goto()` is a real navigation, and the playgrounds depend on that. `packages/workers-shared/asset-worker/src/handler.ts:217` only applies `not_found_handling` when `Sec-Fetch-Mode` is `navigate`, and the router worker branches on `Sec-Fetch-Dest`. A naive `fetch()` swap would silently change what `spa-with-api`, `static`, `sensitive-files` and `deps-assets-importing` exercise — which is the kind of "different rather than fewer errors" that got #12360 reverted. Sending navigation headers keeps the requests equivalent.

**Why not `fetch()`:** the Fetch spec requires implementations to set `Sec-Fetch-Mode` from the request's `mode` (the "append the Fetch metadata headers" step), so `fetch()` overwrites whatever the caller passed with `cors` before the request leaves the process — see `appendFetchMetadata` in undici. `Sec-Fetch-Dest`/`-Site`/`-User` are unimplemented there and pass through untouched, which is why only `Sec-Fetch-Mode` breaks and it's easy to miss.

This is permanent rather than a bug to wait out: no Fetch-based API can send `Sec-Fetch-Mode: navigate`, and `fetch(url, { mode: "navigate" })` is rejected by the `Request` constructor. Setting `MF-Sec-Fetch-Mode` directly doesn't help either, because `src/utils.ts:144` overwrites it from the received `Sec-Fetch-Mode`.

undici's `request()` skips the Fetch layer entirely and sends the headers as given (verified over http and https, and across redirects). Redirect following comes from `interceptors.redirect({ maxRedirections: 20 })` to match `fetch()`'s default. `undici` is already repo-standard via `catalog:default`, and this playground package is `private` and dev-only.

`spa-with-api` (the only playground whose compat date enables `SEC_FETCH_MODE_NAVIGATE_HEADER_PREFERS_ASSET_SERVING`) has a regression test pinning this: `getTextResponse("/api/")` must return the SPA fallback, not the Worker's JSON. It was verified to fail against a `fetch()`-based transport.

**4. Two-second aborts racing a workerd restart.** `runtime-restart.spec.ts` used `AbortSignal.timeout(2_000)` for requests issued while workerd is restarting. If a cold runtime can't answer in 2s, *every* `waitFor` attempt aborts and the retries can never succeed, regardless of the total budget. The abort on the crash-triggering request is left short deliberately, since that one isn't expected to complete.

Finally, `timeout-minutes` goes 30 → 45, since Windows jobs that miss the cache already take up to 25.3 minutes and slow tests are now allowed to finish.

### Verification

`pnpm check` passes (201/201). Both playground suites pass locally:

- serve: 96 files passed, 5 skipped / 286 tests passed, 8 expected fail, 66 skipped
- build/preview: 89 files passed, 12 skipped / 305 tests passed, 55 skipped

Also confirmed the resolved config is what's intended rather than what `mergeConfig` would have produced:

```
testTimeout: 50000, hookTimeout: 50000, teardownTimeout: 50000,
retry: 1, restoreMocks: true, reporters: "dot", fileParallelism: false
```

Real validation has to happen on Windows CI. Worth re-running that job a few times against the 40% baseline.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: this only changes the Vite plugin's own test harness and CI config; there is no user-facing change.

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

> [!NOTE]
> This is a contribution from an AI agent: OpenCode, Claude Opus 4.5.


