### PR TITLE
[wrangler] fix: normalize CRLF before sending D1 commands to the remote query API

### DIFF
--- a/.changeset/d1-crlf-remote-query.md
+++ b/.changeset/d1-crlf-remote-query.md
@@ -2,6 +2,6 @@
 "wrangler": patch
 ---
 
-Normalize CRLF line endings before sending D1 commands to the remote query API
+Normalize structural CRLF line endings before sending D1 commands to the remote query API
 
-`wrangler d1 migrations apply --remote` and `wrangler d1 execute --remote --command` failed with `incomplete input: SQLITE_ERROR` when the SQL contained CRLF line endings inside a compound statement such as a `CREATE TRIGGER ... BEGIN ... END;` body. The command string is now normalized to LF before it is sent to the D1 query API.
+`wrangler d1 migrations apply --remote` and `wrangler d1 execute --remote --command` failed with `incomplete input: SQLITE_ERROR` when the SQL contained CRLF line endings inside a compound statement such as a `CREATE TRIGGER ... BEGIN ... END;` body. Structural line endings are now normalized to LF before the command is sent to the D1 query API, while CRLF inside quoted values and identifiers remains unchanged.

--- a/.changeset/d1-crlf-remote-query.md
+++ b/.changeset/d1-crlf-remote-query.md
@@ -2,6 +2,6 @@
 "wrangler": patch
 ---
 
-fix: normalize CRLF line endings before sending D1 commands to the remote query API
+Normalize CRLF line endings before sending D1 commands to the remote query API
 
 `wrangler d1 migrations apply --remote` and `wrangler d1 execute --remote --command` failed with `incomplete input: SQLITE_ERROR` when the SQL contained CRLF line endings inside a compound statement such as a `CREATE TRIGGER ... BEGIN ... END;` body. The command string is now normalized to LF before it is sent to the D1 query API.

--- a/.changeset/d1-crlf-remote-query.md
+++ b/.changeset/d1-crlf-remote-query.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+fix: normalize CRLF line endings before sending D1 commands to the remote query API
+
+`wrangler d1 migrations apply --remote` and `wrangler d1 execute --remote --command` failed with `incomplete input: SQLITE_ERROR` when the SQL contained CRLF line endings inside a compound statement such as a `CREATE TRIGGER ... BEGIN ... END;` body. The command string is now normalized to LF before it is sent to the D1 query API.

