### PR TITLE
[miniflare] Report tail event forwarding failures between dev sessions

### DIFF
--- a/.changeset/tail-forwarding-speaks-up.md
+++ b/.changeset/tail-forwarding-speaks-up.md
@@ -1,0 +1,7 @@
+---
+"miniflare": patch
+---
+
+Report failures to forward tail events between local dev sessions
+
+When a Worker's tail consumer runs in a separate local dev session and that session becomes unreachable, the failure to deliver tail events was discarded silently. It is now reported as a warning.

--- a/packages/miniflare/src/workers/core/dev-registry-proxy.worker.ts
+++ b/packages/miniflare/src/workers/core/dev-registry-proxy.worker.ts
@@ -161,7 +161,7 @@ export class ExternalServiceProxy extends WorkerEntrypoint<Env, Props> {
 	// Forward tail events to the remote worker via RPC.
 	// Events with rpcMethod==="tail" are filtered out to prevent infinite
 	// recursion (the remote tail() call would itself produce a tail event).
-	tail(events: TraceItem[]) {
+	async tail(events: TraceItem[]) {
 		if (!this._fetcher) {
 			return;
 		}
@@ -176,8 +176,12 @@ export class ExternalServiceProxy extends WorkerEntrypoint<Env, Props> {
 				JSON.stringify(filtered, tailEventsReplacer),
 				tailEventsReviver
 			);
+			// `await` rather than `return`: the RPC rejects when the peer's debug
+			// port has gone away, and returning the promise leaves that rejection
+			// outside this `try`, so it escapes as an unhandled rejection instead of
+			// being reported.
 			// @ts-expect-error .tail is not in the `Fetcher` type but it's a valid RPC call
-			return this._fetcher.tail(serializedEvents);
+			await this._fetcher.tail(serializedEvents);
 		} catch (e) {
 			console.warn(
 				`[dev-registry] Failed to forward tail events to "${

--- a/packages/miniflare/test/dev-registry.spec.ts
+++ b/packages/miniflare/test/dev-registry.spec.ts
@@ -1787,4 +1787,70 @@ describe.sequential("DevRegistry", () => {
 			{ timeout: 10_000, interval: 100 }
 		);
 	});
+	test("reports a failure to forward tail events to a departed peer", async ({
+		expect,
+	}) => {
+		const unsafeDevRegistryPath = await useTmp();
+
+		const remote = new Miniflare({
+			name: "remote-worker",
+			unsafeDevRegistryPath,
+			compatibilityFlags: ["experimental"],
+			modules: true,
+			script: `
+				import { WorkerEntrypoint } from "cloudflare:workers";
+				export default class extends WorkerEntrypoint {
+					tail() {}
+				}
+			`,
+		});
+		useDispose(remote);
+		await remote.ready;
+
+		const logs: string[] = [];
+		const local = new Miniflare({
+			name: "local-worker",
+			unsafeDevRegistryPath,
+			tails: ["remote-worker"],
+			compatibilityFlags: ["experimental"],
+			modules: true,
+			handleStructuredLogs: ({ message }) => void logs.push(message),
+			script: `
+				export default {
+					fetch() {
+						console.log("tail me");
+						return new Response("ok");
+					}
+				}
+			`,
+		});
+		useDispose(local);
+		await local.ready;
+
+		// Establish the tail forwarding path while the peer is alive.
+		await vi.waitFor(
+			async () => {
+				await (await local.dispatchFetch("http://placeholder")).text();
+				expect(logs.join("\n")).toContain("tail me");
+			},
+			{ timeout: 10_000, interval: 100 }
+		);
+
+		// Drop the peer without letting it deregister, so `local` keeps a registry
+		// entry pointing at a debug port that is no longer accepting connections.
+		// The forwarding RPC now rejects; that rejection must be reported rather
+		// than escaping as an unhandled rejection.
+		await remote.dispose();
+		logs.length = 0;
+
+		await vi.waitFor(
+			async () => {
+				await (await local.dispatchFetch("http://placeholder")).text();
+				expect(logs.join("\n")).toContain(
+					`[dev-registry] Failed to forward tail events to "remote-worker"`
+				);
+			},
+			{ timeout: 10_000, interval: 100 }
+		);
+	});
 });


### PR DESCRIPTION
Found while investigating the Windows `fixtures/dev-registry` flake (#14989 has the wider write-up). Independent of that flake and of #14989 — this stands on its own.

`ExternalServiceProxy.tail()` forwards tail events to a tail consumer running in another local dev session. It did:

```ts
try {
  const serializedEvents = JSON.parse(/* ... */);
  return this._fetcher.tail(serializedEvents);
} catch (e) {
  console.warn(`[dev-registry] Failed to forward tail events to ...`);
}
```

`return`ing the promise from inside the `try` means the `catch` only ever guarded the synchronous `JSON` work. The rejection that a departed peer actually produces settled after `tail()` had already returned, so it escaped as an unhandled rejection and the warning never fired.

Verified: with a registered peer whose debug port has gone away, the pre-change code produces **no diagnostic at all**. `await`ing the call routes the rejection into the existing `catch`.

### Tests

Added `reports a failure to forward tail events to a departed peer`, which establishes tail forwarding between two sessions, disposes the peer so the registry entry outlives its debug port, and asserts the warning is emitted. It fails on `main` (times out — the warning never arrives) and passes with the change. Ran 3x in isolation plus the full miniflare suite (1012 passed) to check it isn't order-dependent.

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: this makes a previously-silent local dev failure visible; there is no API or documented behaviour change.

*A picture of a cute animal (not mandatory, but encouraged)*

> [!NOTE]
> This is a contribution from an AI agent: opencode, claude-opus-5.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14993" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->