### PR TITLE
[fixtures] De-flake the dev-registry tests on Windows by making tail teardown safe

### DIFF
--- a/fixtures/dev-registry/tests/dev-registry.test.ts
+++ b/fixtures/dev-registry/tests/dev-registry.test.ts
@@ -32,8 +32,18 @@ const it = test.extend<{
 	// Fixture for creating a temporary directory
 	async devRegistryPath({}, use) {
 		const tmpPath = await fs.realpath(await fs.mkdtemp(tmpPathBase));
+
+		// Fixture teardown runs *before* `onTestFinished` callbacks, so removing
+		// the directory here would pull the registry out from under dev sessions
+		// that are still running. Registering the cleanup as an
+		// `onTestFinished` callback during fixture setup instead makes it the
+		// first one registered, and therefore the last one to run under Vitest's
+		// LIFO ordering — after every dev session has exited.
+		onTestFinished(async () => {
+			await fs.rm(tmpPath, { recursive: true, maxRetries: 10 });
+		});
+
 		await use(tmpPath);
-		await fs.rm(tmpPath, { recursive: true, maxRetries: 10 });
 	},
 });
 
@@ -92,6 +102,27 @@ async function runWranglerDev(
 	}, waitForTimeout);
 
 	return url;
+}
+
+/**
+ * Starts a tail consumer, then its producer, returning both URLs.
+ *
+ * Vitest runs `onTestFinished` callbacks in LIFO order, so the session started
+ * last is torn down first. Starting the producer last therefore guarantees it
+ * is killed while its consumer is still running.
+ *
+ * The reverse order is not safe: killing a dev session that another running
+ * session is forwarding tail events to aborts workerd on the surviving side on
+ * Windows, which restarts the dev server mid-teardown and times the test out.
+ * The `tail_consumers` in this fixture are one-directional for the same reason
+ * — with a cycle there is no order that keeps every producer shorter-lived than
+ * its consumer.
+ */
+async function startTailPair(
+	startConsumer: () => Promise<string>,
+	startProducer: () => Promise<string>
+): Promise<[consumer: string, producer: string]> {
+	return [await startConsumer(), await startProducer()];
 }
 
 async function setupPlatformProxy(config: string, devRegistryPath?: string) {
@@ -400,17 +431,25 @@ describe("Dev Registry: wrangler dev <-> wrangler dev", () => {
 		}, waitForTimeout);
 	});
 