--- a/packages/wrangler/src/__tests__/d1/execute.test.ts
+++ b/packages/wrangler/src/__tests__/d1/execute.test.ts
@@ -302,9 +302,62 @@ To continue without logging in, rerun this command with \`--temporary\`. Wrangle
 			expect(std.out).toMatch("🚣 Executed 1 command in 123.46ms");
 		});
 
-		it("should format batch execution duration with 2 decimal places", async ({
-			expect,
-		}) => {
+	it("should normalize CRLF line endings in commands sent to the remote query API", async ({
+		expect,
+	}) => {
+		setIsTTY(false);
+		writeWranglerConfig({
+			d1_databases: [
+				{ binding: "DATABASE", database_name: "db", database_id: "xxxx" },
+			],
+		});
+
+		msw.use(
+			...getMswSuccessMembershipHandlers([
+				{
+					id: "some-account-id",
+					name: "test-account",
+				},
+			])
+		);
+
+		let sentSql: string | undefined;
+		msw.use(
+			http.get("*/accounts/:accountId/d1/database", async () => {
+				return HttpResponse.json(
+					createFetchResult([
+						{ uuid: "xxxx", name: "db", created_at: "", version: "alpha" },
+					])
+				);
+			}),
+			http.post(
+				"*/accounts/:accountId/d1/database/:databaseId/query",
+				async ({ request }) => {
+					sentSql = ((await request.json()) as { sql: string }).sql;
+					return HttpResponse.json(
+						createFetchResult([
+							{
+								results: [{ result: 1 }],
+								success: true,
+								meta: { duration: 100 },
+							},
+						])
+					);
+				}
+			)
+		);
+
+		await runWrangler(
+			"d1 execute db --remote --command 'CREATE TRIGGER trg BEFORE DELETE ON probe_z\r\nBEGIN\r\n  SELECT RAISE(ABORT, '\''no'\'');\r\nEND;'"
+		);
+
+		expect(sentSql).toBeDefined();
+		expect(sentSql).not.toContain("\r");
+	});
+
+	it("should format batch execution duration with 2 decimal places", async ({
+		expect,
+	}) => {
 			setIsTTY(false);
 			writeWranglerConfig({
 				d1_databases: [

--- a/packages/wrangler/src/__tests__/d1/execute.test.ts
+++ b/packages/wrangler/src/__tests__/d1/execute.test.ts
@@ -302,7 +302,7 @@ To continue without logging in, rerun this command with \`--temporary\`. Wrangle
 			expect(std.out).toMatch("🚣 Executed 1 command in 123.46ms");
 		});
 
-		it("should normalize CRLF line endings in commands sent to the remote query API", async ({
+		it("should preserve quoted CRLF when normalizing commands sent to the remote query API", async ({
 			expect,
 		}) => {
 			setIsTTY(false);
@@ -348,11 +348,12 @@ To continue without logging in, rerun this command with \`--temporary\`. Wrangle
 			);
 
 			await runWrangler(
-				"d1 execute db --remote --command 'CREATE TRIGGER trg BEFORE DELETE ON probe_z\r\nBEGIN\r\n  SELECT RAISE(ABORT, '\''no'\'');\r\nEND;'"
+				"d1 execute db --remote --command \"CREATE TRIGGER trg BEFORE DELETE ON probe_z\r\nBEGIN\r\n  SELECT RAISE(ABORT, 'no\r\nchange');\r\nEND;\""
 			);
 
-			expect(sentSql).toBeDefined();
-			expect(sentSql).not.toContain("\r");
+			expect(sentSql).toBe(
+				"CREATE TRIGGER trg BEFORE DELETE ON probe_z\nBEGIN\n  SELECT RAISE(ABORT, 'no\r\nchange');\nEND;"
+			);
 		});
 
 		it("should format batch execution duration with 2 decimal places", async ({

--- a/packages/wrangler/src/__tests__/d1/execute.test.ts
+++ b/packages/wrangler/src/__tests__/d1/execute.test.ts
@@ -302,62 +302,62 @@ To continue without logging in, rerun this command with \`--temporary\`. Wrangle
 			expect(std.out).toMatch("🚣 Executed 1 command in 123.46ms");
 		});
 
-	it("should normalize CRLF line endings in commands sent to the remote query API", async ({
-		expect,
-	}) => {
-		setIsTTY(false);
-		writeWranglerConfig({
-			d1_databases: [
-				{ binding: "DATABASE", database_name: "db", database_id: "xxxx" },
-			],
-		});
+		it("should normalize CRLF line endings in commands sent to the remote query API", async ({
+			expect,
+		}) => {
+			setIsTTY(false);
+			writeWranglerConfig({
+				d1_databases: [
+					{ binding: "DATABASE", database_name: "db", database_id: "xxxx" },
+				],
+			});
 
-		msw.use(
-			...getMswSuccessMembershipHandlers([
-				{
-					id: "some-account-id",
-					name: "test-account",
-				},
-			])
-		);
+			msw.use(
+				...getMswSuccessMembershipHandlers([
+					{
+						id: "some-account-id",
+						name: "test-account",
+					},
+				])
+			);
 
-		let sentSql: string | undefined;
-		msw.use(
-			http.get("*/accounts/:accountId/d1/database", async () => {
-				return HttpResponse.json(
-					createFetchResult([
-						{ uuid: "xxxx", name: "db", created_at: "", version: "alpha" },
-					])
-				);
-			}),
-			http.post(
-				"*/accounts/:accountId/d1/database/:databaseId/query",
-				async ({ request }) => {
-					sentSql = ((await request.json()) as { sql: string }).sql;
+			let sentSql: string | undefined;
+			msw.use(
+				http.get("*/accounts/:accountId/d1/database", async () => {
 					return HttpResponse.json(
 						createFetchResult([
-							{
-								results: [{ result: 1 }],
-								success: true,
-								meta: { duration: 100 },
-							},
+							{ uuid: "xxxx", name: "db", created_at: "", version: "alpha" },
 						])
 					);
-				}
-			)
-		);
+				}),
+				http.post(
+					"*/accounts/:accountId/d1/database/:databaseId/query",
+					async ({ request }) => {
+						sentSql = ((await request.json()) as { sql: string }).sql;
+						return HttpResponse.json(
+							createFetchResult([
+								{
+									results: [{ result: 1 }],
+									success: true,
+									meta: { duration: 100 },
+								},
+							])
+						);
+					}
+				)
+			);
 
-		await runWrangler(
-			"d1 execute db --remote --command 'CREATE TRIGGER trg BEFORE DELETE ON probe_z\r\nBEGIN\r\n  SELECT RAISE(ABORT, '\''no'\'');\r\nEND;'"
-		);
+			await runWrangler(
+				"d1 execute db --remote --command 'CREATE TRIGGER trg BEFORE DELETE ON probe_z\r\nBEGIN\r\n  SELECT RAISE(ABORT, '\''no'\'');\r\nEND;'"
+			);
 
-		expect(sentSql).toBeDefined();
-		expect(sentSql).not.toContain("\r");
-	});
+			expect(sentSql).toBeDefined();
+			expect(sentSql).not.toContain("\r");
+		});
 
-	it("should format batch execution duration with 2 decimal places", async ({
-		expect,
-	}) => {
+		it("should format batch execution duration with 2 decimal places", async ({
+			expect,
+		}) => {
 			setIsTTY(false);
 			writeWranglerConfig({
 				d1_databases: [

--- a/packages/wrangler/src/__tests__/d1/splitter.test.ts
+++ b/packages/wrangler/src/__tests__/d1/splitter.test.ts
@@ -1,5 +1,22 @@
 import { describe, it } from "vitest";
-import { mayContainMultipleStatements, splitSqlQuery } from "../../d1/splitter";
+import {
+	mayContainMultipleStatements,
+	normalizeSqlLineEndings,
+	splitSqlQuery,
+} from "../../d1/splitter";
+
+describe("normalizeSqlLineEndings()", () => {
+	it("should preserve CRLF inside quoted SQL values and identifiers", ({
+		expect,
+	}) => {
+		const sql =
+			"SELECT 'single''quote\r\nvalue', \"double\r\nquote\", `backtick\r\nquote`, [bracket\r\nquote]; -- don't stop scanning\r\n/* block\r\ncomment */\r\nSELECT 1;";
+
+		expect(normalizeSqlLineEndings(sql)).toBe(
+			"SELECT 'single''quote\r\nvalue', \"double\r\nquote\", `backtick\r\nquote`, [bracket\r\nquote]; -- don't stop scanning\n/* block\ncomment */\nSELECT 1;"
+		);
+	});
+});
 
 describe("mayContainMultipleStatements()", () => {
 	it("should return false if there is only a semi-colon at the end", ({

--- a/packages/wrangler/src/d1/execute.ts
+++ b/packages/wrangler/src/d1/execute.ts
@@ -505,14 +505,17 @@ async function executeRemotely({
 			},
 		];
 	} else {
+		// The D1 query API splits multi-statement SQL on `;` server-side, and
+		// mishandles CRLF line endings inside compound statements such as a
+		// `CREATE TRIGGER ... BEGIN ... END;` body (issue #14991). Normalize
+		// to LF so the server receives the same input that works for LF files.
+		const sql = input.command?.replace(/\r\n/g, "\n");
 		const result = await d1ApiPost<QueryResult[]>(
 			config,
 			accountId,
 			db,
 			"query",
-			{
-				sql: input.command,
-			}
+			{ sql }
 		);
 		logResult(result);
 		return result;

--- a/packages/wrangler/src/d1/execute.ts
+++ b/packages/wrangler/src/d1/execute.ts
@@ -21,7 +21,7 @@ import { confirm } from "../dialogs";
 import { logger } from "../logger";
 import { readableRelative } from "../paths";
 import { requireAuth } from "../user";
-import { splitSqlQuery } from "./splitter";
+import { normalizeSqlLineEndings, splitSqlQuery } from "./splitter";
 import { getDatabaseByNameOrBinding, getDatabaseInfoFromConfig } from "./utils";
 import type {
 	Database,
@@ -508,8 +508,8 @@ async function executeRemotely({
 		// The D1 query API splits multi-statement SQL on `;` server-side, and
 		// mishandles CRLF line endings inside compound statements such as a
 		// `CREATE TRIGGER ... BEGIN ... END;` body (issue #14991). Normalize
-		// to LF so the server receives the same input that works for LF files.
-		const sql = input.command?.replace(/\r\n/g, "\n");
+		// structural line endings while preserving quoted SQL values.
+		const sql = input.command && normalizeSqlLineEndings(input.command);
 		const result = await d1ApiPost<QueryResult[]>(
 			config,
 			accountId,

--- a/packages/wrangler/src/d1/splitter.ts
+++ b/packages/wrangler/src/d1/splitter.ts
@@ -37,6 +37,98 @@ export function splitSqlQuery(sql: string): string[] {
 	}
 }
 
+/**
+ * Normalize structural CRLF line endings without changing quoted SQL values or
+ * identifiers.
+ */
+export function normalizeSqlLineEndings(sql: string): string {
+	let normalized = "";
+	let quoteEnd: "'" | '"' | "`" | "]" | undefined;
+	let inLineComment = false;
+	let inBlockComment = false;
+
+	for (let index = 0; index < sql.length; index++) {
+		const char = sql[index];
+		const nextChar = sql[index + 1];
+
+		if (quoteEnd !== undefined) {
+			normalized += char;
+			if (char === quoteEnd) {
+				if (nextChar === quoteEnd) {
+					normalized += nextChar;
+					index++;
+				} else {
+					quoteEnd = undefined;
+				}
+			}
+			continue;
+		}
+
+		if (inLineComment) {
+			if (char === "\r" && nextChar === "\n") {
+				normalized += "\n";
+				index++;
+				inLineComment = false;
+			} else {
+				normalized += char;
+				inLineComment = char !== "\n";
+			}
+			continue;
+		}
+
+		if (inBlockComment) {
+			if (char === "\r" && nextChar === "\n") {
+				normalized += "\n";
+				index++;
+			} else {
+				normalized += char;
+				if (char === "*" && nextChar === "/") {
+					normalized += nextChar;
+					index++;
+					inBlockComment = false;
+				}
+			}
+			continue;
+		}
+
+		if (char === "-" && nextChar === "-") {
+			normalized += "--";
+			index++;
+			inLineComment = true;
+			continue;
+		}
+
+		if (char === "/" && nextChar === "*") {
+			normalized += "/*";
+			index++;
+			inBlockComment = true;
+			continue;
+		}
+
+		if (char === "'" || char === '"' || char === "`") {
+			normalized += char;
+			quoteEnd = char;
+			continue;
+		}
+
+		if (char === "[") {
+			normalized += char;
+			quoteEnd = "]";
+			continue;
+		}
+
+		if (char === "\r" && nextChar === "\n") {
+			normalized += "\n";
+			index++;
+			continue;
+		}
+
+		normalized += char;
+	}
+
+	return normalized;
+}
+
 function splitSqlIntoStatements(sql: string): string[] {
 	const statements: string[] = [];
 	let str = "";


### PR DESCRIPTION
Fixes https://github.com/cloudflare/workers-sdk/issues/14991

`wrangler d1 migrations apply --remote` failed with `incomplete input: SQLITE_ERROR [7500]` whenever a migration file had CRLF line endings and contained a `CREATE TRIGGER ... BEGIN ... END;` body — the default situation for Windows checkouts with `core.autocrlf=true`.

**Root cause:** `migrations apply --remote` sends the whole migration (plus the tracking `INSERT`) as one `sql` string to the D1 `/query` endpoint, which splits multi-statement SQL on `;` server-side and mishandles structural CRLF inside compound statement bodies. The identical bytes succeed via `execute --remote --file` because that path uses the D1 import API; the client-side splitter is not involved in the command path.

**Fix:** normalize only structural CRLF before sending commands to the remote query API. The SQL-aware normalizer preserves CRLF inside single-, double-, backtick-, and bracket-quoted content, including doubled quote escapes, so remote execution does not silently change stored values.

**Verification:** all 16 D1 splitter tests, 16 D1 execute tests, and 33 D1 migration tests pass. The repository-wide `pnpm check` also passes.

---

- Tests
  - [x] Tests included/updated
- Public documentation
  - [x] Documentation not necessary because: bug fix in an existing command path; no user-facing configuration or API surface changes

> [!NOTE]
> This is a contribution from an AI agent: stareezy-1.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/15044" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
