### PR TITLE
CC-8338, CC-8340: Improve Wrangler container instance listings

### DIFF
--- a/.changeset/bright-moles-search.md
+++ b/.changeset/bright-moles-search.md
@@ -2,6 +2,6 @@
 "wrangler": minor
 ---
 
-Find container instances by exact ID or name
+Adds the ability to find container instances by exact ID or name
 
 `wrangler containers instances <application_id> --search <instance_id_or_name>` now searches every page and returns exact matches in human-readable or JSON output. JSON returns a top-level array, including an empty array when there is no match, while human-readable output prints a no-match message. If multiple instances have the same exact name, every matching instance is returned.

--- a/.changeset/bright-moles-search.md
+++ b/.changeset/bright-moles-search.md
@@ -1,0 +1,7 @@
+---
+"wrangler": minor
+---
+
+Find container instances by exact ID or name
+
+`wrangler containers instances <application_id> --search <instance_id_or_name>` now searches every page and returns exact matches in human-readable or JSON output. JSON returns a top-level array, including an empty array when there is no match, while human-readable output prints a no-match message. If multiple instances have the same exact name, every matching instance is returned.

--- a/.changeset/tidy-pandas-paginate.md
+++ b/.changeset/tidy-pandas-paginate.md
@@ -1,0 +1,7 @@
+---
+"wrangler": minor
+---
+
+Add explicit pagination to container instance JSON output
+
+Use `wrangler containers instances <application_id> --json --per-page <size>` to return one page with machine-readable `result_info`, then pass its `next_page_token` to `--page-token` to retrieve the next page. Plain `--json` remains backward-compatible: it requests the complete list and returns the existing top-level array.

