### PR TITLE
[workers-utils] Bounds-check nested observability head_sampling_rate values

### DIFF
--- a/.changeset/observability-nested-sampling-rate.md
+++ b/.changeset/observability-nested-sampling-rate.md
@@ -1,0 +1,17 @@
+---
+"@cloudflare/workers-utils": patch
+---
+
+Validate `observability.logs.head_sampling_rate` and `observability.traces.head_sampling_rate` are between 0 and 1
+
+The 0–1 range check was only applied to the top level `observability.head_sampling_rate`. The two nested fields were type-checked as numbers but never bounds-checked, so a value such as `10` (a common mix-up with a percentage) was accepted locally and sent to the API.
+
+```jsonc
+{
+	"observability": {
+		"logs": { "enabled": true, "head_sampling_rate": 10 },
+	},
+}
+```
+
+All three fields now report `must be a value between 0 and 1.` consistently.

--- a/packages/workers-utils/src/config/validation.ts
+++ b/packages/workers-utils/src/config/validation.ts
@@ -6519,16 +6519,40 @@ const validateObservability: ValidatorFn = (diagnostics, field, value) => {
 			) && isValid;
 	}
 
-	const samplingRate = val?.head_sampling_rate;
-
-	if (samplingRate && (samplingRate < 0 || samplingRate > 1)) {
-		diagnostics.errors.push(
-			`"${field}.head_sampling_rate" must be a value between 0 and 1.`
-		);
-	}
+	validateHeadSamplingRate(
+		diagnostics,
+		field,
+		"head_sampling_rate",
+		val?.head_sampling_rate
+	);
+	validateHeadSamplingRate(
+		diagnostics,
+		field,
+		"logs.head_sampling_rate",
+		val?.logs?.head_sampling_rate
+	);
+	validateHeadSamplingRate(
+		diagnostics,
+		field,
+		"traces.head_sampling_rate",
+		val?.traces?.head_sampling_rate
+	);
 
 	return isValid;
 };
+
+function validateHeadSamplingRate(
+	diagnostics: Diagnostics,
+	container: string,
+	key: string,
+	samplingRate: number | undefined
+) {
+	if (samplingRate && (samplingRate < 0 || samplingRate > 1)) {
+		diagnostics.errors.push(
+			`"${container}.${key}" must be a value between 0 and 1.`
+		);
+	}
+}
 
 const validateCache: ValidatorFn = (diagnostics, field, value) => {
 	if (value === undefined) {

--- a/packages/workers-utils/tests/config/validation/normalize-and-validate-config.test.ts
+++ b/packages/workers-utils/tests/config/validation/normalize-and-validate-config.test.ts
@@ -10379,6 +10379,73 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
+			it("should error on a nested logs sampling rate out of range", ({
+				expect,
+			}) => {
+				const { diagnostics } = normalizeAndValidateConfig(
+					{
+						observability: {
+							logs: {
+								enabled: true,
+								head_sampling_rate: 10,
+							},
+						},
+					} satisfies RawConfig,
+					undefined,
+					undefined,
+					{ env: undefined }
+				);
+
+				expect(diagnostics.hasWarnings()).toBe(false);
+				expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
+					"Processing wrangler configuration:
+					  - "observability.logs.head_sampling_rate" must be a value between 0 and 1."
+				`);
+			});
+
+			it("should error on a nested traces sampling rate out of range", ({
+				expect,
+			}) => {
+				const { diagnostics } = normalizeAndValidateConfig(
+					{
+						observability: {
+							traces: {
+								enabled: true,
+								head_sampling_rate: -1,
+							},
+						},
+					} satisfies RawConfig,
+					undefined,
+					undefined,
+					{ env: undefined }
+				);
+
+				expect(diagnostics.hasWarnings()).toBe(false);
+				expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
+					"Processing wrangler configuration:
+					  - "observability.traces.head_sampling_rate" must be a value between 0 and 1."
+				`);
+			});
+
+			it("should not error on nested sampling rates within range", ({
+				expect,
+			}) => {
+				const { diagnostics } = normalizeAndValidateConfig(
+					{
+						observability: {
+							logs: { enabled: true, head_sampling_rate: 0.5 },
+							traces: { enabled: true, head_sampling_rate: 1 },
+						},
+					} satisfies RawConfig,
+					undefined,
+					undefined,
+					{ env: undefined }
+				);
+
+				expect(diagnostics.hasWarnings()).toBe(false);
+				expect(diagnostics.hasErrors()).toBe(false);
+			});
+
 			it("should error on invalid additional fields", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{


### PR DESCRIPTION
`validateObservability` bounds-checks `head_sampling_rate` only at the top level. The nested `observability.logs.head_sampling_rate` and `observability.traces.head_sampling_rate` are type-checked as numbers but never range-checked, so the same value is rejected in one position and silently accepted in another:

```jsonc
{ "observability": { "head_sampling_rate": 10 } }
// -> "observability.head_sampling_rate" must be a value between 0 and 1.

{ "observability": { "logs": { "enabled": true, "head_sampling_rate": 10 } } }
// -> accepted, and shipped to the API as-is
```

This extracts the existing check into `validateHeadSamplingRate` and applies it to all three fields, so the nested forms produce the same diagnostic as the top level one.

(The adjacent merged #14746 guarded `observability: null`; this is a different field.)

---

- Tests
  - [x] Tests included/updated
- Public documentation
  - [x] Documentation not necessary because: this enforces the already-documented 0-1 range in two positions that were missing it; no config surface changes.

> [!NOTE]
> This is a contribution from an AI agent: Claude Code (Claude Opus 4.5), working on behalf of @LeSingh1. Review comments will be read and responded to.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/15011" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->