### PR TITLE
[wrangler] Let CLOUDFLARE_ACCOUNT_ID override the cached account id in pages project commands

### DIFF
--- a/.changeset/pages-project-commands-env-account-id.md
+++ b/.changeset/pages-project-commands-env-account-id.md
@@ -2,8 +2,6 @@
 "wrangler": patch
 ---
 
-Let `CLOUDFLARE_ACCOUNT_ID` override the cached account id in `wrangler pages project` commands
+Respect `CLOUDFLARE_ACCOUNT_ID` in `wrangler pages project list`, `create` and `delete`
 
-`pages project list`, `pages project create` and `pages project delete` passed the internal Pages cache (`pages.json`) straight to account selection, which treats `account_id` as user-authored configuration and therefore ranks it above `CLOUDFLARE_ACCOUNT_ID`. In a multi-account setup a stale cached account won silently, so the command targeted the wrong account and failed with `Authentication error [code: 10000]`.
-
-These three commands now overlay the environment account id on top of the cache before resolving auth, which is what `pages deploy`, `pages deployment list`, `pages deployment delete`, `pages download config` and `pages secret` already do. The cache is still used as a fallback when the environment variable is unset.
+These three commands could target a previously used account even when `CLOUDFLARE_ACCOUNT_ID` was set, failing with `Authentication error [code: 10000]` in setups with more than one account. They now use the account named by `CLOUDFLARE_ACCOUNT_ID`, matching the rest of `wrangler pages`. When the variable is unset, the previously used account is still selected, as before.

--- a/.changeset/pages-project-commands-env-account-id.md
+++ b/.changeset/pages-project-commands-env-account-id.md
@@ -1,0 +1,9 @@
+---
+"wrangler": patch
+---
+
+Let `CLOUDFLARE_ACCOUNT_ID` override the cached account id in `wrangler pages project` commands
+
+`pages project list`, `pages project create` and `pages project delete` passed the internal Pages cache (`pages.json`) straight to account selection, which treats `account_id` as user-authored configuration and therefore ranks it above `CLOUDFLARE_ACCOUNT_ID`. In a multi-account setup a stale cached account won silently, so the command targeted the wrong account and failed with `Authentication error [code: 10000]`.
+
+These three commands now overlay the environment account id on top of the cache before resolving auth, which is what `pages deploy`, `pages deployment list`, `pages deployment delete`, `pages download config` and `pages secret` already do. The cache is still used as a fallback when the environment variable is unset.

--- a/packages/wrangler/src/__tests__/pages/project-create.test.ts
+++ b/packages/wrangler/src/__tests__/pages/project-create.test.ts
@@ -1,11 +1,14 @@
 import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
 import { afterEach, describe, it, vi } from "vitest";
+import { saveToConfigCache } from "../../config-cache";
+import { PAGES_CONFIG_CACHE_FILENAME } from "../../pages/constants";
 import { endEventLoop } from "../helpers/end-event-loop";
 import { mockAccountId, mockApiToken } from "./../helpers/mock-account-id";
 import { mockConsoleMethods } from "./../helpers/mock-console";
 import { msw } from "./../helpers/msw";
 import { runWrangler } from "./../helpers/run-wrangler";
