### PR TITLE
[miniflare] Surface workerd fatal crash reports instead of filtering them out

### DIFF
--- a/.changeset/wild-pugs-surface-crashes.md
+++ b/.changeset/wild-pugs-surface-crashes.md
@@ -1,0 +1,9 @@
+---
+"miniflare": patch
+---
+
+Surface the full runtime crash report when workerd crashes, and warn when it is restarted
+
+When workerd crashed, the banner (e.g. `*** std::terminate() called with no exception`) was reported without its stack trace, because the stack trace was being filtered out along with the ordinary hex-stack noise workerd emits. The crash was therefore impossible to diagnose. The `stack:` line and the missing-`$LLVM_SYMBOLIZER` notice that follow a fatal crash banner are now kept, and the whole report is logged at `error` level.
+
+Miniflare also recovers from workerd crashes by restarting the runtime, but did so silently, which made a crash look like an unexplained dev server restart. It now warns, including a count so that a repeatedly-crashing runtime is distinguishable from a one-off.

--- a/packages/miniflare/src/index.ts
+++ b/packages/miniflare/src/index.ts
@@ -955,6 +955,10 @@ export class Miniflare {
 	#runtimeDispatcher?: Dispatcher;
 	#proxyClient?: ProxyClient;
 	#runtimeRestartError?: MiniflareCoreError;
+	// Number of times workerd has crashed and been restarted for this instance.
+	// Reported to the user so a repeatedly-crashing runtime is distinguishable
+	// from a one-off, and so the restart isn't silent.
+	#workerdCrashCount = 0;
 
 	#cfObject?: Record<string, any> = {};
 
@@ -2342,6 +2346,14 @@ export class Miniflare {
 	}
 
 	#handleWorkerdCrash(): void {
+		this.#workerdCrashCount++;
+		// Recovery used to be entirely silent, which made a crash look like an
+		// unexplained dev server restart. Always say something: any crash is a
+		// bug worth reporting, and the count distinguishes a one-off from a loop.
+		this.#log.warn(
+			`The Workers runtime crashed unexpectedly and is being restarted (crash #${this.#workerdCrashCount}). ` +
+				"Any additional runtime output above may indicate the cause."
+		);
 		// A crash destroys the proxy server heap just like a config update.
 		this.#proxyClient?.poisonProxies();
 		void this.#runtimeMutex

