### PR TITLE
[wrangler] Fix modules-watch-stub injection when bundle:false (fixes …

### DIFF
--- a/.changeset/fix-modules-watch-stub-no-bundle.md
+++ b/.changeset/fix-modules-watch-stub-no-bundle.md
@@ -4,8 +4,4 @@
 
 [wrangler] Fix `No such module "wrangler:modules-watch"` crash when running `wrangler pages dev` with `no_bundle = true`
 
-When `bundle: false` (e.g. `"no_bundle": true` in `wrangler.json`, or `--no-bundle` flag), esbuild does not resolve imports inside injected files. Previously, `modules-watch-stub.js` was always injected whenever `watch: true`, regardless of the `bundle` option. This left `import "wrangler:modules-watch"` as an unresolved import in the output, causing a runtime crash in workerd: `Uncaught Error: No such module "wrangler:modules-watch"`.
-
-The fix is to only inject `modules-watch-stub.js` when `bundle: true`. When `bundle: false`, file-system watching is already handled via chokidar, so the esbuild-internal watch stub is not needed.
-
-Fixes #14845.
+Running `wrangler dev` or `wrangler pages dev` with bundling disabled (`"no_bundle": true` in `wrangler.json`, or the `--no-bundle` flag) no longer crashes at startup with `Uncaught Error: No such module "wrangler:modules-watch"`. Live reloading on file changes continues to work as before.

--- a/.changeset/fix-modules-watch-stub-no-bundle.md
+++ b/.changeset/fix-modules-watch-stub-no-bundle.md
@@ -1,0 +1,11 @@
+---
+"wrangler": patch
+---
+
+[wrangler] Fix `No such module "wrangler:modules-watch"` crash when running `wrangler pages dev` with `no_bundle = true`
+
+When `bundle: false` (e.g. `no_bundle = true` in `wrangler.toml`, or `--no-bundle` flag), esbuild does not resolve imports inside injected files. Previously, `modules-watch-stub.js` was always injected whenever `watch: true`, regardless of the `bundle` option. This left `import "wrangler:modules-watch"` as an unresolved import in the output, causing a runtime crash in workerd: `Uncaught Error: No such module "wrangler:modules-watch"`.
+
+The fix is to only inject `modules-watch-stub.js` when `bundle: true`. When `bundle: false`, file-system watching is already handled via chokidar, so the esbuild-internal watch stub is not needed.
+
+Fixes #14845.

--- a/.changeset/fix-modules-watch-stub-no-bundle.md
+++ b/.changeset/fix-modules-watch-stub-no-bundle.md
@@ -4,7 +4,7 @@
 
 [wrangler] Fix `No such module "wrangler:modules-watch"` crash when running `wrangler pages dev` with `no_bundle = true`
 
-When `bundle: false` (e.g. `no_bundle = true` in `wrangler.toml`, or `--no-bundle` flag), esbuild does not resolve imports inside injected files. Previously, `modules-watch-stub.js` was always injected whenever `watch: true`, regardless of the `bundle` option. This left `import "wrangler:modules-watch"` as an unresolved import in the output, causing a runtime crash in workerd: `Uncaught Error: No such module "wrangler:modules-watch"`.
+When `bundle: false` (e.g. `"no_bundle": true` in `wrangler.json`, or `--no-bundle` flag), esbuild does not resolve imports inside injected files. Previously, `modules-watch-stub.js` was always injected whenever `watch: true`, regardless of the `bundle` option. This left `import "wrangler:modules-watch"` as an unresolved import in the output, causing a runtime crash in workerd: `Uncaught Error: No such module "wrangler:modules-watch"`.
 
 The fix is to only inject `modules-watch-stub.js` when `bundle: true`. When `bundle: false`, file-system watching is already handled via chokidar, so the esbuild-internal watch stub is not needed.
 

--- a/.changeset/fix-modules-watch-stub-no-bundle.md
+++ b/.changeset/fix-modules-watch-stub-no-bundle.md
@@ -2,6 +2,6 @@
 "wrangler": patch
 ---
 
-[wrangler] Fix `No such module "wrangler:modules-watch"` crash when running `wrangler pages dev` with `no_bundle = true`
+Fix `wrangler dev` commands crashing with `No such module "wrangler:modules-watch"` when `"no_bundle": true`
 
 Running `wrangler dev` or `wrangler pages dev` with bundling disabled (`"no_bundle": true` in `wrangler.json`, or the `--no-bundle` flag) no longer crashes at startup with `Uncaught Error: No such module "wrangler:modules-watch"`. Live reloading on file changes continues to work as before.

--- a/packages/wrangler/src/__tests__/api/startDevWorker/BundleController.test.ts
+++ b/packages/wrangler/src/__tests__/api/startDevWorker/BundleController.test.ts
@@ -87,7 +87,13 @@ describe("BundleController", { retry: 5, timeout: 10_000 }, () => {
 	afterEach(() => controller.teardown());
 
 	describe("happy path bundle + watch", () => {
-		test("single ts source file", async ({ expect }) => {
+		test.for([
+			{ name: "bundled", build: {} },
+			{
+				name: "unbundled with entrypoint processing",
+				build: { bundle: false, processEntrypoint: true },
+			},
+		])("single ts source file ($name)", async ({ build }, { expect }) => {
 			await seed({
 				"src/index.ts": dedent /* javascript */ `
 				export default {
@@ -101,11 +107,17 @@ describe("BundleController", { retry: 5, timeout: 10_000 }, () => {
 			const config = configDefaults({
 				entrypoint: path.resolve("src/index.ts"),
 				projectRoot: path.resolve("src"),
+				build,
 			});
 			const ev = bus.waitFor("bundleComplete");
 			controller.onConfigUpdate({ type: "configUpdate", config });
-			expect(findSourceFile((await ev).bundle.entrypointSource, "index.ts"))
-				.toMatchInlineSnapshot(`
+			const initialSource = (await ev).bundle.entrypointSource;
+			expect(initialSource).not.toContain("wrangler:modules-watch");
+			if (build.bundle === false) {
+				return;
+			}
+			expect(initialSource).toContain("hello world");
+			expect(findSourceFile(initialSource, "index.ts")).toMatchInlineSnapshot(`
 					"// index.ts
 					var index_exports = {};
 					__export(index_exports, {
@@ -131,8 +143,10 @@ describe("BundleController", { retry: 5, timeout: 10_000 }, () => {
 					} satisfies ExportedHandler
 				`,
 			});
-			expect(findSourceFile((await ev2).bundle.entrypointSource, "index.ts"))
-				.toMatchInlineSnapshot(`
+			const updatedSource = (await ev2).bundle.entrypointSource;
+			expect(updatedSource).not.toContain("wrangler:modules-watch");
+			expect(updatedSource).toContain("hello world 2");
+			expect(findSourceFile(updatedSource, "index.ts")).toMatchInlineSnapshot(`
 					"// index.ts
 					var index_exports = {};
 					__export(index_exports, {

--- a/packages/wrangler/src/deployment-bundle/bundle.ts
+++ b/packages/wrangler/src/deployment-bundle/bundle.ts
@@ -317,7 +317,7 @@ export async function bundleWorker(
 		inject.push(...(result.inject ?? []));
 	}
 
-	if (watch) {
+	if (watch && bundle) {
 		// `esbuild` doesn't support returning `watch*` options from `onStart()`
 		// plugin callbacks. Instead, we define an empty virtual module that is
 		// imported in this injected module. Importing that module registers watchers.
@@ -446,7 +446,7 @@ export async function bundleWorker(
 	// alive and preventing clean exit.
 	let ctx: esbuild.BuildContext<typeof buildOptions> | undefined;
 	try {
-		if (watch) {
+		if (watch && bundle) {
 			ctx = await esbuild.context(buildOptions);
 			await ctx.watch();
 			result = await initialBuildResultPromise;

--- a/packages/wrangler/src/deployment-bundle/bundle.ts
+++ b/packages/wrangler/src/deployment-bundle/bundle.ts
@@ -446,7 +446,7 @@ export async function bundleWorker(
 	// alive and preventing clean exit.
 	let ctx: esbuild.BuildContext<typeof buildOptions> | undefined;
 	try {
-		if (watch && bundle) {
+		if (watch) {
 			ctx = await esbuild.context(buildOptions);
 			await ctx.watch();
 			result = await initialBuildResultPromise;


### PR DESCRIPTION
Fixes #14845.

When `bundle: false` (e.g. `no_bundle = true` in `wrangler.toml`, or the `--no-bundle` flag), esbuild does not resolve imports in injected files. Previously `modules-watch-stub.js` was injected whenever `watch: true`, which left `import "wrangler:modules-watch"` unresolved in the output, causing workerd to crash at runtime:

Uncaught Error: No such module "wrangler:modules-watch"
imported from "pages-shim.js"


Reproducible with `wrangler pages dev` on a Nitro project using the `cloudflare-module` preset (generates `no_bundle = true` in wrangler.toml).

Fix: only inject the stub when `bundle: true`. When bundling is disabled, file watching is already handled by chokidar in `use-esbuild.ts`, so the esbuild-internal watch stub is not needed.

Checkboxes:

Tests: "Additional testing not necessary because:" → the watch stub injection path is tested via existing bundleWorker unit tests; no bundle mode is already covered by chokidar
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/15032" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->