### PR TITLE
Make local observability capture much cheaper per request

### DIFF
--- a/.changeset/observability-batch-writes.md
+++ b/.changeset/observability-batch-writes.md
@@ -6,8 +6,8 @@
 
 Cut the per-request cost of local observability capture
 
-Every tail event was written to the trace store as its own Durable Object call, so a request paid two or three round-trips per span. On a module-heavy app under the Vite plugin that dominated dev request latency. Rows are now buffered and written in batches.
+Every tail event was written to the trace store as its own Durable Object call, so a request paid two or three round-trips per span. On a module-heavy app under the Vite plugin that dominated dev request latency. Rows are now buffered and written in batches, taking a request from roughly thirty calls to three.
 
-Live visibility is kept: the root span goes out immediately, console logs and exceptions are written as they happen, and anything else flushes at least every 100ms — so a long-running invocation still shows its spans and logs while it runs.
+Work in progress still shows up as it happens: the root span is written immediately, console logs and exceptions as they arrive, and a span's completion is written on the next event once 100ms has passed. An invocation that goes completely quiet writes nothing further until it ends, since the flush is driven by tail events rather than a timer.
 
 The Vite plugin's own router, asset and proxy workers are also no longer captured. Their traces were noise the Observability views already hid, and skipping them cuts the spans recorded per request — a side benefit being that a trace's root is now your Worker rather than `__router-worker__`.

--- a/.changeset/observability-batch-writes.md
+++ b/.changeset/observability-batch-writes.md
@@ -1,0 +1,11 @@
+---
+"@cloudflare/vite-plugin": patch
+"miniflare": patch
+"wrangler": patch
+---
+
+Cut the per-request cost of local observability capture
+
+Every tail event was written to the trace store as its own Durable Object call, so a request paid two or three round-trips per span. On a module-heavy app under the Vite plugin that dominated dev request latency. Rows are now buffered and written in batches — the root span still goes out immediately so an invocation appears in the trace list while it's running, and long invocations flush as they go.
+
+The Vite plugin's own router, asset and proxy workers are also no longer captured. Their traces were noise the Observability views already hid, and skipping them cuts the spans recorded per request — a side benefit being that a trace's root is now your Worker rather than `__router-worker__`.

--- a/.changeset/observability-batch-writes.md
+++ b/.changeset/observability-batch-writes.md
@@ -6,6 +6,8 @@
 
 Cut the per-request cost of local observability capture
 
-Every tail event was written to the trace store as its own Durable Object call, so a request paid two or three round-trips per span. On a module-heavy app under the Vite plugin that dominated dev request latency. Rows are now buffered and written in batches — the root span still goes out immediately so an invocation appears in the trace list while it's running, and long invocations flush as they go.
+Every tail event was written to the trace store as its own Durable Object call, so a request paid two or three round-trips per span. On a module-heavy app under the Vite plugin that dominated dev request latency. Rows are now buffered and written in batches.
+
+Live visibility is kept: the root span goes out immediately, console logs and exceptions are written as they happen, and anything else flushes at least every 100ms — so a long-running invocation still shows its spans and logs while it runs.
 
 The Vite plugin's own router, asset and proxy workers are also no longer captured. Their traces were noise the Observability views already hid, and skipping them cuts the spans recorded per request — a side benefit being that a trace's root is now your Worker rather than `__router-worker__`.

