### PR TITLE
Close a compound SQL statement when its END is lowercase

### DIFF
--- a/.changeset/d1-splitter-lowercase-end.md
+++ b/.changeset/d1-splitter-lowercase-end.md
@@ -2,7 +2,7 @@
 "wrangler": patch
 ---
 
-Run every statement in a D1 SQL file when a trigger or CASE block ends with a lowercase `end`
+Fixes D1 SQL statements not handling lowercase `end`s correctly
 
 `wrangler d1 execute` and `wrangler d1 migrations apply` split a SQL file into statements before running them. A `BEGIN` or `CASE` block closed with a lowercase `end` was not recognised as closed, so every statement after it was folded into that block instead of being run on its own. SQLite accepts either case, so a file like this applied only the trigger and silently skipped the table:
 

--- a/.changeset/d1-splitter-lowercase-end.md
+++ b/.changeset/d1-splitter-lowercase-end.md
@@ -1,0 +1,17 @@
+---
+"wrangler": patch
+---
+
+Close a compound SQL statement when its `END` is lowercase
+
+`splitSqlQuery()` matched the opening `BEGIN`/`CASE` of a compound statement case insensitively but matched the closing `END` case sensitively. SQLite accepts either case, so a trigger written with a lowercase `end` never closed, and every statement after it was swallowed into the trigger body rather than being split out and executed.
+
+```sql
+CREATE TRIGGER IF NOT EXISTS update_trigger AFTER UPDATE ON items
+begin
+	DELETE FROM updates WHERE item_id=old.id;
+end;
+CREATE TABLE after_the_trigger (id TEXT PRIMARY KEY);
+```
+
+This produced two statements where the trailing `CREATE TABLE` was folded into the first. The existing tests already covered a lowercase `begin`, but always paired it with an uppercase `END`, so the asymmetry went unnoticed.

--- a/.changeset/d1-splitter-lowercase-end.md
+++ b/.changeset/d1-splitter-lowercase-end.md
@@ -2,9 +2,9 @@
 "wrangler": patch
 ---
 
-Close a compound SQL statement when its `END` is lowercase
+Run every statement in a D1 SQL file when a trigger or CASE block ends with a lowercase `end`
 
-`splitSqlQuery()` matched the opening `BEGIN`/`CASE` of a compound statement case insensitively but matched the closing `END` case sensitively. SQLite accepts either case, so a trigger written with a lowercase `end` never closed, and every statement after it was swallowed into the trigger body rather than being split out and executed.
+`wrangler d1 execute` and `wrangler d1 migrations apply` split a SQL file into statements before running them. A `BEGIN` or `CASE` block closed with a lowercase `end` was not recognised as closed, so every statement after it was folded into that block instead of being run on its own. SQLite accepts either case, so a file like this applied only the trigger and silently skipped the table:
 
 ```sql
 CREATE TRIGGER IF NOT EXISTS update_trigger AFTER UPDATE ON items
@@ -14,4 +14,4 @@ end;
 CREATE TABLE after_the_trigger (id TEXT PRIMARY KEY);
 ```
 
-This produced two statements where the trailing `CREATE TABLE` was folded into the first. The existing tests already covered a lowercase `begin`, but always paired it with an uppercase `END`, so the asymmetry went unnoticed.
+Files written with an uppercase `END` were unaffected. Both cases now behave the same.

