### PR TITLE
Revert "Version Packages (#14977)"

### DIFF
--- a/.changeset/ai-search-create-parse-type.md
+++ b/.changeset/ai-search-create-parse-type.md
@@ -1,0 +1,18 @@
+---
+"wrangler": minor
+---
+
+Add `--parse-type` flag to `wrangler ai-search create`
+
+`wrangler ai-search create` now accepts `--parse-type` to control how a website data source discovers URLs. `sitemap` (the default) reads XML sitemaps; `discover` follows links recursively.
+
+Previously the parse type could only be chosen through the interactive wizard, which was skipped whenever `--source` was supplied — so it was impossible to create a `discover` instance from a script.
+
+```sh
+wrangler ai-search create my-instance \
+  --type web-crawler \
+  --source https://example.com \
+  --parse-type discover
+```
+
+The interactive wizard now offers `Discover` alongside `Sitemap`. `--parse-type` is only valid with `--type web-crawler`; passing it with `--type builtin` or `--type r2` is rejected, since the API stores the value for those source types but never reads it. When the flag is omitted in non-interactive mode the field is left unset and the API default (`sitemap`) applies.

--- a/.changeset/c3-frameworks-update-14974.md
+++ b/.changeset/c3-frameworks-update-14974.md
@@ -1,0 +1,11 @@
+---
+"create-cloudflare": patch
+---
+
+Update dependencies of "create-cloudflare"
+
+The following dependency versions have been updated:
+
+| Dependency | From   | To     |
+| ---------- | ------ | ------ |
+| sv         | 0.16.6 | 0.17.0 |

--- a/.changeset/c3-frameworks-update-14975.md
+++ b/.changeset/c3-frameworks-update-14975.md
@@ -1,0 +1,11 @@
+---
+"create-cloudflare": patch
+---
+
+Update dependencies of "create-cloudflare"
+
+The following dependency versions have been updated:
+
+| Dependency      | From   | To     |
+| --------------- | ------ | ------ |
+| @angular/create | 22.0.9 | 22.1.2 |

--- a/.changeset/c3-frameworks-update-14976.md
+++ b/.changeset/c3-frameworks-update-14976.md
@@ -1,0 +1,11 @@
+---
+"create-cloudflare": patch
+---
+
+Update dependencies of "create-cloudflare"
+
+The following dependency versions have been updated:
+
+| Dependency  | From  | To    |
+| ----------- | ----- | ----- |
+| create-vite | 9.1.1 | 9.1.2 |

--- a/.changeset/container-name-named-env.md
+++ b/.changeset/container-name-named-env.md
@@ -1,0 +1,20 @@
+---
+"@cloudflare/workers-utils": patch
+---
+
+Use the inherited Worker name when generating container names in named environments
+
+When `containers` is declared inside a named environment and the container has no explicit `name`, the default container name was built from the environment's own `name` field. `name` is inheritable, so an environment that doesn't redeclare it left that value `undefined`, producing the error `Must have either a top level "name" and "containers.class_name" field defined, or have field "containers.name" defined.` even though a top level `name` was set — and, if the error was ignored, a container named `undefined-<class_name>-<env>`.
+
+```jsonc
+{
+	"name": "my-worker",
+	"env": {
+		"staging": {
+			"containers": [{ "class_name": "MyContainer", "image": "./Dockerfile" }],
+		},
+	},
+}
+```
+
+`wrangler deploy --env staging` on the configuration above now generates `my-worker-mycontainer-staging`, matching the documented `worker_name-class_name[-env_name]` default. A `name` declared on the environment still takes precedence over the top level one.

--- a/.changeset/dependabot-update-14984.md
+++ b/.changeset/dependabot-update-14984.md
@@ -1,0 +1,13 @@
+---
+"miniflare": patch
+"wrangler": patch
+---
+
+Update dependencies of "miniflare", "wrangler"
+
+The following dependency versions have been updated:
+
+| Dependency                | From          | To            |
+| ------------------------- | ------------- | ------------- |
+| @cloudflare/workers-types | ^5.20260730.1 | ^5.20260731.1 |
+| workerd                   | 1.20260730.1  | 1.20260731.1  |

--- a/.changeset/local-explorer-observability-ui-fixes.md
+++ b/.changeset/local-explorer-observability-ui-fixes.md
@@ -1,0 +1,8 @@
+---
+"@cloudflare/vite-plugin": minor
+"wrangler": minor
+---
+
+Improve the Local Explorer's Observability views
+
+`console.log` messages now render the way the console would (JSON-encoded strings are unwrapped and multi-argument logs are joined), traces and events can be looked up by trace or span id from the search bar, and an event's "View trace" button jumps to the exact invocation that emitted it — even when a trace_id spans several invocations (e.g. a subrequest or self fetch).

