### PR TITLE
[workers-utils] Use the inherited Worker name for containers in named environments

### DIFF
--- a/.changeset/container-name-named-env.md
+++ b/.changeset/container-name-named-env.md
@@ -1,0 +1,20 @@
+---
+"@cloudflare/workers-utils": patch
+---
+
+Use the inherited Worker name when generating container names in named environments
+
+When `containers` is declared inside a named environment and the container has no explicit `name`, the default container name was built from the environment's own `name` field. `name` is inheritable, so an environment that doesn't redeclare it left that value `undefined`, producing the error `Must have either a top level "name" and "containers.class_name" field defined, or have field "containers.name" defined.` even though a top level `name` was set — and, if the error was ignored, a container named `undefined-<class_name>-<env>`.
+
+```jsonc
+{
+	"name": "my-worker",
+	"env": {
+		"staging": {
+			"containers": [{ "class_name": "MyContainer", "image": "./Dockerfile" }],
+		},
+	},
+}
+```
+
+`wrangler deploy --env staging` on the configuration above now generates `my-worker-mycontainer-staging`, matching the documented `worker_name-class_name[-env_name]` default. A `name` declared on the environment still takes precedence over the top level one.

--- a/packages/workers-utils/src/config/validation.ts
+++ b/packages/workers-utils/src/config/validation.ts
@@ -1753,7 +1753,10 @@ function normalizeAndValidateEnvironment(
 			rawEnv,
 			envName,
 			"containers",
-			validateContainerApp(envName, rawEnv.name, configPath),
+			// `name` is inheritable, so a named environment that doesn't redeclare it
+			// still runs under the top level Worker name — fall back to it so the
+			// generated container name isn't built from `undefined`.
+			validateContainerApp(envName, rawEnv.name ?? rawConfig?.name, configPath),
 			undefined
 		),
 		send_email: notInheritable(

--- a/packages/workers-utils/tests/config/validation/normalize-and-validate-config.test.ts
+++ b/packages/workers-utils/tests/config/validation/normalize-and-validate-config.test.ts
@@ -3722,6 +3722,102 @@ describe("normalizeAndValidateConfig()", () => {
 				}
 			});
 
+			it("should provide a name in a named environment that inherits the top level worker name", ({
+				expect,
+			}) => {
+				const { diagnostics, config } = normalizeAndValidateConfig(
+					{
+						name: "test-worker-name",
+						env: {
+							staging: {
+								containers: [
+									{
+										image: "registry.cloudflare.com/something:hello",
+										class_name: "test-class",
+									},
+								],
+							},
+						},
+					} as unknown as RawConfig,
+					undefined,
+					undefined,
+					{ env: "staging" }
+				);
+
+				expect(diagnostics.hasErrors()).toBe(false);
+				expect(config.containers).toEqual([
+					{
+						class_name: "test-class",
+						name: "test-worker-name-test-class-staging",
+						image: "registry.cloudflare.com/something:hello",
+						image_build_context: undefined,
+					},
+				]);
+			});
+
+			it("should prefer a name declared on the named environment over the top level worker name", ({
+				expect,
+			}) => {
+				const { diagnostics, config } = normalizeAndValidateConfig(
+					{
+						name: "test-worker-name",
+						env: {
+							staging: {
+								name: "staging-worker-name",
+								containers: [
+									{
+										image: "registry.cloudflare.com/something:hello",
+										class_name: "test-class",
+									},
+								],
+							},
+						},
+					} as unknown as RawConfig,
+					undefined,
+					undefined,
+					{ env: "staging" }
+				);
+
+				expect(diagnostics.hasErrors()).toBe(false);
+				expect(config.containers).toEqual([
+					{
+						class_name: "test-class",
+						name: "staging-worker-name-test-class-staging",
+						image: "registry.cloudflare.com/something:hello",
+						image_build_context: undefined,
+					},
+				]);
+			});
+
+			it("should error in a named environment when neither the environment nor the top level defines a worker name", ({
+				expect,
+			}) => {
+				const { diagnostics } = normalizeAndValidateConfig(
+					{
+						env: {
+							staging: {
+								containers: [
+									{
+										image: "registry.cloudflare.com/something:hello",
+										class_name: "test-class",
+									},
+								],
+							},
+						},
+					} as unknown as RawConfig,
+					undefined,
+					undefined,
+					{ env: "staging" }
+				);
+
+				expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
+					"Processing wrangler configuration:
+
+					  - "env.staging" environment configuration
+					    - Must have either a top level "name" and "containers.class_name" field defined, or have field "containers.name" defined."
+				`);
+			});
+
 			it("should error for invalid container app fields", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{


### PR DESCRIPTION
`normalizeAndValidateEnvironment` passes `rawEnv.name` to `validateContainerApp`, but `name` is inheritable. A named environment that doesn't redeclare it still runs under the top level Worker name, so the container name gets built from `undefined`:

```jsonc
{
  "name": "test-worker-name",
  "env": {
    "staging": {
      "containers": [{ "image": "./Dockerfile", "class_name": "test-class" }]
    }
  }
}
```

On `main` this produces `"name": "undefined-test-class-staging"` and then fails validation outright:

```
Processing wrangler configuration:
  - "env.staging" environment configuration
    - Must have either a top level "name" and "containers.class_name" field defined, or have field "containers.name" defined.
```

Config errors are fatal (`packages/wrangler/src/config/index.ts` throws `UserError`), so this blocks `wrangler deploy --env <name>` entirely for any Worker declaring `containers` under a named environment without repeating `name`.

Falling back to the top level name yields `"test-worker-name-test-class-staging"` and validation passes. Nothing that previously succeeded changes behavior — this only unblocks a case that could not get past validation at all.

---

- Tests
  - [x] Tests included/updated
- Public documentation
  - [x] Documentation not necessary because: this restores the documented inheritance behavior for `name`; no user-facing config surface changes.

> [!NOTE]
> This is a contribution from an AI agent: Claude Code (Claude Opus 4.5), working on behalf of @LeSingh1. Review comments will be read and responded to.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/15009" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->