### PR TITLE
[wrangler] Respect CLOUDFLARE_ENV when selecting .env and .dev.vars files

### DIFF
--- a/.changeset/cloudflare-env-dot-env-files.md
+++ b/.changeset/cloudflare-env-dot-env-files.md
@@ -1,0 +1,9 @@
+---
+"wrangler": patch
+---
+
+Respect `CLOUDFLARE_ENV` when selecting `.env.<environment>` and `.dev.vars.<environment>` files
+
+`CLOUDFLARE_ENV` is documented as an alternative to `--env`, and the config loader already falls back to it when `--env` is not passed. But the `.env`/`.dev.vars` file lookup only looked at `--env`, so running `CLOUDFLARE_ENV=staging wrangler dev` activated the `staging` config environment while still loading the top-level `.env`/`.dev.vars` files instead of `.env.staging`/`.dev.vars.staging`.
+
+Both lookups now fall back to `CLOUDFLARE_ENV` in the same way the config loader does. `--env` still takes precedence when both are set.

--- a/packages/wrangler/src/__tests__/dev.test.ts
+++ b/packages/wrangler/src/__tests__/dev.test.ts
@@ -1985,6 +1985,70 @@ describe.sequential("wrangler dev", () => {
 				"
 			`);
 		});
+
+		it("should prefer `.dev.vars.<environment>` if `CLOUDFLARE_ENV` is set", async ({
+			expect,
+		}) => {
+			fs.writeFileSync("index.js", `export default {};`);
+			fs.writeFileSync(".dev.vars", "DEFAULT_VAR=default");
+			fs.writeFileSync(".dev.vars.custom", "CUSTOM_VAR=custom");
+
+			writeWranglerConfig({ main: "index.js", env: { custom: {} } });
+			const config = await runWranglerUntilConfig("dev", {
+				CLOUDFLARE_ENV: "custom",
+			});
+			const varBindings: Record<string, unknown> = Object.fromEntries(
+				Object.entries(config.bindings ?? {})
+					.filter(
+						(
+							binding
+						): binding is [
+							string,
+							Extract<Binding, { type: "plain_text" | "secret_text" }>,
+						] =>
+							binding[1].type === "plain_text" ||
+							binding[1].type === "secret_text"
+					)
+					.map(([b, v]) => [b, v.value])
+			);
+
+			expect(varBindings).toEqual({ CUSTOM_VAR: "custom" });
+			expect(std.out).toContain("Using secrets defined in .dev.vars.custom");
+		});
+
+		it("should prefer `--env` over `CLOUDFLARE_ENV` when selecting `.dev.vars.<environment>`", async ({
+			expect,
+		}) => {
+			fs.writeFileSync("index.js", `export default {};`);
+			fs.writeFileSync(".dev.vars", "DEFAULT_VAR=default");
+			fs.writeFileSync(".dev.vars.custom", "CUSTOM_VAR=custom");
+			fs.writeFileSync(".dev.vars.other", "OTHER_VAR=other");
+
+			writeWranglerConfig({
+				main: "index.js",
+				env: { custom: {}, other: {} },
+			});
+			const config = await runWranglerUntilConfig("dev --env custom", {
+				CLOUDFLARE_ENV: "other",
+			});
+			const varBindings: Record<string, unknown> = Object.fromEntries(
+				Object.entries(config.bindings ?? {})
+					.filter(
+						(
+							binding
+						): binding is [
+							string,
+							Extract<Binding, { type: "plain_text" | "secret_text" }>,
+						] =>
+							binding[1].type === "plain_text" ||
+							binding[1].type === "secret_text"
+					)
+					.map(([b, v]) => [b, v.value])
+			);
+
+			expect(varBindings).toEqual({ CUSTOM_VAR: "custom" });
+			expect(std.out).toContain("Using secrets defined in .dev.vars.custom");
+		});
 	});
 
 	describe("secrets config", () => {
@@ -2265,6 +2329,42 @@ describe.sequential("wrangler dev", () => {
 			expect,
 		}) => {
 			await runWranglerUntilConfig("dev --env custom");
+			const out = std.out;
+			expect(extractUsingVars(out)).toMatchInlineSnapshot(`
+				"Using secrets defined in .env
+				Using secrets defined in .env.custom
+				Using secrets defined in .env.custom.local
+				Using secrets defined in .env.local"
+			`);
+			expect(extractBindings(out)).toMatchInlineSnapshot(`
+				"env.__DOT_ENV_LOCAL_DEV_VAR_1 ("(hidden)")          Environment Variable      local
+				env.__DOT_ENV_LOCAL_DEV_VAR_2 ("(hidden)")          Environment Variable      local
+				env.__DOT_ENV_LOCAL_DEV_VAR_3 ("(hidden)")          Environment Variable      local
+				env.__DOT_ENV_LOCAL_DEV_VAR_LOCAL ("(hidden)")      Environment Variable      local"
+			`);
+		});
+
+		it("should populate `process.env` from appropriate `.env.<environment>` files when CLOUDFLARE_ENV is set", async ({
+			expect,
+		}) => {
+			await runWranglerUntilConfig("dev", { CLOUDFLARE_ENV: "custom" });
+			const dotEnvVars = Object.fromEntries(
+				Object.entries(process.env).filter(([key]) =>
+					key.startsWith("__DOT_ENV_LOCAL_DEV_VAR_")
+				)
+			);
+			expect(dotEnvVars).toEqual({
+				__DOT_ENV_LOCAL_DEV_VAR_1: "custom-local-1",
+				__DOT_ENV_LOCAL_DEV_VAR_2: "custom-2",
+				__DOT_ENV_LOCAL_DEV_VAR_3: "custom-local-3",
+				__DOT_ENV_LOCAL_DEV_VAR_LOCAL: "custom-local",
+			});
+		});
+
+		it("should get local dev `vars` from appropriate `.env.<environment>` files when CLOUDFLARE_ENV is set", async ({
+			expect,
+		}) => {
+			await runWranglerUntilConfig("dev", { CLOUDFLARE_ENV: "custom" });
 			const out = std.out;
 			expect(extractUsingVars(out)).toMatchInlineSnapshot(`
 				"Using secrets defined in .env

--- a/packages/wrangler/src/api/startDevWorker/ConfigController.ts
+++ b/packages/wrangler/src/api/startDevWorker/ConfigController.ts
@@ -6,6 +6,7 @@ import {
 	configFileName,
 	formatConfigSnippet,
 	getTodaysCompatDate,
+	getCloudflareEnv,
 	getDisableConfigWatching,
 	getDockerPath,
 	UserError,
@@ -248,7 +249,10 @@ async function resolveBindings(
 }> {
 	const bindings = getBindings(
 		config,
-		input.env,
+		// The config loader resolves the environment as `--env` then
+		// `CLOUDFLARE_ENV`; match that here so the `.env.<env>`/`.dev.vars.<env>`
+		// files line up with the config environment that was actually applied.
+		input.env ?? getCloudflareEnv(),
 		input.envFiles,
 		!input.dev?.remote,
 		input.bindings,

--- a/packages/wrangler/src/index.ts
+++ b/packages/wrangler/src/index.ts
@@ -4,6 +4,7 @@ import { checkMacOSVersion, setLogLevel } from "@cloudflare/cli-shared-helpers";
 import {
 	CommandLineArgsError,
 	experimental_readRawConfig,
+	getCloudflareEnv,
 } from "@cloudflare/workers-utils";
 import chalk from "chalk";
 import { EnvHttpProxyAgent, setGlobalDispatcher } from "undici";
@@ -662,8 +663,11 @@ export function createCLIParser(argv: string[]) {
 		.check(demandSingleValue("env"))
 		.check((args) => {
 			// Set process environment params from `.env` files if available.
+			// The environment is resolved the same way as in the config loader, so
+			// that `.env.<env>` files line up with the active config environment when
+			// it comes from `CLOUDFLARE_ENV` rather than `--env`.
 			const resolvedEnvFilePaths = (
-				args["env-file"] ?? getDefaultEnvFiles(args.env)
+				args["env-file"] ?? getDefaultEnvFiles(args.env ?? getCloudflareEnv())
 			).map((p) => resolve(p));
 			process.env = loadDotEnv(resolvedEnvFilePaths, {
 				includeProcessEnv: true,


### PR DESCRIPTION
`CLOUDFLARE_ENV` is supported as an alternative to `--env`, and the config loader resolves the active environment as `args.env ?? getCloudflareEnv()`. The `.env` and `.dev.vars` file lookups only consulted `args.env`, so `CLOUDFLARE_ENV=staging wrangler dev` activated the `staging` config environment but still loaded the top-level `.env`/`.dev.vars` files instead of `.env.staging`/`.dev.vars.staging`.

Two call sites were affected:

- `packages/wrangler/src/index.ts` — `getDefaultEnvFiles(args.env)`, which populates `process.env` for every command.
- `packages/wrangler/src/dev/start-dev.ts` — `env: args.env`, which reaches `.dev.vars.<env>` / `.env.<env>` selection via `ConfigController` → `getBindings()` → `getVarsForDev()`.

Both now use the same `args.env ?? getCloudflareEnv()` ordering as the config loader, so `--env` continues to take precedence when both are set. A test covers that precedence explicitly — it passes before and after, as a regression guard.

---

- Tests
  - [x] Tests included/updated
- Public documentation
  - [x] Documentation not necessary because: this aligns behaviour with the documented meaning of `CLOUDFLARE_ENV` and with the `--env` flag's own help text ("Environment to use for operations, and for selecting .env and .dev.vars files"). No documented behaviour changes.

> [!NOTE]
> This is a contribution from an AI agent: Claude Code (Claude Opus 4.5), working on behalf of @LeSingh1. Review comments will be read and responded to.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/15022" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->