### PR TITLE
[fixtures] Skip dev-registry tests on Windows

### DIFF
--- a/fixtures/dev-registry/tests/dev-registry.test.ts
+++ b/fixtures/dev-registry/tests/dev-registry.test.ts
@@ -4,7 +4,7 @@ import * as path from "node:path";
 import { resolve } from "node:path";
 /* eslint-disable workers-sdk/no-vitest-import-expect -- uses expect in module-scope helper functions */
 import {
-	describe,
+	describe as baseDescribe,
 	expect,
 	onTestFailed,
 	onTestFinished,
@@ -17,6 +17,11 @@ import {
 	waitForReady,
 } from "../../../packages/vite-plugin-cloudflare/e2e/helpers";
 import { runWranglerDev as baseRunWranglerDev } from "../../shared/src/run-wrangler-long-lived";
+
+// TODO: These tests are consistently failing on Windows in CI and are blocking
+// other work. Skipping them there as a temporary measure until the underlying
+// issue is fixed. There's still value in running them on macOS and Linux.
+const describe = baseDescribe.skipIf(process.platform === "win32");
 
 const waitForTimeout = 20_000;
 const cwd = resolve(__dirname, "..");


### PR DESCRIPTION
The `fixtures/dev-registry` suite is consistently failing on Windows in CI and is blocking unrelated work. This skips it on Windows as a **temporary** measure to unblock the pipeline, while keeping full coverage on macOS and Linux.

The fixture has five top-level `describe` blocks, so rather than wrapping the whole file in a platform conditional (as `fixtures/interactive-dev-tests/tests/index.test.ts` does), this aliases the vitest import and derives a locally-skipped `describe`:

```ts
const describe = baseDescribe.skipIf(process.platform === "win32");
```

That covers all five blocks in a five-line diff with no re-indentation, which keeps the eventual revert trivial.

Verification:

- All 27 tests live inside those five `describe` blocks — no top-level `it`/`test` escapes the skip.
- Forcing the condition to `true` locally reports `27 skipped` and exits 0, so Windows goes green rather than erroring on an empty test file.
- With the real check in place, `vitest list` still enumerates all 27 tests on macOS.
- `oxfmt --check` and `check:type` both pass. Lint is not applicable — `.oxlintrc.jsonc` ignores `fixtures/**`.

Note that this is a blanket file-level skip, so any *new* Windows regression in the dev registry will also go unnoticed on that platform, not just the current failure. The `TODO` marks it as temporary but nothing enforces cleanup, so this should be reverted once the root cause is fixed.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: this is a test-only change that skips an existing suite on one platform. There is no product behaviour change to cover. The skip itself was verified locally as described above.
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: this only affects which platforms an internal test fixture runs on, with no user-facing impact.

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
