### PR TITLE
Bump undici from 7.28.0 to 7.29.0 to resolve 5 CVE advisories

### DIFF
--- a/.changeset/bump-undici-security.md
+++ b/.changeset/bump-undici-security.md
@@ -1,0 +1,19 @@
+---
+"wrangler": patch
+"miniflare": patch
+"@cloudflare/vitest-pool-workers": patch
+"create-cloudflare": patch
+"@cloudflare/workers-utils": patch
+---
+
+Bump `undici` from 7.28.0 to 7.29.0 to resolve 5 CVE advisories
+
+Updated `undici` to address the following vulnerabilities:
+
+- CVE-2026-13697 (High): Cross-user information disclosure via cache directive parsing
+- CVE-2026-16728 (Moderate): Response desynchronization via retry interceptor
+- CVE-2026-15157 (Moderate): CRLF injection via blob-like body type property
+- CVE-2026-14643 (Moderate): Cross-user cache disclosure via whitespace handling
+- CVE-2026-16729 (Moderate): Cookie attribute injection via unsanitized fields
+
+These CVEs were published July 29, 2026 and all patched in `undici@7.29.0`.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -76,8 +76,8 @@ catalogs:
       specifier: 5.8.3
       version: 5.8.3
     undici:
-      specifier: 7.28.0
-      version: 7.28.0
+      specifier: 7.29.0
+      version: 7.29.0
     vite:
       specifier: 8.1.5
       version: 8.1.5
@@ -100,7 +100,7 @@ overrides:
   '@types/react-transition-group>@types/react': ^18
   '@cloudflare/elements>@types/react': ^18
   '@types/node': 22.15.17
-  '@types/node>undici-types': 7.28.0
+  '@types/node>undici-types': 7.29.0
 
 patchedDependencies:
   '@cloudflare/component-listbox@1.10.6':
@@ -200,7 +200,7 @@ importers:
         version: 5.8.3
       undici:
         specifier: catalog:default
-        version: 7.28.0
+        version: 7.29.0
       vitest:
         specifier: catalog:default
         version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@22.15.17)(@vitest/ui@4.1.0)(msw@2.12.4(@types/node@22.15.17)(typescript@5.8.3))(vite@8.1.5(@types/node@22.15.17)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.1))
@@ -302,7 +302,7 @@ importers:
         version: 5.8.3
       undici:
         specifier: catalog:default
-        version: 7.28.0
+        version: 7.29.0
       vitest:
         specifier: catalog:default
         version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@22.15.17)(@vitest/ui@4.1.0)(msw@2.12.4(@types/node@22.15.17)(typescript@5.8.3))(vite@8.1.5(@types/node@22.15.17)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.1))
@@ -323,7 +323,7 @@ importers:
         version: 5.8.3
       undici:
         specifier: catalog:default
-        version: 7.28.0
+        version: 7.29.0
       vitest:
         specifier: catalog:default
         version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@22.15.17)(@vitest/ui@4.1.0)(msw@2.12.4(@types/node@22.15.17)(typescript@5.8.3))(vite@8.1.5(@types/node@22.15.17)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.1))
@@ -362,7 +362,7 @@ importers:
         version: link:../../packages/workers-tsconfig
       undici:
         specifier: catalog:default
-        version: 7.28.0
+        version: 7.29.0
       vitest:
         specifier: catalog:default
         version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@22.15.17)(@vitest/ui@4.1.0)(msw@2.12.4(@types/node@22.15.17)(typescript@5.9.3))(vite@8.1.5(@types/node@22.15.17)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.1))
@@ -395,7 +395,7 @@ importers:
         version: 5.20260801.1
       undici:
         specifier: catalog:default
-        version: 7.28.0
+        version: 7.29.0
       vitest:
         specifier: catalog:default
         version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@22.15.17)(@vitest/ui@4.1.0)(msw@2.12.4(@types/node@22.15.17)(typescript@5.9.3))(vite@8.1.5(@types/node@22.15.17)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.1))
@@ -431,7 +431,7 @@ importers:
         version: 2.2.0
       undici:
         specifier: catalog:default
