### PR TITLE
[miniflare] Keep the dev registry debug port stable across runtime reloads

### DIFF
--- a/.changeset/lucky-ports-hold-still.md
+++ b/.changeset/lucky-ports-hold-still.md
@@ -1,0 +1,11 @@
+---
+"miniflare": patch
+---
+
+Keep the dev registry debug port stable across runtime reloads
+
+When multiple local dev sessions share a dev registry, each one advertises a debug port that its peers connect to over Cap'n Proto and cache connections against. That port was re-allocated on every runtime reload, so any reload left every peer holding a connection to a port nothing was listening on until the registry update reached them. On Windows those stale connections surface as `WSARecv error 64` rather than a clean close.
+
+The debug port now re-binds the same port across reloads, matching how the inspector port is already handled.
+
+Also fixes tail event forwarding between dev sessions silently swallowing failures: the forwarding RPC's rejection escaped the surrounding `try`/`catch` as an unhandled rejection, so a peer going away produced no diagnostic at all.

--- a/.changeset/lucky-ports-hold-still.md
+++ b/.changeset/lucky-ports-hold-still.md
@@ -4,7 +4,7 @@
 
 Keep the dev registry debug port stable across runtime reloads
 
-When multiple local dev sessions share a dev registry, each one advertises a debug port that its peers connect to over Cap'n Proto and cache connections against. That port was re-allocated on every runtime reload, so any reload left every peer holding a connection to a port nothing was listening on until the registry update reached them. On Windows those stale connections surface as `WSARecv error 64` rather than a clean close.
+When multiple local dev sessions share a dev registry, each one advertises a debug port that its peers connect to over Cap'n Proto and cache connections against. That port was re-allocated on every runtime reload, so any reload left every peer holding a connection to a port nothing was listening on until the registry update reached them.
 
 The debug port now re-binds the same port across reloads, matching how the inspector port is already handled.
 

--- a/fixtures/dev-registry/tests/dev-registry.test.ts
+++ b/fixtures/dev-registry/tests/dev-registry.test.ts
@@ -48,6 +48,23 @@ async function runViteDev(
 		console.log("::endgroup::");
 	});
 