+import type { PagesConfigCache } from "../../pages/types";
 
 describe("pages project create", () => {
 	const std = mockConsoleMethods();
@@ -186,11 +189,9 @@ describe("pages project create", () => {
 				{ once: true }
 			)
 		);
-		vi.mock("getConfigCache", () => {
-			return {
-				account_id: "original-account-id",
-				project_name: "an-existing-project",
-			};
+		saveToConfigCache<PagesConfigCache>(PAGES_CONFIG_CACHE_FILENAME, {
+			account_id: "original-account-id",
+			project_name: "an-existing-project",
 		});
 		vi.stubEnv("CLOUDFLARE_ACCOUNT_ID", "new-account-id");
 		await runWrangler(

--- a/packages/wrangler/src/__tests__/pages/project-delete.test.ts
+++ b/packages/wrangler/src/__tests__/pages/project-delete.test.ts
@@ -1,6 +1,8 @@
 import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
 import { afterEach, beforeEach, describe, it, vi } from "vitest";
+import { saveToConfigCache } from "../../config-cache";
+import { PAGES_CONFIG_CACHE_FILENAME } from "../../pages/constants";
 import { endEventLoop } from "../helpers/end-event-loop";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
 import { mockConsoleMethods } from "../helpers/mock-console";
@@ -8,6 +10,7 @@ import { clearDialogs, mockConfirm } from "../helpers/mock-dialogs";
 import { useMockIsTTY } from "../helpers/mock-istty";
 import { msw } from "../helpers/msw";
 import { runWrangler } from "../helpers/run-wrangler";
+import type { PagesConfigCache } from "../../pages/types";
 
 describe("pages project delete", () => {
 	const std = mockConsoleMethods();
@@ -151,11 +154,9 @@ describe("pages project delete", () => {
 			text: `Are you sure you want to delete "an-existing-project"? This action cannot be undone.`,
 			result: true,
 		});
-		vi.mock("getConfigCache", () => {
-			return {
-				account_id: "original-account-id",
-				project_name: "an-existing-project",
-			};
+		saveToConfigCache<PagesConfigCache>(PAGES_CONFIG_CACHE_FILENAME, {
+			account_id: "original-account-id",
+			project_name: "an-existing-project",
 		});
 		vi.stubEnv("CLOUDFLARE_ACCOUNT_ID", "new-account-id");
 		await runWrangler("pages project delete an-existing-project");

--- a/packages/wrangler/src/__tests__/pages/project-list.test.ts
+++ b/packages/wrangler/src/__tests__/pages/project-list.test.ts
@@ -1,12 +1,14 @@
 import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
 import { afterEach, describe, it, vi } from "vitest";
+import { saveToConfigCache } from "../../config-cache";
+import { PAGES_CONFIG_CACHE_FILENAME } from "../../pages/constants";
 import { endEventLoop } from "../helpers/end-event-loop";
 import { mockConsoleMethods } from "../helpers/mock-console";
 import { mockAccountId, mockApiToken } from "./../helpers/mock-account-id";
 import { msw } from "./../helpers/msw";
 import { runWrangler } from "./../helpers/run-wrangler";
-import type { Project } from "./../../pages/types";
+import type { PagesConfigCache, Project } from "./../../pages/types";
 import type { ExpectStatic } from "vitest";
 
 describe("pages project list", () => {
@@ -83,11 +85,9 @@ describe("pages project list", () => {
 	it("should override cached accountId with CLOUDFLARE_ACCOUNT_ID environmental variable if provided", async ({
 		expect,
 	}) => {
-		vi.mock("getConfigCache", () => {
-			return {
-				account_id: "original-account-id",
-				project_name: "an-existing-project",
-			};
+		saveToConfigCache<PagesConfigCache>(PAGES_CONFIG_CACHE_FILENAME, {
+			account_id: "original-account-id",
+			project_name: "an-existing-project",
 		});
 		vi.stubEnv("CLOUDFLARE_ACCOUNT_ID", "new-account-id");
 		const requests = mockProjectListRequest(expect, [], "new-account-id");

--- a/packages/wrangler/src/pages/projects.ts
+++ b/packages/wrangler/src/pages/projects.ts
@@ -1,4 +1,5 @@
 import { execSync } from "node:child_process";
+import { getCloudflareAccountIdFromEnv } from "@cloudflare/workers-auth";
 import {
 	COMPLIANCE_REGION_CONFIG_PUBLIC,
 	UserError,
@@ -42,7 +43,11 @@ export const pagesProjectListCommand = createCommand({
 			PAGES_CONFIG_CACHE_FILENAME
 		);
 
-		const accountId = await requireAuth(config);
+		const envAccountId = getCloudflareAccountIdFromEnv();
+		const accountId = await requireAuth({
+			...config,
+			...(envAccountId ? { account_id: envAccountId } : {}),
+		});
 
 		const projects: Array<Project> = await listProjects({ accountId });
 
@@ -148,7 +153,11 @@ export const pagesProjectCreateCommand = createCommand({
 		const config = getConfigCache<PagesConfigCache>(
 			PAGES_CONFIG_CACHE_FILENAME
 		);
-		const accountId = await requireAuth(config);
+		const envAccountId = getCloudflareAccountIdFromEnv();
+		const accountId = await requireAuth({
+			...config,
+			...(envAccountId ? { account_id: envAccountId } : {}),
+		});
 
 		// When run by an AI agent, delegate new static Pages projects to a Workers
 		// static-assets deploy of the current directory. Accounts that already
@@ -303,7 +312,11 @@ export const pagesProjectDeleteCommand = createCommand({
 		const config = getConfigCache<PagesConfigCache>(
 			PAGES_CONFIG_CACHE_FILENAME
 		);
-		const accountId = await requireAuth(config);
+		const envAccountId = getCloudflareAccountIdFromEnv();
+		const accountId = await requireAuth({
+			...config,
+			...(envAccountId ? { account_id: envAccountId } : {}),
+		});
 
 		const confirmed =
 			args.yes ||


### PR DESCRIPTION
Fixes #14970.

`pages project list`, `pages project create` and `pages project delete` pass the internal Pages cache (`pages.json`) straight to `requireAuth()`. Account selection treats `config.account_id` as user-authored configuration and ranks it above `CLOUDFLARE_ACCOUNT_ID` (`getActiveAccountId` in `packages/workers-auth/src/core/factory.ts`), so a stale cached account silently wins. In a multi-account setup the command then targets the wrong account and fails with `Authentication error [code: 10000]`.

This overlays the environment account id on top of the cache before resolving auth, so an explicit `CLOUDFLARE_ACCOUNT_ID` takes precedence and the cache stays a fallback. That is what the rest of the Pages commands already do: `pages deploy`, `pages deployment list`, `pages deployment delete`, `pages download config` and `pages secret` all build the same `{ ...configCache, ...(envAccountId ? { account_id: envAccountId } : {}) }` object. Only `projects.ts` was missing it.

### On the tests

Each of the three commands already had a test named "should override cached accountId with CLOUDFLARE_ACCOUNT_ID environmental variable if provided", and all three passed against the bug. They seeded the cache with

```ts
vi.mock("getConfigCache", () => ({ account_id: "original-account-id", ... }));
```

`"getConfigCache"` is not a module specifier, so nothing was mocked and the cache was empty — which meant `requireAuth` fell through to the env var and the assertion held for the wrong reason. The three tests now seed the real cache with `saveToConfigCache`, matching how `deployment-list.test.ts` tests the same behaviour.

Verified by reverting `projects.ts` to `main` and re-running: all three fail, each requesting `/accounts/original-account-id/...`. With the fix they pass, and `pnpm -w test:ci -F wrangler -- src/__tests__/pages` is green (20 files, 283 tests). `pnpm check` passes.

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: this restores the documented precedence of `CLOUDFLARE_ACCOUNT_ID` for three commands that were inconsistent with the rest of `wrangler pages`; no user-facing interface changes.

> [!NOTE]
> This is a contribution from an AI agent: Claude Code, claude-opus-5.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14983" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->