-        version: 7.28.0
+        version: 7.29.0
       vitest:
         specifier: catalog:default
         version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@22.15.17)(@vitest/ui@4.1.0)(msw@2.12.4(@types/node@22.15.17)(typescript@5.9.3))(vite@8.1.5(@types/node@22.15.17)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.1))
@@ -455,7 +455,7 @@ importers:
         version: 5.8.3
       undici:
         specifier: catalog:default
-        version: 7.28.0
+        version: 7.29.0
       vitest:
         specifier: catalog:default
         version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@22.15.17)(@vitest/ui@4.1.0)(msw@2.12.4(@types/node@22.15.17)(typescript@5.8.3))(vite@8.1.5(@types/node@22.15.17)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.1))
@@ -482,7 +482,7 @@ importers:
         version: 5.8.3
       undici:
         specifier: catalog:default
-        version: 7.28.0
+        version: 7.29.0
       vitest:
         specifier: catalog:default
         version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@22.15.17)(@vitest/ui@4.1.0)(msw@2.12.4(@types/node@22.15.17)(typescript@5.8.3))(vite@8.1.5(@types/node@22.15.17)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.1))
@@ -527,7 +527,7 @@ importers:
         version: 5.8.3
       undici:
         specifier: catalog:default
-        version: 7.28.0
+        version: 7.29.0
       vitest:
         specifier: catalog:default
         version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@22.15.17)(@vitest/ui@4.1.0)(msw@2.12.4(@types/node@22.15.17)(typescript@5.8.3))(vite@8.1.5(@types/node@22.15.17)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.1))
@@ -544,7 +544,7 @@ importers:
         version: link:../shared
       undici:
         specifier: catalog:default
-        version: 7.28.0
+        version: 7.29.0
       vitest:
         specifier: catalog:default
         version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@22.15.17)(@vitest/ui@4.1.0)(msw@2.12.4(@types/node@22.15.17)(typescript@5.9.3))(vite@8.1.5(@types/node@22.15.17)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.1))
@@ -626,7 +626,7 @@ importers:
         version: 5.8.3
       undici:
         specifier: catalog:default
-        version: 7.28.0
+        version: 7.29.0
       vitest:
         specifier: catalog:default
         version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@22.15.17)(@vitest/ui@4.1.0)(msw@2.12.4(@types/node@22.15.17)(typescript@5.8.3))(vite@8.1.5(@types/node@22.15.17)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.1))
@@ -681,7 +681,7 @@ importers:
         version: 5.20260801.1
       undici:
         specifier: catalog:default
-        version: 7.28.0
+        version: 7.29.0
       vitest:
         specifier: catalog:default
         version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@22.15.17)(@vitest/ui@4.1.0)(msw@2.12.4(@types/node@22.15.17)(typescript@5.9.3))(vite@8.1.5(@types/node@22.15.17)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.1))
@@ -714,7 +714,7 @@ importers:
         version: 1.2.7
       undici:
         specifier: catalog:default
-        version: 7.28.0
+        version: 7.29.0
       vitest:
         specifier: catalog:default
         version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@22.15.17)(@vitest/ui@4.1.0)(msw@2.12.4(@types/node@22.15.17)(typescript@5.9.3))(vite@8.1.5(@types/node@22.15.17)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.1))
@@ -735,7 +735,7 @@ importers:
         version: 5.8.3
       undici:
         specifier: catalog:default
-        version: 7.28.0
+        version: 7.29.0
       vitest:
         specifier: catalog:default
         version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@22.15.17)(@vitest/ui@4.1.0)(msw@2.12.4(@types/node@22.15.17)(typescript@5.8.3))(vite@8.1.5(@types/node@22.15.17)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.1))
@@ -763,7 +763,7 @@ importers:
         version: 5.8.3
       undici:
         specifier: catalog:default
-        version: 7.28.0
+        version: 7.29.0
       vitest:
         specifier: catalog:default
         version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@22.15.17)(@vitest/ui@4.1.0)(msw@2.12.4(@types/node@22.15.17)(typescript@5.8.3))(vite@8.1.5(@types/node@22.15.17)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.1))
@@ -784,7 +784,7 @@ importers:
         version: 5.8.3
       undici:
         specifier: catalog:default