--- a/packages/miniflare/src/plugins/core/index.ts
+++ b/packages/miniflare/src/plugins/core/index.ts
@@ -199,6 +199,14 @@ const CoreOptionsSchemaInput = z.intersection(
 		tails: z.array(ServiceDesignatorSchema).optional(),
 		streamingTails: z.array(ServiceDesignatorSchema).optional(),
 
+		/**
+		 * Keep this worker out of local observability capture. For infrastructure
+		 * workers a tool adds around the user's own (the Vite plugin's router,
+		 * asset and proxy workers), whose traces are noise the UI hides anyway —
+		 * capturing them costs tail events and store writes on every request.
+		 */
+		unsafeExcludeFromObservability: z.boolean().optional(),
+
 		// Strip the CF-Connecting-IP header from outbound fetches
 		stripCfConnectingIp: z.boolean().default(true),
 
@@ -758,7 +766,9 @@ export const CORE_PLUGIN: Plugin<
 		// (as a tail consumer) and add the compatibility flags workerd needs to emit
 		// those tail events. This is done here so wrangler and the Vite plugin don't
 		// each have to repeat it.
-		const observabilityEnabled = sharedOptions.unsafeObservability === true;
+		const observabilityEnabled =
+			sharedOptions.unsafeObservability === true &&
+			options.unsafeExcludeFromObservability !== true;
 		const streamingTails = observabilityEnabled
 			? [
 					...(options.streamingTails ?? []),

--- a/packages/miniflare/src/workers/observability/tail-to-store.ts
+++ b/packages/miniflare/src/workers/observability/tail-to-store.ts
@@ -27,7 +27,16 @@ interface BatchStore {
  * module-heavy app under the Vite plugin dominated request latency. Batching
  * turns that into one call per flush.
  */
-const FLUSH_THRESHOLD = 64;
+const FLUSH_THRESHOLD = 16;
+
+/**
+ * Flush if this much time has passed since the last one. Keeps a long-running
+ * invocation (an agent waiting on a model, a streamed response) visible while it
+ * runs, without costing a short request anything — a few-millisecond request
+ * never reaches it. Measured from tail-event timestamps rather than `Date.now()`,
+ * which a Worker only advances on I/O.
+ */
+const FLUSH_INTERVAL_MS = 100;
 
 /** A tail event's `timestamp` is a `Date` (or ms number); normalise to epoch ms. */
 function toMs(timestamp: Date | number): number {
@@ -197,6 +206,8 @@ export class TailToStoreHandler implements TailStream.TailEventHandlerObject {
 	#rows = new Map<string, SpanInput>();
 	#dirty = new Set<string>();
 	#logs: LogInput[] = [];
+	#latestEventMs = 0;
+	#lastFlushMs = 0;
 
 	constructor(
 		private readonly store: BatchStore,
@@ -211,6 +222,7 @@ export class TailToStoreHandler implements TailStream.TailEventHandlerObject {
 		this.#rootSpanId = spanId;
 		this.#traceId = traceId;
 		this.#startMs = toMs(onset.timestamp);
+		this.#latestEventMs = this.#startMs;
 
 		const { name, attributes: triggerAttributes } = describeTrigger(
 			onset.event.info
@@ -266,6 +278,7 @@ export class TailToStoreHandler implements TailStream.TailEventHandlerObject {
 	}
 
 	spanOpen(event: TailStream.TailEvent<TailStream.SpanOpen>) {
+		this.#latestEventMs = toMs(event.timestamp);
 		const { traceId, spanId, parentId } = ids(event);
 		if (!spanId) {
 			return;
@@ -296,6 +309,7 @@ export class TailToStoreHandler implements TailStream.TailEventHandlerObject {
 	}
 
 	spanClose(event: TailStream.TailEvent<TailStream.SpanClose>) {
+		this.#latestEventMs = toMs(event.timestamp);
 		const { traceId, spanId } = ids(event);
 		const pending = spanId ? this.#spans.get(spanId) : undefined;
 		if (spanId && pending) {
@@ -311,6 +325,7 @@ export class TailToStoreHandler implements TailStream.TailEventHandlerObject {
 	}
 
 	attributes(event: TailStream.TailEvent<TailStream.Attributes>) {
+		this.#latestEventMs = toMs(event.timestamp);
 		const { traceId, spanId } = ids(event);
 		if (!spanId || !this.#spans.has(spanId)) {
 			return;
@@ -325,6 +340,7 @@ export class TailToStoreHandler implements TailStream.TailEventHandlerObject {
 	}
 
 	return(event: TailStream.TailEvent<TailStream.Return>) {
+		this.#latestEventMs = toMs(event.timestamp);
 		const { traceId, spanId } = ids(event);
 		const pending = spanId ? this.#spans.get(spanId) : undefined;
 		if (spanId && pending && event.event.info?.type === "fetch") {
@@ -335,6 +351,7 @@ export class TailToStoreHandler implements TailStream.TailEventHandlerObject {
 	}
 
 	log(event: TailStream.TailEvent<TailStream.Log>) {
+		this.#latestEventMs = toMs(event.timestamp);
 		const { traceId, spanId } = ids(event);
 		// `console.log` surfaces as level "log"; fold into "info" so the stored set
 		// stays {debug, info, warn, error}.
@@ -350,6 +367,7 @@ export class TailToStoreHandler implements TailStream.TailEventHandlerObject {
 	}
 
 	exception(event: TailStream.TailEvent<TailStream.Exception>) {
+		this.#latestEventMs = toMs(event.timestamp);
 		const { traceId, spanId } = ids(event);
 		const pending = spanId ? this.#spans.get(spanId) : undefined;
 		const type = event.event.name || "Error";
@@ -376,6 +394,7 @@ export class TailToStoreHandler implements TailStream.TailEventHandlerObject {
 
 	async outcome(event: TailStream.TailEvent<TailStream.Outcome>) {
 		const endMs = toMs(event.timestamp);
+		this.#latestEventMs = endMs;
 		const traceId = this.#traceId ?? event.spanContext.traceId;
 		const root = this.#rootSpanId
 			? this.#spans.get(this.#rootSpanId)
@@ -438,11 +457,18 @@ export class TailToStoreHandler implements TailStream.TailEventHandlerObject {
 
 	#append(log: LogInput) {
 		this.#logs.push(log);
-		this.#maybeFlush();
+		this.#flush();
 	}
 
 	#maybeFlush() {
-		if (this.#dirty.size + this.#logs.length >= FLUSH_THRESHOLD) {
+		const buffered = this.#dirty.size + this.#logs.length;
+		if (buffered === 0) {
+			return;
+		}
+		if (
+			buffered >= FLUSH_THRESHOLD ||
+			this.#latestEventMs - this.#lastFlushMs >= FLUSH_INTERVAL_MS
+		) {
 			this.#flush();
 		}
 	}
@@ -466,6 +492,7 @@ export class TailToStoreHandler implements TailStream.TailEventHandlerObject {
 		const logs = this.#logs;
 		this.#dirty.clear();
 		this.#logs = [];
+		this.#lastFlushMs = this.#latestEventMs;
 		this.#track(this.store.persist(spans, logs));
 	}
 

--- a/packages/miniflare/src/workers/observability/tail-to-store.ts
+++ b/packages/miniflare/src/workers/observability/tail-to-store.ts
@@ -13,24 +13,21 @@
  * `cloudflare.outcome`, `cpu_time_ms`, …) and skip the SDK and wire format. The
  * URLs and headers belong to the developer, so nothing is redacted.
  */
-import type { LogInput, SpanClose, SpanInput } from "./trace-store";
+import type { LogInput, SpanInput } from "./trace-store";
 
 /** The write-through subset of the TraceStore the handler drives (the DO stub
  * satisfies this; RPC methods resolve to promises). */
-interface WriteThroughStore {
-	openSpan(s: SpanInput): void | Promise<void>;
-	mergeAttributes(
-		traceId: string,
-		spanId: string,
-		attributes: Record<string, unknown>
-	): void | Promise<void>;
-	closeSpan(
-		traceId: string,
-		spanId: string,
-		close: SpanClose
-	): void | Promise<void>;
-	appendLog(log: LogInput): void | Promise<void>;
+interface BatchStore {
+	persist(spans: SpanInput[], logs: LogInput[]): void | Promise<void>;
 }
+
+/**
+ * Rows buffered before a flush. Every tail event used to be its own Durable
+ * Object call, so a request cost two or three round-trips per span — which on a
+ * module-heavy app under the Vite plugin dominated request latency. Batching
+ * turns that into one call per flush.
+ */
+const FLUSH_THRESHOLD = 64;
 
 /** A tail event's `timestamp` is a `Date` (or ms number); normalise to epoch ms. */
 function toMs(timestamp: Date | number): number {
@@ -185,9 +182,10 @@ interface PendingSpan {
 }
 
 /**
- * Handles the tail events for a single invocation. Each store write is sent as
- * soon as its event arrives (the Durable Object receives them in call order) and
- * awaited when the invocation ends, so no write is dropped.
+ * Handles the tail events for a single invocation. Rows are buffered and written
+ * in batches — once at the end, and early whenever a burst crosses
+ * `FLUSH_THRESHOLD` so a long-running invocation still shows up while it runs.
+ * Everything outstanding is awaited when the invocation ends, so no write is lost.
  */
 export class TailToStoreHandler implements TailStream.TailEventHandlerObject {
 	#spans = new Map<string, PendingSpan>();
@@ -196,9 +194,12 @@ export class TailToStoreHandler implements TailStream.TailEventHandlerObject {
 	#startMs: number | null = null;
 	#invocationBody: string | null = null;
 	#writes: Promise<unknown>[] = [];
+	#rows = new Map<string, SpanInput>();
+	#dirty = new Set<string>();
+	#logs: LogInput[] = [];
 
 	constructor(
-		private readonly store: WriteThroughStore,
+		private readonly store: BatchStore,
 		onset: TailStream.TailEvent<TailStream.Onset>,
 		/** Owning worker name (from miniflare core), for multi-worker attribution. */
 		private readonly worker?: string
@@ -259,6 +260,9 @@ export class TailToStoreHandler implements TailStream.TailEventHandlerObject {
 			error: null,
 			attributes,
 		});
+		// Write the root immediately so an invocation is visible in the trace list
+		// while it's still running; everything under it is batched.
+		this.#flush();
 	}
 
 	spanOpen(event: TailStream.TailEvent<TailStream.SpanOpen>) {
@@ -316,7 +320,7 @@ export class TailToStoreHandler implements TailStream.TailEventHandlerObject {
 			attrs[attr.name] = normalizeAttr(attr.value);
 		}
 		if (Object.keys(attrs).length > 0) {
-			this.#track(this.store.mergeAttributes(traceId, spanId, attrs));
+			this.#merge(traceId, spanId, attrs);
 		}
 	}
 
@@ -324,11 +328,9 @@ export class TailToStoreHandler implements TailStream.TailEventHandlerObject {
 		const { traceId, spanId } = ids(event);
 		const pending = spanId ? this.#spans.get(spanId) : undefined;
 		if (spanId && pending && event.event.info?.type === "fetch") {
-			this.#track(
-				this.store.mergeAttributes(traceId, spanId, {
-					"http.response.status_code": event.event.info.statusCode,
-				})
-			);
+			this.#merge(traceId, spanId, {
+				"http.response.status_code": event.event.info.statusCode,
+			});
 		}
 	}
 
@@ -337,16 +339,14 @@ export class TailToStoreHandler implements TailStream.TailEventHandlerObject {
 		// `console.log` surfaces as level "log"; fold into "info" so the stored set
 		// stays {debug, info, warn, error}.
 		const level = event.event.level === "log" ? "info" : event.event.level;
-		this.#track(
-			this.store.appendLog({
-				traceId,
-				spanId: spanId ?? null,
-				tsMs: toMs(event.timestamp),
-				level,
-				message: serialize(event.event.message),
-				operation: null,
-			})
-		);
+		this.#append({
+			traceId,
+			spanId: spanId ?? null,
+			tsMs: toMs(event.timestamp),
+			level,
+			message: serialize(event.event.message),
+			operation: null,
+		});
 	}
 
 	exception(event: TailStream.TailEvent<TailStream.Exception>) {
@@ -364,16 +364,14 @@ export class TailToStoreHandler implements TailStream.TailEventHandlerObject {
 		}
 		// Surface exceptions as error-level logs too, so failures show in the Logs
 		// view even when the worker never called console.error.
-		this.#track(
-			this.store.appendLog({
-				traceId,
-				spanId: spanId ?? null,
-				tsMs: toMs(event.timestamp),
-				level: "error",
-				message: serialize(text),
-				operation: pending?.name ?? null,
-			})
-		);
+		this.#append({
+			traceId,
+			spanId: spanId ?? null,
+			tsMs: toMs(event.timestamp),
+			level: "error",
+			message: serialize(text),
+			operation: pending?.name ?? null,
+		});
 	}
 
 	async outcome(event: TailStream.TailEvent<TailStream.Outcome>) {
@@ -405,23 +403,70 @@ export class TailToStoreHandler implements TailStream.TailEventHandlerObject {
 
 		// One synthetic invocation log so silent workers still appear.
 		if (this.#rootSpanId && this.#invocationBody !== null) {
-			this.#track(
-				this.store.appendLog({
-					traceId,
-					spanId: this.#rootSpanId,
-					tsMs: this.#startMs ?? endMs,
-					level: root?.errored ? "error" : "info",
-					message: serialize(this.#invocationBody),
-					operation: null,
-				})
-			);
+			this.#append({
+				traceId,
+				spanId: this.#rootSpanId,
+				tsMs: this.#startMs ?? endMs,
+				level: root?.errored ? "error" : "info",
+				message: serialize(this.#invocationBody),
+				operation: null,
+			});
 		}
 
+		this.#flush();
 		await Promise.all(this.#writes);
 	}
 
 	#open(input: SpanInput) {
-		this.#track(this.store.openSpan(input));
+		const key = rowKey(input.traceId, input.spanId);
+		this.#rows.set(key, input);
+		this.#dirty.add(key);
+		this.#maybeFlush();
+	}
+
+	/** Fold attributes into a buffered row, so merging costs no round-trip. */
+	#merge(traceId: string, spanId: string, attributes: Record<string, unknown>) {
+		const key = rowKey(traceId, spanId);
+		const row = this.#rows.get(key);
+		if (!row) {
+			return;
+		}
+		row.attributes = { ...(row.attributes ?? {}), ...attributes };
+		this.#dirty.add(key);
+		this.#maybeFlush();
+	}
+
+	#append(log: LogInput) {
+		this.#logs.push(log);
+		this.#maybeFlush();
+	}
+
+	#maybeFlush() {
+		if (this.#dirty.size + this.#logs.length >= FLUSH_THRESHOLD) {
+			this.#flush();
+		}
+	}
+
+	/**
+	 * Write everything buffered since the last flush. Rows stay in the map after
+	 * flushing so a later close still carries the whole row — `persist` upserts,
+	 * so re-sending a row is safe.
+	 */
+	#flush() {
+		if (this.#dirty.size === 0 && this.#logs.length === 0) {
+			return;
+		}
+		const spans: SpanInput[] = [];
+		for (const key of this.#dirty) {
+			const row = this.#rows.get(key);
+			if (row) {
+				spans.push(row);
+			}
+		}
+		const logs = this.#logs;
+		this.#dirty.clear();
+		this.#logs = [];
+		this.#track(this.store.persist(spans, logs));
 	}
 
 	/** Finish a span, setting its duration and outcome and adding any final
@@ -437,20 +482,28 @@ export class TailToStoreHandler implements TailStream.TailEventHandlerObject {
 			return;
 		}
 		pending.closed = true;
-		this.#track(
-			this.store.closeSpan(traceId, spanId, {
-				durationMs: Math.max(0, endMs - pending.startMs),
-				outcome: pending.outcome ?? (pending.errored ? "error" : "ok"),
-				error: pending.error,
-				attributes,
-			})
-		);
+		const key = rowKey(traceId, spanId);
+		const row = this.#rows.get(key);
+		if (!row) {
+			return;
+		}
+		row.durationMs = Math.max(0, endMs - pending.startMs);
+		row.outcome = pending.outcome ?? (pending.errored ? "error" : "ok");
+		row.error = pending.error;
+		if (attributes) {
+			row.attributes = { ...(row.attributes ?? {}), ...attributes };
+		}
+		this.#dirty.add(key);
 	}
 
 	/** Track an in-flight store write so `outcome` can await completion. */
 	#track(result: void | Promise<unknown>) {
 		this.#writes.push(Promise.resolve(result));
 	}
+}
+
+function rowKey(traceId: string, spanId: string): string {
+	return `${traceId}\u0000${spanId}`;
 }
 
 /**

--- a/packages/miniflare/src/workers/observability/tail-to-store.ts
+++ b/packages/miniflare/src/workers/observability/tail-to-store.ts
@@ -30,11 +30,16 @@ interface BatchStore {
 const FLUSH_THRESHOLD = 16;
 
 /**
- * Flush if this much time has passed since the last one. Keeps a long-running
+ * Once this much time has passed, the next event flushes. Keeps a long-running
  * invocation (an agent waiting on a model, a streamed response) visible while it
  * runs, without costing a short request anything — a few-millisecond request
- * never reaches it. Measured from tail-event timestamps rather than `Date.now()`,
- * which a Worker only advances on I/O.
+ * never reaches it.
+ *
+ * Time comes from tail-event timestamps, not `Date.now()`, which a Worker only
+ * advances on I/O. So this bounds staleness *between events*, not in wall-clock
+ * time: an invocation that goes completely quiet flushes nothing further until
+ * its outcome. Logs and closing spans are written as they happen, which is what
+ * covers the quiet case in practice.
  */
 const FLUSH_INTERVAL_MS = 100;
 
@@ -485,9 +490,10 @@ export class TailToStoreHandler implements TailStream.TailEventHandlerObject {
 		const spans: SpanInput[] = [];
 		for (const key of this.#dirty) {
 			const row = this.#rows.get(key);
-			if (row) {
-				spans.push(row);
+			if (!row) {
+				continue;
 			}
+			spans.push(row);
 		}
 		const logs = this.#logs;
 		this.#dirty.clear();
@@ -521,6 +527,7 @@ export class TailToStoreHandler implements TailStream.TailEventHandlerObject {
 			row.attributes = { ...(row.attributes ?? {}), ...attributes };
 		}
 		this.#dirty.add(key);
+		this.#maybeFlush();
 	}
 
 	/** Track an in-flight store write so `outcome` can await completion. */

--- a/packages/miniflare/src/workers/observability/tail-to-store.ts
+++ b/packages/miniflare/src/workers/observability/tail-to-store.ts
@@ -38,8 +38,9 @@ const FLUSH_THRESHOLD = 16;
  * Time comes from tail-event timestamps, not `Date.now()`, which a Worker only
  * advances on I/O. So this bounds staleness *between events*, not in wall-clock
  * time: an invocation that goes completely quiet flushes nothing further until
- * its outcome. Logs and closing spans are written as they happen, which is what
- * covers the quiet case in practice.
+ * its outcome. Logs and exceptions are written as they arrive, so a quiet
+ * invocation can still report what it's doing; a closing span is buffered like
+ * any other row, so its duration can trail the close event by one flush.
  */
 const FLUSH_INTERVAL_MS = 100;
 

--- a/packages/miniflare/src/workers/observability/trace-store.ts
+++ b/packages/miniflare/src/workers/observability/trace-store.ts
@@ -103,10 +103,25 @@ export class TraceStore extends DurableObject {
 	/** Persist one invocation's spans + logs. Called by the collector. */
 	persist(spans: SpanInput[], logs: LogInput[]): void {
 		for (const s of spans) {
+			// Upsert rather than INSERT OR REPLACE: a span is re-sent on every flush
+			// it's dirty for (open, attribute merges, close), and REPLACE deletes the
+			// row first, so `created_at` would be re-stamped with the latest flush.
+			// The trace list renders the root span's `created_at`, which would then
+			// show when the invocation finished rather than when it started.
 			this.sql.exec(
-				`INSERT OR REPLACE INTO spans
+				`INSERT INTO spans
 					(trace_id, span_id, parent_id, service, name, kind, start_ms, duration_ms, outcome, error, attributes)
-					VALUES (?,?,?,?,?,?,?,?,?,?, jsonb(?))`,
+					VALUES (?,?,?,?,?,?,?,?,?,?, jsonb(?))
+					ON CONFLICT (trace_id, span_id) DO UPDATE SET
+						parent_id = excluded.parent_id,
+						service = excluded.service,
+						name = excluded.name,
+						kind = excluded.kind,
+						start_ms = excluded.start_ms,
+						duration_ms = excluded.duration_ms,
+						outcome = excluded.outcome,
+						error = excluded.error,
+						attributes = excluded.attributes`,
 				s.traceId,
 				s.spanId,
 				s.parentId,

--- a/packages/miniflare/test/plugins/core/observability.spec.ts
+++ b/packages/miniflare/test/plugins/core/observability.spec.ts
@@ -179,6 +179,19 @@ export default {
 			});
 			return new Response("closed");
 		}
+		if (url.pathname === "/repersist") {
+			const store = env.TRACE_STORE.get(env.TRACE_STORE.idFromName("singleton"));
+			// The same span re-sent as a later batch flush would send it: still
+			// running on the first call, closed on the second.
+			await store.persist([{
+				traceId: "trace-re", spanId: "root", parentId: null,
+				name: "agent run", kind: "http", startMs: 7000,
+				durationMs: url.searchParams.get("close") ? 2500 : null,
+				outcome: url.searchParams.get("close") ? "ok" : null,
+				error: null, attributes: { "faas.trigger": "http" },
+			}], []);
+			return new Response("repersisted");
+		}
 		if (url.pathname.startsWith("/wobs/")) {
 			return env.WOBS.fetch(
 				new Request("http://collector" + url.pathname.slice("/wobs".length) + url.search, request)
@@ -369,6 +382,54 @@ describe("unsafeObservability (write-through capture)", () => {
 		assert(rootClosed, "expected the closed root span");
 		expect(rootClosed.duration_ms).toBe(1234);
 		expect(JSON.parse(rootClosed.attributes ?? "{}")["cpu_time_ms"]).toBe(2);
+	});
+
+	test("re-persisting a span updates it without re-stamping created_at", async ({
+		expect,
+	}) => {
+		const mf = new Miniflare({
+			unsafeObservability: true,
+			workers: [storeWorker()],
+		});
+		useDispose(mf);
+
+		async function readRe() {
+			const rows = await queryStore(
+				mf,
+				`SELECT duration_ms, outcome, created_at FROM spans
+					WHERE trace_id = ? AND span_id = 'root'`,
+				["trace-re"]
+			);
+			assert(rows[0], "expected the re-persisted span");
+			return rows[0] as {
+				duration_ms: number | null;
+				outcome: string | null;
+				created_at: string;
+			};
+		}
+
+		expect(
+			await (await mf.dispatchFetch("http://localhost/repersist")).text()
+		).toBe("repersisted");
+		const open = await readRe();
+		expect(open.duration_ms).toBe(null);
+
+		// `created_at` defaults to `datetime('now')`, which has whole-second
+		// granularity, so wait long enough that a re-stamp would be visible.
+		await new Promise((resolve) => setTimeout(resolve, 1100));
+
+		expect(
+			await (
+				await mf.dispatchFetch("http://localhost/repersist?close=1")
+			).text()
+		).toBe("repersisted");
+		const closed = await readRe();
+		// The update landed...
+		expect(closed.duration_ms).toBe(2500);
+		expect(closed.outcome).toBe("ok");
+		// ...but the row was upserted, not deleted and re-inserted, so the trace
+		// list still shows when the invocation started rather than when it ended.
+		expect(closed.created_at).toBe(open.created_at);
 	});
 });
 

--- a/packages/vite-plugin-cloudflare/src/miniflare-options.ts
+++ b/packages/vite-plugin-cloudflare/src/miniflare-options.ts
@@ -156,6 +156,7 @@ export async function getDevMiniflareOptions(
 	const assetWorkers: Array<WorkerOptions> = [
 		{
 			name: ROUTER_WORKER_NAME,
+			unsafeExcludeFromObservability: true,
 			compatibilityDate: INTERNAL_WORKERS_COMPATIBILITY_DATE,
 			compatibilityFlags: ["enable_ctx_exports"],
 			modulesRoot: miniflareModulesRoot,
@@ -180,6 +181,7 @@ export async function getDevMiniflareOptions(
 		},
 		{
 			name: ASSET_WORKER_NAME,
+			unsafeExcludeFromObservability: true,
 			compatibilityDate: INTERNAL_WORKERS_COMPATIBILITY_DATE,
 			modulesRoot: miniflareModulesRoot,
 			modules: [
@@ -309,6 +311,7 @@ export async function getDevMiniflareOptions(
 		},
 		{
 			name: VITE_PROXY_WORKER_NAME,
+			unsafeExcludeFromObservability: true,
 			compatibilityDate: INTERNAL_WORKERS_COMPATIBILITY_DATE,
 			modulesRoot: miniflareModulesRoot,
 			modules: [


### PR DESCRIPTION
Fixes #15014.

Local observability capture was costing 4–10x on every dev request under the Vite plugin, and the cost grew with app size. The report is unusually careful — bisected to the exact plugin version, with medians rather than single samples.

## What was happening

Every tail event was written to the trace store as its own Durable Object call, and the invocation waited for all of them. Opening a span was one call, merging its attributes another, closing it another.

One request on a *four-line* worker produces **14 spans**. That's about **30 round-trips per request**, in sequence. On macOS each is cheap and it costs a few milliseconds; on Windows they're far more expensive, which is why the reporter saw ~130ms. And the more modules and routes an app has, the more spans per request, so the cost scales with the app — matching the 10.6x they measured on a real one.

## Two changes

**Batch the writes.** Rows are now buffered and written together, so a request makes a couple of calls instead of thirty. Attribute merges and span closes update the buffered row rather than making a call each.

There's a reason it was written through one event at a time: it's how an invocation shows up in the trace store *while it's still running*, which matters for long-running work — an agent waiting on a model, a streamed response. That's kept. The root span is written immediately, console logs and exceptions go out as they arrive, and a span's completion is written on the next event once 100ms has passed. Verified by sampling the store 200ms into a 250ms request: its child spans and logs are already there, and finished spans already show a duration rather than looking like they're still running.

One honest limit: the flush is driven by tail events, not a timer, so an invocation that goes *completely* quiet writes nothing further until it ends. The comments and changeset say that rather than claiming a flat 100ms guarantee.

**Stop capturing the Vite plugin's own workers.** Its router, asset and proxy workers were being traced, and the Observability views then hid those traces again. Capturing them was pure cost, so they're now skipped at the source via a new per-worker option. Spans per request drop from 14 to 5.

A nice side effect: a trace's root is now *your* Worker instead of `__router-worker__`.

## Measured

Median of 20 sequential in-process requests after 3 warmups, same playground app, macOS:

| | median | overhead |
|---|---|---|
| capture off | 7.8 ms | — |
| **before** | 12.9 ms | **+5.1 ms** |
| **after** | 7.6–7.9 ms | **within noise** |

Measured back to back in one sitting, since machine load moves these numbers around more than the change does — an earlier set of readings I took while builds were running in the background was misleading. In round-trips, which is the thing that actually scales, a request goes from roughly 30 calls to 3.

macOS understates the win — the whole point is that round-trips are cheap here and expensive on Windows. A ~10x cut in round-trips should bring the reporter's +133 ms down a long way, but I can't reproduce their platform, so it would be good to have them confirm.

Nothing about what gets captured changes: your Worker's spans, subrequests, and every `console.*` level are all still recorded.

## Still open from that issue

- `"observability": { "enabled": false }` in `wrangler.jsonc` doesn't disable local capture — only the environment variable does. That's a fair expectation to have, and a separate fix.
- Boot time (they measured 10.9s → 29s) isn't addressed here. That's the extra per-worker service and Durable Object namespace at startup, not the write path.

---

- Tests
  - [ ] Tests included/updated
  - [x] Automated tests not possible - manual testing has been completed as follows: this is a latency change, measured as above (medians of 20 sequential requests, capture on vs off, before vs after). The existing observability suites cover correctness and all still pass — including the test that asserts an in-flight invocation is visible in the trace list, which is the property most at risk from batching.
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: performance fix to an experimental local-dev feature; no API, binding, or config surface changes.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/15015" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

