### PR TITLE
DO NOT MERGE: validate dev registry registration fix on Windows

### DIFF
--- a/.changeset/quiet-workers-register.md
+++ b/.changeset/quiet-workers-register.md
@@ -1,0 +1,9 @@
+---
+"miniflare": minor
+"wrangler": patch
+"@cloudflare/vite-plugin": patch
+---
+
+Add per-worker control over dev registry registration
+
+Miniflare workers can now opt in to the dev registry with `unsafeRegisterWorker`. Wrangler and the Cloudflare Vite plugin use this option to advertise user workers without exposing internal or external workers.

--- a/.github/workflows/test-and-check.yml
+++ b/.github/workflows/test-and-check.yml
@@ -82,7 +82,8 @@ jobs:
         run: node packages/wrangler/src/__tests__/test-old-node-version.js error
 
   test:
-    timeout-minutes: 30
+    # TEMPORARY VALIDATION — not for merge.
+    timeout-minutes: 60
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.os }}-${{ matrix.suite }}-test
       cancel-in-progress: ${{ github.head_ref != 'changeset-release/main' }}
@@ -187,7 +188,9 @@ jobs:
         # Since the dev registry is now file-based (not network-based), fixture tests can safely run in parallel.
         # Concurrency is capped at 2 to avoid CPU starvation on CI runners when multiple fixtures
         # spawn workerd processes simultaneously (Windows runners are especially slow under load).
-        run: pnpm run test:ci --concurrency=2 --log-order=stream --filter="./fixtures/*" ${{ matrix.os == 'ubuntu-latest' && '--filter="!./fixtures/browser-run"' || '' }}
+        # TEMPORARY VALIDATION — not for merge. Isolated so an unrelated fixture
+        # flake can't abort the job before dev-registry runs.
+        run: pnpm run test:ci --log-order=stream --filter="@fixture/dev-registry"
         env:
           NODE_OPTIONS: "--max_old_space_size=8192"
           WRANGLER_LOG_PATH: ${{ runner.temp }}/wrangler-debug-logs/

--- a/fixtures/dev-registry/tests/dev-registry.test.ts
+++ b/fixtures/dev-registry/tests/dev-registry.test.ts
@@ -18,10 +18,9 @@ import {
 } from "../../../packages/vite-plugin-cloudflare/e2e/helpers";
 import { runWranglerDev as baseRunWranglerDev } from "../../shared/src/run-wrangler-long-lived";
 
-// TODO: These tests are consistently failing on Windows in CI and are blocking
-// other work. Skipping them there as a temporary measure until the underlying
-// issue is fixed. There's still value in running them on macOS and Linux.
-const describe = baseDescribe.skipIf(process.platform === "win32");
+// TEMPORARY VALIDATION — not for merge. #15018's Windows skip is lifted so the
+// fix can be measured against the suite it is meant to help.
+const describe = baseDescribe;
 
 const waitForTimeout = 20_000;
 const cwd = resolve(__dirname, "..");
@@ -46,11 +45,20 @@ async function runViteDev(
 	});
 	const url = await waitForReady(proc);
 
-	onTestFailed(() => {
-		console.log(`::group::Vite dev session (${config})`);
+	// TEMPORARY VALIDATION — not for merge. Dump on finish rather than only on
+	// failure: dumping only failed tests biases the record, and a buffer that
+	// ends mid-recovery then looks identical to a genuine stall.
+	onTestFinished(() => {
+		console.log(
+			`::group::Vite dev session (${config}) captured-at ${new Date().toISOString()}`
+		);
 		console.log(proc.stdout);
 		console.log(proc.stderr);
 		console.log("::endgroup::");
+		const output = proc.stdout + proc.stderr;
+		if (/std::terminate|crashed unexpectedly/.test(output)) {
+			console.log(`CRASH-DETECTED ${config}`);
+		}
 	});
 
 	// Wait for the dev session to be ready
@@ -517,298 +525,302 @@ describe("Dev Registry: wrangler dev <-> wrangler dev", () => {
 	});
 });
 