--- a/packages/wrangler/src/__tests__/d1/splitter.test.ts
+++ b/packages/wrangler/src/__tests__/d1/splitter.test.ts
@@ -331,9 +331,6 @@ describe("splitSqlQuery()", () => {
 	it("should handle a lowercase end closing a compound statement", ({
 		expect,
 	}) => {
-		// SQLite accepts either case. Only the BEGIN side was matched case
-		// insensitively, so a lowercase `end` never closed the compound statement
-		// and every following statement was swallowed into the trigger.
 		expect(
 			splitSqlQuery(`
 	CREATE TRIGGER IF NOT EXISTS update_trigger AFTER UPDATE ON items

--- a/packages/wrangler/src/__tests__/d1/splitter.test.ts
+++ b/packages/wrangler/src/__tests__/d1/splitter.test.ts
@@ -328,6 +328,30 @@ describe("splitSqlQuery()", () => {
 		`);
 	});
 
+	it("should handle a lowercase end closing a compound statement", ({
+		expect,
+	}) => {
+		// SQLite accepts either case. Only the BEGIN side was matched case
+		// insensitively, so a lowercase `end` never closed the compound statement
+		// and every following statement was swallowed into the trigger.
+		expect(
+			splitSqlQuery(`
+	CREATE TRIGGER IF NOT EXISTS update_trigger AFTER UPDATE ON items
+	begin
+		DELETE FROM updates WHERE item_id=old.id;
+	end;
+	CREATE TABLE after_the_trigger (id TEXT PRIMARY KEY);`)
+		).toMatchInlineSnapshot(`
+			[
+			  "CREATE TRIGGER IF NOT EXISTS update_trigger AFTER UPDATE ON items
+				begin
+					DELETE FROM updates WHERE item_id=old.id;
+				end",
+			  "CREATE TABLE after_the_trigger (id TEXT PRIMARY KEY)",
+			]
+		`);
+	});
+
 	it("should handle compound statements for CASEs", ({ expect }) => {
 		expect(
 			splitSqlQuery(`

--- a/packages/wrangler/src/d1/splitter.ts
+++ b/packages/wrangler/src/d1/splitter.ts
@@ -166,5 +166,5 @@ function isCompoundStatementStart(str: string) {
  * Returns true if the `str` ends with a compound statement `END` marker.
  */
 function isCompoundStatementEnd(str: string) {
-	return /\sEND[;\s]$/.test(str);
+	return /\sEND[;\s]$/i.test(str);
 }


### PR DESCRIPTION
Spotted while investigating #14991. Independent of that issue and of any fix for it.

## The bug

`splitSqlQuery()` matches the two ends of a compound statement asymmetrically:

```ts
function isCompoundStatementStart(str: string) { return /\s(BEGIN|CASE)\s$/i.test(str); }  // case insensitive
function isCompoundStatementEnd(str: string)   { return /\sEND[;\s]$/.test(str); }         // case sensitive
```

SQLite accepts either case. With a lowercase `end`, the compound statement never closes, so `compoundStatementStack` stays non-empty and every subsequent `;` is treated as being inside the trigger body. Everything after the trigger is folded into it instead of being split out and executed.

```sql
CREATE TRIGGER IF NOT EXISTS update_trigger AFTER UPDATE ON items
begin
	DELETE FROM updates WHERE item_id=old.id;
end;
CREATE TABLE after_the_trigger (id TEXT PRIMARY KEY);
```

Before, 2 statements, with the `CREATE TABLE` swallowed:

```
[0] "CREATE TABLE t (id TEXT)"
[1] "CREATE TRIGGER g BEFORE DELETE ON t\nbegin\n  SELECT RAISE(ABORT,'no');\n..."
```

After, 3 statements, matching the uppercase behaviour exactly. `CASE ... end` inside a trigger body is affected the same way, collapsing 3 statements into 1.

## Why it was not caught

`should handle compound statements for BEGINs` already exercises a lowercase `begin`, so case insensitivity was clearly intended. But every case in that test pairs it with an uppercase `END`, so only the start predicate was ever exercised in lowercase.

## Change

One character: add the `i` flag to `isCompoundStatementEnd`, so both predicates agree.

This does not widen what counts as an end marker beyond the existing behaviour. `\sEND` still requires whitespace immediately before, so an identifier such as `weekend;` does not match, exactly as it did not before.

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: this restores the documented and already intended behaviour of statement splitting. `DISTINCT`/`BEGIN`/`END` case handling is not described anywhere in the public docs, and nothing about the supported SQL surface changes.

Added `should handle a lowercase end closing a compound statement`, placed next to the existing lowercase-`begin` coverage. Verified it is a real regression test rather than a passing assertion: with the `i` flag reverted the suite reports 1 failed of 16, and with the fix 16 of 16 pass. `oxfmt --check` is clean on both changed files.