--- a/packages/miniflare/src/runtime/structured-logs.ts
+++ b/packages/miniflare/src/runtime/structured-logs.ts
@@ -17,6 +17,13 @@ export function handleStructuredLogsFromStream(
 ) {
 	let streamAccumulator = "";
 
+	// Created once per stream rather than per chunk, because the wrapped handler
+	// keeps state across lines: a fatal crash banner and the stack trace that
+	// follows it can arrive in separate `data` events.
+	const adjustedStructuredLogsHandler = wrapStructuredLogsHandler(
+		structuredLogsHandler
+	);
+
 	stream.on("data", (chunk: Buffer | string) => {
 		const fullStreamOutput = `${streamAccumulator}${chunk}`;
 
@@ -26,10 +33,6 @@ export function handleStructuredLogsFromStream(
 		// last one, we know that anything in between will include
 		// one or more structured logs
 		const lastNewlineIdx = fullStreamOutput.lastIndexOf("\n");
-
-		const adjustedStructuredLogsHandler = wrapStructuredLogsHandler(
-			structuredLogsHandler
-		);
 
 		if (lastNewlineIdx > 0) {
 			// If we've found a newline we will take the structured logs
@@ -79,6 +82,19 @@ const messageClassifiers = {
 			containsHexStack
 		);
 	},
+	// Is this chunk workerd announcing a fatal, process-ending crash?
+	//
+	// These banners come from kj's crash handlers, which write straight to
+	// stderr and so bypass structured logging entirely. Each one is followed by
+	// a `stack:` line that `isInternal` would otherwise discard, leaving users
+	// (and CI logs) with an abort message carrying no context at all.
+	// workerd references:
+	//  - https://github.com/cloudflare/workerd/blob/main/deps/kj/kj/exception.c%2B%2B
+	isFatalCrash(chunk: string) {
+		return /^\*\*\* (?:std::terminate\(\)|Fatal uncaught|Received signal|Uncaught exception)/.test(
+			chunk
+		);
+	},
 	// Is this chunk an Address In Use error?
 	isAddressInUse(chunk: string) {
 		return chunk.includes("Address already in use; toString() = ");
@@ -101,7 +117,23 @@ const messageClassifiers = {
 function wrapStructuredLogsHandler(
 	structuredLogsHandler: StructuredLogsHandler
 ) {
+	// Set when a fatal crash banner is seen, so that the diagnostics printed
+	// immediately afterwards (the `stack:` line, the missing-$LLVM_SYMBOLIZER
+	// notice) are let through instead of being filtered as internal noise.
+	// Cleared by the first line that isn't internal noise, i.e. once the crash
+	// report has been fully emitted.
+	let reportingFatalCrash = false;
+
 	return (structuredLog: WorkerdStructuredLog) => {
+		if (messageClassifiers.isFatalCrash(structuredLog.message)) {
+			reportingFatalCrash = true;
+			return structuredLogsHandler({
+				timestamp: structuredLog.timestamp,
+				level: "error",
+				message: structuredLog.message,
+			});
+		}
+
 		// TODO: the following code analyzes the message without considering its log level,
 		//       ideally, in order to avoid false positives, we should run this logic scoped
 		//       to the relevant log levels (as we do for `isCodeMovedWarning`)
@@ -136,10 +168,24 @@ function wrapStructuredLogsHandler(
 				});
 			}
 
+			if (reportingFatalCrash) {
+				// Part of the crash report started just above: keep it, at `error`
+				// so it isn't lost among ordinary dev server output. Without this
+				// the `stack:` line is dropped and the crash has no context.
+				return structuredLogsHandler({
+					timestamp: structuredLog.timestamp,
+					level: "error",
+					message: structuredLog.message,
+				});
+			}
+
 			// IGNORABLE:
 			// anything else not handled above is considered ignorable
 			return;
 		}
+
+		// An ordinary log line means the crash report (if any) is complete.
+		reportingFatalCrash = false;
 
 		if (
 			(structuredLog.level === "info" || structuredLog.level === "error") &&

--- a/packages/miniflare/test/index.spec.ts
+++ b/packages/miniflare/test/index.spec.ts
@@ -17,6 +17,7 @@ import {
 	DeferredPromise,
 	fetch,
 	kCurrentWorker,
+	LogLevel,
 	Miniflare,
 	MiniflareCoreError,
 	Response,
@@ -2925,6 +2926,43 @@ test("Miniflare: workerd crash in handler => restart", async ({ expect }) => {
 	const restartedWorker = await mf.getWorker();
 	const r4 = await restartedWorker.fetch("http://placeholder/");
 	expect(await r4.text()).toBe("ok 2");
+});
+
+test("Miniflare: warns when workerd is restarted after a crash", async ({
+	expect,
+}) => {
+	const log = new TestLog();
+	const runtimeRestarted = new DeferredPromise<void>();
+	const mf = new Miniflare({
+		log,
+		modules: true,
+		unsafeHandleRuntimeRestart: () => runtimeRestarted.resolve(),
+		script: `
+			import { abortIsolate } from "cloudflare:workers";
+			export default {
+				fetch(request) {
+					if (new URL(request.url).searchParams.get("crash")) {
+						abortIsolate("test crash");
+					}
+					return new Response("ok");
+				},
+			}
+		`,
+	});
+	useDispose(mf);
+
+	await mf.ready;
+	await expect(
+		mf.dispatchFetch("http://placeholder/?crash=1")
+	).rejects.toThrow();
+	await runtimeRestarted;
+
+	// Recovering silently makes a crash look like an unexplained restart, so the
+	// user must always be told, even though Miniflare goes on to recover.
+	expect(log.logsAtLevel(LogLevel.WARN)).toContain(
+		"The Workers runtime crashed unexpectedly and is being restarted (crash #1). " +
+			"Any additional runtime output above may indicate the cause."
+	);
 });
 
 test("Miniflare: logs post-restart callback failures", async ({ expect }) => {

--- a/packages/miniflare/test/runtime/structured-logs.spec.ts
+++ b/packages/miniflare/test/runtime/structured-logs.spec.ts
@@ -1,0 +1,171 @@
+import { PassThrough } from "node:stream";
+import { setImmediate as flush } from "node:timers/promises";
+import { test } from "vitest";
+// Imported from source rather than the package entry: this helper is internal
+// to the runtime and deliberately not part of Miniflare's public API.
+import { handleStructuredLogsFromStream } from "../../src/runtime/structured-logs";
+import type { WorkerdStructuredLog } from "miniflare";
+
+/** A line as workerd emits it when structured logging is enabled. */
+function structured(level: string, message: string) {
+	return `${JSON.stringify({ timestamp: 1700000000000, level, message })}\n`;
+}
+
+/**
+ * kj's crash handlers write straight to stderr, so these lines are plain text
+ * rather than structured logs.
+ */
+const CRASH_BANNER = "*** std::terminate() called with no exception\n";
+const CRASH_STACK =
+	"stack: 7ff6a1b2c3d4 7ff6a1b2c3d5 7ff6a1b2c3d6 7ff6a1b2c3d7\n";
+
+/**
+ * Feeds `chunks` through the stream handler, one `data` event each, and returns
+ * the logs that made it to the handler. Writing one chunk at a time matters:
+ * workerd's output arrives in arbitrary chunks, and a crash banner can land in
+ * a different chunk from the stack trace that follows it.
+ */
+async function collect(chunks: string[]) {
+	const collected: Pick<WorkerdStructuredLog, "level" | "message">[] = [];
+	const stream = new PassThrough();
+	handleStructuredLogsFromStream(stream, ({ level, message }) => {
+		collected.push({ level, message });
+	});
+
+	for (const chunk of chunks) {
+		stream.write(chunk);
+		await flush();
+	}
+	stream.end();
+	await flush();
+
+	return collected;
+}
+
+test("a fatal crash banner is surfaced as an error along with its stack trace", async ({
+	expect,
+}) => {
+	expect(await collect([CRASH_BANNER + CRASH_STACK])).toEqual([
+		{
+			level: "error",
+			message: "*** std::terminate() called with no exception",
+		},
+		{
+			level: "error",
+			message: "stack: 7ff6a1b2c3d4 7ff6a1b2c3d5 7ff6a1b2c3d6 7ff6a1b2c3d7",
+		},
+	]);
+});
+
+test("a crash stack trace is surfaced even when it arrives in a later chunk", async ({
+	expect,
+}) => {
+	expect(await collect([CRASH_BANNER, CRASH_STACK])).toEqual([
+		{
+			level: "error",
+			message: "*** std::terminate() called with no exception",
+		},
+		{
+			level: "error",
+			message: "stack: 7ff6a1b2c3d4 7ff6a1b2c3d5 7ff6a1b2c3d6 7ff6a1b2c3d7",
+		},
+	]);
+});
+
+test("the missing-$LLVM_SYMBOLIZER notice is kept when it is part of a crash report", async ({
+	expect,
+}) => {
+	const notice =
+		"Not symbolizing stack traces because $LLVM_SYMBOLIZER is not set\n";
+
+	expect(await collect([CRASH_BANNER, notice, CRASH_STACK])).toEqual([
+		{
+			level: "error",
+			message: "*** std::terminate() called with no exception",
+		},
+		{
+			level: "error",
+			message:
+				"Not symbolizing stack traces because $LLVM_SYMBOLIZER is not set",
+		},
+		{
+			level: "error",
+			message: "stack: 7ff6a1b2c3d4 7ff6a1b2c3d5 7ff6a1b2c3d6 7ff6a1b2c3d7",
+		},
+	]);
+});
+
+test("stack traces unrelated to a crash are still filtered out", async ({
+	expect,
+}) => {
+	expect(await collect([CRASH_STACK, structured("log", "__LOG__")])).toEqual([
+		{ level: "log", message: "__LOG__" },
+	]);
+});
+
+test("filtering resumes once the crash report is over", async ({ expect }) => {
+	const collected = await collect([
+		CRASH_BANNER,
+		CRASH_STACK,
+		// An ordinary log line ends the crash report...
+		structured("log", "__LOG__"),
+		// ...so this unrelated stack trace is noise again.
+		CRASH_STACK,
+	]);
+
+	expect(collected).toEqual([
+		{
+			level: "error",
+			message: "*** std::terminate() called with no exception",
+		},
+		{
+			level: "error",
+			message: "stack: 7ff6a1b2c3d4 7ff6a1b2c3d5 7ff6a1b2c3d6 7ff6a1b2c3d7",
+		},
+		{ level: "log", message: "__LOG__" },
+	]);
+});
+
+test("all of kj's fatal crash banners are recognised", async ({ expect }) => {
+	const banners = [
+		"*** std::terminate() called with no exception",
+		"*** Fatal uncaught kj::Exception: kj/async-io.c++:123: disconnected",
+		"*** Received signal #11: Segmentation fault",
+		"*** Uncaught exception: something went wrong",
+	];
+
+	expect(await collect(banners.map((banner) => `${banner}\n`))).toEqual(
+		banners.map((message) => ({ level: "error", message }))
+	);
+});
+
+test("address-in-use errors are still swallowed, even during a crash report", async ({
+	expect,
+}) => {
+	const addressInUse =
+		"kj/async-io-unix.c++:1: failed: Address already in use; toString() = 127.0.0.1:8787; stack: 7ff6a1b2c3d4 7ff6a1b2c3d5 7ff6a1b2c3d6\n";
+
+	// Miniflare turns this into a `MiniflareCoreError`, so showing the raw log
+	// too would surface the same failure twice.
+	expect(await collect([CRASH_BANNER, addressInUse])).toEqual([
+		{
+			level: "error",
+			message: "*** std::terminate() called with no exception",
+		},
+	]);
+});
+
+test("access violations still get their Windows-specific explanation", async ({
+	expect,
+}) => {
+	const accessViolation =
+		"kj/exception.c++:1: failed: access violation; stack: 7ff6a1b2c3d4 7ff6a1b2c3d5 7ff6a1b2c3d6\n";
+
+	const collected = await collect([CRASH_BANNER, accessViolation]);
+
+	expect(collected).toHaveLength(2);
+	expect(collected[1]?.level).toBe("error");
+	expect(collected[1]?.message).toContain(
+		"There was an access violation in the runtime."
+	);
+});


### PR DESCRIPTION
_Describe your change..._

`fixtures/dev-registry` has been failing on Windows CI at a high rate. Across 19 recent `test-and-check` runs where the fixture actually executed (it is often a turbo cache hit), the Windows fixtures job failed on it **7 times (37%)**, and a workerd crash was present in **11 (58%)**. macOS and Linux: 0.

The failure is always the same test — `Dev Registry: vite dev <-> vite dev > supports exported handler fetch over service binding` — and always `Test timed out in 50000ms` on both attempts. Every failing log contains this in exactly one of the `vite dev` child processes:

```
➜  Local:   http://localhost:5173/
*** std::terminate() called with no exception
9:43:12 AM [vite] server restarted.
*** std::terminate() called with no exception
```

That is workerd aborting, `#handleWorkerdCrash` respawning it, and the Vite plugin's `unsafeHandleRuntimeRestart` restarting the dev server — which then calls `setOptions()` and respawns workerd a second time. It costs ~30s per crash, which is what eats the test budget. (Notably it always hits the *first-started* session in the test, i.e. the one on port 5173, whichever config that happens to be.)

**The problem is that the crash carries no diagnostic information**, so there is nothing to act on. `messageClassifiers.isInternal` discards anything matching `/stack:( (0|[a-f\d]{4,})){3,}/` — a pattern added for Windows hex stacks — and kj emits the crash stack as a separate line immediately after the banner. So the stack was being thrown away.

This PR fixes that, ahead of fixing the crash itself:

- Recognise kj's fatal crash banners (`*** std::terminate()`, `*** Fatal uncaught`, `*** Received signal`, `*** Uncaught exception`) and keep the `stack:` line and missing-`$LLVM_SYMBOLIZER` notice that follow one, reporting the whole report at `error` level. Address-in-use and access-violation handling keep priority, so their existing messages are unchanged.
- Create the wrapped log handler once per stream instead of once per chunk, so the latch survives the banner and its stack trace arriving in separate `data` events.
- Warn when the runtime is restarted after a crash. Recovery was completely silent, so a user on Windows today sees their dev server restart for no stated reason. The crash count distinguishes a one-off from a restart loop.

Before / after, from `test/index.spec.ts`:

```
# before (stdout, level "log")
*** Fatal uncaught kj::Exception: workerd/server/server.c++:4180: failed: abortIsolate() called, terminating process; reason = test crash

# after (stderr, level "error")
*** Fatal uncaught kj::Exception: workerd/server/server.c++:4180: failed: abortIsolate() called, terminating process; reason = test crash
stack: 10451606b 104c193a7 104846dd3 10588bb4b 105889d3f ...
```

This is a user-facing improvement in its own right, and it has already done its job here. With a temporary diagnostic on top (since reverted) the Windows fixtures job captured the crash for the first time:

```
  ➜  Local:   http://localhost:5173/          <- stdout
12:02:16 PM [vite] server restarted.          <- stdout
*** std::terminate() called with no exception <- stderr
stack: 7ff845f81249 7ff697ab63a5 7ff845f9baff 7ff845f83a9c 7ff845f9ae8c 7ff845f82ce1
       7ff845f9b8f7 7ff854e6700e 7ff854d0e592 7ff845f9b3d5 7ff845f81c1f 7ff845f82dd7
       7ff845f9b8f7 7ff854e66f8e 7ff854d12326 7ff854d0a960 7ff8525375f9 7ff845f855a8
       7ff69914045f 7ff697ab5f63 7ff699145512 7ff69914c416 7ff699145a6b 7ff69914c416
       7ff699142fbb 7ff697aa1e77 7ff69af7219e 7ff8540fe8d6 7ff854d8c53b
The Workers runtime crashed unexpectedly and is being restarted (crash #1). Any additional runtime output above may indicate the cause.
```

Two things fall straight out of that, neither of which was visible before:

- The stack is **byte-identical across all 11 crashes in the run**, so this is a deterministic code path rather than corruption or resource exhaustion. It bottoms out at `BaseThreadInitThunk`/`RtlUserThreadStart` with CRT and ntdll unwind frames on top, i.e. a C++ exception escaping a workerd worker thread, and it contains a repeated frame (`…c416` twice) so something re-enters.
- It always hits the **first-started session** (port 5173), whichever config that happens to be, across both instrumented runs. That session is the only one that starts with an empty registry and has to learn about its peers via `setRegistry` pushes; later sessions boot with the registry already baked into their config. That asymmetry is the live lead.

Note on reading the excerpt above: the test helper accumulates stdout and stderr into *separate* buffers and the diagnostic printed them one after the other, so the relative order of the Vite line and the crash lines there is an artifact of concatenation, not real interleaving. (This change is what moved the banner from stdout to stderr, by reclassifying it to `error`.) Ordering has to be read from pre-change logs, where both appear on stdout — and those show the first crash arriving *before* any Vite restart, with the `server restarted.` in between being the crash recovery itself.

Follow-up work will fix the crash and reduce the recovery cost (one crash currently costs two workerd spawns plus a full Vite restart, ~30s, with no backoff).

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: this changes internal diagnostic output only. There is no new API, flag or configuration; users simply get the stack trace that workerd already emitted, plus a warning when the runtime is restarted after a crash.

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

> [!NOTE]
> This is a contribution from an AI agent: OpenCode, claude-opus-5.