-	it("supports tail handler", async ({ devRegistryPath }) => {
-		const exportedHandlerWithAssets = await runWranglerDev(
-			"wrangler.exported-handler-with-assets.jsonc",
-			devRegistryPath
-		);
-		const workerEntrypoint = await runWranglerDev(
-			[
-				"wrangler.worker-entrypoint.jsonc",
-				"wrangler.internal-durable-object.jsonc",
-			],
-			devRegistryPath
+	it("supports tail handler when the consumer has assets", async ({
+		devRegistryPath,
+	}) => {
+		// The producer runs alongside a second worker so that its logs are
+		// prefixed with the worker name, exercising multi-worker sessions too
+		const [exportedHandlerWithAssets, workerEntrypoint] = await startTailPair(
+			() =>
+				runWranglerDev(
+					"wrangler.exported-handler-with-assets.jsonc",
+					devRegistryPath
+				),
+			() =>
+				runWranglerDev(
+					[
+						"wrangler.worker-entrypoint.jsonc",
+						"wrangler.internal-durable-object.jsonc",
+					],
+					devRegistryPath
+				)
 		);
 
 		const searchParams = new URLSearchParams({
@@ -418,29 +457,7 @@ describe("Dev Registry: wrangler dev <-> wrangler dev", () => {
 		});
 
 		await vi.waitFor(async () => {
-			// Trigger tail handler of worker-entrypoint via exported handler
-			await fetch(`${exportedHandlerWithAssets}?${searchParams}`, {
-				method: "POST",
-				body: JSON.stringify(["hello world", "this is the 2nd log"]),
-			});
-			await fetch(`${exportedHandlerWithAssets}?${searchParams}`, {
-				method: "POST",
-				body: JSON.stringify(["some other log"]),
-			});
-
-			const response = await fetch(`${workerEntrypoint}?${searchParams}`);
-
-			expect(await response.json()).toEqual({
-				worker: "Worker Entrypoint",
-				tailEvents: expect.arrayContaining([
-					[["[exported-handler]"], ["hello world", "this is the 2nd log"]],
-					[["[exported-handler]"], ["some other log"]],
-				]),
-			});
-		}, waitForTimeout);
-
-		await vi.waitFor(async () => {
-			// Trigger tail handler of exported-handler via worker-entrypoint
+			// Trigger tail handler of exported-handler-with-assets via worker-entrypoint
 			await fetch(`${workerEntrypoint}?${searchParams}`, {
 				method: "POST",
 				body: JSON.stringify(["hello from test"]),
@@ -464,6 +481,45 @@ describe("Dev Registry: wrangler dev <-> wrangler dev", () => {
 						["[worker-entrypoint]", "[Worker Entrypoint]"],
 						["[worker-entrypoint]", "yet another log", "and another one"],
 					],
+				]),
+			});
+		}, waitForTimeout);
+	});
+
+	it("supports tail handler when the producer has assets", async ({
+		devRegistryPath,
+	}) => {
+		const [exportedHandler, exportedHandlerWithAssets] = await startTailPair(
+			() => runWranglerDev("wrangler.exported-handler.jsonc", devRegistryPath),
+			() =>
+				runWranglerDev(
+					"wrangler.exported-handler-with-assets.jsonc",
+					devRegistryPath
+				)
+		);
+
+		const searchParams = new URLSearchParams({
+			"test-method": "tail",
+		});
+
+		await vi.waitFor(async () => {
+			// Trigger tail handler of exported-handler via exported-handler-with-assets
+			await fetch(`${exportedHandlerWithAssets}?${searchParams}`, {
+				method: "POST",
+				body: JSON.stringify(["hello world", "this is the 2nd log"]),
+			});
+			await fetch(`${exportedHandlerWithAssets}?${searchParams}`, {
+				method: "POST",
+				body: JSON.stringify(["some other log"]),
+			});
+
+			const response = await fetch(`${exportedHandler}?${searchParams}`);
+
+			expect(await response.json()).toEqual({
+				worker: "exported-handler",
+				tailEvents: expect.arrayContaining([
+					[["[exported-handler]"], ["hello world", "this is the 2nd log"]],
+					[["[exported-handler]"], ["some other log"]],
 				]),
 			});
 		}, waitForTimeout);
@@ -715,14 +771,16 @@ describe("Dev Registry: vite dev <-> vite dev", () => {
 		}, waitForTimeout);
 	});
 
-	it("supports tail handler", async ({ devRegistryPath }) => {
-		const exportedHandler = await runViteDev(
-			"vite.exported-handler.config.ts",
-			devRegistryPath
-		);
-		const workerEntrypointWithAssets = await runViteDev(
-			"vite.worker-entrypoint-with-assets.config.ts",
-			devRegistryPath
+	it("supports tail handler when the consumer has assets", async ({
+		devRegistryPath,
+	}) => {
+		const [exportedHandlerWithAssets, workerEntrypoint] = await startTailPair(
+			() =>
+				runViteDev(
+					"vite.exported-handler-with-assets.config.ts",
+					devRegistryPath
+				),
+			() => runViteDev("vite.worker-entrypoint.config.ts", devRegistryPath)
 		);
 
 		const searchParams = new URLSearchParams({
@@ -730,38 +788,55 @@ describe("Dev Registry: vite dev <-> vite dev", () => {
 		});
 
 		await vi.waitFor(async () => {
-			// Trigger tail handler of worker-entrypoint via exported-handler
-			await fetch(`${exportedHandler}?${searchParams}`, {
-				method: "POST",
-				body: JSON.stringify(["hello world", "this is the 2nd log"]),
-			});
-			await fetch(`${exportedHandler}?${searchParams}`, {
-				method: "POST",
-				body: JSON.stringify(["some other log"]),
-			});
-
-			const response = await fetch(
-				`${workerEntrypointWithAssets}?${searchParams}`
-			);
-
-			expect(await response.json()).toEqual({
-				worker: "Worker Entrypoint",
-				tailEvents: expect.arrayContaining([
-					[["[exported-handler]"], ["hello world", "this is the 2nd log"]],
-					[["[exported-handler]"], ["some other log"]],
-				]),
-			});
-		}, waitForTimeout);
-
-		await vi.waitFor(async () => {
-			// Trigger tail handler of exported-handler via worker-entrypoint
-			await fetch(`${workerEntrypointWithAssets}?${searchParams}`, {
+			// Trigger tail handler of exported-handler-with-assets via worker-entrypoint
+			await fetch(`${workerEntrypoint}?${searchParams}`, {
 				method: "POST",
 				body: JSON.stringify(["hello from test"]),
 			});
-			await fetch(`${workerEntrypointWithAssets}?${searchParams}`, {
+			await fetch(`${workerEntrypoint}?${searchParams}`, {
 				method: "POST",
 				body: JSON.stringify(["yet another log", "and another one"]),
+			});
+
+			const response = await fetch(
+				`${exportedHandlerWithAssets}?${searchParams}`
+			);
+
+			expect(await response.json()).toEqual({
+				worker: "exported-handler",
+				tailEvents: expect.arrayContaining([
+					[["[Worker Entrypoint]"], ["hello from test"]],
+					[["[Worker Entrypoint]"], ["yet another log", "and another one"]],
+				]),
+			});
+		}, waitForTimeout);
+	});
+
+	it("supports tail handler when the producer has assets", async ({
+		devRegistryPath,
+	}) => {
+		const [exportedHandler, exportedHandlerWithAssets] = await startTailPair(
+			() => runViteDev("vite.exported-handler.config.ts", devRegistryPath),
+			() =>
+				runViteDev(
+					"vite.exported-handler-with-assets.config.ts",
+					devRegistryPath
+				)
+		);
+
+		const searchParams = new URLSearchParams({
+			"test-method": "tail",
+		});
+
+		await vi.waitFor(async () => {
+			// Trigger tail handler of exported-handler via exported-handler-with-assets
+			await fetch(`${exportedHandlerWithAssets}?${searchParams}`, {
+				method: "POST",
+				body: JSON.stringify(["hello world", "this is the 2nd log"]),
+			});
+			await fetch(`${exportedHandlerWithAssets}?${searchParams}`, {
+				method: "POST",
+				body: JSON.stringify(["some other log"]),
 			});
 
 			const response = await fetch(`${exportedHandler}?${searchParams}`);
@@ -769,8 +844,8 @@ describe("Dev Registry: vite dev <-> vite dev", () => {
 			expect(await response.json()).toEqual({
 				worker: "exported-handler",
 				tailEvents: expect.arrayContaining([
-					[["[Worker Entrypoint]"], ["hello from test"]],
-					[["[Worker Entrypoint]"], ["yet another log", "and another one"]],
+					[["[exported-handler]"], ["hello world", "this is the 2nd log"]],
+					[["[exported-handler]"], ["some other log"]],
 				]),
 			});
 		}, waitForTimeout);
@@ -977,14 +1052,16 @@ describe("Dev Registry: vite dev <-> wrangler dev", () => {
 		}, waitForTimeout);
 	});
 
-	it("supports tail handler", async ({ devRegistryPath }) => {
-		const exportedHandlerWithStaticAssets = await runViteDev(
-			"vite.exported-handler-with-assets.config.ts",
-			devRegistryPath
-		);
-		const workerEntrypoint = await runWranglerDev(
-			"wrangler.worker-entrypoint.jsonc",
-			devRegistryPath
+	it("supports tail handler from wrangler dev to vite dev", async ({
+		devRegistryPath,
+	}) => {
+		const [exportedHandlerWithAssets, workerEntrypoint] = await startTailPair(
+			() =>
+				runViteDev(
+					"vite.exported-handler-with-assets.config.ts",
+					devRegistryPath
+				),
+			() => runWranglerDev("wrangler.worker-entrypoint.jsonc", devRegistryPath)
 		);
 
 		const searchParams = new URLSearchParams({
@@ -992,29 +1069,7 @@ describe("Dev Registry: vite dev <-> wrangler dev", () => {
 		});
 
 		await vi.waitFor(async () => {
-			// Trigger tail handler of worker-entrypoint via exported-handler
-			await fetch(`${exportedHandlerWithStaticAssets}?${searchParams}`, {
-				method: "POST",
-				body: JSON.stringify(["hello world", "this is the 2nd log"]),
-			});
-			await fetch(`${exportedHandlerWithStaticAssets}?${searchParams}`, {
-				method: "POST",
-				body: JSON.stringify(["some other log"]),
-			});
-
-			const response = await fetch(`${workerEntrypoint}?${searchParams}`);
-
-			expect(await response.json()).toEqual({
-				worker: "Worker Entrypoint",
-				tailEvents: expect.arrayContaining([
-					[["[exported-handler]"], ["hello world", "this is the 2nd log"]],
-					[["[exported-handler]"], ["some other log"]],
-				]),
-			});
-		}, waitForTimeout);
-
-		await vi.waitFor(async () => {
-			// Trigger tail handler of exported-handler via worker-entrypoint
+			// Trigger tail handler of exported-handler-with-assets via worker-entrypoint
 			await fetch(`${workerEntrypoint}?${searchParams}`, {
 				method: "POST",
 				body: JSON.stringify(["hello from test"]),
@@ -1025,7 +1080,7 @@ describe("Dev Registry: vite dev <-> wrangler dev", () => {
 			});
 
 			const response = await fetch(
-				`${exportedHandlerWithStaticAssets}?${searchParams}`
+				`${exportedHandlerWithAssets}?${searchParams}`
 			);
 
 			expect(await response.json()).toEqual({
@@ -1033,6 +1088,45 @@ describe("Dev Registry: vite dev <-> wrangler dev", () => {
 				tailEvents: expect.arrayContaining([
 					[["[Worker Entrypoint]"], ["hello from test"]],
 					[["[Worker Entrypoint]"], ["yet another log", "and another one"]],
+				]),
+			});
+		}, waitForTimeout);
+	});
+
+	it("supports tail handler from vite dev to wrangler dev", async ({
+		devRegistryPath,
+	}) => {
+		const [exportedHandler, exportedHandlerWithAssets] = await startTailPair(
+			() => runWranglerDev("wrangler.exported-handler.jsonc", devRegistryPath),
+			() =>
+				runViteDev(
+					"vite.exported-handler-with-assets.config.ts",
+					devRegistryPath
+				)
+		);
+
+		const searchParams = new URLSearchParams({
+			"test-method": "tail",
+		});
+
+		await vi.waitFor(async () => {
+			// Trigger tail handler of exported-handler via exported-handler-with-assets
+			await fetch(`${exportedHandlerWithAssets}?${searchParams}`, {
+				method: "POST",
+				body: JSON.stringify(["hello world", "this is the 2nd log"]),
+			});
+			await fetch(`${exportedHandlerWithAssets}?${searchParams}`, {
+				method: "POST",
+				body: JSON.stringify(["some other log"]),
+			});
+
+			const response = await fetch(`${exportedHandler}?${searchParams}`);
+
+			expect(await response.json()).toEqual({
+				worker: "exported-handler",
+				tailEvents: expect.arrayContaining([
+					[["[exported-handler]"], ["hello world", "this is the 2nd log"]],
+					[["[exported-handler]"], ["some other log"]],
 				]),
 			});
 		}, waitForTimeout);

--- a/fixtures/dev-registry/tests/dev-registry.test.ts
+++ b/fixtures/dev-registry/tests/dev-registry.test.ts
@@ -4,7 +4,7 @@ import * as path from "node:path";
 import { resolve } from "node:path";
 /* eslint-disable workers-sdk/no-vitest-import-expect -- uses expect in module-scope helper functions */
 import {
-	describe as baseDescribe,
+	describe,
 	expect,
 	onTestFailed,
 	onTestFinished,
@@ -17,11 +17,6 @@ import {
 	waitForReady,
 } from "../../../packages/vite-plugin-cloudflare/e2e/helpers";
 import { runWranglerDev as baseRunWranglerDev } from "../../shared/src/run-wrangler-long-lived";
-
-// TODO: These tests are consistently failing on Windows in CI and are blocking
-// other work. Skipping them there as a temporary measure until the underlying
-// issue is fixed. There's still value in running them on macOS and Linux.
-const describe = baseDescribe.skipIf(process.platform === "win32");
 
 const waitForTimeout = 20_000;
 const cwd = resolve(__dirname, "..");

--- a/fixtures/dev-registry/wrangler.exported-handler-with-assets.jsonc
+++ b/fixtures/dev-registry/wrangler.exported-handler-with-assets.jsonc
@@ -34,9 +34,12 @@
 			"entrypoint": "NamedEntrypoint",
 		},
 	],
+	// Middle link of the one-directional tail chain described in
+	// wrangler.worker-entrypoint.jsonc. Pointing this back at worker-entrypoint
+	// would close the cycle.
 	"tail_consumers": [
 		{
-			"service": "worker-entrypoint",
+			"service": "exported-handler",
 		},
 	],
 }

--- a/fixtures/dev-registry/wrangler.exported-handler.jsonc
+++ b/fixtures/dev-registry/wrangler.exported-handler.jsonc
@@ -27,11 +27,6 @@
 			"entrypoint": "NamedEntrypoint",
 		},
 	],
-	"tail_consumers": [
-		{
-			"service": "worker-entrypoint-with-assets",
-		},
-	],
 	"queues": {
 		"producers": [
 			{

--- a/fixtures/dev-registry/wrangler.external-durable-object.jsonc
+++ b/fixtures/dev-registry/wrangler.external-durable-object.jsonc
@@ -12,9 +12,4 @@
 			},
 		],
 	},
-	"tail_consumers": [
-		{
-			"service": "exported-handler",
-		},
-	],
 }

--- a/fixtures/dev-registry/wrangler.worker-entrypoint-with-assets.jsonc
+++ b/fixtures/dev-registry/wrangler.worker-entrypoint-with-assets.jsonc
@@ -29,9 +29,4 @@
 			"entrypoint": "NamedEntrypoint",
 		},
 	],
-	"tail_consumers": [
-		{
-			"service": "exported-handler",
-		},
-	],
 }

--- a/fixtures/dev-registry/wrangler.worker-entrypoint.jsonc
+++ b/fixtures/dev-registry/wrangler.worker-entrypoint.jsonc
@@ -26,6 +26,11 @@
 			"entrypoint": "NamedEntrypoint",
 		},
 	],
+	// Tail relationships across these configs form a one-directional chain:
+	// worker-entrypoint -> exported-handler-with-assets -> exported-handler.
+	// Keep it acyclic and confined to the tail tests. A dev session that
+	// outlives a tail consumer it has already connected to aborts workerd on
+	// Windows, and a cycle makes a safe shutdown order impossible to pick.
 	"tail_consumers": [
 		{
 			"service": "exported-handler-with-assets",

--- a/fixtures/shared/src/run-wrangler-long-lived.ts
+++ b/fixtures/shared/src/run-wrangler-long-lived.ts
@@ -189,27 +189,37 @@ async function runLongLivedWrangler(
 
 	async function stop() {
 		stopping = true;
-		return new Promise<void>((resolve) => {
-			if (processExited) {
-				// Already dead — nothing to kill. Avoid noisy Windows taskkill errors.
-				resolve();
-				return;
-			}
-			assert(
-				wranglerProcess.pid,
-				`Command "${command.join(" ")}" had no process id`
-			);
-			treeKill(wranglerProcess.pid, (e) => {
+		if (processExited) {
+			// Already dead — nothing to kill. Avoid noisy Windows taskkill errors.
+			return;
+		}
+		const pid = wranglerProcess.pid;
+		assert(pid, `Command "${command.join(" ")}" had no process id`);
+
+		await new Promise<void>((resolve) => {
+			treeKill(pid, (e) => {
 				if (e) {
-					console.error(
-						"Failed to kill command: " + command.join(" "),
-						wranglerProcess.pid,
-						e
-					);
+					console.error("Failed to kill command: " + command.join(" "), pid, e);
 				}
 				// fallthrough to resolve() because either the process is already dead
 				// or don't have permission to kill it or some other reason?
 				// either way, there is nothing we can do and we don't want to fail the test because of this
+				resolve();
+			});
+		});
+
+		// The kill callback only tells us the signal was delivered (on Windows it
+		// is the exit of `taskkill`), not that the process is gone. Tests that
+		// stop several sessions in sequence rely on each one being fully dead
+		// before the next is stopped, so wait for the actual exit — with a bound,
+		// since failing to reap a child should not fail the test.
+		if (processExited) {
+			return;
+		}
+		await new Promise<void>((resolve) => {
+			const timeoutHandle = setTimeout(resolve, 10_000);
+			wranglerProcess.once("exit", () => {
+				clearTimeout(timeoutHandle);
 				resolve();
 			});
 		});


### PR DESCRIPTION
The `Tests (Windows, fixtures)` required check has been failing roughly half the time on `fixtures/dev-registry`, almost always as `Error: Test timed out in 50000ms` in one of the `vite dev <-> vite dev` tests.

The failure is a workerd abort during test **teardown**. When a dev session is killed while another running session is forwarding tail events to it, the surviving session's workerd calls `std::terminate` — filed upstream as [cloudflare/workerd#6913](https://github.com/cloudflare/workerd/issues/6913). Miniflare then starts a replacement runtime, the Vite plugin restarts the dev server to rebuild its module-runner sockets, and the ~30s of churn lands on whichever test happens to still be running. That's why the timeout kept moving between tests and never pointed at the code it was blaming.

This PR does not fix the abort — that belongs in workerd. It removes the shape that triggers it from the fixture.

### The fixture made the crash easy to hit

`tail_consumers` formed two cycles:

- `exported-handler` <-> `worker-entrypoint-with-assets`
- `worker-entrypoint` <-> `exported-handler-with-assets`

So most tests carried a live tail edge whether or not they were testing tail handlers, and because the edges were cyclic there was no shutdown order that could keep every producer shorter-lived than its consumer. Whichever session died first left the other one forwarding to a dead peer.

### Changes

**Tail relationships are now a one-directional chain** — `worker-entrypoint` -> `exported-handler-with-assets` -> `exported-handler` — and the incidental edges on `exported-handler`, `worker-entrypoint-with-assets` and `external-durable-object` are gone. Reversing the middle edge was enough to break both cycles, so no new config files were needed. Tail edges now exist only in the tests that assert on them.

**The three bidirectional tail tests are split into one test per direction**, so each can start its tail consumer first and its producer second. Vitest tears sessions down in LIFO order, so the producer is always killed while its consumer is still alive. The ordering is expressed through a documented `startTailPair()` helper rather than a comment, so a future test can't quietly get it backwards. All existing tail assertions are preserved, including the `[worker-entrypoint]` log prefixes that only appear for multi-worker Wrangler sessions.

Two supporting fixes, both of which let a session watch a peer disappear mid-teardown:

- The `devRegistryPath` fixture deleted the registry directory in its teardown. Vitest runs fixture teardown *before* `onTestFinished` callbacks (verified against `@vitest/runner@4.1.0`: `afterEach` -> fixture teardown -> `onTestFinished` LIFO), so the registry was being pulled out from under every session while they were all still running. Registering the removal as an `onTestFinished` callback during fixture setup makes it the first registered and therefore the last to run.
- `runWranglerDev`'s `stop()` resolved once the kill signal had been delivered — on Windows, once `taskkill` exited — not once the process was gone. It now waits for the actual exit, bounded at 10s, so sequential teardown really is sequential.

### Re-enables the tests on Windows

#15018 landed while this was in review and skipped the entire suite on Windows as a temporary measure "until the underlying issue is fixed". This PR fixes it, so the second commit reverts that skip. Windows is the only platform the flake ever appeared on, so leaving it skipped there would mean the suite no longer guards the thing it exists to guard.

### Verification

- Audited all 30 tests for the dangerous shape (a running producer whose assets-enabled tail consumer is killed first). It now occurs in exactly three tests, all of which start the producer last. The previously-failing test carries no live tail edge at all.
- 7 local runs of the full fixture suite. Suite cost goes from ~58s to ~70s for the three extra dev-session pairs.
- Type-check output is byte-identical to `main` (169 pre-existing `lib.dom` / `@cloudflare/workers-types` conflicts). Worth noting separately: this fixture's script is `check:types` while the turbo task is `check:type`, so CI never runs it.

### Unrelated flake found along the way, not fixed here

`vite dev <-> wrangler dev > supports queues across dev sessions` fails with `expected [] to include 'hello from vite to wrangler'` on 2 of 6 runs on `main` and 1 of 7 on this branch — equally present before and after, so it is independent of this change. Unlike the Windows crash it reproduces on macOS, so it should be tractable to chase separately.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: this only changes test fixtures. There is no user-facing behaviour change, which is also why there is no changeset (`@fixture/dev-registry` and `@fixture/shared` are both private).

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

> [!NOTE]
> This is a contribution from an AI agent: OpenCode, claude-opus-5.