-        version: 7.28.0
+        version: 7.29.0
       vitest:
         specifier: catalog:default
         version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@22.15.17)(@vitest/ui@4.1.0)(msw@2.12.4(@types/node@22.15.17)(typescript@5.8.3))(vite@8.1.5(@types/node@22.15.17)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.1))
@@ -802,7 +802,7 @@ importers:
         version: 5.8.3
       undici:
         specifier: catalog:default
-        version: 7.28.0
+        version: 7.29.0
       vitest:
         specifier: catalog:default
         version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@22.15.17)(@vitest/ui@4.1.0)(msw@2.12.4(@types/node@22.15.17)(typescript@5.8.3))(vite@8.1.5(@types/node@22.15.17)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.1))
@@ -823,7 +823,7 @@ importers:
         version: 5.8.3
       undici:
         specifier: catalog:default
-        version: 7.28.0
+        version: 7.29.0
       vitest:
         specifier: catalog:default
         version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@22.15.17)(@vitest/ui@4.1.0)(msw@2.12.4(@types/node@22.15.17)(typescript@5.8.3))(vite@8.1.5(@types/node@22.15.17)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.1))
@@ -844,7 +844,7 @@ importers:
         version: 5.8.3
       undici:
         specifier: catalog:default
-        version: 7.28.0
+        version: 7.29.0
       vitest:
         specifier: catalog:default
         version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@22.15.17)(@vitest/ui@4.1.0)(msw@2.12.4(@types/node@22.15.17)(typescript@5.8.3))(vite@8.1.5(@types/node@22.15.17)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.1))
@@ -865,7 +865,7 @@ importers:
         version: 5.8.3
       undici:
         specifier: catalog:default
-        version: 7.28.0
+        version: 7.29.0
       vitest:
         specifier: catalog:default
         version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@22.15.17)(@vitest/ui@4.1.0)(msw@2.12.4(@types/node@22.15.17)(typescript@5.8.3))(vite@8.1.5(@types/node@22.15.17)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.1))
@@ -905,7 +905,7 @@ importers:
         version: 5.8.3
       undici:
         specifier: catalog:default
-        version: 7.28.0
+        version: 7.29.0
       vitest:
         specifier: catalog:default
         version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@22.15.17)(@vitest/ui@4.1.0)(msw@2.12.4(@types/node@22.15.17)(typescript@5.8.3))(vite@8.1.5(@types/node@22.15.17)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.1))
@@ -926,7 +926,7 @@ importers:
         version: 5.8.3
       undici:
         specifier: catalog:default
-        version: 7.28.0
+        version: 7.29.0
       vitest:
         specifier: catalog:default
         version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@22.15.17)(@vitest/ui@4.1.0)(msw@2.12.4(@types/node@22.15.17)(typescript@5.8.3))(vite@8.1.5(@types/node@22.15.17)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.1))
@@ -941,7 +941,7 @@ importers:
         version: link:../../packages/workers-tsconfig
       undici:
         specifier: catalog:default
-        version: 7.28.0
+        version: 7.29.0
       vitest:
         specifier: catalog:default
         version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@22.15.17)(@vitest/ui@4.1.0)(msw@2.12.4(@types/node@22.15.17)(typescript@5.9.3))(vite@8.1.5(@types/node@22.15.17)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.1))
@@ -962,7 +962,7 @@ importers:
         version: 5.8.3
       undici:
         specifier: catalog:default
-        version: 7.28.0
+        version: 7.29.0
       vitest:
         specifier: catalog:default
         version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@22.15.17)(@vitest/ui@4.1.0)(msw@2.12.4(@types/node@22.15.17)(typescript@5.8.3))(vite@8.1.5(@types/node@22.15.17)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.1))
@@ -983,7 +983,7 @@ importers:
         version: 5.8.3
       undici:
         specifier: catalog:default
-        version: 7.28.0
+        version: 7.29.0
       vitest:
         specifier: catalog:default
         version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@22.15.17)(@vitest/ui@4.1.0)(msw@2.12.4(@types/node@22.15.17)(typescript@5.8.3))(vite@8.1.5(@types/node@22.15.17)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.1))
