### PR TITLE
[miniflare] Persist local rate limit counters so they survive Durable Object eviction

### DIFF
--- a/.changeset/ratelimit-period-scoped-counters.md
+++ b/.changeset/ratelimit-period-scoped-counters.md
@@ -1,0 +1,26 @@
+---
+"miniflare": patch
+---
+
+Fix local rate limiting being disabled entirely when bindings share a `namespace_id` but use different periods
+
+The emulated Ratelimit binding tracked one counter per key per namespace, ignoring the period. Two bindings pointing at the same `namespace_id` with different `simple.period` values therefore overwrote each other's counter on every call — each one seeing a window it did not recognise, and so resetting the count to zero — with the result that neither binding ever limited anything:
+
+```jsonc
+{
+	"ratelimits": [
+		{
+			"name": "BURST",
+			"namespace_id": "1001",
+			"simple": { "limit": 20, "period": 10 },
+		},
+		{
+			"name": "SUSTAINED",
+			"namespace_id": "1001",
+			"simple": { "limit": 50, "period": 60 },
+		},
+	],
+}
+```
+
+Counters are now tracked per period, matching production, where a counter is identified by a bucket index and bucket start timestamp that are both derived from the period. Bindings that share a `namespace_id` and a period still share a counter for a given key.

--- a/.changeset/ratelimit-survive-eviction.md
+++ b/.changeset/ratelimit-survive-eviction.md
@@ -1,0 +1,9 @@
+---
+"miniflare": patch
+---
+
+Fix local rate limit counters silently resetting after ~10s of inactivity
+
+The emulated Ratelimit binding kept its counters on the JS heap of an internal Durable Object. `workerd` evicts idle Durable Objects after around 10 seconds, taking the counters with them, so in `wrangler dev` you could hit your Worker, pause to look at something, and find your limit had silently reset part way through the window.
+
+Counters now live in the Durable Object's storage, which survives eviction. They are still cleared by `deleteAllDurableObjects()`, so `reset()` from `@cloudflare/vitest-pool-workers` continues to reset rate limit state between tests, exactly as it does for KV, R2 and D1. Counters are now also written to the persistence directory, so they survive a `wrangler dev` restart within the same window.

