### PR TITLE
[vite-plugin] Include the plugin build hash in playground test cache keys

### DIFF
--- a/.github/workflows/vite-plugin-playgrounds.yml
+++ b/.github/workflows/vite-plugin-playgrounds.yml
@@ -63,6 +63,32 @@ jobs:
           pnpm dotenv -- pnpm turbo build --filter @cloudflare/vite-plugin
         env:
           NODE_OPTIONS: "--max_old_space_size=8192"
+      # The test steps below pass `--only`, which does not merely skip *running*
+      # dependencies — it strips them from the cache key as well. Left alone,
+      # the playground tests are cached on a key that ignores
+      # `@cloudflare/vite-plugin`, `wrangler`, `miniflare` and `workerd`, so
+      # they replay from cache and never actually run on internal PRs (#14967).
+      #
+      # The turbo hash for `@cloudflare/vite-plugin#build` covers that whole
+      # dependency graph, so exporting it here and declaring it as a task `env`
+      # in `playground/turbo.json` restores the invalidation `--only` removed.
+      #
+      # This must run before the Vite downgrade steps so that the hash
+      # describes the plugin that was actually built and tested.
+      - name: Export plugin build hash for the playground cache key
+        if: steps.changes.outputs.everything_but_markdown == 'true'
+        shell: bash
+        run: |
+          pnpm dotenv -- pnpm turbo build --filter @cloudflare/vite-plugin --dry=json |
+            node --input-type=module -e '
+              import { readFileSync } from "node:fs";
+              const { tasks } = JSON.parse(readFileSync(0, "utf8"));
+              const task = tasks.find((t) => t.taskId === "@cloudflare/vite-plugin#build");
+              if (!task) {
+                throw new Error("No @cloudflare/vite-plugin#build task in the turbo summary");
+              }
+              console.log(`VITE_PLUGIN_BUILD_HASH=${task.hash}`);
+            ' >> "$GITHUB_ENV"
       - name: Downgrade to Vite 6
         if: steps.changes.outputs.everything_but_markdown == 'true' && matrix.vite == 'vite-6'
         run: |
@@ -75,6 +101,8 @@ jobs:
         if: steps.changes.outputs.everything_but_markdown == 'true'
         # We use `--only` to prevent TurboRepo from rebuilding dependencies
         # This ensures the Vite plugin is not rebuilt using a different Vite version
+        # `VITE_PLUGIN_BUILD_HASH` puts the stripped dependency hashes back into
+        # the cache key — see "Export plugin build hash" above
         run: |
           pnpm dotenv -- pnpm turbo test:ci:serve --filter @vite-plugin-cloudflare/playground --only
         env:
@@ -88,6 +116,8 @@ jobs:
         if: steps.changes.outputs.everything_but_markdown == 'true'
         # We use `--only` to prevent TurboRepo from rebuilding dependencies
         # This ensures the Vite plugin is not rebuilt using a different Vite version
+        # `VITE_PLUGIN_BUILD_HASH` puts the stripped dependency hashes back into
+        # the cache key — see "Export plugin build hash" above
         run: |
           pnpm dotenv -- pnpm turbo test:ci:build --filter @vite-plugin-cloudflare/playground --only
         env:

--- a/packages/vite-plugin-cloudflare/playground/turbo.json
+++ b/packages/vite-plugin-cloudflare/playground/turbo.json
@@ -11,9 +11,27 @@
 				"VITE_TEST_BUILD"
 			]
 		},
