### PR TITLE
fix(miniflare): apply EXIF orientation in local Images binding and cf.image transforms

### DIFF
--- a/.changeset/images-local-exif-orientation.md
+++ b/.changeset/images-local-exif-orientation.md
@@ -1,0 +1,5 @@
+---
+"miniflare": patch
+---
+
+Fix the local Images binding and `cf.image` transforms ignoring EXIF orientation. Previously, photos stored with an EXIF orientation flag (e.g. phone portrait photos, stored as landscape pixels plus a rotation flag) came back sideways from local transforms, while the production Images binding auto-orients them. Local dev now bakes the EXIF rotation into the pixels before applying transforms, matching production behavior.

--- a/packages/miniflare/src/plugins/images/fetcher.ts
+++ b/packages/miniflare/src/plugins/images/fetcher.ts
@@ -62,12 +62,12 @@ export async function imagesLocalFetcher(request: Request): Promise<Response> {
 		);
 	}
 
-	const transformer = sharp(await body.arrayBuffer(), {});
+	const source = await body.arrayBuffer();
 
 	const url = new URL(request.url);
 
 	if (url.pathname == "/info") {
-		return runInfo(transformer);
+		return runInfo(sharp(source, {}));
 	} else {
 		const badTransformsResponse = errorResponse(
 			400,
@@ -97,7 +97,14 @@ export async function imagesLocalFetcher(request: Request): Promise<Response> {
 				);
 			}
 
-			return runTransform(transformer, transforms, outputFormat);
+			// Production applies EXIF orientation before any transforms;
+			// autoOrient bakes the rotation into the pixels at decode so
+			// EXIF-rotated photos (e.g. phone portraits) come out upright.
+			return runTransform(
+				sharp(source, { autoOrient: true }),
+				transforms,
+				outputFormat
+			);
 		} catch {
 			return badTransformsResponse;
 		}
@@ -402,7 +409,7 @@ export async function cfImageLocalFetcher(request: Request): Promise<Response> {
 		}
 
 		if (options.format === "json") {
-			const jsonTransformer = sharp(source);
+			const jsonTransformer = sharp(source, { autoOrient: true });
 			applyCfImageTransforms(jsonTransformer, options);
 			const { info } = await jsonTransformer.toBuffer({
 				resolveWithObject: true,
@@ -419,7 +426,9 @@ export async function cfImageLocalFetcher(request: Request): Promise<Response> {
 			});
 		}
 
-		const transformer = sharp(source);
+		// Production applies EXIF orientation before any transforms;
+		// autoOrient bakes the rotation into the pixels at decode.
+		const transformer = sharp(source, { autoOrient: true });
 		applyCfImageTransforms(transformer, options);
 
 		const quality = resolveQuality(options.quality);

--- a/packages/miniflare/test/plugins/images/transform.spec.ts
+++ b/packages/miniflare/test/plugins/images/transform.spec.ts
@@ -78,7 +78,8 @@ describe("Images binding local transforms", () => {
 
 	async function transform(
 		transformOpts: Record<string, unknown>,
-		format = "image/png"
+		format = "image/png",
+		source: Buffer = sourcePng
 	) {
 		const params = new URLSearchParams({
 			transform: JSON.stringify(transformOpts),
@@ -86,10 +87,22 @@ describe("Images binding local transforms", () => {
 		});
 		const res = await mf.dispatchFetch(`http://localhost/?${params}`, {
 			method: "POST",
-			body: sourcePng,
+			body: source,
 		});
 		const body = Buffer.from(await res.arrayBuffer());
 		return { res, body };
+	}
+
+	// The 200x100 white-top/red-bottom source as a JPEG tagged with EXIF
+	// orientation 6 ("rotate 90° CW to display") - the layout phone cameras
+	// use for portrait photos. A production-matching transform bakes that
+	// rotation in, producing an upright 100x200 image with red on the left
+	// (the source's bottom half) and white on the right.
+	async function exifRotatedJpeg() {
+		return sharp(sourcePng)
+			.jpeg({ quality: 95 })
+			.withMetadata({ orientation: 6 })
+			.toBuffer();
 	}
 
 	async function pixelAt(body: Buffer, x: number, y: number) {
@@ -203,5 +216,41 @@ describe("Images binding local transforms", () => {
 		});
 		const { r, g, b } = await pixelAt(body, 0, 0);
 		expect([r, g, b]).toEqual([255, 255, 255]);
+	});
+
+	test("EXIF orientation is applied before transforms (matches production)", async ({
+		expect,
+	}) => {
+		// Production auto-orients per EXIF before transforming; without it the
+		// 200x100 source would pass through sideways as 200x100.
+		const { body } = await transform({}, "image/png", await exifRotatedJpeg());
+		const meta = await sharp(body).metadata();
+		expect(meta.width).toBe(100);
+		expect(meta.height).toBe(200);
+
+		// After the 90° CW rotation the source's red bottom half lands on the
+		// left and the white top half on the right. JPEG encoding is lossy, so
+		// sample deep inside each half and allow small artifacts.
+		const left = await pixelAt(body, 25, 100);
+		expect(left.r).toBeGreaterThan(240);
+		expect(left.g).toBeLessThan(15);
+		expect(left.b).toBeLessThan(15);
+		const right = await pixelAt(body, 75, 100);
+		expect(right.r).toBeGreaterThan(240);
+		expect(right.g).toBeGreaterThan(240);
+		expect(right.b).toBeGreaterThan(240);
+	});
+
+	test("EXIF orientation composes with resize", async ({ expect }) => {
+		// width applies to the upright (100x200) image, not the stored
+		// sideways (200x100) pixels.
+		const { body } = await transform(
+			{ width: 50 },
+			"image/png",
+			await exifRotatedJpeg()
+		);
+		const meta = await sharp(body).metadata();
+		expect(meta.width).toBe(50);
+		expect(meta.height).toBe(100);
 	});
 });


### PR DESCRIPTION
Fixes #15029

## What this PR solves / how to test

The local (low-fidelity) Images binding polyfill decoded images as stored, without applying their EXIF orientation flag. Production auto-orients before transforming, so phone photos (stored as landscape pixels + EXIF `Orientation: 6`) rendered sideways in `wrangler dev` but upright when deployed. Downstream, this made Astro's `@astrojs/cloudflare` adapter show EXIF-rotated photos sideways in `astro dev`.

This PR decodes with sharp's `autoOrient` input option in both local fetchers:

- `imagesLocalFetcher` (`env.IMAGES.input(...).transform(...)`)
- `cfImageLocalFetcher` (`fetch(url, { cf: { image } })`), including the `format: "json"` path

`autoOrient` bakes the EXIF rotation into the pixels at decode and clears the flag; an explicit user `rotate` still composes on top. The `/info` path is intentionally unchanged (it keeps reporting the stored dimensions from metadata).

To test: run any Worker with an `images` binding and transform a JPEG that carries EXIF `Orientation: 6` (e.g. an iPhone portrait photo). Before this change the local output is sideways; after, it is upright and matches `wrangler dev --remote` / production.

Includes regression tests in `transform.spec.ts` that tag the existing fixture with EXIF orientation 6 and assert the output is upright (dimensions swapped, rotated pixel layout) and that resize applies to the upright image.

## Author has addressed the following

- Tests
  - [x] TESTED: added regression tests in `packages/miniflare/test/plugins/images/transform.spec.ts`; ran `test/plugins/images/` and `test/plugins/core/cf-image.spec.ts` locally (34 passed)
- Public documentation
  - [x] Not necessary because: this fixes a local/production fidelity bug; no documented behavior changes

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/15031" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->