--- a/packages/miniflare/src/plugins/ratelimit/index.ts
+++ b/packages/miniflare/src/plugins/ratelimit/index.ts
@@ -102,26 +102,26 @@ export const RATELIMIT_PLUGIN: Plugin<typeof RatelimitOptionsSchema> = {
 		);
 	},
 	async getServices({ options, tmpPath, resourcePersistencePath }) {
-		if (!options.ratelimits) {
-			return [];
-		}
 		// One entry service + Durable Object instance per unique namespace_id.
 		// Multiple bindings sharing a namespace collapse to a single counter.
-		const services: Service[] = [];
-		const seenNamespaces = new Set<string>();
-		for (const { namespace_id } of Object.values(options.ratelimits)) {
-			if (seenNamespaces.has(namespace_id)) {
-				continue;
-			}
-			seenNamespaces.add(namespace_id);
-			services.push({
-				name: getUserBindingServiceName(
-					RATELIMIT_ENTRY_SERVICE_PREFIX,
-					namespace_id
-				),
-				worker: objectEntryWorker(RATELIMIT_OBJECT, namespace_id),
-			});
+		const namespaceIds = new Set(
+			Object.values(options.ratelimits ?? {}).map((c) => c.namespace_id)
+		);
+		// Wrangler passes `ratelimits: {}` rather than omitting it when a Worker
+		// has no rate limit bindings, so bail on emptiness rather than presence.
+		// Otherwise every `wrangler dev` session would create an unused storage
+		// directory in the user's persistence directory.
+		if (namespaceIds.size === 0) {
+			return [];
 		}
+
+		const services: Service[] = [...namespaceIds].map((namespace_id) => ({
+			name: getUserBindingServiceName(
+				RATELIMIT_ENTRY_SERVICE_PREFIX,
+				namespace_id
+			),
+			worker: objectEntryWorker(RATELIMIT_OBJECT, namespace_id),
+		}));
 
 		const persistPath = getPersistPath(
 			RATELIMIT_PLUGIN_NAME,

--- a/packages/miniflare/src/plugins/ratelimit/index.ts
+++ b/packages/miniflare/src/plugins/ratelimit/index.ts
@@ -1,10 +1,11 @@
+import fs from "node:fs/promises";
 import SCRIPT_RATELIMIT_CLIENT from "worker:ratelimit/ratelimit";
 import SCRIPT_RATELIMIT_OBJECT from "worker:ratelimit/ratelimit-object";
 import { z } from "zod";
-import { kVoid } from "../../runtime";
 import { SharedBindings } from "../../workers";
 import {
 	getMiniflareObjectBindings,
+	getPersistPath,
 	getUserBindingServiceName,
 	objectEntryWorker,
 	ProxyNodeBinding,
@@ -43,6 +44,7 @@ export const RATELIMIT_PLUGIN_NAME = "ratelimit";
 const SERVICE_RATELIMIT_PREFIX = `${RATELIMIT_PLUGIN_NAME}`;
 const SERVICE_RATELIMIT_MODULE = `cloudflare-internal:${SERVICE_RATELIMIT_PREFIX}:module`;
 const RATELIMIT_ENTRY_SERVICE_PREFIX = `${RATELIMIT_PLUGIN_NAME}:ns`;
+const RATELIMIT_STORAGE_SERVICE_NAME = `${RATELIMIT_PLUGIN_NAME}:storage`;
 const RATELIMIT_OBJECT_CLASS_NAME = "RateLimiterObject";
 const RATELIMIT_OBJECT: Worker_Binding_DurableObjectNamespaceDesignator = {
 	serviceName: RATELIMIT_ENTRY_SERVICE_PREFIX,
@@ -99,7 +101,7 @@ export const RATELIMIT_PLUGIN: Plugin<typeof RatelimitOptionsSchema> = {
 			])
 		);
 	},
-	async getServices({ options }) {
+	async getServices({ options, tmpPath, resourcePersistencePath }) {
 		if (!options.ratelimits) {
 			return [];
 		}
@@ -121,6 +123,17 @@ export const RATELIMIT_PLUGIN: Plugin<typeof RatelimitOptionsSchema> = {
 			});
 		}
 
+		const persistPath = getPersistPath(
+			RATELIMIT_PLUGIN_NAME,
+			tmpPath,
+			resourcePersistencePath
+		);
+		await fs.mkdir(persistPath, { recursive: true });
+		services.push({
+			name: RATELIMIT_STORAGE_SERVICE_NAME,
+			disk: { path: persistPath, writable: true },
+		});
+
 		const uniqueKey = `miniflare-${RATELIMIT_OBJECT_CLASS_NAME}`;
 		services.push({
 			name: RATELIMIT_ENTRY_SERVICE_PREFIX,
@@ -134,12 +147,22 @@ export const RATELIMIT_PLUGIN: Plugin<typeof RatelimitOptionsSchema> = {
 					},
 				],
 				durableObjectNamespaces: [
-					{ className: RATELIMIT_OBJECT_CLASS_NAME, uniqueKey },
+					{
+						className: RATELIMIT_OBJECT_CLASS_NAME,
+						uniqueKey,
+						enableSql: true,
+					},
 				],
-				// Counters are only ever needed for the lifetime of the Miniflare
-				// process, never persisted across restarts (matching the previous
-				// purely in-memory implementation).
-				durableObjectStorage: { inMemory: kVoid },
+				// Counters must outlive the Durable Object itself. `workerd` evicts
+				// idle objects after ~10s, which would silently reset every counter
+				// mid-window if the state lived on the heap (or in `inMemory` storage,
+				// which is backed by a per-actor `ActorCache` and is just as lossy).
+				//
+				// The namespace deliberately stays evictable: `deleteAllDurableObjects()`
+				// (what vitest-pool-workers' `reset()` calls) skips namespaces with
+				// `preventEviction` set, and it is what resets these counters between
+				// tests, via `ActorNamespace::deleteAll()` -> `SqliteDatabase::reset()`.
+				durableObjectStorage: { localDisk: RATELIMIT_STORAGE_SERVICE_NAME },
 				bindings: [
 					{
 						name: SharedBindings.MAYBE_SERVICE_LOOPBACK,

--- a/packages/miniflare/src/workers/ratelimit/ratelimit-object.worker.ts
+++ b/packages/miniflare/src/workers/ratelimit/ratelimit-object.worker.ts
@@ -1,9 +1,15 @@
-// Durable Object backing the emulated Ratelimit binding. Moving bucket/epoch
-// state here (instead of an in-memory object behind a `wrapped` binding)
-// means it's automatically torn down by `deleteAllDurableObjects()`, so
-// vitest-pool-workers' `reset()` clears it for free.
-import { MiniflareDurableObject, POST } from "miniflare:shared";
-import type { RouteHandler } from "miniflare:shared";
+// Durable Object backing the emulated Ratelimit binding.
+//
+// Counters live in `state.storage` (SQLite on disk, see the `ratelimit` plugin)
+// rather than on the heap, because `workerd` evicts idle Durable Objects after
+// ~10s and heap state would take the counters with it, silently resetting the
+// limit part way through a window.
+//
+// Durable storage is still cleared by `deleteAllDurableObjects()`, so
+// vitest-pool-workers' `reset()` clears it for free — the same mechanism that
+// resets the KV, R2 and D1 simulators.
+import { drain, get, MiniflareDurableObject, POST } from "miniflare:shared";
+import type { RouteHandler, TypedSql } from "miniflare:shared";
 
 interface LimitRequestBody {
 	key: string;
@@ -15,25 +21,70 @@ interface LimitResult {
 	success: boolean;
 }
 
+// One counter per key, shared by every binding pointing at this namespace.
+// `period` is a property of the namespace rather than of an individual call, so
+// it deliberately isn't part of the key: bindings that share a `namespace_id`
+// are documented to share counters for a given key.
+type BucketRow = {
+	key: string;
+	epoch: number;
+	count: number;
+};
+
+const SQL_SCHEMA = `
+CREATE TABLE IF NOT EXISTS _mf_ratelimit_buckets (
+  key TEXT PRIMARY KEY,
+  epoch INTEGER NOT NULL,
+  count INTEGER NOT NULL
+);
+`;
+
+function sqlStmts(db: TypedSql) {
+	return {
+		getBucket: db.stmt<Pick<BucketRow, "key">, BucketRow>(
+			"SELECT key, epoch, count FROM _mf_ratelimit_buckets WHERE key = :key"
+		),
+		putBucket: db.stmt<BucketRow>(
+			`INSERT OR REPLACE INTO _mf_ratelimit_buckets (key, epoch, count)
+        VALUES (:key, :epoch, :count)`
+		),
+		// Windows are aligned to the wall clock, so every key in the namespace
+		// rolls over at the same instant. Clearing them all together matches the
+		// previous `#buckets.clear()` and stops the table growing without bound.
+		deleteExpired: db.stmt<Pick<BucketRow, "epoch">>(
+			"DELETE FROM _mf_ratelimit_buckets WHERE epoch != :epoch"
+		),
+	};
+}
+
 export class RateLimiterObject extends MiniflareDurableObject {
-	#buckets = new Map<string, number>();
-	#epoch = 0;
+	#stmts?: ReturnType<typeof sqlStmts>;
+	get stmts() {
+		if (this.#stmts === undefined) {
+			this.db.exec(SQL_SCHEMA);
+			this.#stmts = sqlStmts(this.db);
+		}
+		return this.#stmts;
+	}
 
 	@POST("/limit")
 	limit: RouteHandler = async (req) => {
 		const { key, limit, period } = await req.json<LimitRequestBody>();
 
 		const epoch = Math.floor(Date.now() / (period * 1000));
-		if (epoch !== this.#epoch) {
-			this.#epoch = epoch;
-			this.#buckets.clear();
+		const bucket = get(this.stmts.getBucket({ key }));
+
+		let count = 0;
+		if (bucket !== undefined && bucket.epoch === epoch) {
+			count = bucket.count;
+		} else {
+			drain(this.stmts.deleteExpired({ epoch }));
 		}
 
-		const value = this.#buckets.get(key) ?? 0;
-		if (value >= limit) {
+		if (count >= limit) {
 			return Response.json({ success: false } satisfies LimitResult);
 		}
-		this.#buckets.set(key, value + 1);
+		this.stmts.putBucket({ key, epoch, count: count + 1 });
 		return Response.json({ success: true } satisfies LimitResult);
 	};
 }

--- a/packages/miniflare/src/workers/ratelimit/ratelimit-object.worker.ts
+++ b/packages/miniflare/src/workers/ratelimit/ratelimit-object.worker.ts
@@ -21,38 +21,55 @@ interface LimitResult {
 	success: boolean;
 }
 
-// One counter per key, shared by every binding pointing at this namespace.
-// `period` is a property of the namespace rather than of an individual call, so
-// it deliberately isn't part of the key: bindings that share a `namespace_id`
-// are documented to share counters for a given key.
+// Counters are scoped to `(key, period)`, mirroring production: there, an entry
+// is identified by `(account_id, namespace, hash(key), bucket, bucket_start_ts)`
+// and both `bucket` and `bucket_start_ts` are derived from the period, so
+// differing periods never share a counter. See
+// https://gitlab.cfdata.org/cloudflare/egs/doppler/-/blob/main/doppler-lib/src/counts.rs
+//
+// Bindings that share a `namespace_id` still share a counter for a given key,
+// because in the normal case they also share a period. Were `period` left out of
+// the key, two such bindings configured with different periods would instead
+// overwrite each other's row on every call — each seeing a foreign epoch, so
+// each resetting the count to zero — and neither would ever limit anything.
+//
+// Note the limit itself is deliberately *not* part of the key, again matching
+// production, where it is a threshold applied to a shared count rather than part
+// of the counter's identity.
 type BucketRow = {
 	key: string;
+	period: number;
 	epoch: number;
 	count: number;
 };
 
 const SQL_SCHEMA = `
 CREATE TABLE IF NOT EXISTS _mf_ratelimit_buckets (
-  key TEXT PRIMARY KEY,
+  key TEXT NOT NULL,
+  period INTEGER NOT NULL,
   epoch INTEGER NOT NULL,
-  count INTEGER NOT NULL
+  count INTEGER NOT NULL,
+  PRIMARY KEY (key, period)
 );
 `;
 
 function sqlStmts(db: TypedSql) {
 	return {
-		getBucket: db.stmt<Pick<BucketRow, "key">, BucketRow>(
-			"SELECT key, epoch, count FROM _mf_ratelimit_buckets WHERE key = :key"
+		getBucket: db.stmt<Pick<BucketRow, "key" | "period">, BucketRow>(
+			`SELECT key, period, epoch, count FROM _mf_ratelimit_buckets
+        WHERE key = :key AND period = :period`
 		),
 		putBucket: db.stmt<BucketRow>(
-			`INSERT OR REPLACE INTO _mf_ratelimit_buckets (key, epoch, count)
-        VALUES (:key, :epoch, :count)`
+			`INSERT OR REPLACE INTO _mf_ratelimit_buckets (key, period, epoch, count)
+        VALUES (:key, :period, :epoch, :count)`
 		),
-		// Windows are aligned to the wall clock, so every key in the namespace
+		// Windows are aligned to the wall clock, so every key sharing a period
 		// rolls over at the same instant. Clearing them all together matches the
 		// previous `#buckets.clear()` and stops the table growing without bound.
-		deleteExpired: db.stmt<Pick<BucketRow, "epoch">>(
-			"DELETE FROM _mf_ratelimit_buckets WHERE epoch != :epoch"
+		// It has to stay scoped to the period, or rolling one period's window over
+		// would discard the counters belonging to the other.
+		deleteExpired: db.stmt<Pick<BucketRow, "period" | "epoch">>(
+			"DELETE FROM _mf_ratelimit_buckets WHERE period = :period AND epoch != :epoch"
 		),
 	};
 }
@@ -72,19 +89,19 @@ export class RateLimiterObject extends MiniflareDurableObject {
 		const { key, limit, period } = await req.json<LimitRequestBody>();
 
 		const epoch = Math.floor(Date.now() / (period * 1000));
-		const bucket = get(this.stmts.getBucket({ key }));
+		const bucket = get(this.stmts.getBucket({ key, period }));
 
 		let count = 0;
 		if (bucket !== undefined && bucket.epoch === epoch) {
 			count = bucket.count;
 		} else {
-			drain(this.stmts.deleteExpired({ epoch }));
+			drain(this.stmts.deleteExpired({ period, epoch }));
 		}
 
 		if (count >= limit) {
 			return Response.json({ success: false } satisfies LimitResult);
 		}
-		this.stmts.putBucket({ key, epoch, count: count + 1 });
+		this.stmts.putBucket({ key, period, epoch, count: count + 1 });
 		return Response.json({ success: true } satisfies LimitResult);
 	};
 }

--- a/packages/miniflare/src/workers/ratelimit/ratelimit.worker.ts
+++ b/packages/miniflare/src/workers/ratelimit/ratelimit.worker.ts
@@ -12,12 +12,12 @@ interface RatelimitConfig {
 }
 
 // options for Ratelimit
-//   (should be kept in sync with https://bitbucket.cfdata.org/projects/EW/repos/edgeworker/browse/src/edgeworker/internal-api/ratelimit.capnp)
+//   (should be kept in sync with `RatelimitOptions` in https://gitlab.cfdata.org/cloudflare/ew/edgeworker/-/blob/master/src/edgeworker/internal-api/ratelimit.h)
 const RatelimitOptionKeys = ["key", "limit", "period"];
 const RatelimitPeriodValues = [10, 60];
 
 // result from Ratelimit call
-//   (should be kept in sync with https://bitbucket.cfdata.org/projects/EW/repos/edgeworker/browse/src/edgeworker/internal-api/ratelimit.capnp)
+//   (should be kept in sync with `RatelimitResult` in https://gitlab.cfdata.org/cloudflare/ew/edgeworker/-/blob/master/src/edgeworker/internal-api/ratelimit.h)
 interface RatelimitResult {
 	success: boolean;
 }

--- a/packages/miniflare/test/plugins/ratelimit/index.spec.ts
+++ b/packages/miniflare/test/plugins/ratelimit/index.spec.ts
@@ -1,7 +1,8 @@
+import fs from "node:fs/promises";
 import { setTimeout as sleep } from "node:timers/promises";
-import { Miniflare } from "miniflare";
+import { Miniflare, RATELIMIT_PLUGIN_NAME } from "miniflare";
 import { test } from "vitest";
-import { useDispose } from "../../test-shared";
+import { useDispose, useTmp } from "../../test-shared";
 import type { MiniflareOptions } from "miniflare";
 
 /**
@@ -298,4 +299,74 @@ test("ratelimit counters survive a workerd restart", async ({ expect }) => {
 	await mf.setOptions(options);
 
 	expect(await call()).toBe(429);
+});
+
+test("ratelimit persists on file-system", async ({ expect }) => {
+	const tmp = await useTmp();
+	const options = {
+		ratelimits: {
+			TESTRATE: {
+				namespace_id: "persist",
+				simple: { limit: 1, period: 60 },
+			},
+		},
+		resourcePersistencePath: tmp,
+
+		modules: true,
+		script: `
+		export default {
+			async fetch(request, env, ctx) {
+				const { success } = await env.TESTRATE.limit({ key: "k" });
+				return new Response(success ? "ok" : "limited", {
+					status: success ? 200 : 429,
+				});
+			},
+		}
+		`,
+	} satisfies MiniflareOptions;
+
+	const call = async (mf: Miniflare) => {
+		const res = await mf.dispatchFetch("http://localhost");
+		await res.text();
+		return res.status;
+	};
+
+	await waitForFreshRateLimitWindow([60]);
+
+	let mf = new Miniflare(options);
+	useDispose(mf);
+	expect(await call(mf)).toBe(200);
+
+	const names = await fs.readdir(tmp);
+	expect(names.includes(RATELIMIT_PLUGIN_NAME)).toBe(true);
+
+	// A whole new Miniflare instance, as after restarting `wrangler dev`: the
+	// window hasn't rolled over, so the limit must still be exhausted.
+	await mf.dispose();
+	mf = new Miniflare(options);
+	useDispose(mf);
+	expect(await call(mf)).toBe(429);
+});
+
+test("ratelimit creates no storage directory when unconfigured", async ({
+	expect,
+}) => {
+	const tmp = await useTmp();
+	// Wrangler passes an empty object rather than omitting `ratelimits` when a
+	// Worker declares no rate limit bindings, so this must not leave a stray
+	// directory behind in the user's persistence directory.
+	const mf = new Miniflare({
+		ratelimits: {},
+		resourcePersistencePath: tmp,
+
+		modules: true,
+		script: `export default { fetch: () => new Response("ok") }`,
+	});
+	useDispose(mf);
+
+	const res = await mf.dispatchFetch("http://localhost");
+	expect(await res.text()).toBe("ok");
+
+	const names = await fs.readdir(tmp);
+	expect(names.includes(RATELIMIT_PLUGIN_NAME)).toBe(false);
 });

--- a/packages/miniflare/test/plugins/ratelimit/index.spec.ts
+++ b/packages/miniflare/test/plugins/ratelimit/index.spec.ts
@@ -13,15 +13,34 @@ import type { MiniflareOptions } from "miniflare";
  * A burst that straddles a boundary therefore has its count reset part way
  * through, so a test sending `limit + 1` requests and expecting the last to be
  * rejected fails whenever the boundary lands mid-burst. Await this first: it
- * returns immediately unless the current window is nearly over, in which case
- * it waits for the next one so the burst runs inside a single window.
+ * returns immediately unless one of the current windows is nearly over, in
+ * which case it waits for the next one so the burst runs inside a single window
+ * of every period it was given.
  */
-async function waitForFreshRateLimitWindow(periodSeconds: number) {
-	const periodMs = periodSeconds * 1000;
-	const remainingMs = periodMs - (Date.now() % periodMs);
-	if (remainingMs < 10_000) {
+async function waitForFreshRateLimitWindow(
+	periodsSeconds: number[],
+	minRemainingMs = 10_000
+) {
+	const remaining = () =>
+		Math.min(
+			...periodsSeconds.map((periodSeconds) => {
+				const periodMs = periodSeconds * 1000;
+				return periodMs - (Date.now() % periodMs);
+			})
+		);
+	// A window can never offer more headroom than its own length, so asking for
+	// more than the shortest period would never be satisfied.
+	const targetMs = Math.min(
+		minRemainingMs,
+		(Math.min(...periodsSeconds) * 1000) / 2
+	);
+	// Periods divide one another, so skipping past the closest boundary realigns
+	// all of them at once and this loop runs at most twice.
+	let remainingMs = remaining();
+	while (remainingMs < targetMs) {
 		// Overshoot slightly so the next request is unambiguously in the new window.
 		await sleep(remainingMs + 50);
+		remainingMs = remaining();
 	}
 }
 
@@ -54,7 +73,7 @@ test("ratelimit", async ({ expect }) => {
 	});
 	useDispose(mf);
 
-	await waitForFreshRateLimitWindow(60);
+	await waitForFreshRateLimitWindow([60]);
 
 	let res = await mf.dispatchFetch("http://localhost");
 	expect(res.status).toBe(200);
@@ -173,7 +192,7 @@ test("ratelimit counters are keyed by namespace_id", async ({ expect }) => {
 		return res.status;
 	};
 
-	await waitForFreshRateLimitWindow(60);
+	await waitForFreshRateLimitWindow([60]);
 
 	// RATE_A and RATE_B share the "shared" namespace, so they increment the same
 	// counter: two successes across the pair, then the third call is limited.
@@ -186,6 +205,56 @@ test("ratelimit counters are keyed by namespace_id", async ({ expect }) => {
 	expect(await call("RATE_C")).toBe(200);
 	expect(await call("RATE_C")).toBe(200);
 	expect(await call("RATE_C")).toBe(429);
+});
+
+test("ratelimit counters are scoped per period", async ({ expect }) => {
+	const mf = new Miniflare({
+		ratelimits: {
+			// Same namespace, different windows. Production identifies a counter by
+			// bucket index and bucket start timestamp, both derived from the period,
+			// so these two must not share (nor clobber) a counter.
+			RATE_SLOW: {
+				namespace_id: "shared",
+				simple: { limit: 1, period: 60 },
+			},
+			RATE_FAST: {
+				namespace_id: "shared",
+				simple: { limit: 1, period: 10 },
+			},
+		},
+
+		modules: true,
+		script: `
+		export default {
+			async fetch(request, env, ctx) {
+				const binding = new URL(request.url).searchParams.get("b");
+				const { success } = await env[binding].limit({ key: "k" });
+				return new Response(success ? "ok" : "limited", {
+					status: success ? 200 : 429,
+				});
+			},
+		}
+		`,
+	});
+	useDispose(mf);
+
+	const call = async (b: string) => {
+		const res = await mf.dispatchFetch(`http://localhost?b=${b}`);
+		await res.text();
+		return res.status;
+	};
+
+	await waitForFreshRateLimitWindow([10, 60], 3_000);
+
+	expect(await call("RATE_SLOW")).toBe(200);
+	expect(await call("RATE_FAST")).toBe(200);
+
+	// The discriminating assertion: if the period weren't part of the counter's
+	// identity, RATE_FAST's call would have replaced RATE_SLOW's row with an
+	// epoch RATE_SLOW can never match, so RATE_SLOW would start from zero again
+	// here — and by symmetry neither binding would ever limit anything.
+	expect(await call("RATE_SLOW")).toBe(429);
+	expect(await call("RATE_FAST")).toBe(429);
 });
 
 test("ratelimit counters survive a workerd restart", async ({ expect }) => {
@@ -219,7 +288,7 @@ test("ratelimit counters survive a workerd restart", async ({ expect }) => {
 		return res.status;
 	};
 
-	await waitForFreshRateLimitWindow(60);
+	await waitForFreshRateLimitWindow([60]);
 
 	expect(await call()).toBe(200);
 

--- a/packages/miniflare/test/plugins/ratelimit/index.spec.ts
+++ b/packages/miniflare/test/plugins/ratelimit/index.spec.ts
@@ -2,12 +2,13 @@ import { setTimeout as sleep } from "node:timers/promises";
 import { Miniflare } from "miniflare";
 import { test } from "vitest";
 import { useDispose } from "../../test-shared";
+import type { MiniflareOptions } from "miniflare";
 
 /**
  * The emulated rate limiter buckets requests into fixed windows aligned to the
  * wall clock (`Math.floor(Date.now() / (period * 1000))`, see
- * `src/workers/ratelimit/ratelimit-object.worker.ts`) and clears every counter
- * when the window rolls over.
+ * `src/workers/ratelimit/ratelimit-object.worker.ts`) and resets a counter when
+ * its window rolls over.
  *
  * A burst that straddles a boundary therefore has its count reset part way
  * through, so a test sending `limit + 1` requests and expecting the last to be
@@ -185,4 +186,47 @@ test("ratelimit counters are keyed by namespace_id", async ({ expect }) => {
 	expect(await call("RATE_C")).toBe(200);
 	expect(await call("RATE_C")).toBe(200);
 	expect(await call("RATE_C")).toBe(429);
+});
+
+test("ratelimit counters survive a workerd restart", async ({ expect }) => {
+	const options = {
+		ratelimits: {
+			TESTRATE: {
+				namespace_id: "restart",
+				simple: { limit: 1, period: 60 },
+			},
+		},
+
+		modules: true,
+		script: `
+		export default {
+			async fetch(request, env, ctx) {
+				const { success } = await env.TESTRATE.limit({ key: "k" });
+				return new Response(success ? "ok" : "limited", {
+					status: success ? 200 : 429,
+				});
+			},
+		}
+		`,
+	} satisfies MiniflareOptions;
+
+	const mf = new Miniflare(options);
+	useDispose(mf);
+
+	const call = async () => {
+		const res = await mf.dispatchFetch("http://localhost");
+		await res.text();
+		return res.status;
+	};
+
+	await waitForFreshRateLimitWindow(60);
+
+	expect(await call()).toBe(200);
+
+	// `setOptions()` restarts `workerd`, tearing down every Durable Object. This
+	// is a strictly stronger teardown than the ~10s idle eviction that used to
+	// silently reset the counters, so it proves the state is durable.
+	await mf.setOptions(options);
+
+	expect(await call()).toBe(429);
 });


### PR DESCRIPTION
Fixes #14962.

Miniflare's emulated Ratelimit binding kept its bucket/epoch state on the JS heap of the internal `RateLimiterObject`. That namespace is evictable, so once workerd evicted the idle object (after ~10s) the counters were gone and the next `limit()` call started from zero, even though the rate limit window had not rolled over. In practice the emulation only held for tight bursts: in `wrangler dev` you could hit your Worker, pause for ~15 seconds to look at something, hit it again, and your limit had silently reset.

Counters now live in the Durable Object's `state.storage`, backed by a disk directory service like the KV, R2 and D1 simulators.

The second commit fixes the related bug the issue also flagged — see "Mixed periods in one namespace" below. The third fixes a stray directory the first one would otherwise have created.

#### Why not `preventEviction`?

`Server::deleteAllActors` guards with `if (ns->isEvictable())`, so pinning the namespace makes it immune to `deleteAllDurableObjects()` — which is exactly what `vitest-pool-workers`' `reset()` calls. Confirmed empirically: `preventEviction: true` makes `fixtures/vitest-pool-workers-examples/reset/test/reset.test.ts` fail on "sees reset ratelimit state after reset".

#### Why not `inMemory` storage?

The issue left this as an open question. It turns out `inMemory` would not have helped either, despite what the `compatibility-date.capnp` docs claim ("data will persist for the lifetime of the process... individual objects will still shut down when idle as normal"). When a namespace has no `actorStorage`, `ActorContainer::start()` builds `kj::heap<ActorCache>(newEmptyReadOnlyActorStorage(), ...)` per actor, owned by the `Worker::Actor` that eviction destroys. It is exactly as lossy as the heap. Verified empirically: flipping this branch to `inMemory` fails every rate limit test, because that mode isn't SQLite-backed so `state.storage.sql` isn't even available.

#### Does `reset()` still work?

Yes, and no new mechanism was needed. `ActorNamespace::deleteAll()` calls `resetStorage()` → `SqliteDatabase::reset()` *before* aborting the actor, which is precisely how the KV, R2 and D1 simulators are already reset. The existing `reset` fixture passes unchanged.

Because the counters go through `getPersistPath()`, they also now survive a `wrangler dev` restart within the same window — consistent with every other stateful plugin, and arguably more faithful to production. Under `vitest-pool-workers`, which does not set `resourcePersistencePath`, they land in Miniflare's temp directory and are discarded on dispose as before.

#### Mixed periods in one namespace

The issue also flagged that the epoch was namespace-wide while `period` arrives per request, so bindings sharing a `namespace_id` with different periods clear each other's counters. This is fixed in the second commit, by adding `period` to the bucket table's primary key and scoping the expiry sweep to it.

This went back and forth, so for the record — the deciding evidence is production's own counter identity. In `doppler-lib/src/counts.rs`:

```rust
pub struct Key {
    pub account_id: u64,
    pub namespace: u64,        // the binding's namespaceId
    pub id: u64,               // hash(key)
    pub bucket: u64,           // (time / period) % NUM_BUCKETS
    pub bucket_start_ts: u32,  // (time / period) * period
}
```

`bucket` and `bucket_start_ts` are both derived from the period (`get_buckets()` in `doppler-lib/src/memcache.rs`), so production partitions counters by period implicitly. Two bindings on one `namespace_id` with different periods each keep a working counter there. Note also that the limit itself is *not* part of the key — it is a threshold applied to a shared count — which is why differing `simple.limit` on a shared namespace remains coherent and is left alone here.

Miniflare did the opposite: a single row per key meant each call saw an epoch belonging to the other's window, reset the count to zero, and then deleted the other's row as expired, so **neither binding limited anything at all**. That is a strictly worse divergence than the alternative, and it pre-exists this PR — `main` has the same flaw via its single `#epoch` scalar plus `#buckets.clear()`.

When periods match — the normal case, and the only one the [public docs](https://developers.cloudflare.com/workers/runtime-apis/bindings/rate-limit/) describe — `(key, period)` and `key` partition identically, so the documented "bindings sharing a `namespace_id` share counters for a given key" behaviour is unchanged.

#### No stray directory when rate limiting isn't used

Wrangler passes `ratelimits: {}` rather than omitting the key when a Worker declares no rate limit bindings (`packages/wrangler/src/dev/miniflare/index.ts:1073`), and `{}` is truthy. The plugin's `!options.ratelimits` guard therefore let every dev session reach the new `fs.mkdir()` and leave an unused `ratelimit` directory behind. The third commit bails on emptiness instead, which also avoids registering an unreferenced Durable Object namespace.

#### Known limitation (pre-existing, not introduced here)

`ActorContainer::resetStorage()` is guarded by `KJ_IF_SOME(a, actor)`, so it only resets *running* actors. If a disk-backed simulator DO has already been evicted when `reset()` runs, its `.sqlite` file survives. This affects KV/R2/D1 identically today and only triggers if >10s elapse between touching a resource and calling `reset()`. Probably worth an upstream workerd issue.

#### Also out of scope

Miniflare uses a fixed window; production uses a sliding window (`prev * (1 - elapsed/period) + cur`) and skips the increment when already over the threshold. Worth a follow-up, but it is a behaviour change rather than a bug fix, so it is not in this PR.

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: this restores the documented behaviour of the local Ratelimit emulation (counters holding for the configured period). There is no API, configuration or user-facing surface change.

Four tests were added to `packages/miniflare/test/plugins/ratelimit/index.spec.ts`:

**"ratelimit counters survive a workerd restart"** — exhausts the limit, calls `setOptions()` (which unconditionally kills and respawns workerd via `Runtime#updateConfig`, tearing down every Durable Object), and asserts the next call is still rejected. This is a strictly stronger teardown than the ~10s idle eviction, and runs in milliseconds rather than needing a real sleep. Verified it fails against the old heap implementation and passes with the fix.

**"ratelimit counters are scoped per period"** — two bindings on one `namespace_id`, one with `period: 10` and one with `period: 60`, both `limit: 1`. Verified it fails against the key-only schema, and with exactly the predicted symptom: the third call returns 200 instead of 429, i.e. no limiting whatsoever.

**"ratelimit persists on file-system"** — exhausts the limit, disposes, and builds a fresh `Miniflare` sharing the same `resourcePersistencePath`; the window hasn't rolled over, so the limit is still exhausted. Covers the `wrangler dev` restart claim above.

**"ratelimit creates no storage directory when unconfigured"** — `ratelimits: {}` must not leave a `ratelimit` directory in the persistence directory. Verified it fails against the presence-only guard.

The issue's verbatim repro (one call, 20s sleep inside a single 60s window, second call) was also run as a throwaway test against a real eviction and passes with the fix. It is not included in the suite because it costs ~55s of wall clock for a property the restart test already covers.

`waitForFreshRateLimitWindow()` (added in #14961 to de-flake bucket boundaries) now takes a list of periods so the mixed-period test can require headroom in both windows at once. Its threshold for the existing 60s tests is unchanged, and because 10 divides 60 a single sleep realigns both, so the new test waits ~3s at worst.

The existing "ratelimit counters are keyed by namespace_id" test and the `reset` fixture's "shares ratelimit state across bindings with the same namespace_id" cover the documented shared-counter semantics, and both pass unchanged.

Also verified: full miniflare suite (1006 passed), the `@scoped/reset` vitest-pool-workers fixture (11 passed), and `pnpm check` (201/201).

*A picture of a cute animal (not mandatory, but encouraged)*

![A sleepy dormouse curled up, about to be evicted from memory](https://upload.wikimedia.org/wikipedia/commons/thumb/8/8a/Muscardinus_avellanarius_1.jpg/440px-Muscardinus_avellanarius_1.jpg)

> [!NOTE]
> This is a contribution from an AI agent: opencode, claude-opus-5.