@@ -1001,7 +1001,7 @@ importers:
         version: 5.8.3
       undici:
         specifier: catalog:default
-        version: 7.28.0
+        version: 7.29.0
       vitest:
         specifier: catalog:default
         version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@22.15.17)(@vitest/ui@4.1.0)(msw@2.12.4(@types/node@22.15.17)(typescript@5.8.3))(vite@8.1.5(@types/node@22.15.17)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.1))
@@ -1019,7 +1019,7 @@ importers:
         version: 5.8.3
       undici:
         specifier: catalog:default
-        version: 7.28.0
+        version: 7.29.0
       vitest:
         specifier: catalog:default
         version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@22.15.17)(@vitest/ui@4.1.0)(msw@2.12.4(@types/node@22.15.17)(typescript@5.8.3))(vite@8.1.5(@types/node@22.15.17)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.1))
@@ -1037,7 +1037,7 @@ importers:
         version: 5.8.3
       undici:
         specifier: catalog:default
-        version: 7.28.0
+        version: 7.29.0
       vitest:
         specifier: catalog:default
         version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@22.15.17)(@vitest/ui@4.1.0)(msw@2.12.4(@types/node@22.15.17)(typescript@5.8.3))(vite@8.1.5(@types/node@22.15.17)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.1))
@@ -1055,7 +1055,7 @@ importers:
         version: 5.8.3
       undici:
         specifier: catalog:default
-        version: 7.28.0
+        version: 7.29.0
       vitest:
         specifier: catalog:default
         version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@22.15.17)(@vitest/ui@4.1.0)(msw@2.12.4(@types/node@22.15.17)(typescript@5.8.3))(vite@8.1.5(@types/node@22.15.17)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.1))
@@ -1073,7 +1073,7 @@ importers:
         version: 5.8.3
       undici:
         specifier: catalog:default
-        version: 7.28.0
+        version: 7.29.0
       vitest:
         specifier: catalog:default
         version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@22.15.17)(@vitest/ui@4.1.0)(msw@2.12.4(@types/node@22.15.17)(typescript@5.8.3))(vite@8.1.5(@types/node@22.15.17)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.1))
@@ -1091,7 +1091,7 @@ importers:
         version: 5.8.3
       undici:
         specifier: catalog:default
-        version: 7.28.0
+        version: 7.29.0
       vitest:
         specifier: catalog:default
         version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@22.15.17)(@vitest/ui@4.1.0)(msw@2.12.4(@types/node@22.15.17)(typescript@5.8.3))(vite@8.1.5(@types/node@22.15.17)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.1))
@@ -1106,7 +1106,7 @@ importers:
         version: link:../../packages/workers-tsconfig
       undici:
         specifier: catalog:default
-        version: 7.28.0
+        version: 7.29.0
       vitest:
         specifier: catalog:default
         version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@22.15.17)(@vitest/ui@4.1.0)(msw@2.12.4(@types/node@22.15.17)(typescript@5.9.3))(vite@8.1.5(@types/node@22.15.17)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.1))
@@ -1121,7 +1121,7 @@ importers:
         version: link:../../packages/workers-tsconfig
       undici:
         specifier: catalog:default
-        version: 7.28.0
+        version: 7.29.0
       vitest:
         specifier: catalog:default
         version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@22.15.17)(@vitest/ui@4.1.0)(msw@2.12.4(@types/node@22.15.17)(typescript@5.9.3))(vite@8.1.5(@types/node@22.15.17)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.1))
@@ -1333,7 +1333,7 @@ importers:
         version: link:../shared
       undici:
         specifier: catalog:default
-        version: 7.28.0
+        version: 7.29.0
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -1355,7 +1355,7 @@ importers:
         version: 5.8.3
       undici:
         specifier: catalog:default
-        version: 7.28.0
+        version: 7.29.0
       vitest:
         specifier: catalog:default
         version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@22.15.17)(@vitest/ui@4.1.0)(msw@2.12.4(@types/node@22.15.17)(typescript@5.8.3))(vite@8.1.5(@types/node@22.15.17)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.1))
@@ -1451,7 +1451,7 @@ importers:
         version: 5.8.3
       undici:
         specifier: catalog:default
