### PR TITLE
EXPERIMENT (do not merge): BASELINE control for #15017 (pre-fix, pre-skip)

### DIFF
--- a/.github/workflows/test-and-check.yml
+++ b/.github/workflows/test-and-check.yml
@@ -82,7 +82,7 @@ jobs:
         run: node packages/wrangler/src/__tests__/test-old-node-version.js error
 
   test:
-    timeout-minutes: 30
+    timeout-minutes: 60
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.os }}-${{ matrix.suite }}-test
       cancel-in-progress: ${{ github.head_ref != 'changeset-release/main' }}
@@ -187,7 +187,26 @@ jobs:
         # Since the dev registry is now file-based (not network-based), fixture tests can safely run in parallel.
         # Concurrency is capped at 2 to avoid CPU starvation on CI runners when multiple fixtures
         # spawn workerd processes simultaneously (Windows runners are especially slow under load).
-        run: pnpm run test:ci --concurrency=2 --log-order=stream --filter="./fixtures/*" ${{ matrix.os == 'ubuntu-latest' && '--filter="!./fixtures/browser-run"' || '' }}
+        shell: bash
+        run: |
+          # TEMPORARY VALIDATION HARNESS — do not merge.
+          # Runs only the dev-registry fixture, repeatedly, without turbo caching,
+          # tallying each iteration so one flake does not hide the rest.
+          pass=0
+          fail=0
+          for i in 1 2 3 4 5 6; do
+            echo "::group::dev-registry iteration $i"
+            if pnpm run test:ci --force --log-order=stream --filter="@fixture/dev-registry"; then
+              pass=$((pass + 1))
+              echo "ITERATION $i RESULT: PASS"
+            else
+              fail=$((fail + 1))
+              echo "ITERATION $i RESULT: FAIL"
+            fi
+            echo "::endgroup::"
+          done
+          echo "TALLY ${{ matrix.description }}: pass=$pass fail=$fail"
+          test "$fail" -eq 0
         env:
           NODE_OPTIONS: "--max_old_space_size=8192"
           WRANGLER_LOG_PATH: ${{ runner.temp }}/wrangler-debug-logs/

--- a/fixtures/dev-registry/tests/dev-registry.test.ts
+++ b/fixtures/dev-registry/tests/dev-registry.test.ts
@@ -4,7 +4,7 @@ import * as path from "node:path";
 import { resolve } from "node:path";
 /* eslint-disable workers-sdk/no-vitest-import-expect -- uses expect in module-scope helper functions */
 import {
-	describe as baseDescribe,
+	describe,
 	expect,
 	onTestFailed,
 	onTestFinished,
@@ -17,11 +17,6 @@ import {
 	waitForReady,
 } from "../../../packages/vite-plugin-cloudflare/e2e/helpers";
 import { runWranglerDev as baseRunWranglerDev } from "../../shared/src/run-wrangler-long-lived";
-
-// TODO: These tests are consistently failing on Windows in CI and are blocking
-// other work. Skipping them there as a temporary measure until the underlying
-// issue is fixed. There's still value in running them on macOS and Linux.
-const describe = baseDescribe.skipIf(process.platform === "win32");
 
 const waitForTimeout = 20_000;
 const cwd = resolve(__dirname, "..");


### PR DESCRIPTION
Scratch harness. Not for merge. Control arm for https://github.com/cloudflare/workers-sdk/pull/15017.

Pre-fix **and** pre-skip dev-registry fixture (both cyclic `tail_consumers` restored, #15018's Windows skip reverted) plus a temporary harness that runs **only** `@fixture/dev-registry`, six times, uncached, with a per-iteration tally.

| arm | Windows result |
| --- | --- |
| #15017 (fix) | `pass=6 fail=0`, 30/30 tests each, 0 `std::terminate`, 0 timeouts, durations 237-250s |
| pre-fix + pre-skip (this run) | measuring |

An earlier attempt at this control was void: #15018 landed mid-experiment and the PR merge ref picked it up, so all 27 tests were skipped on Windows (`↓ 27 tests | 27 skipped`, 4.7s per iteration).

Search the job log for `TALLY` and `ITERATION n RESULT`.