### PR TITLE
[miniflare] Fix dev registry test opt-in

### DIFF
--- a/packages/miniflare/test/dev-registry.spec.ts
+++ b/packages/miniflare/test/dev-registry.spec.ts
@@ -1846,6 +1846,7 @@ describe("registry churn across config updates", () => {
 		const unsafeDevRegistryPath = await useTmp();
 		const mf = new Miniflare({
 			name: "stable-worker",
+			unsafeRegisterWorker: true,
 			unsafeDevRegistryPath,
 			modules: true,
 			script: script("before"),
@@ -1880,6 +1881,7 @@ describe("registry churn across config updates", () => {
 
 		await mf.setOptions({
 			name: "stable-worker",
+			unsafeRegisterWorker: true,
 			unsafeDevRegistryPath,
 			modules: true,
 			script: script("after"),
@@ -1908,6 +1910,7 @@ describe("registry churn across config updates", () => {
 		const unsafeDevRegistryPath = await useTmp();
 		const mf = new Miniflare({
 			name: "doomed-worker",
+			unsafeRegisterWorker: true,
 			unsafeDevRegistryPath,
 			modules: true,
 			script: script("before"),
@@ -1929,6 +1932,7 @@ describe("registry churn across config updates", () => {
 		await expect(
 			mf.setOptions({
 				name: "doomed-worker",
+				unsafeRegisterWorker: true,
 				unsafeDevRegistryPath,
 				modules: true,
 				script: script("after"),
@@ -1951,10 +1955,20 @@ describe("registry churn across config updates", () => {
 		const mf = new Miniflare({
 			unsafeDevRegistryPath,
 			workers: [
-				{ name: "kept-worker", modules: true, script: script("kept") },
+				{
+					name: "kept-worker",
+					unsafeRegisterWorker: true,
+					modules: true,
+					script: script("kept"),
+				},
 				// A name that exists on `Object.prototype`, so a membership test that
 				// walks the prototype chain would report it as still configured.
-				{ name: "constructor", modules: true, script: script("dropped") },
+				{
+					name: "constructor",
+					unsafeRegisterWorker: true,
+					modules: true,
+					script: script("dropped"),
+				},
 			],
 		});
 		useDispose(mf);
@@ -1973,7 +1987,14 @@ describe("registry churn across config updates", () => {
 
 		await mf.setOptions({
 			unsafeDevRegistryPath,
-			workers: [{ name: "kept-worker", modules: true, script: script("kept") }],
+			workers: [
+				{
+					name: "kept-worker",
+					unsafeRegisterWorker: true,
+					modules: true,
+					script: script("kept"),
+				},
+			],
 		});
 
 		await vi.waitFor(
@@ -1993,8 +2014,18 @@ describe("registry churn across config updates", () => {
 		const mf = new Miniflare({
 			unsafeDevRegistryPath,
 			workers: [
-				{ name: "kept-worker", modules: true, script: script("kept") },
-				{ name: "dropped-worker", modules: true, script: script("dropped") },
+				{
+					name: "kept-worker",
+					unsafeRegisterWorker: true,
+					modules: true,
+					script: script("kept"),
+				},
+				{
+					name: "dropped-worker",
+					unsafeRegisterWorker: true,
+					modules: true,
+					script: script("dropped"),
+				},
 			],
 		});
 		useDispose(mf);
@@ -2011,7 +2042,14 @@ describe("registry churn across config updates", () => {
 
 		await mf.setOptions({
 			unsafeDevRegistryPath,
-			workers: [{ name: "kept-worker", modules: true, script: script("kept") }],
+			workers: [
+				{
+					name: "kept-worker",
+					unsafeRegisterWorker: true,
+					modules: true,
+					script: script("kept"),
+				},
+			],
 		});
 
 		await vi.waitFor(


### PR DESCRIPTION
The dev-registry registration default is now opt-in. Add `unsafeRegisterWorker: true` to the registry-churn test workers, including retained workers on configuration updates.

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: this corrects test fixtures for an existing option.

> [!NOTE]
> This is a contribution from an AI agent: pi, GPT-5.6 Terra.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/15050" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->