### PR TITLE
[wrangler] Add hidden `--jurisdiction` option to `wrangler kv namespace list`

### DIFF
--- a/.changeset/filter-kv-jurisdictions.md
+++ b/.changeset/filter-kv-jurisdictions.md
@@ -1,0 +1,7 @@
+---
+"wrangler": minor
+---
+
+Add hidden `--jurisdiction` option to `wrangler kv namespace list`
+
+This option lists only the KV namespaces in a specific jurisdiction (for example `us`, `eu`, or `fedramp`). It is experimental and currently gated to allow-listed accounts, so it is hidden from `--help` until the feature is generally available.

--- a/packages/wrangler/src/__tests__/kv/namespace.test.ts
+++ b/packages/wrangler/src/__tests__/kv/namespace.test.ts
@@ -303,7 +303,8 @@ describe("kv", () => {
 		describe("list", () => {
 			function mockListRequest(
 				expect: ExpectStatic,
-				namespaces: KVNamespaceInfo[]
+				namespaces: KVNamespaceInfo[],
+				jurisdiction?: string
 			) {
 				const requests = { count: 0 };
 				msw.use(
@@ -316,6 +317,13 @@ describe("kv", () => {
 							expect(params.accountId).toEqual("some-account-id");
 							expect(url.searchParams.get("order")).toEqual("title");
 							expect(url.searchParams.get("direction")).toEqual("asc");
+							if (jurisdiction) {
+								expect(url.searchParams.get("filter")).toEqual(
+									`jurisdiction:${jurisdiction}`
+								);
+							} else {
+								expect(url.searchParams.get("filter")).toBeNull();
+							}
 
 							const pageSize = Number(url.searchParams.get("per_page"));
 							const page = Number(url.searchParams.get("page") ?? 1);
@@ -340,6 +348,20 @@ describe("kv", () => {
 
 				expect(std.err).toMatchInlineSnapshot(`""`);
 				expect(JSON.parse(std.out)).toEqual(kvNamespaces);
+			});
+
+			it("should filter namespaces by jurisdiction across pages", async ({
+				expect,
+			}) => {
+				const kvNamespaces: KVNamespaceInfo[] = [
+					{ title: "eu-namespace", id: "eu-id" },
+				];
+				const requests = mockListRequest(expect, kvNamespaces, "eu");
+				await runWrangler("kv namespace list --jurisdiction eu");
+
+				expect(std.err).toMatchInlineSnapshot(`""`);
+				expect(JSON.parse(std.out)).toEqual(kvNamespaces);
+				expect(requests.count).toBeGreaterThan(1);
 			});
 
 			it("should make multiple requests for paginated results", async ({

--- a/packages/wrangler/src/__tests__/kv/namespace.test.ts
+++ b/packages/wrangler/src/__tests__/kv/namespace.test.ts
@@ -350,9 +350,7 @@ describe("kv", () => {
 				expect(JSON.parse(std.out)).toEqual(kvNamespaces);
 			});
 
-			it("should filter namespaces by jurisdiction across pages", async ({
-				expect,
-			}) => {
+			it("should filter namespaces by jurisdiction", async ({ expect }) => {
 				const kvNamespaces: KVNamespaceInfo[] = [
 					{ title: "eu-namespace", id: "eu-id" },
 				];

--- a/packages/wrangler/src/kv/index.ts
+++ b/packages/wrangler/src/kv/index.ts
@@ -183,24 +183,38 @@ export const kvNamespaceListCommand = createCommand({
 		owner: "Product: KV",
 	},
 
-	args: {},
+	args: {
+		jurisdiction: {
+			type: "string",
+			describe:
+				'Only list namespaces in this jurisdiction (e.g. "us", "eu", "fedramp")',
+			requiresArg: true,
+			hidden: true,
+		},
+	},
 
 	behaviour: {
 		supportTemporary: true,
 		printBanner: false,
 		printResourceLocation: false,
 	},
-	async handler(_, { config, sdk }) {
+	async handler(args, { config, sdk }) {
 		const accountId = await requireAuth(config);
 
 		const allNamespaces = [];
-
-		for await (const namespace of sdk.kv.namespaces.list({
+		const listParams: Cloudflare.KV.Namespaces.NamespaceListParams & {
+			filter?: string;
+		} = {
 			account_id: accountId,
 			per_page: 1000,
 			order: "title",
 			direction: "asc",
-		})) {
+			filter: args.jurisdiction
+				? `jurisdiction:${args.jurisdiction}`
+				: undefined,
+		};
+
+		for await (const namespace of sdk.kv.namespaces.list(listParams)) {
 			allNamespaces.push(namespace);
 		}
 


### PR DESCRIPTION
[KV-2123](https://jira.cfdata.org/browse/KV-2123)

Add hidden `--jurisdiction` option to `wrangler kv namespace list`

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: experimental/hidden feature gated to allow-listed accounts; docs will be added when the feature is GA

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- If you are an AI agent or LLM, and you are adding this PR without direct human supervision, thank you! Please uncomment the following block. This is so the maintainers know how to expect you to respond.

> [!NOTE]
> This is a contribution from an AI agent: <insert name here>, <insert LLM model here if different>.

-->