-describe("Dev Registry: vite dev <-> vite dev", () => {
-	it("supports exported handler fetch over service binding", async ({
-		devRegistryPath,
-	}) => {
-		const workerEntrypointWithAssets = await runViteDev(
-			"vite.worker-entrypoint-with-assets.config.ts",
-			devRegistryPath
-		);
-		await runViteDev("vite.worker-entrypoint.config.ts", devRegistryPath);
-
-		// Test fallback before exported-handler is started
-		await vi.waitFor(async () => {
-			const searchParams = new URLSearchParams({
-				"test-service": "exported-handler",
-				"test-method": "fetch",
-			});
-			const response = await fetch(
-				`${workerEntrypointWithAssets}?${searchParams}`
+for (const validationRound of [1, 2, 3, 4]) {
+	describe(`Dev Registry: vite dev <-> vite dev [round ${validationRound}]`, () => {
+		it("supports exported handler fetch over service binding", async ({
+			devRegistryPath,
+		}) => {
+			const workerEntrypointWithAssets = await runViteDev(
+				"vite.worker-entrypoint-with-assets.config.ts",
+				devRegistryPath
 			);
+			await runViteDev("vite.worker-entrypoint.config.ts", devRegistryPath);
 
-			expect(response.status).toBe(503);
-			expect(await response.text()).toEqual(
-				`Worker "exported-handler" not found. Make sure it is running locally.`
-			);
-		}, waitForTimeout);
-
-		const exportedHandler = await runViteDev(
-			"vite.exported-handler.config.ts",
-			devRegistryPath
-		);
-
-		// Test exported-handler -> worker-entrypoint-with-assets
-		await vi.waitFor(async () => {
-			const searchParams = new URLSearchParams({
-				"test-service": "worker-entrypoint-with-assets",
-				"test-method": "fetch",
-			});
-			const response = await fetch(`${exportedHandler}?${searchParams}`);
-
-			expect(await response.text()).toBe("Hello from Worker Entrypoint!");
-			expect(response.status).toBe(200);
-
-			// Test fetching asset from "worker-entrypoint-with-assets" over service binding
-			// Exported handler has no assets, so it will hit the user worker and
-			// forward the request to "worker-entrypoint-with-assets" with the asset path
-			const assetResponse = await fetch(
-				`${exportedHandler}/example.txt?${searchParams}`
-			);
-			expect(await assetResponse.text()).toBe("This is an example asset file");
-		}, waitForTimeout);
-
-		// Test worker-entrypoint-with-assets -> exported-handler
-		await vi.waitFor(async () => {
-			const searchParams = new URLSearchParams({
-				"test-service": "exported-handler",
-				"test-method": "fetch",
-			});
-			const response = await fetch(
-				`${workerEntrypointWithAssets}?${searchParams}`
-			);
-
-			expect(await response.text()).toEqual("Hello from exported handler!");
-			expect(response.status).toBe(200);
-		}, waitForTimeout);
-
-		// Test exported-handler -> named-entrypoint
-		await vi.waitFor(async () => {
-			const searchParams = new URLSearchParams({
-				"test-service": "named-entrypoint",
-				"test-method": "fetch",
-			});
-			const response = await fetch(`${exportedHandler}?${searchParams}`);
-
-			expect(await response.text()).toEqual("Hello from Named Entrypoint!");
-			expect(response.status).toBe(200);
-		}, waitForTimeout);
-
-		// Test exported-handler -> named-entrypoint-with-assets
-		await vi.waitFor(async () => {
-			const searchParams = new URLSearchParams({
-				"test-service": "named-entrypoint-with-assets",
-				"test-method": "fetch",
-			});
-			const response = await fetch(`${exportedHandler}?${searchParams}`);
-
-			expect(await response.text()).toEqual("Hello from Named Entrypoint!");
-			expect(response.status).toBe(200);
-		}, waitForTimeout);
-	});
-
-	it("supports RPC over service binding", async ({ devRegistryPath }) => {
-		const exportedHandler = await runViteDev(
-			"vite.exported-handler.config.ts",
-			devRegistryPath
-		);
-		await runViteDev("vite.worker-entrypoint.config.ts", devRegistryPath);
-
-		// Test fallback before worker-entrypoint-with-assets is started
-		await vi.waitFor(async () => {
-			const searchParams = new URLSearchParams({
-				"test-service": "worker-entrypoint-with-assets",
-				"test-method": "rpc",
-			});
-			const response = await fetch(`${exportedHandler}?${searchParams}`);
-
-			expect(response.status).toBe(500);
-			expect(await response.text()).toEqual(
-				`Worker "worker-entrypoint-with-assets" not found. Make sure it is running locally.`
-			);
-		}, waitForTimeout);
-
-		await runViteDev(
-			"vite.worker-entrypoint-with-assets.config.ts",
-			devRegistryPath
-		);
-
-		// Test exported-handler -> worker-entrypoint RPC
-		await vi.waitFor(async () => {
-			const searchParams = new URLSearchParams({
-				"test-service": "worker-entrypoint",
-				"test-method": "rpc",
-			});
-			const response = await fetch(`${exportedHandler}?${searchParams}`);
-
-			expect(response.status).toBe(200);
-			expect(await response.text()).toEqual("Pong");
-		}, waitForTimeout);
-
-		// Test exported-handler -> worker-entrypoint-with-assets RPC
-		await vi.waitFor(async () => {
-			const searchParams = new URLSearchParams({
-				"test-service": "worker-entrypoint-with-assets",
-				"test-method": "rpc",
-			});
-			const response = await fetch(`${exportedHandler}?${searchParams}`);
-
-			expect(response.status).toBe(200);
-			expect(await response.text()).toEqual("Pong");
-		}, waitForTimeout);
-
-		// Test exported-handler -> named-entrypoint RPC
-		await vi.waitFor(async () => {
-			const searchParams = new URLSearchParams({
-				"test-service": "named-entrypoint",
-				"test-method": "rpc",
-			});
-			const response = await fetch(`${exportedHandler}?${searchParams}`);
-
-			expect(response.status).toBe(200);
-			expect(await response.text()).toEqual("Pong from Named Entrypoint");
-		}, waitForTimeout);
-
-		// Test exported-handler -> named-entrypoint-with-assets RPC
-		await vi.waitFor(async () => {
-			const searchParams = new URLSearchParams({
-				"test-service": "named-entrypoint-with-assets",
-				"test-method": "rpc",
-			});
-			const response = await fetch(`${exportedHandler}?${searchParams}`);
-
-			expect(response.status).toBe(200);
-			expect(await response.text()).toEqual("Pong from Named Entrypoint");
-		}, waitForTimeout);
-	});
-
-	it("supports WebSocket upgrade over service binding", async ({
-		devRegistryPath,
-	}) => {
-		const exportedHandler = await runViteDev(
-			"vite.exported-handler.config.ts",
-			devRegistryPath
-		);
-		await runViteDev("vite.worker-entrypoint.config.ts", devRegistryPath);
-
-		// Test exported-handler -> worker-entrypoint WebSocket proxy
-		await vi.waitFor(async () => {
-			const searchParams = new URLSearchParams({
-				"test-service": "worker-entrypoint",
-				"test-method": "websocket-proxy",
-			});
-			const wsUrl = `${exportedHandler.replace("http", "ws")}?${searchParams}`;
-			const ws = new WebSocket(wsUrl);
-
-			const message = await new Promise<string>((resolve, reject) => {
-				ws.addEventListener("open", () => ws.send("hello"));
-				ws.addEventListener("message", (event) => {
-					resolve(String(event.data));
-					ws.close();
+			// Test fallback before exported-handler is started
+			await vi.waitFor(async () => {
+				const searchParams = new URLSearchParams({
+					"test-service": "exported-handler",
+					"test-method": "fetch",
 				});
-				ws.addEventListener("error", () =>
-					reject(new Error("WebSocket connection failed"))
+				const response = await fetch(
+					`${workerEntrypointWithAssets}?${searchParams}`
 				);
-			});
 
-			expect(message).toBe("echo:hello");
-		}, waitForTimeout);
-	});
+				expect(response.status).toBe(503);
+				expect(await response.text()).toEqual(
+					`Worker "exported-handler" not found. Make sure it is running locally.`
+				);
+			}, waitForTimeout);
 
-	it("supports tail handler", async ({ devRegistryPath }) => {
-		const exportedHandler = await runViteDev(
-			"vite.exported-handler.config.ts",
-			devRegistryPath
-		);
-		const workerEntrypointWithAssets = await runViteDev(
-			"vite.worker-entrypoint-with-assets.config.ts",
-			devRegistryPath
-		);
+			const exportedHandler = await runViteDev(
+				"vite.exported-handler.config.ts",
+				devRegistryPath
+			);
 
-		const searchParams = new URLSearchParams({
-			"test-method": "tail",
+			// Test exported-handler -> worker-entrypoint-with-assets
+			await vi.waitFor(async () => {
+				const searchParams = new URLSearchParams({
+					"test-service": "worker-entrypoint-with-assets",
+					"test-method": "fetch",
+				});
+				const response = await fetch(`${exportedHandler}?${searchParams}`);
+
+				expect(await response.text()).toBe("Hello from Worker Entrypoint!");
+				expect(response.status).toBe(200);
+
+				// Test fetching asset from "worker-entrypoint-with-assets" over service binding
+				// Exported handler has no assets, so it will hit the user worker and
+				// forward the request to "worker-entrypoint-with-assets" with the asset path
+				const assetResponse = await fetch(
+					`${exportedHandler}/example.txt?${searchParams}`
+				);
+				expect(await assetResponse.text()).toBe(
+					"This is an example asset file"
+				);
+			}, waitForTimeout);
+
+			// Test worker-entrypoint-with-assets -> exported-handler
+			await vi.waitFor(async () => {
+				const searchParams = new URLSearchParams({
+					"test-service": "exported-handler",
+					"test-method": "fetch",
+				});
+				const response = await fetch(
+					`${workerEntrypointWithAssets}?${searchParams}`
+				);
+
+				expect(await response.text()).toEqual("Hello from exported handler!");
+				expect(response.status).toBe(200);
+			}, waitForTimeout);
+
+			// Test exported-handler -> named-entrypoint
+			await vi.waitFor(async () => {
+				const searchParams = new URLSearchParams({
+					"test-service": "named-entrypoint",
+					"test-method": "fetch",
+				});
+				const response = await fetch(`${exportedHandler}?${searchParams}`);
+
+				expect(await response.text()).toEqual("Hello from Named Entrypoint!");
+				expect(response.status).toBe(200);
+			}, waitForTimeout);
+
+			// Test exported-handler -> named-entrypoint-with-assets
+			await vi.waitFor(async () => {
+				const searchParams = new URLSearchParams({
+					"test-service": "named-entrypoint-with-assets",
+					"test-method": "fetch",
+				});
+				const response = await fetch(`${exportedHandler}?${searchParams}`);
+
+				expect(await response.text()).toEqual("Hello from Named Entrypoint!");
+				expect(response.status).toBe(200);
+			}, waitForTimeout);
 		});
 
-		await vi.waitFor(async () => {
-			// Trigger tail handler of worker-entrypoint via exported-handler
-			await fetch(`${exportedHandler}?${searchParams}`, {
-				method: "POST",
-				body: JSON.stringify(["hello world", "this is the 2nd log"]),
-			});
-			await fetch(`${exportedHandler}?${searchParams}`, {
-				method: "POST",
-				body: JSON.stringify(["some other log"]),
-			});
+		it("supports RPC over service binding", async ({ devRegistryPath }) => {
+			const exportedHandler = await runViteDev(
+				"vite.exported-handler.config.ts",
+				devRegistryPath
+			);
+			await runViteDev("vite.worker-entrypoint.config.ts", devRegistryPath);
 
-			const response = await fetch(
-				`${workerEntrypointWithAssets}?${searchParams}`
+			// Test fallback before worker-entrypoint-with-assets is started
+			await vi.waitFor(async () => {
+				const searchParams = new URLSearchParams({
+					"test-service": "worker-entrypoint-with-assets",
+					"test-method": "rpc",
+				});
+				const response = await fetch(`${exportedHandler}?${searchParams}`);
+
+				expect(response.status).toBe(500);
+				expect(await response.text()).toEqual(
+					`Worker "worker-entrypoint-with-assets" not found. Make sure it is running locally.`
+				);
+			}, waitForTimeout);
+
+			await runViteDev(
+				"vite.worker-entrypoint-with-assets.config.ts",
+				devRegistryPath
 			);
 
-			expect(await response.json()).toEqual({
-				worker: "Worker Entrypoint",
-				tailEvents: expect.arrayContaining([
-					[["[exported-handler]"], ["hello world", "this is the 2nd log"]],
-					[["[exported-handler]"], ["some other log"]],
-				]),
-			});
-		}, waitForTimeout);
+			// Test exported-handler -> worker-entrypoint RPC
+			await vi.waitFor(async () => {
+				const searchParams = new URLSearchParams({
+					"test-service": "worker-entrypoint",
+					"test-method": "rpc",
+				});
+				const response = await fetch(`${exportedHandler}?${searchParams}`);
 
-		await vi.waitFor(async () => {
-			// Trigger tail handler of exported-handler via worker-entrypoint
-			await fetch(`${workerEntrypointWithAssets}?${searchParams}`, {
-				method: "POST",
-				body: JSON.stringify(["hello from test"]),
-			});
-			await fetch(`${workerEntrypointWithAssets}?${searchParams}`, {
-				method: "POST",
-				body: JSON.stringify(["yet another log", "and another one"]),
+				expect(response.status).toBe(200);
+				expect(await response.text()).toEqual("Pong");
+			}, waitForTimeout);
+
+			// Test exported-handler -> worker-entrypoint-with-assets RPC
+			await vi.waitFor(async () => {
+				const searchParams = new URLSearchParams({
+					"test-service": "worker-entrypoint-with-assets",
+					"test-method": "rpc",
+				});
+				const response = await fetch(`${exportedHandler}?${searchParams}`);
+
+				expect(response.status).toBe(200);
+				expect(await response.text()).toEqual("Pong");
+			}, waitForTimeout);
+
+			// Test exported-handler -> named-entrypoint RPC
+			await vi.waitFor(async () => {
+				const searchParams = new URLSearchParams({
+					"test-service": "named-entrypoint",
+					"test-method": "rpc",
+				});
+				const response = await fetch(`${exportedHandler}?${searchParams}`);
+
+				expect(response.status).toBe(200);
+				expect(await response.text()).toEqual("Pong from Named Entrypoint");
+			}, waitForTimeout);
+
+			// Test exported-handler -> named-entrypoint-with-assets RPC
+			await vi.waitFor(async () => {
+				const searchParams = new URLSearchParams({
+					"test-service": "named-entrypoint-with-assets",
+					"test-method": "rpc",
+				});
+				const response = await fetch(`${exportedHandler}?${searchParams}`);
+
+				expect(response.status).toBe(200);
+				expect(await response.text()).toEqual("Pong from Named Entrypoint");
+			}, waitForTimeout);
+		});
+
+		it("supports WebSocket upgrade over service binding", async ({
+			devRegistryPath,
+		}) => {
+			const exportedHandler = await runViteDev(
+				"vite.exported-handler.config.ts",
+				devRegistryPath
+			);
+			await runViteDev("vite.worker-entrypoint.config.ts", devRegistryPath);
+
+			// Test exported-handler -> worker-entrypoint WebSocket proxy
+			await vi.waitFor(async () => {
+				const searchParams = new URLSearchParams({
+					"test-service": "worker-entrypoint",
+					"test-method": "websocket-proxy",
+				});
+				const wsUrl = `${exportedHandler.replace("http", "ws")}?${searchParams}`;
+				const ws = new WebSocket(wsUrl);
+
+				const message = await new Promise<string>((resolve, reject) => {
+					ws.addEventListener("open", () => ws.send("hello"));
+					ws.addEventListener("message", (event) => {
+						resolve(String(event.data));
+						ws.close();
+					});
+					ws.addEventListener("error", () =>
+						reject(new Error("WebSocket connection failed"))
+					);
+				});
+
+				expect(message).toBe("echo:hello");
+			}, waitForTimeout);
+		});
+
+		it("supports tail handler", async ({ devRegistryPath }) => {
+			const exportedHandler = await runViteDev(
+				"vite.exported-handler.config.ts",
+				devRegistryPath
+			);
+			const workerEntrypointWithAssets = await runViteDev(
+				"vite.worker-entrypoint-with-assets.config.ts",
+				devRegistryPath
+			);
+
+			const searchParams = new URLSearchParams({
+				"test-method": "tail",
 			});
 
-			const response = await fetch(`${exportedHandler}?${searchParams}`);
+			await vi.waitFor(async () => {
+				// Trigger tail handler of worker-entrypoint via exported-handler
+				await fetch(`${exportedHandler}?${searchParams}`, {
+					method: "POST",
+					body: JSON.stringify(["hello world", "this is the 2nd log"]),
+				});
+				await fetch(`${exportedHandler}?${searchParams}`, {
+					method: "POST",
+					body: JSON.stringify(["some other log"]),
+				});
 
-			expect(await response.json()).toEqual({
-				worker: "exported-handler",
-				tailEvents: expect.arrayContaining([
-					[["[Worker Entrypoint]"], ["hello from test"]],
-					[["[Worker Entrypoint]"], ["yet another log", "and another one"]],
-				]),
-			});
-		}, waitForTimeout);
+				const response = await fetch(
+					`${workerEntrypointWithAssets}?${searchParams}`
+				);
+
+				expect(await response.json()).toEqual({
+					worker: "Worker Entrypoint",
+					tailEvents: expect.arrayContaining([
+						[["[exported-handler]"], ["hello world", "this is the 2nd log"]],
+						[["[exported-handler]"], ["some other log"]],
+					]),
+				});
+			}, waitForTimeout);
+
+			await vi.waitFor(async () => {
+				// Trigger tail handler of exported-handler via worker-entrypoint
+				await fetch(`${workerEntrypointWithAssets}?${searchParams}`, {
+					method: "POST",
+					body: JSON.stringify(["hello from test"]),
+				});
+				await fetch(`${workerEntrypointWithAssets}?${searchParams}`, {
+					method: "POST",
+					body: JSON.stringify(["yet another log", "and another one"]),
+				});
+
+				const response = await fetch(`${exportedHandler}?${searchParams}`);
+
+				expect(await response.json()).toEqual({
+					worker: "exported-handler",
+					tailEvents: expect.arrayContaining([
+						[["[Worker Entrypoint]"], ["hello from test"]],
+						[["[Worker Entrypoint]"], ["yet another log", "and another one"]],
+					]),
+				});
+			}, waitForTimeout);
+		});
+
+		it("supports queues across dev sessions", async ({ devRegistryPath }) => {
+			const exportedHandler = await runViteDev(
+				"vite.exported-handler.config.ts",
+				devRegistryPath
+			);
+			const workerEntrypoint = await runViteDev(
+				"vite.worker-entrypoint.config.ts",
+				devRegistryPath
+			);
+
+			await vi.waitFor(async () => {
+				const sendParams = new URLSearchParams({
+					"test-method": "queue-send",
+				});
+				const sendResponse = await fetch(`${exportedHandler}?${sendParams}`, {
+					method: "POST",
+					body: "hello from vite producer",
+				});
+				expect(await sendResponse.text()).toBe("Queued");
+				expect(sendResponse.status).toBe(200);
+
+				const receivedParams = new URLSearchParams({
+					"test-method": "queue-received",
+				});
+				const receivedResponse = await fetch(
+					`${workerEntrypoint}?${receivedParams}`
+				);
+				expect(await receivedResponse.json()).toContain(
+					"hello from vite producer"
+				);
+			}, waitForTimeout);
+		});
 	});
-
-	it("supports queues across dev sessions", async ({ devRegistryPath }) => {
-		const exportedHandler = await runViteDev(
-			"vite.exported-handler.config.ts",
-			devRegistryPath
-		);
-		const workerEntrypoint = await runViteDev(
-			"vite.worker-entrypoint.config.ts",
-			devRegistryPath
-		);
-
-		await vi.waitFor(async () => {
-			const sendParams = new URLSearchParams({
-				"test-method": "queue-send",
-			});
-			const sendResponse = await fetch(`${exportedHandler}?${sendParams}`, {
-				method: "POST",
-				body: "hello from vite producer",
-			});
-			expect(await sendResponse.text()).toBe("Queued");
-			expect(sendResponse.status).toBe(200);
-
-			const receivedParams = new URLSearchParams({
-				"test-method": "queue-received",
-			});
-			const receivedResponse = await fetch(
-				`${workerEntrypoint}?${receivedParams}`
-			);
-			expect(await receivedResponse.json()).toContain(
-				"hello from vite producer"
-			);
-		}, waitForTimeout);
-	});
-});
+}
 
 describe("Dev Registry: vite dev <-> wrangler dev", () => {
 	it("uses the same dev registry path by default", async () => {

--- a/fixtures/entrypoints-rpc-tests/tests/entrypoints.spec.ts
+++ b/fixtures/entrypoints-rpc-tests/tests/entrypoints.spec.ts
@@ -890,6 +890,7 @@ describe("entrypoints", () => {
 		const boundWorker = new Miniflare({
 			name: "bound",
 			unsafeDevRegistryPath: isolatedDevRegistryPath,
+			unsafeRegisterWorker: true,
 			compatibilityFlags: ["experimental"],
 			modules: true,
 			https: true,

--- a/packages/miniflare/README.md
+++ b/packages/miniflare/README.md
@@ -218,6 +218,11 @@ parameter in module format Workers.
   Unique name for this worker. Only required if multiple `workers` are
   specified.
 
+- `unsafeRegisterWorker?: boolean`
+
+  If `true`, advertises this Worker in the dev registry configured by
+  `unsafeDevRegistryPath`. Defaults to `false`.
+
 - `rootPath?: string`
 
   Path against which all other path options for this Worker are resolved
@@ -597,7 +602,9 @@ Options shared between all Workers/"nanoservices".
 - `unsafeDevRegistryPath?: string`
 
   Path to the dev registry directory. This allows Miniflare to automatically
-  discover external services and Durable Objects running on another miniflare instance and connect them.
+  discover external services and Durable Objects running on another Miniflare
+  instance and connect them. Workers must opt in to being advertised by setting
+  `unsafeRegisterWorker` to `true`.
 
 - `unsafeDevRegistryDurableObjectProxy?: boolean`
 

--- a/packages/miniflare/src/index.ts
+++ b/packages/miniflare/src/index.ts
@@ -2695,7 +2695,7 @@ export class Miniflare {
 
 		const entries: [string, WorkerDefinition][] = [];
 		for (const workerOpts of this.#workerOpts) {
-			if (!workerOpts.core.name) {
+			if (!workerOpts.core.name || !workerOpts.core.unsafeRegisterWorker) {
 				continue;
 			}
 

--- a/packages/miniflare/src/plugins/core/index.ts
+++ b/packages/miniflare/src/plugins/core/index.ts
@@ -189,6 +189,7 @@ const CoreOptionsSchemaInput = z.intersection(
 
 		unsafeEvalBinding: z.string().optional(),
 		unsafeUseModuleFallbackService: z.boolean().optional(),
+		unsafeRegisterWorker: z.boolean().optional(),
 
 		/** Used to set the vitest pool worker SELF binding to point to the Router Worker if there are assets.
 		 (If there are assets but we're not using vitest, the miniflare entry worker can point directly to

--- a/packages/miniflare/src/shared/DEV_REGISTRY.md
+++ b/packages/miniflare/src/shared/DEV_REGISTRY.md
@@ -4,7 +4,7 @@ The dev registry enables cross-process communication between multiple `wrangler 
 
 ## Overview
 
-Each `wrangler dev` process writes its worker's connection info to a shared filesystem directory. When Worker A needs to talk to Worker B, a proxy worker inside A's workerd process reads B's debug port address from the registry and connects via Cap'n Proto RPC.
+Each `wrangler dev` process writes its user worker's connection info to a shared filesystem directory. Internal and external workers are not advertised. When Worker A needs to talk to Worker B, a proxy worker inside A's workerd process reads B's debug port address from the registry and connects via Cap'n Proto RPC.
 
 ```mermaid
 graph TB
@@ -55,6 +55,7 @@ type WorkerDefinition = {
 ```
 
 - **Heartbeat**: Every 30s, the file's mtime is touched to signal that the Worker is still running.
+- **Registration**: Only workers with `unsafeRegisterWorker: true` are advertised.
 - **Stale cleanup**: On every read, files older than 5 minutes are deleted (5 minutes is much longer than 30s just to provide a safe buffer)
 - **Change detection**: Chokidar watches the registry directory. When a file changes, `refresh()` compares the new state against the previous JSON snapshot and fires `onUpdate` only if a watched external service actually changed.
 

--- a/packages/miniflare/src/shared/dev-registry.ts
+++ b/packages/miniflare/src/shared/dev-registry.ts
@@ -152,14 +152,15 @@ export class DevRegistry {
 	}
 
 	public register(workers: Record<string, WorkerDefinition>) {
-		if (!this.registryPath) {
+		const entries = Object.entries(workers);
+		if (!this.registryPath || entries.length === 0) {
 			return;
 		}
 
 		// Make sure the registry path exists
 		mkdirSync(this.registryPath, { recursive: true });
 
-		for (const [name, definition] of Object.entries(workers)) {
+		for (const [name, definition] of entries) {
 			const definitionPath = path.join(this.registryPath, name);
 			const existingHeartbeat = this.heartbeats.get(name);
 			if (existingHeartbeat) {

--- a/packages/miniflare/test/dev-registry.spec.ts
+++ b/packages/miniflare/test/dev-registry.spec.ts
@@ -4,10 +4,30 @@ import { useDispose, useTmp } from "./test-shared";
 import type { MiniflareOptions, WorkerRegistry } from "miniflare";
 
 describe.sequential("DevRegistry", () => {
+	test("only registers workers that opt in", async ({ expect }) => {
+		const unsafeDevRegistryPath = await useTmp();
+		const workerOptions = {
+			name: "worker",
+			unsafeDevRegistryPath,
+			compatibilityFlags: ["experimental"],
+			modules: true,
+			script: `export default { fetch() { return new Response("ok"); } };`,
+		} satisfies MiniflareOptions;
+		const mf = new Miniflare(workerOptions);
+		useDispose(mf);
+		await mf.ready;
+
+		expect(getWorkerRegistry(unsafeDevRegistryPath)).toEqual({});
+
+		await mf.setOptions({ ...workerOptions, unsafeRegisterWorker: true });
+		expect(getWorkerRegistry(unsafeDevRegistryPath)["worker"]).toBeDefined();
+	});
+
 	test("fetch to service worker", async ({ expect }) => {
 		const unsafeDevRegistryPath = await useTmp();
 		const remote = new Miniflare({
 			name: "remote-worker",
+			unsafeRegisterWorker: true,
 			unsafeDevRegistryPath,
 			compatibilityFlags: ["experimental"],
 			script: `addEventListener("fetch", (event) => {
@@ -92,6 +112,7 @@ describe.sequential("DevRegistry", () => {
 
 		const remote = new Miniflare({
 			name: "remote-worker",
+			unsafeRegisterWorker: true,
 			unsafeDevRegistryPath,
 			compatibilityFlags: ["experimental"],
 			modules: true,
@@ -169,6 +190,7 @@ describe.sequential("DevRegistry", () => {
 
 		const remote = new Miniflare({
 			name: "remote-worker",
+			unsafeRegisterWorker: true,
 			unsafeDevRegistryPath,
 			compatibilityFlags: ["experimental"],
 			modules: true,
@@ -245,6 +267,7 @@ describe.sequential("DevRegistry", () => {
 
 		const remote = new Miniflare({
 			name: "remote-worker",
+			unsafeRegisterWorker: true,
 			unsafeDevRegistryPath,
 			compatibilityFlags: ["experimental"],
 			modules: true,
@@ -316,6 +339,7 @@ describe.sequential("DevRegistry", () => {
 
 		const remote = new Miniflare({
 			name: "remote-worker",
+			unsafeRegisterWorker: true,
 			unsafeDevRegistryPath,
 			compatibilityFlags: ["experimental"],
 			modules: true,
@@ -356,6 +380,7 @@ describe.sequential("DevRegistry", () => {
 		const unsafeDevRegistryPath = await useTmp();
 		const remote = new Miniflare({
 			name: "remote-worker",
+			unsafeRegisterWorker: true,
 			unsafeDevRegistryPath,
 			compatibilityFlags: ["experimental"],
 			modules: true,
@@ -444,6 +469,7 @@ describe.sequential("DevRegistry", () => {
 
 		const remote = new Miniflare({
 			name: "remote-worker",
+			unsafeRegisterWorker: true,
 			unsafeDevRegistryPath,
 			compatibilityFlags: ["experimental"],
 			modules: true,
@@ -527,6 +553,7 @@ describe.sequential("DevRegistry", () => {
 
 		const remote = new Miniflare({
 			name: "remote-worker",
+			unsafeRegisterWorker: true,
 			unsafeDevRegistryPath,
 			compatibilityFlags: ["experimental"],
 			modules: true,
@@ -568,6 +595,7 @@ describe.sequential("DevRegistry", () => {
 		const unsafeDevRegistryPath = await useTmp();
 		const remote = new Miniflare({
 			name: "remote-worker",
+			unsafeRegisterWorker: true,
 			unsafeDevRegistryPath,
 
 			compatibilityFlags: ["experimental"],
@@ -635,6 +663,7 @@ describe.sequential("DevRegistry", () => {
 		const unsafeDevRegistryPath = await useTmp();
 		const remote = new Miniflare({
 			name: "remote-worker",
+			unsafeRegisterWorker: true,
 			unsafeDevRegistryPath,
 
 			compatibilityFlags: ["experimental"],
@@ -735,6 +764,7 @@ describe.sequential("DevRegistry", () => {
 
 		const remote = new Miniflare({
 			name: "remote-worker",
+			unsafeRegisterWorker: true,
 			unsafeDevRegistryPath,
 
 			compatibilityFlags: ["experimental"],
@@ -813,6 +843,7 @@ describe.sequential("DevRegistry", () => {
 
 		const remote = new Miniflare({
 			name: "remote-worker",
+			unsafeRegisterWorker: true,
 			unsafeDevRegistryPath,
 
 			compatibilityFlags: ["experimental"],
@@ -873,6 +904,7 @@ describe.sequential("DevRegistry", () => {
 
 		const remote = new Miniflare({
 			name: "remote-worker",
+			unsafeRegisterWorker: true,
 			unsafeDevRegistryPath,
 
 			workflows: {
@@ -916,6 +948,7 @@ describe.sequential("DevRegistry", () => {
 
 		const remote = new Miniflare({
 			name: "remote-worker",
+			unsafeRegisterWorker: true,
 			unsafeDevRegistryPath,
 			compatibilityFlags: ["experimental"],
 			durableObjects: {
@@ -979,6 +1012,7 @@ describe.sequential("DevRegistry", () => {
 		// Restart remote — gets a new debug port, registry file updates
 		await remote.setOptions({
 			name: "remote-worker",
+			unsafeRegisterWorker: true,
 			unsafeDevRegistryPath,
 			compatibilityFlags: ["experimental"],
 			durableObjects: {
@@ -1017,6 +1051,7 @@ describe.sequential("DevRegistry", () => {
 
 		const remote = new Miniflare({
 			name: "remote-worker",
+			unsafeRegisterWorker: true,
 			unsafeDevRegistryPath,
 			compatibilityFlags: ["experimental"],
 			modules: true,
@@ -1066,6 +1101,7 @@ describe.sequential("DevRegistry", () => {
 		// Restart remote — gets a new debug port, registry file updates
 		await remote.setOptions({
 			name: "remote-worker",
+			unsafeRegisterWorker: true,
 			unsafeDevRegistryPath,
 			compatibilityFlags: ["experimental"],
 			modules: true,
@@ -1093,6 +1129,7 @@ describe.sequential("DevRegistry", () => {
 		const unsafeDevRegistryPath = await useTmp();
 		const remote = new Miniflare({
 			name: "remote-worker",
+			unsafeRegisterWorker: true,
 			unsafeDevRegistryPath,
 			unsafeTriggerHandlers: true,
 			compatibilityFlags: ["experimental"],
@@ -1155,6 +1192,7 @@ describe.sequential("DevRegistry", () => {
 		const unsafeDevRegistryPath = await useTmp();
 		const remote = new Miniflare({
 			name: "remote-worker",
+			unsafeRegisterWorker: true,
 			unsafeDevRegistryPath,
 			compatibilityFlags: ["experimental"],
 			modules: true,
@@ -1264,6 +1302,7 @@ describe.sequential("DevRegistry", () => {
 		const unsafeDevRegistryPath = await useTmp();
 		const remote = new Miniflare({
 			name: "remote-worker",
+			unsafeRegisterWorker: true,
 			unsafeDevRegistryPath,
 			compatibilityFlags: ["experimental"],
 			modules: true,
@@ -1366,6 +1405,7 @@ describe.sequential("DevRegistry", () => {
 		};
 		const remoteOptions: MiniflareOptions = {
 			name: "remote-worker",
+			unsafeRegisterWorker: true,
 			compatibilityFlags: ["experimental"],
 			modules: true,
 			script: `
@@ -1471,6 +1511,7 @@ describe.sequential("DevRegistry", () => {
 
 		const remote = new Miniflare({
 			name: "remote-worker",
+			unsafeRegisterWorker: true,
 			unsafeDevRegistryPath,
 			compatibilityFlags: ["experimental"],
 			modules: true,
@@ -1538,6 +1579,7 @@ describe.sequential("DevRegistry", () => {
 
 		const remote = new Miniflare({
 			name: "remote-worker",
+			unsafeRegisterWorker: true,
 			unsafeDevRegistryPath,
 
 			https: true,
@@ -1622,6 +1664,7 @@ describe.sequential("DevRegistry", () => {
 		const unrelated = new Miniflare({
 			name: "unrelated-worker",
 			unsafeDevRegistryPath,
+			unsafeRegisterWorker: true,
 			compatibilityFlags: ["experimental"],
 			modules: true,
 			script: `
@@ -1643,6 +1686,7 @@ describe.sequential("DevRegistry", () => {
 		// Create remote worker (one we're actually bound to) - this should trigger the callback
 		const remote = new Miniflare({
 			name: "remote-worker",
+			unsafeRegisterWorker: true,
 			unsafeDevRegistryPath,
 			compatibilityFlags: ["experimental"],
 			modules: true,
@@ -1746,6 +1790,7 @@ describe.sequential("DevRegistry", () => {
 		const sharedOptions = {
 			name: "consumer-worker",
 			unsafeDevRegistryPath,
+			unsafeRegisterWorker: true,
 			compatibilityFlags: ["experimental"],
 			modules: true,
 		} satisfies Partial<MiniflareOptions>;

--- a/packages/miniflare/test/plugins/local-explorer/aggregation.spec.ts
+++ b/packages/miniflare/test/plugins/local-explorer/aggregation.spec.ts
@@ -39,6 +39,7 @@ describe("Cross-process aggregation", () => {
 
 		instanceA = new Miniflare({
 			name: "worker-a",
+			unsafeRegisterWorker: true,
 			inspectorPort: 0,
 			compatibilityDate: "2025-01-01",
 			modules: true,
@@ -68,6 +69,7 @@ describe("Cross-process aggregation", () => {
 
 		instanceB = new Miniflare({
 			name: "worker-b",
+			unsafeRegisterWorker: true,
 			inspectorPort: 0,
 			compatibilityDate: "2025-01-01",
 			modules: true,
@@ -406,6 +408,7 @@ describe("Multi-worker peer deduplication", () => {
 
 		instanceA = new Miniflare({
 			name: "worker-a",
+			unsafeRegisterWorker: true,
 			inspectorPort: 0,
 			compatibilityDate: "2025-01-01",
 			modules: true,
@@ -428,6 +431,7 @@ describe("Multi-worker peer deduplication", () => {
 			workers: [
 				{
 					name: "worker-b1",
+					unsafeRegisterWorker: true,
 					modules: true,
 					script: `export default { fetch() { return new Response("Worker B1"); } }`,
 					kvNamespaces: {
@@ -436,6 +440,7 @@ describe("Multi-worker peer deduplication", () => {
 				},
 				{
 					name: "worker-b2",
+					unsafeRegisterWorker: true,
 					modules: true,
 					script: `export default { fetch() { return new Response("Worker B2"); } }`,
 					kvNamespaces: {
@@ -510,6 +515,7 @@ describe("Same ID across multiple instances with different persistence directori
 		// ties it to a specific instance.
 		instanceA = new Miniflare({
 			name: "worker-a",
+			unsafeRegisterWorker: true,
 			inspectorPort: 0,
 			compatibilityDate: "2025-01-01",
 			modules: true,
@@ -531,6 +537,7 @@ describe("Same ID across multiple instances with different persistence directori
 
 		instanceB = new Miniflare({
 			name: "worker-b",
+			unsafeRegisterWorker: true,
 			inspectorPort: 0,
 			compatibilityDate: "2025-01-01",
 			modules: true,
@@ -627,6 +634,7 @@ describe("Same ID across multiple instances with same persistence directories", 
 		// ties it to a specific instance.
 		instanceA = new Miniflare({
 			name: "worker-a",
+			unsafeRegisterWorker: true,
 			inspectorPort: 0,
 			compatibilityDate: "2025-01-01",
 			modules: true,
@@ -646,6 +654,7 @@ describe("Same ID across multiple instances with same persistence directories", 
 
 		instanceB = new Miniflare({
 			name: "worker-b",
+			unsafeRegisterWorker: true,
 			inspectorPort: 0,
 			compatibilityDate: "2025-01-01",
 			modules: true,

--- a/packages/miniflare/test/plugins/local-explorer/index.spec.ts
+++ b/packages/miniflare/test/plugins/local-explorer/index.spec.ts
@@ -605,6 +605,7 @@ describe("Local Explorer /api/local/workers endpoint", () => {
 			workers: [
 				{
 					name: "worker-a1",
+					unsafeRegisterWorker: true,
 					modules: true,
 					script: `
 						export class TestDO {
@@ -628,6 +629,7 @@ describe("Local Explorer /api/local/workers endpoint", () => {
 				},
 				{
 					name: "worker-a2",
+					unsafeRegisterWorker: true,
 					modules: true,
 					script: `export default { fetch() { return new Response("Worker A2"); } }`,
 					kvNamespaces: {
@@ -640,6 +642,7 @@ describe("Local Explorer /api/local/workers endpoint", () => {
 		// Instance B has one worker
 		instanceB = new Miniflare({
 			name: "worker-b",
+			unsafeRegisterWorker: true,
 			inspectorPort: 0,
 			compatibilityDate: "2025-01-01",
 			modules: true,

--- a/packages/miniflare/test/plugins/queues/cross-process.spec.ts
+++ b/packages/miniflare/test/plugins/queues/cross-process.spec.ts
@@ -13,6 +13,7 @@ function createConsumer(
 ): Miniflare {
 	return new Miniflare({
 		name,
+		unsafeRegisterWorker: true,
 		unsafeDevRegistryPath,
 		compatibilityFlags: ["experimental"],
 		queueConsumers: {
@@ -171,6 +172,7 @@ describe.sequential("cross-process queues", () => {
 		// message moves to "my-dlq", whose consumer lives in the other process.
 		const failingConsumer = new Miniflare({
 			name: "failing-consumer",
+			unsafeRegisterWorker: true,
 			unsafeDevRegistryPath,
 			compatibilityFlags: ["experimental"],
 			queueProducers: { QUEUE: { queueName: "my-queue" } },

--- a/packages/vite-plugin-cloudflare/src/miniflare-options.ts
+++ b/packages/vite-plugin-cloudflare/src/miniflare-options.ts
@@ -442,6 +442,7 @@ export async function getDevMiniflareOptions(
 								worker: {
 									...workerOptions,
 									name: worker.config.name,
+									unsafeRegisterWorker: true,
 									modulesRoot: miniflareModulesRoot,
 									modules: [
 										{
@@ -835,6 +836,7 @@ export async function getPreviewMiniflareOptions(
 						...workerOptions,
 						name: workerOptions.name ?? workerConfig.name,
 						unsafeInspectorProxy: inputInspectorPort !== false,
+						unsafeRegisterWorker: true,
 						...(previewWorker.source === "build-output" && previewWorker.bundle
 							? getModulesFromManifest(previewWorker.bundle)
 							: miniflareWorkerOptions.main

--- a/packages/wrangler/src/api/integrations/platform/index.ts
+++ b/packages/wrangler/src/api/integrations/platform/index.ts
@@ -331,6 +331,7 @@ async function getMiniflareOptionsFromConfig(args: {
 				script: "",
 				modules: true,
 				name: config.name,
+				unsafeRegisterWorker: true,
 				zone: getZoneFromConfig(config),
 				...bindingOptions,
 				...assetOptions,

--- a/packages/wrangler/src/dev/miniflare/index.ts
+++ b/packages/wrangler/src/dev/miniflare/index.ts
@@ -1200,6 +1200,7 @@ export async function buildMiniflareOptions(
 		workers: [
 			{
 				name: getName(config),
+				unsafeRegisterWorker: true,
 				compatibilityDate: config.compatibilityDate,
 				compatibilityFlags: config.compatibilityFlags,
 


### PR DESCRIPTION
Temporary validation harness for #15040, addressing #15035. Not for merge.

This reuses #15038's harness so the result is directly comparable with Pete's validation of #15037. It lifts #15018's Windows skip on `fixtures/dev-registry`, repeats the `vite dev <-> vite dev` suite four times, dumps every session's timestamped output, reports `CRASH-DETECTED` per session, isolates the fixture in the workflow, and raises the job timeout.

This PR should be closed once the Windows result has been measured and recorded on #15040.

---

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: this branch is a throwaway measurement harness and will never be merged.
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: throwaway validation branch.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/15041" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->