-        version: 7.28.0
+        version: 7.29.0
       vitest:
         specifier: catalog:default
         version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@22.15.17)(@vitest/ui@4.1.0)(msw@2.12.4(@types/node@22.15.17)(typescript@5.8.3))(vite@8.1.5(@types/node@22.15.17)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.1))
@@ -1472,7 +1472,7 @@ importers:
         version: 5.8.3
       undici:
         specifier: catalog:default
-        version: 7.28.0
+        version: 7.29.0
       vitest:
         specifier: catalog:default
         version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@22.15.17)(@vitest/ui@4.1.0)(msw@2.12.4(@types/node@22.15.17)(typescript@5.8.3))(vite@8.1.5(@types/node@22.15.17)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.1))
@@ -1493,7 +1493,7 @@ importers:
         version: 5.8.3
       undici:
         specifier: catalog:default
-        version: 7.28.0
+        version: 7.29.0
       vitest:
         specifier: catalog:default
         version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@22.15.17)(@vitest/ui@4.1.0)(msw@2.12.4(@types/node@22.15.17)(typescript@5.8.3))(vite@8.1.5(@types/node@22.15.17)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.1))
@@ -1514,7 +1514,7 @@ importers:
         version: 5.8.3
       undici:
         specifier: catalog:default
-        version: 7.28.0
+        version: 7.29.0
       vitest:
         specifier: catalog:default
         version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@22.15.17)(@vitest/ui@4.1.0)(msw@2.12.4(@types/node@22.15.17)(typescript@5.8.3))(vite@8.1.5(@types/node@22.15.17)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.1))
@@ -1535,7 +1535,7 @@ importers:
         version: 5.8.3
       undici:
         specifier: catalog:default
-        version: 7.28.0
+        version: 7.29.0
       vitest:
         specifier: catalog:default
         version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@22.15.17)(@vitest/ui@4.1.0)(msw@2.12.4(@types/node@22.15.17)(typescript@5.8.3))(vite@8.1.5(@types/node@22.15.17)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.1))
@@ -1568,7 +1568,7 @@ importers:
         version: 5.8.3
       undici:
         specifier: catalog:default
-        version: 7.28.0
+        version: 7.29.0
       vitest:
         specifier: catalog:default
         version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@22.15.17)(@vitest/ui@4.1.0)(msw@2.12.4(@types/node@22.15.17)(typescript@5.8.3))(vite@8.1.5(@types/node@22.15.17)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.1))
@@ -1595,7 +1595,7 @@ importers:
         version: 5.8.3
       undici:
         specifier: catalog:default
-        version: 7.28.0
+        version: 7.29.0
       vitest:
         specifier: catalog:default
         version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@22.15.17)(@vitest/ui@4.1.0)(msw@2.12.4(@types/node@22.15.17)(typescript@5.8.3))(vite@8.1.5(@types/node@22.15.17)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.1))
@@ -1616,7 +1616,7 @@ importers:
         version: 5.8.3
       undici:
         specifier: catalog:default
-        version: 7.28.0
+        version: 7.29.0
       vitest:
         specifier: catalog:default
         version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@22.15.17)(@vitest/ui@4.1.0)(msw@2.12.4(@types/node@22.15.17)(typescript@5.8.3))(vite@8.1.5(@types/node@22.15.17)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.1))
@@ -1634,7 +1634,7 @@ importers:
         version: 5.8.3
       undici:
         specifier: catalog:default
-        version: 7.28.0
+        version: 7.29.0
       vitest:
         specifier: catalog:default
         version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@22.15.17)(@vitest/ui@4.1.0)(msw@2.12.4(@types/node@22.15.17)(typescript@5.8.3))(vite@8.1.5(@types/node@22.15.17)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.1))
@@ -1965,7 +1965,7 @@ importers:
         version: 5.8.3
       undici:
         specifier: catalog:default
-        version: 7.28.0
+        version: 7.29.0
       vite:
         specifier: catalog:default
         version: 8.1.5(@types/node@22.15.17)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.1)
@@ -2019,7 +2019,7 @@ importers:
         version: 6.1.1
       undici:
         specifier: catalog:default
