### PR TITLE
[wrangler] Skip the CAA half of the unenv-preset testDns E2E

### DIFF
--- a/packages/wrangler/e2e/unenv-preset/preset.test.ts
+++ b/packages/wrangler/e2e/unenv-preset/preset.test.ts
@@ -9,6 +9,19 @@ import { retry } from "../helpers/retry";
 import { waitForLong } from "../helpers/wait-for";
 import { WorkerdTests } from "./worker/index";
 
+// Tests from `WorkerdTests` that are known to be broken, keyed by test name with
+// the reason reported by vitest. Prefer this over deleting the test so the
+// coverage is easy to restore once the underlying issue is fixed.
+const SKIPPED_TESTS: Record<string, string> = {
+	// Cloudflare's 1.1.1.1 DoH JSON API is rolling out presentation-format `data`
+	// values (`0 issue "pki.goog"`) in place of the RFC 3597 hex encoding that
+	// workerd's `node:dns` CAA parser requires, so `dns.resolveCaa()` throws on
+	// the colos that have already switched.
+	// See https://github.com/cloudflare/workerd/issues/6912.
+	testDnsCaa:
+		"workerd cannot parse presentation-format CAA records (cloudflare/workerd#6912)",
+};
+
 type TestConfig = {
 	name: string;
 	compatibilityDate: string;
@@ -894,7 +907,12 @@ describe.each(groupedLocalConfigs)(
 		test.for(Object.keys(WorkerdTests))(
 			"%s",
 			{ timeout: 20_000 },
-			async (testName, { expect }) => {
+			async (testName, { expect, skip }) => {
+				const skipReason = SKIPPED_TESTS[testName];
+				if (skipReason !== undefined) {
+					skip(skipReason);
+				}
+
 				// Retries the callback until it succeeds or times out.
 				// Useful for the i.e. DNS tests where underlying requests might error/timeout.
 				await waitForLong(
@@ -960,7 +978,12 @@ describe.runIf(Boolean(CLOUDFLARE_ACCOUNT_ID))(
 		test.for(Object.keys(WorkerdTests))(
 			"%s",
 			{ timeout: 20_000 },
-			async (testName, { expect }) => {
+			async (testName, { expect, skip }) => {
+				const skipReason = SKIPPED_TESTS[testName];
+				if (skipReason !== undefined) {
+					skip(skipReason);
+				}
+
 				// Retries the callback until it succeeds or times out.
 				// Useful for the i.e. DNS tests where underlying requests might error/timeout.
 				await waitForLong(
@@ -1027,7 +1050,12 @@ describe.runIf(Boolean(CLOUDFLARE_ACCOUNT_ID))(
 		test.for(Object.keys(WorkerdTests))(
 			"%s",
 			{ timeout: 20_000 },
-			async (testName, { expect }) => {
+			async (testName, { expect, skip }) => {
+				const skipReason = SKIPPED_TESTS[testName];
+				if (skipReason !== undefined) {
+					skip(skipReason);
+				}
+
 				// Retries the callback until it succeeds or times out.
 				// Useful for the i.e. DNS tests where underlying requests might error/timeout.
 				await waitForLong(

--- a/packages/wrangler/e2e/unenv-preset/worker/index.ts
+++ b/packages/wrangler/e2e/unenv-preset/worker/index.ts
@@ -249,7 +249,9 @@ export const WorkerdTests: Record<string, () => Promise<void>> = {
 				resolve(null);
 			});
 		});
+	},
 
+	async testDnsCaa() {
 		const dnsPromises = await import("node:dns/promises");
 		const results = await dnsPromises.resolveCaa("google.com");
 		assert.ok(Array.isArray(results));


### PR DESCRIPTION
Upstream bug: <https://github.com/cloudflare/workerd/issues/6912>

`packages/wrangler/e2e/unenv-preset` → `testDns` has been failing intermittently on `main` since 2026-07-30, with:

```
Error: CAA record data too short: expected critical and prefix length fields
```

This is not a flake. Cloudflare's 1.1.1.1 DoH JSON API is [rolling out a new `data` encoding](https://developers.cloudflare.com/changelog/post/2026-07-28-improved-record-display-format/) (changelog 2026-07-28), replacing RFC 3597 generic hex with standard presentation format for CAA and several other record types, and explicitly notes that "during the roll out responses may use either the old or new format".

workerd's `node:dns` only understands the old encoding. `parse_caa_record` splits `data` on whitespace and unconditionally treats the first two tokens as the `\#` marker and rdata length, so `0 issue "pki.goog"` (3 tokens) trips the length guard and `dns.resolveCaa()` throws on any colo that has already switched. `dns.resolveNaptr()` is broken the same way. Filed as cloudflare/workerd#6912; nothing in this repo can fix it.

So this PR just stops the E2E being red on unrelated PRs. `resolveCaa` moves out of `testDns` into its own `testDnsCaa` entry, which is skipped via a new `SKIPPED_TESTS` map. The TXT half of `testDns` keeps running (TXT was already presentation format and is unaffected), and the CAA coverage stays in the tree so it is a one-line change to restore once workerd handles both encodings. All three suites (local plus both remote ones) iterate `Object.keys(WorkerdTests)`, so the single map covers every call site.

### Evidence this is systemic, not noise

- The changelog is dated 2026-07-28; the first failing run I found is 2026-07-30T12:06Z.
- Reproduced on 15 of the recent Wrangler E2E runs I sampled, including `changeset-release/main` (no PR code involved), on both Linux and macOS runners.
- Within a single job it fails deterministically for the whole 19s retry window — same colo, cached answer — which is what separates it from ordinary DNS flakiness. Some whole runs still pass, matching a partial rollout.

### Verification

Ran the local preset suite against real workerd (`WRANGLER_E2E_TEST_FILE=e2e/unenv-preset/preset.test.ts ... -t testDns`, configs temporarily narrowed to one):

```
✓ Local preset test: ... > testDns 107ms
↓ Local preset test: ... > testDnsCaa 0ms [workerd cannot parse presentation-format CAA records (cloudflare/workerd#6912)]
```

Also re-ran with the `SKIPPED_TESTS` entry removed to confirm the extracted body is still valid and it is only the skip suppressing it — both `testDns` and `testDnsCaa` pass from my location, which is still being served the old hex encoding.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: this only changes which E2E assertions run; there is no user-facing behaviour or API change.

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

> [!NOTE]
> This is a contribution from an AI agent: opencode, claude-opus-5.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/15016" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->