+		// `dependsOn: ["build"]` is load-bearing despite this package having no
+		// `build` script: turbo inserts a no-op `#build` node for the missing
+		// script which inherits `dependsOn: ["^build"]` from the root config,
+		// folding `@cloudflare/vite-plugin#build` and its entire dependency
+		// graph into these tasks' hashes. Do not remove it.
+		//
+		// That covers local runs. CI passes `--only`
+		// (`.github/workflows/vite-plugin-playgrounds.yml`), which strips
+		// dependency hashes from the cache key, so the workflow exports the
+		// hash turbo computed for `@cloudflare/vite-plugin#build` as
+		// `VITE_PLUGIN_BUILD_HASH` and it is declared here to restore the same
+		// invalidation. Without it these tests replay from cache whenever a PR
+		// only touches the plugin, wrangler, miniflare or workerd (#14967).
 		"test:ci:serve": {
 			"dependsOn": ["build"],
-			"env": ["NODE_DEBUG", "NODE_ENV", "VITE_VERSION"],
+			"env": [
+				"NODE_DEBUG",
+				"NODE_ENV",
+				"VITE_PLUGIN_BUILD_HASH",
+				"VITE_VERSION"
+			],
 			"passThroughEnv": [
 				"CLOUDFLARE_VITE_BUILD",
 				"VITE_DEBUG_SERVE",
@@ -24,7 +42,13 @@
 		},
 		"test:ci:build": {
 			"dependsOn": ["build"],
-			"env": ["NODE_DEBUG", "NODE_ENV", "VITE_TEST_BUILD", "VITE_VERSION"],
+			"env": [
+				"NODE_DEBUG",
+				"NODE_ENV",
+				"VITE_PLUGIN_BUILD_HASH",
+				"VITE_TEST_BUILD",
+				"VITE_VERSION"
+			],
 			"passThroughEnv": [
 				"CLOUDFLARE_VITE_BUILD",
 				"VITE_DEBUG_SERVE",


### PR DESCRIPTION
Fixes #14967.

`@vite-plugin-cloudflare/playground#test:ci:serve` and `#test:ci:build` were cached on a key that excluded the Vite plugin, Wrangler, Miniflare and workerd, so on internal PRs the whole `vite-plugin-playgrounds.yml` workflow was almost always a turbo cache replay that ran no tests.

The cause is `--only`. It does not merely skip *executing* dependencies, it strips them from the task hash:

```
turbo test:ci:serve --filter @vite-plugin-cloudflare/playground --dry
  hash: 8bd7454eebb5f23f | deps: ['@vite-plugin-cloudflare/playground#build']

turbo test:ci:serve --filter @vite-plugin-cloudflare/playground --dry --only
  hash: a3c45b31fe22e15d | deps: []
```

`--only` has to stay: it is what stops turbo rebuilding the plugin against the downgraded Vite in the vite-6/vite-7 legs. So instead of dropping it, this PR puts the missing information back into the key by hand.

A new workflow step runs `turbo build --filter @cloudflare/vite-plugin --dry=json` and exports the hash turbo computed for `@cloudflare/vite-plugin#build` as `VITE_PLUGIN_BUILD_HASH`, which `playground/turbo.json` then declares in `env` for both test tasks. That hash covers the plugin's entire dependency graph — `wrangler`, `miniflare` and `workerd` are runtime `dependencies` of the plugin and are not bundled into its `dist`, so hashing the built output would not have been enough. The step runs before the Vite downgrade steps, so the hash describes the plugin that was actually built and tested.

This is the same technique `VITE_VERSION` already uses in that file: a cache-key discriminator that no code reads.

`dependsOn: ["build"]` is kept and now carries a comment explaining why. It is not dead config, despite the playground having no `build` script — turbo inserts a no-op `#build` node that inherits `dependsOn: ["^build"]` from the root config and propagates dependency hashes correctly, which is what makes local and non-`--only` runs correct.

Expect this to start running the suite on most internal PRs. That is the point, and #14965 landed first so the suite should be green.

---

- Tests
  - [ ] Tests included/updated
  - [x] Automated tests not possible - manual testing has been completed as follows:

    This is a CI cache-key change; there is nothing to assert at runtime. Verified by comparing turbo hashes, running the exact `run:` block parsed out of the workflow YAML under GitHub's default `bash --noprofile --norc -eo pipefail`:

    ```
    BEFORE
      VITE_PLUGIN_BUILD_HASH=74fe2642df2e9717
      test:ci:serve --only -> cfd442bae75c0c7f
      test:ci:build --only -> e4e02c64e963e190

    AFTER appending a comment to packages/wrangler/src/index.ts
      VITE_PLUGIN_BUILD_HASH=1a9239970d3bc5c3
      test:ci:serve --only -> da1f670ba7983c4f
      test:ci:build --only -> e149026f4f5ab7a2
    ```

    On `main` none of those three values move. Also checked:
    - Deterministic — the same env value reproduces the same hash.
    - `env`-declared vars still affect the hash under `TURBO_ENV_MODE=loose`, which is what `install-dependencies` sets in CI.
    - Success path writes exactly one clean line to `$GITHUB_ENV` (turbo's banner goes to stderr).
    - Failure path (turbo exits non-zero, or the task is missing from the summary) exits 1 and writes **0 bytes** to `$GITHUB_ENV`, so it cannot silently fall back to the broken key.
    - `pnpm check:format`, `pnpm check:workflows` and `node lint-turbo.mjs` all pass.
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: this only changes CI configuration for an internal, private playground package. There is no user-facing behaviour change and nothing published.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14985" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->