-        version: 7.28.0
+        version: 7.29.0
     devDependencies:
       '@cloudflare/containers-shared':
         specifier: workspace:*
@@ -2294,7 +2294,7 @@ importers:
         version: 0.35.2
       undici:
         specifier: catalog:default
-        version: 7.28.0
+        version: 7.29.0
       workerd:
         specifier: catalog:default
         version: 1.20260801.1
@@ -2583,7 +2583,7 @@ importers:
         version: 4.0.0(patch_hash=60bdb1dcdbde0a135bb56d6fa1a1027caba891b149e2cfcb48d6a5b3524e0a91)
       undici:
         specifier: catalog:default
-        version: 7.28.0
+        version: 7.29.0
       wrangler:
         specifier: workspace:*
         version: link:../wrangler
@@ -2653,7 +2653,7 @@ importers:
         version: link:../miniflare
       undici:
         specifier: catalog:default
-        version: 7.28.0
+        version: 7.29.0
       ws:
         specifier: catalog:default
         version: 8.21.0
@@ -2891,7 +2891,7 @@ importers:
         version: 5.8.3
       undici:
         specifier: catalog:default
-        version: 7.28.0
+        version: 7.29.0
       vitest:
         specifier: catalog:default
         version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@22.15.17)(@vitest/ui@4.1.0)(msw@2.12.4(@types/node@22.15.17)(typescript@5.8.3))(vite@8.1.5(@types/node@22.15.17)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.1))
@@ -4105,7 +4105,7 @@ importers:
         version: 5.8.3
       undici:
         specifier: catalog:default
-        version: 7.28.0
+        version: 7.29.0
       vitest:
         specifier: catalog:default
         version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@22.15.17)(@vitest/ui@4.1.0)(msw@2.12.4(@types/node@22.15.17)(typescript@5.8.3))(vite@8.1.5(@types/node@22.15.17)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.1))
@@ -4117,7 +4117,7 @@ importers:
         version: link:../workers-utils
       undici:
         specifier: catalog:default
-        version: 7.28.0
+        version: 7.29.0
     devDependencies:
       '@cloudflare/workers-tsconfig':
         specifier: workspace:*
@@ -4297,7 +4297,7 @@ importers:
         version: 4.13.0
       undici:
         specifier: catalog:default
-        version: 7.28.0
+        version: 7.29.0
       vite:
         specifier: catalog:default
         version: 8.1.5(@types/node@22.15.17)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.1)
@@ -4350,7 +4350,7 @@ importers:
     dependencies:
       undici:
         specifier: catalog:default
-        version: 7.28.0
+        version: 7.29.0
     devDependencies:
       '@cloudflare/workers-shared':
         specifier: workspace:*
@@ -4767,7 +4767,7 @@ importers:
         version: 5.8.3
       undici:
         specifier: catalog:default
-        version: 7.28.0
+        version: 7.29.0
       vitest:
         specifier: catalog:default
         version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@22.15.17)(@vitest/ui@4.1.0)(msw@2.12.4(@types/node@22.15.17)(typescript@5.8.3))(vite@8.1.5(@types/node@22.15.17)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.1))
@@ -4825,7 +4825,7 @@ importers:
         version: 2.2.0
       undici:
         specifier: catalog:default
-        version: 7.28.0
+        version: 7.29.0
       wrangler:
         specifier: workspace:*
         version: link:../packages/wrangler
@@ -15471,8 +15471,8 @@ packages:
   unconfig@7.3.3:
     resolution: {integrity: sha512-QCkQoOnJF8L107gxfHL0uavn7WD9b3dpBcFX6HtfQYmjw2YzWxGuFQ0N0J6tE9oguCBJn9KOvfqYDCMPHIZrBA==}
 
-  undici-types@7.28.0:
-    resolution: {integrity: sha512-LJAfY+2w6HGeT8d8J1wNQsUGUEGio6NWWpwdwurQe4f6oojzCFuGLizl1KSve4irsTxyLly1QhEeE6iapdaIvQ==}
+  undici-types@7.29.0:
+    resolution: {integrity: sha512-vamA8dGlzMwhpyYpQp9d8vka3o4D/yn5I7ez7Or+msDA4bZ8Uh+Zy91WvWf3I73gDAkFha9JcYRqm2li0Npfgg==}
 
   undici@5.28.5:
     resolution: {integrity: sha512-zICwjrDrcrUE0pyyJc1I2QzBkLM8FINsgOrt6WjA+BgajVq9Nxu2PbFFXUrAggLfDXlZGZBVZYw7WNV5KiBiBA==}