+	// TEMPORARY DIAGNOSTIC — revert before merging (see #14989).
+	// `onTestFailed` only fires when the test fails, but a workerd crash is often
+	// recovered from within the test's budget, so the crash report never reaches
+	// CI. Dump the session log whenever the runtime crashed, pass or fail.
+	onTestFinished(() => {
+		const output = `${proc.stdout}\n${proc.stderr}`;
+		if (
+			/std::terminate|Fatal uncaught|Received signal|crashed unexpectedly/.test(
+				output
+			)
+		) {
+			console.log(`::group::[RUNTIME CRASH] Vite dev session (${config})`);
+			console.log(output);
+			console.log("::endgroup::");
+		}
+	});
+
 	// Wait for the dev session to be ready
 	await vi.waitFor(async () => {
 		const resposne = await fetch(url, { method: "HEAD" });

--- a/fixtures/dev-registry/tests/dev-registry.test.ts
+++ b/fixtures/dev-registry/tests/dev-registry.test.ts
@@ -48,23 +48,6 @@ async function runViteDev(
 		console.log("::endgroup::");
 	});
 
-	// TEMPORARY DIAGNOSTIC — revert before merging (see #14989).
-	// `onTestFailed` only fires when the test fails, but a workerd crash is often
-	// recovered from within the test's budget, so the crash report never reaches
-	// CI. Dump the session log whenever the runtime crashed, pass or fail.
-	onTestFinished(() => {
-		const output = `${proc.stdout}\n${proc.stderr}`;
-		if (
-			/std::terminate|Fatal uncaught|Received signal|crashed unexpectedly/.test(
-				output
-			)
-		) {
-			console.log(`::group::[RUNTIME CRASH] Vite dev session (${config})`);
-			console.log(output);
-			console.log("::endgroup::");
-		}
-	});
-
 	// Wait for the dev session to be ready
 	await vi.waitFor(async () => {
 		const resposne = await fetch(url, { method: "HEAD" });

--- a/packages/miniflare/src/index.ts
+++ b/packages/miniflare/src/index.ts
@@ -2481,8 +2481,22 @@ export class Miniflare {
 			loopbackAddress,
 			requiredSockets,
 			inspectorAddress: runtimeInspectorAddress,
+			// Keep the debug port stable across restarts. Peer dev sessions hold
+			// Cap'n Proto connections to this address and cache `Fetcher`s keyed by
+			// it, so letting it move on every `setOptions()` leaves every peer
+			// pointing at a port nothing is listening on until the registry update
+			// reaches them. On Windows those stale connections surface as
+			// `WSARecv error 64` (`ERROR_NETNAME_DELETED`) rather than a clean
+			// close. Requesting the previous port re-binds the same address, so
+			// existing peers reconnect instead of failing.
 			debugPortAddress: this.#devRegistry.isEnabled()
-				? "127.0.0.1:0"
+				? this.#getSocketAddress(
+						SOCKET_DEBUG_PORT,
+						0,
+						"127.0.0.1",
+						0,
+						reusePorts
+					)
 				: undefined,
 			verbose: this.#sharedOpts.core.verbose,
 			handleStructuredLogs: this.#sharedOpts.core.handleStructuredLogs,

--- a/packages/miniflare/src/workers/core/dev-registry-proxy.worker.ts
+++ b/packages/miniflare/src/workers/core/dev-registry-proxy.worker.ts
@@ -161,7 +161,7 @@ export class ExternalServiceProxy extends WorkerEntrypoint<Env, Props> {
 	// Forward tail events to the remote worker via RPC.
 	// Events with rpcMethod==="tail" are filtered out to prevent infinite
 	// recursion (the remote tail() call would itself produce a tail event).
-	tail(events: TraceItem[]) {
+	async tail(events: TraceItem[]) {
 		if (!this._fetcher) {
 			return;
 		}
@@ -176,8 +176,12 @@ export class ExternalServiceProxy extends WorkerEntrypoint<Env, Props> {
 				JSON.stringify(filtered, tailEventsReplacer),
 				tailEventsReviver
 			);
+			// `await` rather than `return`: the RPC rejects when the peer's debug
+			// port has gone away, and returning the promise leaves that rejection
+			// outside this `try`, so it escapes as an unhandled rejection instead of
+			// being reported.
 			// @ts-expect-error .tail is not in the `Fetcher` type but it's a valid RPC call
-			return this._fetcher.tail(serializedEvents);
+			await this._fetcher.tail(serializedEvents);
 		} catch (e) {
 			console.warn(
 				`[dev-registry] Failed to forward tail events to "${

--- a/packages/miniflare/test/dev-registry.spec.ts
+++ b/packages/miniflare/test/dev-registry.spec.ts
@@ -1787,4 +1787,115 @@ describe.sequential("DevRegistry", () => {
 			{ timeout: 10_000, interval: 100 }
 		);
 	});
+
+	test("keeps the same debug port across reloads", async ({ expect }) => {
+		const unsafeDevRegistryPath = await useTmp();
+		const sharedOptions = {
+			name: "restarting-worker",
+			unsafeDevRegistryPath,
+			compatibilityFlags: ["experimental"],
+			modules: true,
+		} satisfies Partial<MiniflareOptions>;
+
+		const mf = new Miniflare({
+			...sharedOptions,
+			script: `export default { fetch() { return new Response("v1"); } }`,
+		});
+		useDispose(mf);
+		await mf.ready;
+
+		let firstAddress: string | undefined;
+		await vi.waitFor(
+			() => {
+				firstAddress = getWorkerRegistry(unsafeDevRegistryPath)[
+					"restarting-worker"
+				]?.debugPortAddress;
+				expect(firstAddress).toMatch(/^127\.0\.0\.1:\d+$/);
+			},
+			{ timeout: 10_000, interval: 100 }
+		);
+
+		await mf.setOptions({
+			...sharedOptions,
+			script: `export default { fetch() { return new Response("v2"); } }`,
+		});
+		// Confirm the runtime really did reload.
+		expect(await (await mf.dispatchFetch("http://placeholder")).text()).toBe(
+			"v2"
+		);
+
+		// Peers cache Cap'n Proto connections keyed by this address, so a reload
+		// must re-bind the same port rather than moving to a fresh one.
+		const secondAddress = getWorkerRegistry(unsafeDevRegistryPath)[
+			"restarting-worker"
+		]?.debugPortAddress;
+		expect(secondAddress).toBe(firstAddress);
+	});
+
+	test("reports a failure to forward tail events to a departed peer", async ({
+		expect,
+	}) => {
+		const unsafeDevRegistryPath = await useTmp();
+
+		const remote = new Miniflare({
+			name: "remote-worker",
+			unsafeDevRegistryPath,
+			compatibilityFlags: ["experimental"],
+			modules: true,
+			script: `
+				import { WorkerEntrypoint } from "cloudflare:workers";
+				export default class extends WorkerEntrypoint {
+					tail() {}
+				}
+			`,
+		});
+		useDispose(remote);
+		await remote.ready;
+
+		const logs: string[] = [];
+		const local = new Miniflare({
+			name: "local-worker",
+			unsafeDevRegistryPath,
+			tails: ["remote-worker"],
+			compatibilityFlags: ["experimental"],
+			modules: true,
+			handleStructuredLogs: ({ message }) => void logs.push(message),
+			script: `
+				export default {
+					fetch() {
+						console.log("tail me");
+						return new Response("ok");
+					}
+				}
+			`,
+		});
+		useDispose(local);
+		await local.ready;
+
+		// Establish the tail forwarding path while the peer is alive.
+		await vi.waitFor(
+			async () => {
+				await (await local.dispatchFetch("http://placeholder")).text();
+				expect(logs.join("\n")).toContain("tail me");
+			},
+			{ timeout: 10_000, interval: 100 }
+		);
+
+		// Drop the peer without letting it deregister, so `local` keeps a registry
+		// entry pointing at a debug port that is no longer accepting connections.
+		// The forwarding RPC now rejects; that rejection must be reported rather
+		// than escaping as an unhandled rejection.
+		await remote.dispose();
+		logs.length = 0;
+
+		await vi.waitFor(
+			async () => {
+				await (await local.dispatchFetch("http://placeholder")).text();
+				expect(logs.join("\n")).toContain(
+					`[dev-registry] Failed to forward tail events to "remote-worker"`
+				);
+			},
+			{ timeout: 10_000, interval: 100 }
+		);
+	});
 });


### PR DESCRIPTION
Two correctness fixes found while investigating the Windows `fixtures/dev-registry` flake. **Neither fixes the flake** — see "What this doesn't do" below. They're worth landing on their own merits.

Stacked on #14989 — please merge that first; this branch includes its commits.

### 1. The debug port moved on every reload

Peer dev sessions reach each other through workerd's debug port over Cap'n Proto, and cache connections against the advertised address (`createProxyDurableObjectClass` keys `_cachedFetcher` on `_cachedDebugPortAddress`). But `debugPortAddress` was hardcoded to `127.0.0.1:0`, so every runtime reload allocated a brand new port — unlike the inspector port, which already goes through `#getSocketAddress` with `#previousRuntimeInspectorPort` specifically to stay put.

A reload isn't only something the user triggers. A plain `vite dev` startup spawns two workerd generations, and the second one is silent — no `server restarted.` in the log. Probing the registry directory during startup catches it:

```
t=1.0s  __asset-worker__ -> 127.0.0.1:63887   <- generation 1
t=1.2s  __asset-worker__ -> 127.0.0.1:63899   <- generation 2; 63887 now dead
...
restarts: A=0
```

A peer that reads the registry during that window connects to `63887` and keeps holding it after nothing is listening there. Requesting the previously allocated port re-binds the same address, so peers reconnect to a live listener instead.

### 2. Tail forwarding swallowed failures

`tail()` did `return this._fetcher.tail(...)` from inside a `try`/`catch`, so the rejection a departed peer produces landed outside the `try` and escaped as an unhandled rejection — the `catch` only ever guarded the synchronous `JSON` work. Confirmed: before this change a dead peer produced no diagnostic at all. Now `await`ed, so it's reported.

### What this doesn't do

It does not fix the Windows flake. I thought it would; CI says otherwise.

Baseline for `fixtures/dev-registry` on Windows is a **37% job failure rate** (7/19 runs that actually executed rather than hitting a turbo cache) with a workerd `std::terminate` present in **58%**. With this branch, the Windows fixtures job still failed the same way: 2 failed / 25 passed, `supports exported handler fetch over service binding` and `supports RPC over service binding` both timing out at ~101s, with 4 crash reports in the log. The crash stack is byte-identical to before once ASLR bases are normalised, so it's the same code path.

The investigation did narrow it though. Across two instrumented runs, **every crash lands in the session on port 5173** — the first-started one — regardless of which config that is (4/4 this run, and the same before). That points at an asymmetry I'm still chasing: later sessions boot with the registry already populated in their config, whereas the first session starts empty and has to be told about its peers via `setRegistry` pushes.

The `std::terminate` itself is in workerd's C++ on a non-main thread, and the stack is unsymbolized (`$LLVM_SYMBOLIZER` isn't set on the runners and release workerd is stripped), so it's likely a workerd bug rather than something fixable here. I'll raise it upstream if the remaining lead doesn't pan out.

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: this fixes internal port-allocation behaviour in local dev; there is no user-facing API or documented behaviour change.

Both tests were verified to fail without their fix:

- `keeps the same debug port across reloads` — without it: `expected '127.0.0.1:55734' to be '127.0.0.1:55732'`
- `reports a failure to forward tail events to a departed peer` — without it: times out, because the warning is never emitted

*A picture of a cute animal (not mandatory, but encouraged)*

> [!NOTE]
> This is a contribution from an AI agent: opencode, claude-opus-5.