--- a/.changeset/ratelimit-period-scoped-counters.md
+++ b/.changeset/ratelimit-period-scoped-counters.md
@@ -1,0 +1,26 @@
+---
+"miniflare": patch
+---
+
+Fix local rate limiting being disabled entirely when bindings share a `namespace_id` but use different periods
+
+The emulated Ratelimit binding tracked one counter per key per namespace, ignoring the period. Two bindings pointing at the same `namespace_id` with different `simple.period` values therefore overwrote each other's counter on every call — each one seeing a window it did not recognise, and so resetting the count to zero — with the result that neither binding ever limited anything:
+
+```jsonc
+{
+	"ratelimits": [
+		{
+			"name": "BURST",
+			"namespace_id": "1001",
+			"simple": { "limit": 20, "period": 10 },
+		},
+		{
+			"name": "SUSTAINED",
+			"namespace_id": "1001",
+			"simple": { "limit": 50, "period": 60 },
+		},
+	],
+}
+```
+
+Counters are now tracked per period, matching production, where a counter is identified by a bucket index and bucket start timestamp that are both derived from the period. Bindings that share a `namespace_id` and a period still share a counter for a given key.

--- a/.changeset/ratelimit-survive-eviction.md
+++ b/.changeset/ratelimit-survive-eviction.md
@@ -1,0 +1,9 @@
+---
+"miniflare": patch
+---
+
+Fix local rate limit counters silently resetting after ~10s of inactivity
+
+The emulated Ratelimit binding kept its counters on the JS heap of an internal Durable Object. `workerd` evicts idle Durable Objects after around 10 seconds, taking the counters with them, so in `wrangler dev` you could hit your Worker, pause to look at something, and find your limit had silently reset part way through the window.
+
+Counters now live in the Durable Object's storage, which survives eviction. They are still cleared by `deleteAllDurableObjects()`, so `reset()` from `@cloudflare/vitest-pool-workers` continues to reset rate limit state between tests, exactly as it does for KV, R2 and D1. Counters are now also written to the persistence directory, so they survive a `wrangler dev` restart within the same window.

--- a/.changeset/vite-plugin-agent-explorer-hint.md
+++ b/.changeset/vite-plugin-agent-explorer-hint.md
@@ -1,0 +1,7 @@
+---
+"@cloudflare/vite-plugin": minor
+---
+
+Surface Local Explorer API to headless agents
+
+When a Vite dev or preview server with the Cloudflare plugin is started in a headless AI agent environment, the plugin now prints the Local Explorer API URL and useful resource routes to stdout so agents can discover and call them programmatically.

--- a/.changeset/wild-pugs-surface-crashes.md
+++ b/.changeset/wild-pugs-surface-crashes.md
@@ -1,0 +1,9 @@
+---
+"miniflare": patch
+---
+
+Surface the full runtime crash report when workerd crashes, and warn when it is restarted
+
+When workerd crashed, the banner (e.g. `*** std::terminate() called with no exception`) was reported without its stack trace, because the stack trace was being filtered out along with the ordinary hex-stack noise workerd emits. The crash was therefore impossible to diagnose. The `stack:` line and the missing-`$LLVM_SYMBOLIZER` notice that follow a fatal crash banner are now kept, and the whole report is logged at `error` level.
+
+Miniflare also recovers from workerd crashes by restarting the runtime, but did so silently, which made a crash look like an unexplained dev server restart. It now warns, including a count so that a repeatedly-crashing runtime is distinguishable from a one-off.

--- a/.changeset/wrangler-login-device-flow.md
+++ b/.changeset/wrangler-login-device-flow.md
@@ -1,0 +1,18 @@
+---
+"@cloudflare/workers-auth": minor
+"wrangler": minor
+---
+
+Add support for OAuth 2.0 Device Authorization Grant to `wrangler login`
+
+Run `wrangler login --device` to authenticate without a local callback server. Useful in containers, remote SSH sessions, Codespaces, and any other environment where `localhost:8976` is unreachable from your browser.
+
+The new flow:
+
+- prints the verification URL and user code to the terminal,
+- attempts to open the verification URL in your default browser automatically (suppressed via `--browser=false`),
+- and polls the token endpoint until you approve the request (with a 5-minute hard cap).
+
+The verification URL is supplied by the authorization server, so it is rejected unless it is an `https` URL on the same auth domain the device code was requested from — it is never printed or opened otherwise.
+
+`--callback-host` and `--callback-port` cannot be combined with `--device`, since this flow does not start a local callback server.

--- a/packages/autoconfig/CHANGELOG.md
+++ b/packages/autoconfig/CHANGELOG.md
@@ -1,13 +1,5 @@
 # @cloudflare/autoconfig
 