@@ -15482,8 +15482,8 @@ packages:
     resolution: {integrity: sha512-BM/JzwwaRXxrLdElV2Uo6cTLEjhSb3WXboncJamZ15NgUURmvlXvxa6xkwIOILIjPNo9i8ku136ZvWV0Uly8+w==}
     engines: {node: '>=20.18.1'}
 
-  undici@7.28.0:
-    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
+  undici@7.29.0:
+    resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
     engines: {node: '>=20.18.1'}
 
   unenv@2.0.0-rc.24:
@@ -20866,7 +20866,7 @@ snapshots:
 
   '@types/node@22.15.17':
     dependencies:
-      undici-types: 7.28.0
+      undici-types: 7.29.0
 
   '@types/normalize-package-data@2.4.4': {}
 
@@ -27296,7 +27296,7 @@ snapshots:
       jiti: 2.6.1
       quansync: 0.2.11
 
-  undici-types@7.28.0: {}
+  undici-types@7.29.0: {}
 
   undici@5.28.5:
     dependencies:
@@ -27304,7 +27304,7 @@ snapshots:
 
   undici@7.24.4: {}
 
-  undici@7.28.0: {}
+  undici@7.29.0: {}
 
   unenv@2.0.0-rc.24:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -113,10 +113,10 @@ catalog:
   "@vitest/snapshot": 4.1.0
   "@vitest/ui": 4.1.0
   typescript: "5.8.3"
-  undici: "7.28.0"
+  undici: "7.29.0"
   # Override undici-types from @types/node so that the Cloudflare SDK typings match our installed
   # version of Undici
-  undici-types: "7.28.0"
+  undici-types: "7.29.0"
   vitest: "4.1.0"
   vite: "8.1.5"
   "ws": "8.21.0"


### PR DESCRIPTION
**Description:**

Fixes #15042

Users installing `wrangler` from npm get 3 `npm audit` vulnerabilities (2 moderate, 1 high). Running `npm audit fix` does nothing because `undici` is a transitive dependency through `miniflare`, pinned at `7.28.0` in the pnpm catalog. The only option — `npm audit fix --force` — downgrades wrangler to v4.35.0 (a SemVer major break) and then introduces 4 more vulnerabilities from `sharp` and `ws` pulled in by the old version. There is no safe resolution path for users.

The root cause is `undici@7.28.0`, which is affected by 5 CVE advisories published July 29, 2026:

- CVE-2026-13697 (High): Cross-user information disclosure via cache directive parsing
- CVE-2026-16728 (Moderate): Response desynchronization via retry interceptor
- CVE-2026-15157 (Moderate): CRLF injection via blob-like body type property
- CVE-2026-14643 (Moderate): Cross-user cache disclosure via whitespace handling
- CVE-2026-16729 (Moderate): Cookie attribute injection via unsanitized fields

All 5 are patched in `undici@7.29.0`. `sharp` (0.35.2) and `ws` (8.21.0) are already on patched versions — the advisories for those only appear if a user follows the broken `--force` downgrade path.

Bumped `undici` and `undici-types` from `"7.28.0"` to `"7.29.0"` in the pnpm catalog. No code changes required — `undici` 7.29.0 has no breaking API changes from 7.28.0.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [x] Automated tests not possible - manual testing has been completed as follows: ran `pnpm test -F wrangler` (4,835 tests passed, 7 pre-existing environment-only failures in `log-file.test.ts`), `pnpm check:type` on affected packages (all clean), and `pnpm check:format` (4,797 files clean). No new tests needed — this is a dependency version bump with no API or behavior change.
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: This is a CVE-driven dependency bump with no user-facing API or behavior changes.

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

> [!NOTE]
> This is a contribution from an AI agent: DeepSeek V4 Pro (deepseek)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/15054" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->