### PR TITLE
[wrangler] fix: reject secret names with leading or trailing whitespace

### DIFF
--- a/.changeset/secret-name-whitespace.md
+++ b/.changeset/secret-name-whitespace.md
@@ -2,6 +2,6 @@
 "wrangler": patch
 ---
 
-fix: reject secret names with leading or trailing whitespace
+Reject secret names with leading or trailing whitespace
 
 The Workers dashboard accepts secret names with accidental leading or trailing spaces, producing a binding that is silently inaccessible as `env.<name>`. `wrangler secret put` and `wrangler secret bulk` now reject such names with a clear error instead of deploying them.

--- a/.changeset/secret-name-whitespace.md
+++ b/.changeset/secret-name-whitespace.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+fix: reject secret names with leading or trailing whitespace
+
+The Workers dashboard accepts secret names with accidental leading or trailing spaces, producing a binding that is silently inaccessible as `env.<name>`. `wrangler secret put` and `wrangler secret bulk` now reject such names with a clear error instead of deploying them.

--- a/packages/wrangler/src/__tests__/secret.test.ts
+++ b/packages/wrangler/src/__tests__/secret.test.ts
@@ -146,6 +146,16 @@ describe("wrangler secret", () => {
 			);
 		});
 
+		it("should reject secret names with leading or trailing whitespace", async ({
+			expect,
+		}) => {
+			await expect(
+				runWrangler("secret put ' secret-name ' --name script-name")
+			).rejects.toThrowErrorMatchingInlineSnapshot(
+				`[Error: The secret name " secret-name " must not start or end with whitespace, otherwise the binding would be inaccessible as env.secret-name. Please recreate the secret without surrounding whitespace.]`
+			);
+		});
+
 		describe("interactive", () => {
 			beforeEach(() => {
 				setIsTTY(true);
@@ -1020,6 +1030,21 @@ describe("wrangler secret", () => {
 				"
 			`);
 			expect(std.warn).toMatchInlineSnapshot(`""`);
+		});
+
+		it("should reject bulk secret names with leading or trailing whitespace", async ({
+			expect,
+		}) => {
+			mockReadlineInput(
+				JSON.stringify({
+					" secret1 ": "secret-value",
+				})
+			);
+			await expect(
+				runWrangler(`secret bulk --name script-name`)
+			).rejects.toThrowErrorMatchingInlineSnapshot(
+				`[Error: The secret name " secret1 " must not start or end with whitespace, otherwise the binding would be inaccessible as env.secret1. Please recreate the secret without surrounding whitespace.]`
+			);
 		});
 
 		it("should use secret bulk w/ pipe input", async ({ expect }) => {

--- a/packages/wrangler/src/secret/index.ts
+++ b/packages/wrangler/src/secret/index.ts
@@ -369,9 +369,6 @@ async function putBulkSecrets(
 	const toDelete: Array<string> = [];
 	for (const [key, value] of secretEntries) {
 		if (value != null) {
-			// Only validate create/update keys: deleting a legacy
-			// whitespace-prefixed secret must stay possible.
-			validateSecretName(key);
 			toCreate.push(key);
 			secrets[key] = { name: key, text: value, type: "secret_text" };
 		} else {
@@ -443,6 +440,15 @@ export const secretBulkCommand = createCommand({
 		}
 
 		const { content, secretSource, secretFormat } = result;
+		for (const [name, value] of Object.entries(content)) {
+			// Only validate create/update keys: deleting a legacy
+			// whitespace-prefixed secret must stay possible. Validated here,
+			// before the upload try/catch, so a local name error is not
+			// reported as an upload failure.
+			if (value != null) {
+				validateSecretName(name);
+			}
+		}
 		const hasSecretsToCreate = Object.values(content).some(
 			(value) => value != null
 		);

--- a/packages/wrangler/src/secret/index.ts
+++ b/packages/wrangler/src/secret/index.ts
@@ -13,6 +13,7 @@ import * as metrics from "../metrics";
 import { requireAuth } from "../user";
 import { getLegacyScriptName } from "../utils/getLegacyScriptName";
 import { readFromStdin, trimTrailingWhitespace } from "../utils/std";
+import { validateSecretName } from "../utils/validateSecretName";
 import type { Config } from "@cloudflare/workers-utils";
 
 export const VERSION_NOT_DEPLOYED_ERR_CODE = 10215;
@@ -120,6 +121,8 @@ export const secretPutCommand = createCommand({
 				{ telemetryMessage: "secret put pages project" }
 			);
 		}
+
+		validateSecretName(args.key);
 
 		const scriptName = getLegacyScriptName(args, config);
 		if (!scriptName) {
@@ -366,6 +369,9 @@ async function putBulkSecrets(
 	const toDelete: Array<string> = [];
 	for (const [key, value] of secretEntries) {
 		if (value != null) {
+			// Only validate create/update keys: deleting a legacy
+			// whitespace-prefixed secret must stay possible.
+			validateSecretName(key);
 			toCreate.push(key);
 			secrets[key] = { name: key, text: value, type: "secret_text" };
 		} else {

--- a/packages/wrangler/src/utils/validateSecretName.ts
+++ b/packages/wrangler/src/utils/validateSecretName.ts
@@ -1,0 +1,19 @@
+import { UserError } from "@cloudflare/workers-utils";
+
+/**
+ * Validate a secret variable name before it is sent to the API.
+ *
+ * The dashboard accepts names with accidental leading/trailing whitespace,
+ * which produces a binding that is silently inaccessible as `env.<name>`
+ * (issue #15019). Reject them here so the mistake is caught before deploy.
+ */
+export function validateSecretName(name: string): void {
+	if (name !== name.trim()) {
+		throw new UserError(
+			`The secret name "${name}" must not start or end with whitespace, ` +
+				`otherwise the binding would be inaccessible as env.${name.trim()}. ` +
+				`Please recreate the secret without surrounding whitespace.`,
+			{ telemetryMessage: "secret invalid secret name whitespace" }
+		);
+	}
+}

--- a/packages/wrangler/src/versions/secrets/bulk.ts
+++ b/packages/wrangler/src/versions/secrets/bulk.ts
@@ -5,6 +5,7 @@ import * as metrics from "../../metrics";
 import { parseBulkInputToObject } from "../../secret";
 import { requireAuth } from "../../user";
 import { getLegacyScriptName } from "../../utils/getLegacyScriptName";
+import { validateSecretName } from "../../utils/validateSecretName";
 import { patchLatestWorkerVersionWithSecrets } from "./index";
 
 export const versionsSecretBulkCommand = createCommand({
@@ -65,6 +66,13 @@ export const versionsSecretBulkCommand = createCommand({
 		const { content: secrets, secretSource, secretFormat } = result;
 
 		const secretEntries = Object.entries(secrets);
+		for (const [name, value] of secretEntries) {
+			// Only validate create/update keys: deleting a legacy
+			// whitespace-prefixed secret must stay possible.
+			if (value != null) {
+				validateSecretName(name);
+			}
+		}
 
 		const newVersion = await patchLatestWorkerVersionWithSecrets({
 			config,

--- a/packages/wrangler/src/versions/secrets/put.ts
+++ b/packages/wrangler/src/versions/secrets/put.ts
@@ -6,6 +6,7 @@ import * as metrics from "../../metrics";
 import { requireAuth } from "../../user";
 import { getLegacyScriptName } from "../../utils/getLegacyScriptName";
 import { readFromStdin, trimTrailingWhitespace } from "../../utils/std";
+import { validateSecretName } from "../../utils/validateSecretName";
 import { patchLatestWorkerVersionWithSecrets } from "./index";
 
 export const versionsSecretPutCommand = createCommand({
@@ -58,6 +59,8 @@ export const versionsSecretPutCommand = createCommand({
 				{ telemetryMessage: "versions secrets put missing secret name" }
 			);
 		}
+
+		validateSecretName(args.key);
 
 		const accountId = await requireAuth(config);
 


### PR DESCRIPTION
Fixes https://github.com/cloudflare/workers-sdk/issues/15019

The Workers dashboard accepts secret variable names with accidental leading or trailing spaces, producing a binding that is silently inaccessible as `env.<name>` — the expected binding is `undefined` with no warning.

**Fix:** validate secret names in `wrangler secret put`, `secret bulk`, `versions secret put`, and `versions secret bulk`, rejecting names with leading/trailing whitespace with a clear error before anything reaches the API. Bulk **deletes** are exempt so legacy whitespace-prefixed secrets (created via the dashboard) can still be cleaned up with `secret bulk`.

New shared helper `src/utils/validateSecretName.ts`; wired into all four command paths.

---

- Tests
  - [x] Tests included/updated
- Public documentation
  - [x] Documentation not necessary because: bug fix in existing command behavior; no user-facing configuration or API surface changes

> [!NOTE]
> This is a contribution from an AI agent: stareezy-1.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/15045" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->