### PR TITLE
[workers-utils] Report a non-array queues.consumers as a config error instead of crashing

### DIFF
--- a/.changeset/queues-consumers-not-array.md
+++ b/.changeset/queues-consumers-not-array.md
@@ -1,0 +1,9 @@
+---
+"@cloudflare/workers-utils": patch
+---
+
+Report a non-array `queues.consumers` as a configuration error instead of crashing
+
+`validateQueues` pushed the `The field "queues.consumers" should be an array` diagnostic and then iterated the value anyway. `"queues": { "consumers": null }` therefore threw `TypeError: Cannot read properties of null (reading 'length')` before the diagnostic could be rendered, and `"queues": { "consumers": "my-queue" }` walked the string character by character, adding one bogus `"queues.consumers[0]" should be a objects, but got "m"` error per character on top of the real one.
+
+The intended error is now the only thing reported, matching how the sibling `queues.producers` field already behaves.

--- a/.changeset/queues-consumers-not-array.md
+++ b/.changeset/queues-consumers-not-array.md
@@ -2,8 +2,6 @@
 "@cloudflare/workers-utils": patch
 ---
 
-Report a non-array `queues.consumers` as a configuration error instead of crashing
+Report an invalid `queues.consumers` value as a configuration error instead of crashing
 
-`validateQueues` pushed the `The field "queues.consumers" should be an array` diagnostic and then iterated the value anyway. `"queues": { "consumers": null }` therefore threw `TypeError: Cannot read properties of null (reading 'length')` before the diagnostic could be rendered, and `"queues": { "consumers": "my-queue" }` walked the string character by character, adding one bogus `"queues.consumers[0]" should be a objects, but got "m"` error per character on top of the real one.
-
-The intended error is now the only thing reported, matching how the sibling `queues.producers` field already behaves.
+Previously, setting `queues.consumers` to something other than an array (for example `null` or a string) could crash Wrangler or produce a flood of confusing extra errors. You now get a single clear message telling you the field must be an array.

--- a/packages/workers-utils/src/config/validation.ts
+++ b/packages/workers-utils/src/config/validation.ts
@@ -5131,13 +5131,13 @@ function validateQueues(envName: string): ValidatorFn {
 					)}.`
 				);
 				isValid = false;
-			}
-
-			for (let i = 0; i < consumers.length; i++) {
-				const consumer = consumers[i];
-				const consumerPath = `${fieldPath}.consumers[${i}]`;
-				if (!validateConsumer(diagnostics, consumerPath, consumer, config)) {
-					isValid = false;
+			} else {
+				for (let i = 0; i < consumers.length; i++) {
+					const consumer = consumers[i];
+					const consumerPath = `${fieldPath}.consumers[${i}]`;
+					if (!validateConsumer(diagnostics, consumerPath, consumer, config)) {
+						isValid = false;
+					}
 				}
 			}
 		}

--- a/packages/workers-utils/tests/config/validation/normalize-and-validate-config.test.ts
+++ b/packages/workers-utils/tests/config/validation/normalize-and-validate-config.test.ts
@@ -4965,6 +4965,34 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
+			it("should error if queues.consumers is null", ({ expect }) => {
+				const { diagnostics } = normalizeAndValidateConfig(
+					{ queues: { consumers: null } } as unknown as RawConfig,
+					undefined,
+					undefined,
+					{ env: undefined }
+				);
+
+				expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
+					"Processing wrangler configuration:
+					  - The field "queues.consumers" should be an array but got null."
+				`);
+			});
+
+			it("should error once if queues.consumers is a string", ({ expect }) => {
+				const { diagnostics } = normalizeAndValidateConfig(
+					{ queues: { consumers: "my-queue" } } as unknown as RawConfig,
+					undefined,
+					undefined,
+					{ env: undefined }
+				);
+
+				expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
+					"Processing wrangler configuration:
+					  - The field "queues.consumers" should be an array but got "my-queue"."
+				`);
+			});
+
 			it("should error if queues producer bindings are not valid", ({
 				expect,
 			}) => {


### PR DESCRIPTION
`validateQueues` pushes the "should be an array" diagnostic for a non-array `queues.consumers`, but then iterates the value anyway — there is no `else` or early return. The diagnostic it just prepared never reaches the user.

With `consumers: null`:

```
TypeError: Cannot read properties of null (reading 'length')
    at src/config/validation.ts:5116
```

With `consumers: "my-queue"` the string is iterated character by character, so the real error is buried under one spurious diagnostic per character:

```
- The field "queues.consumers" should be an array but got "my-queue".
- "queues.consumers[0]" should be a objects, but got "m".
- "queues.consumers[1]" should be a objects, but got "y".
... (6 more)
```

Guarding the loop behind the array check lets the intended diagnostic surface on its own.

---

- Tests
  - [x] Tests included/updated
- Public documentation
  - [x] Documentation not necessary because: this corrects validation error reporting only; no config surface or API changes.

> [!NOTE]
> This is a contribution from an AI agent: Claude Code (Claude Opus 4.5), working on behalf of @LeSingh1. Review comments will be read and responded to.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/15010" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->