-## 0.2.4
-
-### Patch Changes
-
-- Updated dependencies [[`b5c083b`](https://github.com/cloudflare/workers-sdk/commit/b5c083bf601d71bad82ccc044df55ba4584085e2)]:
-  - @cloudflare/workers-utils@0.31.1
-  - @cloudflare/cli-shared-helpers@0.1.20
-
 ## 0.2.3
 
 ### Patch Changes

--- a/packages/autoconfig/package.json
+++ b/packages/autoconfig/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@cloudflare/autoconfig",
-	"version": "0.2.4",
+	"version": "0.2.3",
 	"description": "Framework autoconfig detection and configuration for Cloudflare Workers",
 	"license": "MIT OR Apache-2.0",
 	"repository": {

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,12 +1,5 @@
 # @cloudflare/cli
 
-## 0.1.20
-
-### Patch Changes
-
-- Updated dependencies [[`b5c083b`](https://github.com/cloudflare/workers-sdk/commit/b5c083bf601d71bad82ccc044df55ba4584085e2)]:
-  - @cloudflare/workers-utils@0.31.1
-
 ## 0.1.19
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@cloudflare/cli-shared-helpers",
-	"version": "0.1.20",
+	"version": "0.1.19",
 	"description": "Internal shared CLI helpers for workers-sdk. Not intended for external use — APIs may change without notice.",
 	"keywords": [
 		"cli",

--- a/packages/create-cloudflare/CHANGELOG.md
+++ b/packages/create-cloudflare/CHANGELOG.md
@@ -1,33 +1,5 @@
 # create-cloudflare
 
-## 2.70.17
-
-### Patch Changes
-
-- [#14974](https://github.com/cloudflare/workers-sdk/pull/14974) [`3dc2ea3`](https://github.com/cloudflare/workers-sdk/commit/3dc2ea3add206d19c9c81db45c82efc76f80f323) Thanks [@dependabot](https://github.com/apps/dependabot)! - Update dependencies of "create-cloudflare"
-
-  The following dependency versions have been updated:
-
-  | Dependency | From   | To     |
-  | ---------- | ------ | ------ |
-  | sv         | 0.16.6 | 0.17.0 |
-
-- [#14975](https://github.com/cloudflare/workers-sdk/pull/14975) [`1f6844a`](https://github.com/cloudflare/workers-sdk/commit/1f6844a9dcda808d96721c60caf34385048ee59c) Thanks [@dependabot](https://github.com/apps/dependabot)! - Update dependencies of "create-cloudflare"
-
-  The following dependency versions have been updated:
-
-  | Dependency      | From   | To     |
-  | --------------- | ------ | ------ |
-  | @angular/create | 22.0.9 | 22.1.2 |
-
-- [#14976](https://github.com/cloudflare/workers-sdk/pull/14976) [`1e1cfc0`](https://github.com/cloudflare/workers-sdk/commit/1e1cfc08ff7d99501da4469839a99796a9b46c93) Thanks [@dependabot](https://github.com/apps/dependabot)! - Update dependencies of "create-cloudflare"
-
-  The following dependency versions have been updated:
-
-  | Dependency  | From  | To    |
-  | ----------- | ----- | ----- |
-  | create-vite | 9.1.1 | 9.1.2 |
-
 ## 2.70.16
 
 ### Patch Changes

--- a/packages/create-cloudflare/package.json
+++ b/packages/create-cloudflare/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "create-cloudflare",
-	"version": "2.70.17",
+	"version": "2.70.16",
 	"description": "A CLI for creating and deploying new applications to Cloudflare.",
 	"keywords": [
 		"cloudflare",

--- a/packages/deploy-helpers/CHANGELOG.md
+++ b/packages/deploy-helpers/CHANGELOG.md
@@ -1,14 +1,5 @@
 # @cloudflare/deploy-helpers
 
-## 0.6.5
-
-### Patch Changes
-
-- Updated dependencies [[`b5c083b`](https://github.com/cloudflare/workers-sdk/commit/b5c083bf601d71bad82ccc044df55ba4584085e2), [`9c74538`](https://github.com/cloudflare/workers-sdk/commit/9c7453837e3293787c0cb1778520f630aea7e5ca), [`a88d169`](https://github.com/cloudflare/workers-sdk/commit/a88d1691d57bf44616ad15556a51b7f8ca17375c), [`a88d169`](https://github.com/cloudflare/workers-sdk/commit/a88d1691d57bf44616ad15556a51b7f8ca17375c), [`daf65f2`](https://github.com/cloudflare/workers-sdk/commit/daf65f28cecf35e251dc6e476d5bbd82972d68de)]:
-  - @cloudflare/workers-utils@0.31.1
-  - miniflare@5.20260731.0-alpha
-  - @cloudflare/cli-shared-helpers@0.1.20
-
 ## 0.6.4
 
 ### Patch Changes

--- a/packages/deploy-helpers/package.json
+++ b/packages/deploy-helpers/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@cloudflare/deploy-helpers",
-	"version": "0.6.5",
+	"version": "0.6.4",
 	"description": "Internal deploy helpers for workers-sdk. Not intended for external use — APIs may change without notice.",
 	"homepage": "https://github.com/cloudflare/workers-sdk/tree/main/packages/deploy-helpers#readme",
 	"bugs": {

--- a/packages/miniflare/CHANGELOG.md
+++ b/packages/miniflare/CHANGELOG.md
@@ -1,53 +1,5 @@
 # miniflare
 
-## 5.20260731.0-alpha
-
-### Patch Changes
-
-- [#14984](https://github.com/cloudflare/workers-sdk/pull/14984) [`9c74538`](https://github.com/cloudflare/workers-sdk/commit/9c7453837e3293787c0cb1778520f630aea7e5ca) Thanks [@dependabot](https://github.com/apps/dependabot)! - Update dependencies of "miniflare", "wrangler"
-
-  The following dependency versions have been updated:
-
-  | Dependency                | From          | To            |
-  | ------------------------- | ------------- | ------------- |
-  | @cloudflare/workers-types | ^5.20260730.1 | ^5.20260731.1 |
-  | workerd                   | 1.20260730.1  | 1.20260731.1  |
-
-- [#14968](https://github.com/cloudflare/workers-sdk/pull/14968) [`a88d169`](https://github.com/cloudflare/workers-sdk/commit/a88d1691d57bf44616ad15556a51b7f8ca17375c) Thanks [@petebacondarwin](https://github.com/petebacondarwin)! - Fix local rate limiting being disabled entirely when bindings share a `namespace_id` but use different periods
-
-  The emulated Ratelimit binding tracked one counter per key per namespace, ignoring the period. Two bindings pointing at the same `namespace_id` with different `simple.period` values therefore overwrote each other's counter on every call — each one seeing a window it did not recognise, and so resetting the count to zero — with the result that neither binding ever limited anything:
-
-  ```jsonc
-  {
-    "ratelimits": [
-      {
-        "name": "BURST",
-        "namespace_id": "1001",
-        "simple": { "limit": 20, "period": 10 }
-      },
-      {
-        "name": "SUSTAINED",
-        "namespace_id": "1001",
-        "simple": { "limit": 50, "period": 60 }
-      }
-    ]
-  }
-  ```
-
-  Counters are now tracked per period, matching production, where a counter is identified by a bucket index and bucket start timestamp that are both derived from the period. Bindings that share a `namespace_id` and a period still share a counter for a given key.
-
-- [#14968](https://github.com/cloudflare/workers-sdk/pull/14968) [`a88d169`](https://github.com/cloudflare/workers-sdk/commit/a88d1691d57bf44616ad15556a51b7f8ca17375c) Thanks [@petebacondarwin](https://github.com/petebacondarwin)! - Fix local rate limit counters silently resetting after ~10s of inactivity
-
-  The emulated Ratelimit binding kept its counters on the JS heap of an internal Durable Object. `workerd` evicts idle Durable Objects after around 10 seconds, taking the counters with them, so in `wrangler dev` you could hit your Worker, pause to look at something, and find your limit had silently reset part way through the window.
-
-  Counters now live in the Durable Object's storage, which survives eviction. They are still cleared by `deleteAllDurableObjects()`, so `reset()` from `@cloudflare/vitest-pool-workers` continues to reset rate limit state between tests, exactly as it does for KV, R2 and D1. Counters are now also written to the persistence directory, so they survive a `wrangler dev` restart within the same window.
-
-- [#14989](https://github.com/cloudflare/workers-sdk/pull/14989) [`daf65f2`](https://github.com/cloudflare/workers-sdk/commit/daf65f28cecf35e251dc6e476d5bbd82972d68de) Thanks [@petebacondarwin](https://github.com/petebacondarwin)! - Surface the full runtime crash report when workerd crashes, and warn when it is restarted
-
-  When workerd crashed, the banner (e.g. `*** std::terminate() called with no exception`) was reported without its stack trace, because the stack trace was being filtered out along with the ordinary hex-stack noise workerd emits. The crash was therefore impossible to diagnose. The `stack:` line and the missing-`$LLVM_SYMBOLIZER` notice that follow a fatal crash banner are now kept, and the whole report is logged at `error` level.
-
-  Miniflare also recovers from workerd crashes by restarting the runtime, but did so silently, which made a crash look like an unexplained dev server restart. It now warns, including a count so that a repeatedly-crashing runtime is distinguishable from a one-off.
-
 ## 5.20260730.0-alpha
 
 ### Major Changes

--- a/packages/miniflare/package.json
+++ b/packages/miniflare/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "miniflare",
-	"version": "5.20260731.0-alpha",
+	"version": "5.20260730.0-alpha",
 	"description": "Fun, full-featured, fully-local simulator for Cloudflare Workers",
 	"keywords": [
 		"cloudflare",

--- a/packages/pages-shared/CHANGELOG.md
+++ b/packages/pages-shared/CHANGELOG.md
@@ -1,12 +1,5 @@
 # @cloudflare/pages-shared
 
-## 0.13.164
-
-### Patch Changes
-
-- Updated dependencies [[`9c74538`](https://github.com/cloudflare/workers-sdk/commit/9c7453837e3293787c0cb1778520f630aea7e5ca), [`a88d169`](https://github.com/cloudflare/workers-sdk/commit/a88d1691d57bf44616ad15556a51b7f8ca17375c), [`a88d169`](https://github.com/cloudflare/workers-sdk/commit/a88d1691d57bf44616ad15556a51b7f8ca17375c), [`daf65f2`](https://github.com/cloudflare/workers-sdk/commit/daf65f28cecf35e251dc6e476d5bbd82972d68de)]:
-  - miniflare@5.20260731.0-alpha
-
 ## 0.13.163
 
 ### Patch Changes

--- a/packages/pages-shared/package.json
+++ b/packages/pages-shared/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@cloudflare/pages-shared",
-	"version": "0.13.164",
+	"version": "0.13.163",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/cloudflare/workers-sdk.git",

--- a/packages/remote-bindings/CHANGELOG.md
+++ b/packages/remote-bindings/CHANGELOG.md
@@ -1,16 +1,5 @@
 # @cloudflare/remote-bindings
 
-## 0.0.7
-
-### Patch Changes
-
-- Updated dependencies [[`b5c083b`](https://github.com/cloudflare/workers-sdk/commit/b5c083bf601d71bad82ccc044df55ba4584085e2), [`9c74538`](https://github.com/cloudflare/workers-sdk/commit/9c7453837e3293787c0cb1778520f630aea7e5ca), [`a88d169`](https://github.com/cloudflare/workers-sdk/commit/a88d1691d57bf44616ad15556a51b7f8ca17375c), [`a88d169`](https://github.com/cloudflare/workers-sdk/commit/a88d1691d57bf44616ad15556a51b7f8ca17375c), [`daf65f2`](https://github.com/cloudflare/workers-sdk/commit/daf65f28cecf35e251dc6e476d5bbd82972d68de), [`a9e5abb`](https://github.com/cloudflare/workers-sdk/commit/a9e5abb8c0c2e7895b0bb09c6c8e8ffd3dbc3bc0)]:
-  - @cloudflare/workers-utils@0.31.1
-  - miniflare@5.20260731.0-alpha
-  - @cloudflare/workers-auth@0.6.0
-  - @cloudflare/cli-shared-helpers@0.1.20
-  - @cloudflare/deploy-helpers@0.6.5
-
 ## 0.0.6
 
 ### Patch Changes

--- a/packages/remote-bindings/package.json
+++ b/packages/remote-bindings/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@cloudflare/remote-bindings",
-	"version": "0.0.7",
+	"version": "0.0.6",
 	"private": true,
 	"homepage": "https://github.com/cloudflare/workers-sdk/tree/main/packages/remote-bindings#readme",
 	"bugs": {

--- a/packages/runtime-types/CHANGELOG.md
+++ b/packages/runtime-types/CHANGELOG.md
@@ -1,12 +1,5 @@
 # @cloudflare/runtime-types
 
-## 0.0.9
-
-### Patch Changes
-
-- Updated dependencies [[`9c74538`](https://github.com/cloudflare/workers-sdk/commit/9c7453837e3293787c0cb1778520f630aea7e5ca), [`a88d169`](https://github.com/cloudflare/workers-sdk/commit/a88d1691d57bf44616ad15556a51b7f8ca17375c), [`a88d169`](https://github.com/cloudflare/workers-sdk/commit/a88d1691d57bf44616ad15556a51b7f8ca17375c), [`daf65f2`](https://github.com/cloudflare/workers-sdk/commit/daf65f28cecf35e251dc6e476d5bbd82972d68de)]:
-  - miniflare@5.20260731.0-alpha
-
 ## 0.0.8
 
 ### Patch Changes

--- a/packages/runtime-types/package.json
+++ b/packages/runtime-types/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@cloudflare/runtime-types",
-	"version": "0.0.9",
+	"version": "0.0.8",
 	"private": true,
 	"homepage": "https://github.com/cloudflare/workers-sdk/tree/main/packages/runtime-types#readme",
 	"bugs": {

--- a/packages/vite-plugin-cloudflare/CHANGELOG.md
+++ b/packages/vite-plugin-cloudflare/CHANGELOG.md
@@ -1,23 +1,5 @@
 # @cloudflare/vite-plugin
 
-## 1.51.0
-
-### Minor Changes
-
-- [#14941](https://github.com/cloudflare/workers-sdk/pull/14941) [`266172b`](https://github.com/cloudflare/workers-sdk/commit/266172b98c27770e6d48d3fd42790e2125115e5e) Thanks [@nickpatt](https://github.com/nickpatt)! - Improve the Local Explorer's Observability views
-
-  `console.log` messages now render the way the console would (JSON-encoded strings are unwrapped and multi-argument logs are joined), traces and events can be looked up by trace or span id from the search bar, and an event's "View trace" button jumps to the exact invocation that emitted it — even when a trace_id spans several invocations (e.g. a subrequest or self fetch).
-
-- [#14996](https://github.com/cloudflare/workers-sdk/pull/14996) [`ebd1dfd`](https://github.com/cloudflare/workers-sdk/commit/ebd1dfd3778dd3fdb9a63a5596852287eb4029b1) Thanks [@nickpatt](https://github.com/nickpatt)! - Surface Local Explorer API to headless agents
-
-  When a Vite dev or preview server with the Cloudflare plugin is started in a headless AI agent environment, the plugin now prints the Local Explorer API URL and useful resource routes to stdout so agents can discover and call them programmatically.
-
-### Patch Changes
-
-- Updated dependencies [[`20470fa`](https://github.com/cloudflare/workers-sdk/commit/20470fa8b09761c50b5c2c1d6a5f2652b61bd271), [`9c74538`](https://github.com/cloudflare/workers-sdk/commit/9c7453837e3293787c0cb1778520f630aea7e5ca), [`266172b`](https://github.com/cloudflare/workers-sdk/commit/266172b98c27770e6d48d3fd42790e2125115e5e), [`a88d169`](https://github.com/cloudflare/workers-sdk/commit/a88d1691d57bf44616ad15556a51b7f8ca17375c), [`a88d169`](https://github.com/cloudflare/workers-sdk/commit/a88d1691d57bf44616ad15556a51b7f8ca17375c), [`daf65f2`](https://github.com/cloudflare/workers-sdk/commit/daf65f28cecf35e251dc6e476d5bbd82972d68de), [`a9e5abb`](https://github.com/cloudflare/workers-sdk/commit/a9e5abb8c0c2e7895b0bb09c6c8e8ffd3dbc3bc0)]:
-  - wrangler@4.119.0
-  - miniflare@5.20260731.0-alpha
-
 ## 1.50.0
 
 ### Minor Changes

--- a/packages/vite-plugin-cloudflare/package.json
+++ b/packages/vite-plugin-cloudflare/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@cloudflare/vite-plugin",
-	"version": "1.51.0",
+	"version": "1.50.0",
 	"description": "Cloudflare plugin for Vite",
 	"keywords": [
 		"cloudflare",

--- a/packages/vitest-pool-workers/CHANGELOG.md
+++ b/packages/vitest-pool-workers/CHANGELOG.md
@@ -1,13 +1,5 @@
 # @cloudflare/vitest-pool-workers
 
-## 0.20.2
-
-### Patch Changes
-
-- Updated dependencies [[`20470fa`](https://github.com/cloudflare/workers-sdk/commit/20470fa8b09761c50b5c2c1d6a5f2652b61bd271), [`9c74538`](https://github.com/cloudflare/workers-sdk/commit/9c7453837e3293787c0cb1778520f630aea7e5ca), [`266172b`](https://github.com/cloudflare/workers-sdk/commit/266172b98c27770e6d48d3fd42790e2125115e5e), [`a88d169`](https://github.com/cloudflare/workers-sdk/commit/a88d1691d57bf44616ad15556a51b7f8ca17375c), [`a88d169`](https://github.com/cloudflare/workers-sdk/commit/a88d1691d57bf44616ad15556a51b7f8ca17375c), [`daf65f2`](https://github.com/cloudflare/workers-sdk/commit/daf65f28cecf35e251dc6e476d5bbd82972d68de), [`a9e5abb`](https://github.com/cloudflare/workers-sdk/commit/a9e5abb8c0c2e7895b0bb09c6c8e8ffd3dbc3bc0)]:
-  - wrangler@4.119.0
-  - miniflare@5.20260731.0-alpha
-
 ## 0.20.1
 
 ### Patch Changes

--- a/packages/vitest-pool-workers/package.json
+++ b/packages/vitest-pool-workers/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@cloudflare/vitest-pool-workers",
-	"version": "0.20.2",
+	"version": "0.20.1",
 	"description": "Workers Vitest integration for writing Vitest unit and integration tests that run inside the Workers runtime",
 	"keywords": [
 		"cloudflare",

--- a/packages/workers-auth/CHANGELOG.md
+++ b/packages/workers-auth/CHANGELOG.md
@@ -1,28 +1,5 @@
 # @cloudflare/workers-auth
 
-## 0.6.0
-
-### Minor Changes
-
-- [#14064](https://github.com/cloudflare/workers-sdk/pull/14064) [`a9e5abb`](https://github.com/cloudflare/workers-sdk/commit/a9e5abb8c0c2e7895b0bb09c6c8e8ffd3dbc3bc0) Thanks [@petebacondarwin](https://github.com/petebacondarwin)! - Add support for OAuth 2.0 Device Authorization Grant to `wrangler login`
-
-  Run `wrangler login --device` to authenticate without a local callback server. Useful in containers, remote SSH sessions, Codespaces, and any other environment where `localhost:8976` is unreachable from your browser.
-
-  The new flow:
-
-  - prints the verification URL and user code to the terminal,
-  - attempts to open the verification URL in your default browser automatically (suppressed via `--browser=false`),
-  - and polls the token endpoint until you approve the request (with a 5-minute hard cap).
-
-  The verification URL is supplied by the authorization server, so it is rejected unless it is an `https` URL on the same auth domain the device code was requested from — it is never printed or opened otherwise.
-
-  `--callback-host` and `--callback-port` cannot be combined with `--device`, since this flow does not start a local callback server.
-
-### Patch Changes
-
-- Updated dependencies [[`b5c083b`](https://github.com/cloudflare/workers-sdk/commit/b5c083bf601d71bad82ccc044df55ba4584085e2)]:
-  - @cloudflare/workers-utils@0.31.1
-
 ## 0.5.6
 
 ### Patch Changes

--- a/packages/workers-auth/package.json
+++ b/packages/workers-auth/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@cloudflare/workers-auth",
-	"version": "0.6.0",
+	"version": "0.5.6",
 	"description": "Internal OAuth 2.0 + PKCE flow for Cloudflare CLIs. Not intended for external use — APIs may change without notice.",
 	"homepage": "https://github.com/cloudflare/workers-sdk/tree/main/packages/workers-auth#readme",
 	"bugs": {

--- a/packages/workers-utils/CHANGELOG.md
+++ b/packages/workers-utils/CHANGELOG.md
@@ -1,26 +1,5 @@
 # @cloudflare/workers-utils
 
-## 0.31.1
-
-### Patch Changes
-
-- [#15009](https://github.com/cloudflare/workers-sdk/pull/15009) [`b5c083b`](https://github.com/cloudflare/workers-sdk/commit/b5c083bf601d71bad82ccc044df55ba4584085e2) Thanks [@LeSingh1](https://github.com/LeSingh1)! - Use the inherited Worker name when generating container names in named environments
-
-  When `containers` is declared inside a named environment and the container has no explicit `name`, the default container name was built from the environment's own `name` field. `name` is inheritable, so an environment that doesn't redeclare it left that value `undefined`, producing the error `Must have either a top level "name" and "containers.class_name" field defined, or have field "containers.name" defined.` even though a top level `name` was set — and, if the error was ignored, a container named `undefined-<class_name>-<env>`.
-
-  ```jsonc
-  {
-    "name": "my-worker",
-    "env": {
-      "staging": {
-        "containers": [{ "class_name": "MyContainer", "image": "./Dockerfile" }]
-      }
-    }
-  }
-  ```
-
-  `wrangler deploy --env staging` on the configuration above now generates `my-worker-mycontainer-staging`, matching the documented `worker_name-class_name[-env_name]` default. A `name` declared on the environment still takes precedence over the top level one.
-
 ## 0.31.0
 
 ### Minor Changes

--- a/packages/workers-utils/package.json
+++ b/packages/workers-utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@cloudflare/workers-utils",
-	"version": "0.31.1",
+	"version": "0.31.0",
 	"description": "Internal utility package for workers-sdk. Not intended for external use — APIs may change without notice.",
 	"homepage": "https://github.com/cloudflare/workers-sdk/tree/main/packages/workers-utils#readme",
 	"bugs": {

--- a/packages/wrangler/CHANGELOG.md
+++ b/packages/wrangler/CHANGELOG.md
@@ -1,56 +1,5 @@
 # wrangler
 
-## 4.119.0
-
-### Minor Changes
-
-- [#14952](https://github.com/cloudflare/workers-sdk/pull/14952) [`20470fa`](https://github.com/cloudflare/workers-sdk/commit/20470fa8b09761c50b5c2c1d6a5f2652b61bd271) Thanks [@nelsonjsduarte](https://github.com/nelsonjsduarte)! - Add `--parse-type` flag to `wrangler ai-search create`
-
-  `wrangler ai-search create` now accepts `--parse-type` to control how a website data source discovers URLs. `sitemap` (the default) reads XML sitemaps; `discover` follows links recursively.
-
-  Previously the parse type could only be chosen through the interactive wizard, which was skipped whenever `--source` was supplied — so it was impossible to create a `discover` instance from a script.
-
-  ```sh
-  wrangler ai-search create my-instance \
-    --type web-crawler \
-    --source https://example.com \
-    --parse-type discover
-  ```
-
-  The interactive wizard now offers `Discover` alongside `Sitemap`. `--parse-type` is only valid with `--type web-crawler`; passing it with `--type builtin` or `--type r2` is rejected, since the API stores the value for those source types but never reads it. When the flag is omitted in non-interactive mode the field is left unset and the API default (`sitemap`) applies.
-
-- [#14941](https://github.com/cloudflare/workers-sdk/pull/14941) [`266172b`](https://github.com/cloudflare/workers-sdk/commit/266172b98c27770e6d48d3fd42790e2125115e5e) Thanks [@nickpatt](https://github.com/nickpatt)! - Improve the Local Explorer's Observability views
-
-  `console.log` messages now render the way the console would (JSON-encoded strings are unwrapped and multi-argument logs are joined), traces and events can be looked up by trace or span id from the search bar, and an event's "View trace" button jumps to the exact invocation that emitted it — even when a trace_id spans several invocations (e.g. a subrequest or self fetch).
-
-- [#14064](https://github.com/cloudflare/workers-sdk/pull/14064) [`a9e5abb`](https://github.com/cloudflare/workers-sdk/commit/a9e5abb8c0c2e7895b0bb09c6c8e8ffd3dbc3bc0) Thanks [@petebacondarwin](https://github.com/petebacondarwin)! - Add support for OAuth 2.0 Device Authorization Grant to `wrangler login`
-
-  Run `wrangler login --device` to authenticate without a local callback server. Useful in containers, remote SSH sessions, Codespaces, and any other environment where `localhost:8976` is unreachable from your browser.
-
-  The new flow:
-
-  - prints the verification URL and user code to the terminal,
-  - attempts to open the verification URL in your default browser automatically (suppressed via `--browser=false`),
-  - and polls the token endpoint until you approve the request (with a 5-minute hard cap).
-
-  The verification URL is supplied by the authorization server, so it is rejected unless it is an `https` URL on the same auth domain the device code was requested from — it is never printed or opened otherwise.
-
-  `--callback-host` and `--callback-port` cannot be combined with `--device`, since this flow does not start a local callback server.
-
-### Patch Changes
-
-- [#14984](https://github.com/cloudflare/workers-sdk/pull/14984) [`9c74538`](https://github.com/cloudflare/workers-sdk/commit/9c7453837e3293787c0cb1778520f630aea7e5ca) Thanks [@dependabot](https://github.com/apps/dependabot)! - Update dependencies of "miniflare", "wrangler"
-
-  The following dependency versions have been updated:
-
-  | Dependency                | From          | To            |
-  | ------------------------- | ------------- | ------------- |
-  | @cloudflare/workers-types | ^5.20260730.1 | ^5.20260731.1 |
-  | workerd                   | 1.20260730.1  | 1.20260731.1  |
-
-- Updated dependencies [[`9c74538`](https://github.com/cloudflare/workers-sdk/commit/9c7453837e3293787c0cb1778520f630aea7e5ca), [`a88d169`](https://github.com/cloudflare/workers-sdk/commit/a88d1691d57bf44616ad15556a51b7f8ca17375c), [`a88d169`](https://github.com/cloudflare/workers-sdk/commit/a88d1691d57bf44616ad15556a51b7f8ca17375c), [`daf65f2`](https://github.com/cloudflare/workers-sdk/commit/daf65f28cecf35e251dc6e476d5bbd82972d68de)]:
-  - miniflare@5.20260731.0-alpha
-
 ## 4.118.0
 
 ### Minor Changes

--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "wrangler",
-	"version": "4.119.0",
+	"version": "4.118.0",
 	"description": "Command-line interface for all things Cloudflare Workers",
 	"keywords": [
 		"assembly",


### PR DESCRIPTION
This reverts commit 42c4227798c21cfde8dbfb087be1bb9078dab185.

The reason for this is that the release workflow of https://github.com/cloudflare/workers-sdk/pull/14977 didn't actually release the packages so we need to revert it and try to cut the release again

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: release reverse
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: release reverse

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- If you are an AI agent or LLM, and you are adding this PR without direct human supervision, thank you! Please uncomment the following block. This is so the maintainers know how to expect you to respond.

> [!NOTE]
> This is a contribution from an AI agent: <insert name here>, <insert LLM model here if different>.

-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/15033" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->