### PR TITLE
update the age header when responding from cache

### DIFF
--- a/.changeset/increment-cache-response-age.md
+++ b/.changeset/increment-cache-response-age.md
@@ -1,0 +1,6 @@
+---
+"miniflare": patch
+---
+
+Increment the Age response header when responding from cache.
+

--- a/packages/miniflare/src/workers/cache/cache.worker.ts
+++ b/packages/miniflare/src/workers/cache/cache.worker.ts
@@ -304,10 +304,9 @@ export class CacheObject extends MiniflareDurableObject {
 		// case, we just threw a `CacheMiss`)
 		assert(resHeaders !== undefined);
 		const now = this.timers.now();
-		resHeaders.set(
-			"Age",
-			String(Math.round((now - (cached.metadata.stored || now)) / 1000))
-		);
+		const age = parseInt(resHeaders.get("age") || "0", 10);
+		const cachedDuration = Math.round((now - (cached.metadata.stored || now)) / 1000)
+		resHeaders.set("Age", age + cachedDuration);
 		resHeaders.set("CF-Cache-Status", "HIT");
 		resRanges ??= [];
 

--- a/packages/miniflare/src/workers/cache/cache.worker.ts
+++ b/packages/miniflare/src/workers/cache/cache.worker.ts
@@ -305,8 +305,10 @@ export class CacheObject extends MiniflareDurableObject {
 		assert(resHeaders !== undefined);
 		const now = this.timers.now();
 		const age = parseInt(resHeaders.get("age") || "0", 10);
-		const cachedDuration = Math.round((now - (cached.metadata.stored || now)) / 1000)
-		resHeaders.set("Age", age + cachedDuration);
+		const cachedDuration = Math.round(
+			(now - (cached.metadata.stored || now)) / 1000
+		);
+		resHeaders.set("Age", String(age + cachedDuration));
 		resHeaders.set("CF-Cache-Status", "HIT");
 		resRanges ??= [];
 

--- a/packages/miniflare/src/workers/cache/cache.worker.ts
+++ b/packages/miniflare/src/workers/cache/cache.worker.ts
@@ -303,7 +303,10 @@ export class CacheObject extends MiniflareDurableObject {
 		// case, we just threw a `CacheMiss`)
 		assert(resHeaders !== undefined);
 		const now = this.timers.now();
-		resHeaders.set("Age", Math.round(now - (cached.metadata.stored || now)));
+		resHeaders.set(
+			"Age",
+			String(Math.round((now - (cached.metadata.stored || now)) / 1000))
+		);
 		resHeaders.set("CF-Cache-Status", "HIT");
 		resRanges ??= [];
 

--- a/packages/miniflare/src/workers/cache/cache.worker.ts
+++ b/packages/miniflare/src/workers/cache/cache.worker.ts
@@ -30,6 +30,7 @@ interface CacheMetadata {
 	headers: string[][];
 	status: number;
 	size: number;
+	stored?: number;
 }
 
 type CacheRouteHandler = RouteHandler<

--- a/packages/miniflare/src/workers/cache/cache.worker.ts
+++ b/packages/miniflare/src/workers/cache/cache.worker.ts
@@ -302,6 +302,8 @@ export class CacheObject extends MiniflareDurableObject {
 		// time we don't do this is when the entry isn't found, or expired, in which
 		// case, we just threw a `CacheMiss`)
 		assert(resHeaders !== undefined);
+		const now = this.timers.now();
+		resHeaders.set("Age", Math.round(now - (cached.metadata.stored || now)));
 		resHeaders.set("CF-Cache-Status", "HIT");
 		resRanges ??= [];
 
@@ -356,6 +358,7 @@ export class CacheObject extends MiniflareDurableObject {
 			headers: Object.entries(headers),
 			status: res.status,
 			size,
+			stored: this.timers.now(),
 		}));
 
 		await this.storage.put({


### PR DESCRIPTION
Fixes #[insert GH or internal issue link(s)].

When responding from the cache (HIT), update the Age header to be relative to the time the object was stored.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [ ] Documentation not necessary because:

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->



<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/15052" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->