--- a/packages/wrangler/src/__tests__/containers/instances.test.ts
+++ b/packages/wrangler/src/__tests__/containers/instances.test.ts
@@ -116,8 +116,9 @@ describe("containers instances", () => {
 			  -v, --version         Show version number  [boolean]
 
 			OPTIONS
-			      --per-page  Number of instances per page  [number] [default: 25]
-			      --json      Return output as JSON  [boolean] [default: false]"
+			      --per-page    Number of instances per page  [number]
+			      --page-token  Continuation token for explicitly paginated JSON output  [string]
+			      --json        Return output as JSON  [boolean] [default: false]"
 		`);
 	});
 
@@ -290,8 +291,19 @@ describe("containers instances", () => {
 		expect(std.out).toContain("22222222-2222-2222-2222-222222222222");
 	});
 
+	it("should reject a page token without JSON output", async ({ expect }) => {
+		setIsTTY(false);
+		setWranglerConfig({});
+
+		await expect(
+			runWrangler(`containers instances ${APP_ID} --page-token next-page`)
+		).rejects.toThrowErrorMatchingInlineSnapshot(
+			`[Error: --page-token requires --json]`
+		);
+	});
+
 	describe("--json", () => {
-		it("should output flat JSON matching table columns for non-DO apps", async ({
+		it("should preserve the complete top-level array for non-DO apps", async ({
 			expect,
 		}) => {
 			setIsTTY(false);
@@ -299,7 +311,10 @@ describe("containers instances", () => {
 			msw.use(
 				http.get(
 					"*/dash/applications/*/instances",
-					async () => {
+					async ({ request }) => {
+						const url = new URL(request.url);
+						expect(url.searchParams.has("per_page")).toBe(false);
+						expect(url.searchParams.has("page_token")).toBe(false);
 						return HttpResponse.json({
 							success: true,
 							result: MOCK_INSTANCES,
@@ -391,11 +406,10 @@ describe("containers instances", () => {
 				)
 			);
 			await runWrangler(`containers instances ${APP_ID} --json`);
-			const output = JSON.parse(std.out);
-			expect(output).toEqual([]);
+			expect(JSON.parse(std.out)).toEqual([]);
 		});
 
-		it("should fetch all results in a single unpaginated request", async ({
+		it("should return one page and its continuation metadata", async ({
 			expect,
 		}) => {
 			setIsTTY(false);
@@ -407,13 +421,147 @@ describe("containers instances", () => {
 					async ({ request }) => {
 						requestCount++;
 						const url = new URL(request.url);
-						// --json omits per_page so the API returns everything
+						expect(url.searchParams.get("per_page")).toBe("1");
+						expect(url.searchParams.has("page_token")).toBe(false);
+						return HttpResponse.json({
+							success: true,
+							result: {
+								instances: [MOCK_INSTANCES.instances[0]],
+								durable_objects: [],
+							},
+							result_info: {
+								per_page: 1,
+								next_page_token: "next-page",
+							},
+							errors: [],
+							messages: [],
+						});
+					},
+					{ once: true }
+				)
+			);
+			await runWrangler(`containers instances ${APP_ID} --json --per-page 1`);
+			expect(requestCount).toBe(1);
+			const output = JSON.parse(std.out);
+			expect(output.instances).toHaveLength(1);
+			expect(output.instances[0].id).toBe(
+				"11111111-1111-1111-1111-111111111111"
+			);
+			expect(output.result_info).toEqual({
+				per_page: 1,
+				page_token: null,
+				next_page_token: "next-page",
+			});
+		});
+
+		it("should continue from an explicit page token", async ({ expect }) => {
+			setIsTTY(false);
+			setWranglerConfig({});
+			msw.use(
+				http.get(
+					"*/dash/applications/*/instances",
+					async ({ request }) => {
+						const url = new URL(request.url);
+						expect(url.searchParams.get("per_page")).toBe("1");
+						expect(url.searchParams.get("page_token")).toBe("next-page");
+						return HttpResponse.json({
+							success: true,
+							result: {
+								instances: [MOCK_INSTANCES.instances[1]],
+								durable_objects: [],
+							},
+							result_info: {
+								per_page: 1,
+								page_token: "next-page",
+							},
+							errors: [],
+							messages: [],
+						});
+					},
+					{ once: true }
+				)
+			);
+
+			await runWrangler(
+				`containers instances ${APP_ID} --json --per-page 1 --page-token next-page`
+			);
+
+			expect(JSON.parse(std.out)).toEqual({
+				instances: [
+					{
+						id: "22222222-2222-2222-2222-222222222222",
+						state: "provisioning",
+						location: "iad01",
+						version: 2,
+						created: "2025-06-01T11:00:00Z",
+					},
+				],
+				result_info: {
+					per_page: 1,
+					page_token: "next-page",
+					next_page_token: null,
+				},
+			});
+		});
+
+		it("should continue with a page token without sending a default page size", async ({
+			expect,
+		}) => {
+			setIsTTY(false);
+			setWranglerConfig({});
+			msw.use(
+				http.get(
+					"*/dash/applications/*/instances",
+					async ({ request }) => {
+						const url = new URL(request.url);
+						expect(url.searchParams.has("per_page")).toBe(false);
+						expect(url.searchParams.get("page_token")).toBe("next-page");
+						return HttpResponse.json({
+							success: true,
+							result: {
+								instances: [MOCK_INSTANCES.instances[1]],
+								durable_objects: [],
+							},
+							result_info: {
+								per_page: 50,
+								page_token: "next-page",
+							},
+							errors: [],
+							messages: [],
+						});
+					},
+					{ once: true }
+				)
+			);
+
+			await runWrangler(
+				`containers instances ${APP_ID} --json --page-token next-page`
+			);
+
+			expect(JSON.parse(std.out).result_info).toEqual({
+				per_page: 50,
+				page_token: "next-page",
+				next_page_token: null,
+			});
+		});
+
+		it("should support APIs that return the complete list without pagination metadata", async ({
+			expect,
+		}) => {
+			setIsTTY(false);
+			setWranglerConfig({});
+			let requestCount = 0;
+			msw.use(
+				http.get(
+					"*/dash/applications/*/instances",
+					async ({ request }) => {
+						requestCount++;
+						const url = new URL(request.url);
 						expect(url.searchParams.has("per_page")).toBe(false);
 						expect(url.searchParams.has("page_token")).toBe(false);
 						return HttpResponse.json({
 							success: true,
 							result: MOCK_INSTANCES,
-							result_info: { per_page: 50 },
 							errors: [],
 							messages: [],
 						});
@@ -425,8 +573,6 @@ describe("containers instances", () => {
 			expect(requestCount).toBe(1);
 			const output = JSON.parse(std.out);
 			expect(output).toHaveLength(2);
-			expect(output[0].id).toBe("11111111-1111-1111-1111-111111111111");
-			expect(output[1].id).toBe("22222222-2222-2222-2222-222222222222");
 		});
 	});
 });

--- a/packages/wrangler/src/__tests__/containers/instances.test.ts
+++ b/packages/wrangler/src/__tests__/containers/instances.test.ts
@@ -117,6 +117,7 @@ describe("containers instances", () => {
 
 			OPTIONS
 			      --per-page    Number of instances per page  [number]
+			      --search      Find instances matching an exact instance ID or name  [string]
 			      --page-token  Continuation token for explicitly paginated JSON output  [string]
 			      --json        Return output as JSON  [boolean] [default: false]"
 		`);
@@ -300,6 +301,217 @@ describe("containers instances", () => {
 		).rejects.toThrowErrorMatchingInlineSnapshot(
 			`[Error: --page-token requires --json]`
 		);
+	});
+
+	describe("--search", () => {
+		it("should find an instance by exact ID across every page", async ({
+			expect,
+		}) => {
+			setIsTTY(false);
+			setWranglerConfig({});
+			let requestCount = 0;
+			msw.use(
+				http.get("*/dash/applications/*/instances", async ({ request }) => {
+					requestCount++;
+					const url = new URL(request.url);
+					expect(url.searchParams.get("per_page")).toBe("1");
+
+					if (requestCount === 1) {
+						expect(url.searchParams.has("page_token")).toBe(false);
+						return HttpResponse.json({
+							success: true,
+							result: {
+								instances: [MOCK_INSTANCES.instances[0]],
+								durable_objects: [],
+							},
+							result_info: {
+								per_page: 1,
+								next_page_token: "next-page",
+							},
+							errors: [],
+							messages: [],
+						});
+					}
+
+					expect(url.searchParams.get("page_token")).toBe("next-page");
+					return HttpResponse.json({
+						success: true,
+						result: {
+							instances: [MOCK_INSTANCES.instances[1]],
+							durable_objects: [],
+						},
+						result_info: { per_page: 1 },
+						errors: [],
+						messages: [],
+					});
+				})
+			);
+
+			await runWrangler(
+				`containers instances ${APP_ID} --search 22222222-2222-2222-2222-222222222222 --per-page 1`
+			);
+
+			expect(requestCount).toBe(2);
+			expect(std.out).not.toContain("11111111-1111-1111-1111-111111111111");
+			expect(std.out).toContain("22222222-2222-2222-2222-222222222222");
+		});
+
+		it("should find an instance by exact name in JSON output", async ({
+			expect,
+		}) => {
+			setIsTTY(false);
+			setWranglerConfig({});
+			let requestCount = 0;
+			msw.use(
+				http.get("*/dash/applications/*/instances", async ({ request }) => {
+					requestCount++;
+					const url = new URL(request.url);
+					expect(url.searchParams.get("per_page")).toBe("1");
+
+					if (requestCount === 1) {
+						expect(url.searchParams.has("page_token")).toBe(false);
+						return HttpResponse.json({
+							success: true,
+							result: {
+								instances: [],
+								durable_objects: [MOCK_DO_INSTANCES.durable_objects[0]],
+							},
+							result_info: {
+								per_page: 1,
+								next_page_token: "next-page",
+							},
+							errors: [],
+							messages: [],
+						});
+					}
+
+					expect(url.searchParams.get("page_token")).toBe("next-page");
+					return HttpResponse.json({
+						success: true,
+						result: {
+							instances: [MOCK_DO_INSTANCES.instances[0]],
+							durable_objects: [],
+						},
+						result_info: { per_page: 1 },
+						errors: [],
+						messages: [],
+					});
+				})
+			);
+
+			await runWrangler(
+				`containers instances ${APP_ID} --search random-76 --json --per-page 1`
+			);
+
+			expect(requestCount).toBe(2);
+			expect(JSON.parse(std.out)).toEqual([
+				{
+					id: "do-instance-1111",
+					name: "random-76",
+					state: "running",
+					location: "dfw01",
+					version: 57,
+					created: "2025-06-01T10:00:00Z",
+				},
+			]);
+		});
+
+		it("should explain when no exact human-readable match is found", async ({
+			expect,
+		}) => {
+			setIsTTY(false);
+			setWranglerConfig({});
+			msw.use(
+				http.get(
+					"*/dash/applications/*/instances",
+					async () => {
+						return HttpResponse.json({
+							success: true,
+							result: MOCK_DO_INSTANCES,
+							result_info: { per_page: 50 },
+							errors: [],
+							messages: [],
+						});
+					},
+					{ once: true }
+				)
+			);
+
+			await runWrangler(`containers instances ${APP_ID} --search random`);
+
+			expect(std.out).toBe(
+				'No instances found matching "random" by exact ID or name.'
+			);
+		});
+
+		it("should return an empty JSON result when no exact match is found", async ({
+			expect,
+		}) => {
+			setIsTTY(false);
+			setWranglerConfig({});
+			msw.use(
+				http.get(
+					"*/dash/applications/*/instances",
+					async () => {
+						return HttpResponse.json({
+							success: true,
+							result: MOCK_INSTANCES,
+							result_info: { per_page: 50 },
+							errors: [],
+							messages: [],
+						});
+					},
+					{ once: true }
+				)
+			);
+
+			await runWrangler(
+				`containers instances ${APP_ID} --search 11111111 --json`
+			);
+
+			expect(JSON.parse(std.out)).toEqual([]);
+		});
+
+		it("should return every instance with the same exact name", async ({
+			expect,
+		}) => {
+			setIsTTY(false);
+			setWranglerConfig({});
+			msw.use(
+				http.get(
+					"*/dash/applications/*/instances",
+					async () => {
+						return HttpResponse.json({
+							success: true,
+							result: {
+								...MOCK_DO_INSTANCES,
+								durable_objects: MOCK_DO_INSTANCES.durable_objects.map(
+									(instance) => ({
+										...instance,
+										name: "shared-name",
+									})
+								),
+							},
+							result_info: { per_page: 50 },
+							errors: [],
+							messages: [],
+						});
+					},
+					{ once: true }
+				)
+			);
+
+			await runWrangler(
+				`containers instances ${APP_ID} --search shared-name --json`
+			);
+
+			const output = JSON.parse(std.out);
+			expect(output).toHaveLength(2);
+			expect(output.map(({ id }: { id: string }) => id)).toEqual([
+				"do-instance-1111",
+				"do-instance-2222",
+			]);
+		});
 	});
 
 	describe("--json", () => {

--- a/packages/wrangler/src/containers/instances.ts
+++ b/packages/wrangler/src/containers/instances.ts
@@ -13,6 +13,7 @@ import type {
 	DashApplicationDurableObjectInstance,
 	DashApplicationInstance,
 	DashApplicationInstances,
+	ResultInfo,
 } from "@cloudflare/containers-shared";
 
 type InstanceState =
@@ -24,6 +25,8 @@ type InstanceState =
 	| "unhealthy"
 	| "inactive"
 	| "unknown";
+
+const DEFAULT_PER_PAGE = 25;
 
 function deriveInstanceState(instance: DashApplicationInstance): InstanceState {
 	const status = instance.current_placement?.status;
@@ -100,6 +103,7 @@ async function fetchPage(
 ): Promise<{
 	data: DashApplicationInstances;
 	nextPageToken?: string;
+	resultInfo?: ResultInfo;
 }> {
 	try {
 		const page = await ApplicationsService.listDashApplicationInstances(
@@ -110,6 +114,7 @@ async function fetchPage(
 		return {
 			data: page.data,
 			nextPageToken: page.resultInfo?.next_page_token,
+			resultInfo: page.resultInfo,
 		};
 	} catch (err) {
 		if (!(err instanceof Error)) {
@@ -167,6 +172,22 @@ function rowsToJsonOutput(rows: InstanceRow[]): Record<string, unknown>[] {
 	});
 }
 
+function instancesToJsonOutput(
+	rows: InstanceRow[],
+	perPage: number,
+	pageToken?: string,
+	nextPageToken?: string
+) {
+	return {
+		instances: rowsToJsonOutput(rows),
+		result_info: {
+			per_page: perPage,
+			page_token: pageToken ?? null,
+			next_page_token: nextPageToken ?? null,
+		},
+	};
+}
+
 function renderTable(rows: InstanceRow[]): void {
 	const hasDurableObjects = rows.some((r) => r.durableObject);
 
@@ -214,7 +235,6 @@ const instancesArgs = {
 	"per-page": {
 		describe: "Number of instances per page",
 		type: "number",
-		default: 25,
 		coerce: (val: number) => {
 			if (val < 1) {
 				throw new UserError("--per-page must be at least 1", {
@@ -223,6 +243,10 @@ const instancesArgs = {
 			}
 			return val;
 		},
+	},
+	"page-token": {
+		describe: "Continuation token for explicitly paginated JSON output",
+		type: "string",
 	},
 	json: {
 		describe: "Return output as JSON",
@@ -243,12 +267,35 @@ export async function instancesCommand(args: InstancesArgs): Promise<void> {
 		);
 	}
 
+	if (args.pageToken !== undefined && !args.json) {
+		throw new UserError("--page-token requires --json", {
+			telemetryMessage: "containers instances page-token without json",
+		});
+	}
+
+	const perPage = args.perPage ?? DEFAULT_PER_PAGE;
+
 	// --json: output JSON and exit
 	if (args.json) {
 		try {
-			const { data } = await fetchPage(args.ID);
-			const rows = buildInstanceRows(data);
-			logger.json(rowsToJsonOutput(rows));
+			const isPaginated =
+				args.perPage !== undefined || args.pageToken !== undefined;
+			const result = await fetchPage(args.ID, args.perPage, args.pageToken);
+			const rows = buildInstanceRows(result.data);
+
+			if (!isPaginated) {
+				logger.json(rowsToJsonOutput(rows));
+				return;
+			}
+
+			logger.json(
+				instancesToJsonOutput(
+					rows,
+					result.resultInfo?.per_page ?? perPage,
+					result.resultInfo?.page_token ?? args.pageToken,
+					result.nextPageToken
+				)
+			);
 			return;
 		} catch (err) {
 			if (err instanceof UserError) {
@@ -286,7 +333,7 @@ export async function instancesCommand(args: InstancesArgs): Promise<void> {
 		let data: DashApplicationInstances;
 		let nextPageToken: string | undefined;
 		try {
-			const result = await fetchPage(args.ID, args.perPage, pageToken);
+			const result = await fetchPage(args.ID, perPage, pageToken);
 			data = result.data;
 			nextPageToken = result.nextPageToken;
 		} finally {
@@ -311,7 +358,7 @@ export async function instancesCommand(args: InstancesArgs): Promise<void> {
 		if (pageToken) {
 			logger.log(
 				dim(
-					`Showing ${totalShown} instances. Press Enter to load ${args.perPage} more, or q/Esc to stop.`
+					`Showing ${totalShown} instances. Press Enter to load ${perPage} more, or q/Esc to stop.`
 				)
 			);
 			await new Promise<void>((resolve) => {

--- a/packages/wrangler/src/containers/instances.ts
+++ b/packages/wrangler/src/containers/instances.ts
@@ -96,6 +96,21 @@ function buildInstanceRows(data: DashApplicationInstances): InstanceRow[] {
 	}));
 }
 
+function filterInstanceRows(
+	rows: InstanceRow[],
+	search?: string
+): InstanceRow[] {
+	if (search === undefined) {
+		return rows;
+	}
+
+	return rows.filter(
+		(row) =>
+			(row.durableObject?.id ?? row.instance?.id) === search ||
+			row.durableObject?.name === search
+	);
+}
+
 async function fetchPage(
 	applicationId: string,
 	perPage?: number,
@@ -138,6 +153,28 @@ async function fetchPage(
 			`There has been an internal error fetching instances.\n${err.message}`
 		);
 	}
+}
+
+async function fetchAllRows(
+	applicationId: string,
+	perPage: number = DEFAULT_PER_PAGE
+): Promise<InstanceRow[]> {
+	// Searches span every page, so join only after all raw API data is present.
+	const instances: DashApplicationInstance[] = [];
+	const durableObjects: DashApplicationDurableObjectInstance[] = [];
+	let pageToken: string | undefined;
+
+	do {
+		const result = await fetchPage(applicationId, perPage, pageToken);
+		instances.push(...result.data.instances);
+		durableObjects.push(...(result.data.durable_objects ?? []));
+		pageToken = result.nextPageToken;
+	} while (pageToken);
+
+	return buildInstanceRows({
+		instances,
+		durable_objects: durableObjects,
+	});
 }
 
 function rowsToJsonOutput(rows: InstanceRow[]): Record<string, unknown>[] {
@@ -244,9 +281,15 @@ const instancesArgs = {
 			return val;
 		},
 	},
+	search: {
+		describe: "Find instances matching an exact instance ID or name",
+		type: "string",
+		conflicts: "page-token",
+	},
 	"page-token": {
 		describe: "Continuation token for explicitly paginated JSON output",
 		type: "string",
+		conflicts: "search",
 	},
 	json: {
 		describe: "Return output as JSON",
@@ -278,6 +321,15 @@ export async function instancesCommand(args: InstancesArgs): Promise<void> {
 	// --json: output JSON and exit
 	if (args.json) {
 		try {
+			if (args.search !== undefined) {
+				const rows = filterInstanceRows(
+					await fetchAllRows(args.ID, perPage),
+					args.search
+				);
+				logger.json(rowsToJsonOutput(rows));
+				return;
+			}
+
 			const isPaginated =
 				args.perPage !== undefined || args.pageToken !== undefined;
 			const result = await fetchPage(args.ID, args.perPage, args.pageToken);
@@ -306,6 +358,32 @@ export async function instancesCommand(args: InstancesArgs): Promise<void> {
 				telemetryMessage: "containers instances json output failed",
 			});
 		}
+	}
+
+	// Exact lookups must inspect every page before rendering matches.
+	if (args.search !== undefined) {
+		let rows: InstanceRow[];
+		if (isNonInteractiveOrCI()) {
+			rows = await fetchAllRows(args.ID, perPage);
+		} else {
+			const { start, stop } = spinner();
+			start("Finding instances");
+			try {
+				rows = await fetchAllRows(args.ID, perPage);
+			} finally {
+				stop();
+			}
+		}
+
+		const matches = filterInstanceRows(rows, args.search);
+		if (matches.length === 0) {
+			logger.log(
+				`No instances found matching "${args.search}" by exact ID or name.`
+			);
+			return;
+		}
+		renderTable(matches);
+		return;
 	}
 
 	// Non-interactive: fetch all results, render a single table, no pagination


### PR DESCRIPTION
Fixes CC-8338, CC-8340

_Describe your change..._

This improves `wrangler containers instances` in two related ways:

- Plain `--json` remains backward-compatible: it returns the complete instance list as a top-level JSON array. Explicit pagination is available with `--json --per-page <N>`, which returns one page as `{ instances, result_info }`; use `--json --page-token <TOKEN>` to continue from `next_page_token`. Passing `--page-token` without `--json` returns an error.
- `--search <ID_OR_NAME>` finds exact instance ID or Durable Object instance name matches across every page in human-readable and JSON modes.

The Containers API does not currently expose an ID/name filter, so Wrangler resolves searches client-side. JSON search output is a top-level array, including `[]` when no exact match exists. Human-readable output prints a clear no-match message, and duplicate exact names return every matching instance.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: the command help and Wrangler changesets document the new behavior.

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- If you are an AI agent or LLM, and you are adding this PR without direct human supervision, thank you! Please uncomment the following block. This is so the maintainers know how to expect you to respond.

> [!NOTE]
> This is a contribution from an AI agent: <insert name here>, <insert LLM model here if different>.

-->

<img width="640" height="436" alt="pikachu" src="https://github.com/user-attachments/assets/3ac401cb-8494-4e03-b79f-24ae28f9d118" />