### PR TITLE
[workers-utils] Report a null observability.logs/traces as a config error

### DIFF
--- a/.changeset/observability-nested-null-validation.md
+++ b/.changeset/observability-nested-null-validation.md
@@ -1,0 +1,9 @@
+---
+"@cloudflare/workers-utils": patch
+---
+
+Report a null `observability.logs`/`observability.traces` as a config error instead of crashing
+
+`{ "observability": { "enabled": true, "logs": null } }` crashed with `TypeError: Cannot read properties of null (reading 'enabled')` instead of producing a validation error. Because `typeof null === "object"`, null passed the type check for these nested objects and then the per-property checks dereferenced it.
+
+Null is now rejected with a normal config error, matching how a null top-level `observability` is already handled.

--- a/.changeset/observability-nested-null-validation.md
+++ b/.changeset/observability-nested-null-validation.md
@@ -4,6 +4,6 @@
 
 Report a null `observability.logs`/`observability.traces` as a config error instead of crashing
 
-`{ "observability": { "enabled": true, "logs": null } }` crashed with `TypeError: Cannot read properties of null (reading 'enabled')` instead of producing a validation error. Because `typeof null === "object"`, null passed the type check for these nested objects and then the per-property checks dereferenced it.
+Setting `observability.logs` or `observability.traces` to `null` in your Wrangler configuration previously crashed with an unhandled error instead of reporting a configuration problem.
 
 Null is now rejected with a normal config error, matching how a null top-level `observability` is already handled.

--- a/packages/workers-utils/src/config/validation.ts
+++ b/packages/workers-utils/src/config/validation.ts
@@ -6416,7 +6416,14 @@ const validateObservability: ValidatorFn = (diagnostics, field, value) => {
 	/**
 	 * Validate the optional nested logs configuration
 	 */
-	if (typeof val.logs === "object") {
+	if (val.logs === null) {
+		// `typeof null === "object"`, so the check above accepts null; reject it
+		// here rather than crashing on the nested property checks below.
+		diagnostics.errors.push(
+			`Expected "${field}.logs" to be of type object but got null.`
+		);
+		isValid = false;
+	} else if (typeof val.logs === "object") {
 		isValid =
 			validateOptionalProperty(
 				diagnostics,
@@ -6474,7 +6481,14 @@ const validateObservability: ValidatorFn = (diagnostics, field, value) => {
 	/**
 	 * Validate the optional nested traces configuration
 	 */
-	if (typeof val.traces === "object") {
+	if (val.traces === null) {
+		// `typeof null === "object"`, so the check above accepts null; reject it
+		// here rather than crashing on the nested property checks below.
+		diagnostics.errors.push(
+			`Expected "${field}.traces" to be of type object but got null.`
+		);
+		isValid = false;
+	} else if (typeof val.traces === "object") {
 		isValid =
 			validateOptionalProperty(
 				diagnostics,

--- a/packages/workers-utils/tests/config/validation/normalize-and-validate-config.test.ts
+++ b/packages/workers-utils/tests/config/validation/normalize-and-validate-config.test.ts
@@ -10226,6 +10226,42 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
+			it("should error if observability.logs is null", ({ expect }) => {
+				const { diagnostics } = normalizeAndValidateConfig(
+					{
+						observability: { enabled: true, logs: null },
+					} as unknown as RawConfig,
+					undefined,
+					undefined,
+					{ env: undefined }
+				);
+
+				expect(diagnostics.hasWarnings()).toBe(false);
+				expect(diagnostics.hasErrors()).toBe(true);
+				expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
+					"Processing wrangler configuration:
+					  - Expected "observability.logs" to be of type object but got null."
+				`);
+			});
+
+			it("should error if observability.traces is null", ({ expect }) => {
+				const { diagnostics } = normalizeAndValidateConfig(
+					{
+						observability: { enabled: true, traces: null },
+					} as unknown as RawConfig,
+					undefined,
+					undefined,
+					{ env: undefined }
+				);
+
+				expect(diagnostics.hasWarnings()).toBe(false);
+				expect(diagnostics.hasErrors()).toBe(true);
+				expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
+					"Processing wrangler configuration:
+					  - Expected "observability.traces" to be of type object but got null."
+				`);
+			});
+
 			it("should not warn on full observability config", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{


### PR DESCRIPTION
A null nested observability block crashes config validation instead of reporting a config error:

```jsonc
{ "observability": { "enabled": true, "logs": null } }
```

```
TypeError: Cannot read properties of null (reading 'enabled')
```

`typeof null === "object"`, so a null `logs`/`traces` passes the object type check and the per-property checks then dereference it. A null *top-level* `observability` is already rejected with a normal validation error, so only the nested case is affected.

This rejects null for the nested blocks the same way, so the user gets a diagnostic naming the offending key rather than a stack trace. Tests cover `logs: null` and `traces: null`; both throw the `TypeError` before the change.

---

- Tests
  - [x] Tests included/updated
- Public documentation
  - [x] Documentation not necessary because: it rejects a value that previously crashed validation; no documented config surface changes.

> [!NOTE]
> This is a contribution from an AI agent: Claude Code (Claude Opus 4.5), working on behalf of @LeSingh1. Review comments will be read and responded to.
