### PR TITLE
chore: ignore major workers-types updates in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -46,3 +46,9 @@ updates:
     allow:
       - dependency-name: "workerd"
       - dependency-name: "@cloudflare/workers-types"
+    # @prisma/adapter-d1 still depends on workers-types v4, which causes
+    # Dependabot to open no-op v4-to-v5 lockfile updates.
+    ignore:
+      - dependency-name: "@cloudflare/workers-types"
+        update-types:
+          - "version-update:semver-major"


### PR DESCRIPTION
Prevent Dependabot from opening no-op major updates for `@cloudflare/workers-types`.

`@prisma/adapter-d1` [still depends on workers-types v4](https://github.com/cloudflare/workers-sdk/blob/main/pnpm-lock.yaml#L19206-L19210). Dependabot detects that transitive lockfile entry and repeatedly attempts a v4-to-v5 update, but only produces unrelated lockfile churn. Ignore semver-major workers-types updates while retaining minor and patch updates for the repository's v5 dependency.

Example: #15030

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: this only changes Dependabot configuration, and `pnpm check:workflows` passes.
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: this is an internal dependency automation change with no user-facing behavior.

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
