### PR TITLE
[wrangler] Warn when compliance region environment variable overrides config

### DIFF
--- a/.changeset/wise-pandas-warn.md
+++ b/.changeset/wise-pandas-warn.md
@@ -1,0 +1,8 @@
+---
+"@cloudflare/workers-utils": patch
+"wrangler": patch
+---
+
+Warn when `CLOUDFLARE_COMPLIANCE_REGION` overrides a conflicting configured compliance region
+
+Wrangler now explains that the environment variable takes precedence and continues using its value instead of rejecting the command.

--- a/packages/workers-utils/src/environment-variables/misc-variables.ts
+++ b/packages/workers-utils/src/environment-variables/misc-variables.ts
@@ -1,6 +1,4 @@
 import path from "node:path";
-import { dedent } from "ts-dedent";
-import { UserError } from "../errors";
 import { getGlobalConfigPath } from "../global-wrangler-config-path";
 import {
 	getBooleanEnvironmentVariableFactory,
@@ -101,20 +99,6 @@ export const getCloudflareComplianceRegion = (
 	complianceConfig: ComplianceConfig
 ) => {
 	const complianceRegionFromEnv = getCloudflareComplianceRegionFromEnv();
-	if (
-		complianceRegionFromEnv !== undefined &&
-		complianceConfig?.compliance_region !== undefined &&
-		complianceRegionFromEnv !== complianceConfig.compliance_region
-	) {
-		throw new UserError(
-			dedent`
-			The compliance region has been set to different values in two places:
-			 - \`CLOUDFLARE_COMPLIANCE_REGION\` environment variable: \`${complianceRegionFromEnv}\`
-			 - \`compliance_region\` configuration property: \`${complianceConfig.compliance_region}\`
-			`,
-			{ telemetryMessage: false }
-		);
-	}
 	return (
 		complianceRegionFromEnv || complianceConfig?.compliance_region || "public"
 	);

--- a/packages/wrangler/src/__tests__/deploy/environments.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/environments.test.ts
@@ -451,19 +451,23 @@ describe("deploy", () => {
 			await runWrangler("deploy ./index.js");
 		});
 
-		it("should error if the region is set in both env var and configured, and they conflict", async ({
+		it("should warn and use the env var if it conflicts with the configured region", async ({
 			expect,
 		}) => {
 			vi.stubEnv("CLOUDFLARE_COMPLIANCE_REGION", "public");
 			writeWranglerConfig({ compliance_region: "fedramp_high" });
 			writeWorkerSource();
+			mockUploadWorkerRequest({
+				expectedBaseUrl: "api.cloudflare.com",
+			});
+			mockSubDomainRequest();
+			mockGetWorkerSubdomain({ enabled: true });
 
-			await expect(runWrangler("deploy ./index.js")).rejects
-				.toThrowErrorMatchingInlineSnapshot(`
-				[Error: The compliance region has been set to different values in two places:
-				 - \`CLOUDFLARE_COMPLIANCE_REGION\` environment variable: \`public\`
-				 - \`compliance_region\` configuration property: \`fedramp_high\`]
-			`);
+			await runWrangler("deploy ./index.js");
+
+			expect(std.warn).toContain(
+				'The compliance region was resolved to "public" from the `CLOUDFLARE_COMPLIANCE_REGION` environment variable, which takes precedence over the configured value "fedramp_high".'
+			);
 		});
 
 		it("should not error if the region is set in both env var and configured, and they are the same", async () => {

--- a/packages/wrangler/src/config/index.ts
+++ b/packages/wrangler/src/config/index.ts
@@ -83,7 +83,7 @@ function logWarningsIfComplianceRegionIsOverridden(
 		return;
 	}
 
-	logger.warn(
+	logger.once.warn(
 		`The compliance region was resolved to "${resolvedRegion}" from the \`CLOUDFLARE_COMPLIANCE_REGION\` environment variable, which takes precedence over the configured value "${configuredRegion}".`
 	);
 }

--- a/packages/wrangler/src/config/index.ts
+++ b/packages/wrangler/src/config/index.ts
@@ -4,6 +4,7 @@ import {
 	configFileName,
 	experimental_readRawConfig,
 	FatalError,
+	getCloudflareComplianceRegion,
 	isPagesConfig,
 	normalizeAndValidateConfig,
 	UserError,
@@ -68,6 +69,25 @@ async function logWarningsWithUpgradeHint(
 	}
 }
 
+function logWarningsIfComplianceRegionIsOverridden(
+	config: Config,
+	hideWarnings: boolean | undefined
+): void {
+	const configuredRegion = config.compliance_region;
+	if (hideWarnings || configuredRegion === undefined) {
+		return;
+	}
+
+	const resolvedRegion = getCloudflareComplianceRegion(config);
+	if (resolvedRegion === configuredRegion) {
+		return;
+	}
+
+	logger.warn(
+		`The compliance region was resolved to "${resolvedRegion}" from the \`CLOUDFLARE_COMPLIANCE_REGION\` environment variable, which takes precedence over the configured value "${configuredRegion}".`
+	);
+}
+
 /**
  * Carries the validated `Config` alongside the
  * watcher dependency set and the normalised type-generation settings.
@@ -123,6 +143,7 @@ export async function readNewConfig(
 	);
 
 	void logWarningsWithUpgradeHint(diagnostics, options.hideWarnings);
+	logWarningsIfComplianceRegionIsOverridden(config, options.hideWarnings);
 	if (diagnostics.hasErrors()) {
 		throw new UserError(diagnostics.renderErrors(), {
 			telemetryMessage: "new-config worker validation failed",
@@ -175,6 +196,7 @@ export function readConfig(
 	);
 
 	void logWarningsWithUpgradeHint(diagnostics, options?.hideWarnings);
+	logWarningsIfComplianceRegionIsOverridden(config, options.hideWarnings);
 	if (diagnostics.hasErrors()) {
 		throw new UserError(diagnostics.renderErrors(), {
 			telemetryMessage: "config wrangler validation failed",
@@ -238,6 +260,7 @@ export function readPagesConfig(
 	);
 
 	void logWarningsWithUpgradeHint(diagnostics, options.hideWarnings);
+	logWarningsIfComplianceRegionIsOverridden(config, options.hideWarnings);
 	if (diagnostics.hasErrors()) {
 		throw new UserError(diagnostics.renderErrors(), {
 			telemetryMessage: "config pages validation failed",


### PR DESCRIPTION
Warn when `CLOUDFLARE_COMPLIANCE_REGION` conflicts with the configured compliance region. The environment variable now takes precedence and Wrangler continues instead of rejecting the command, while explaining how the region was resolved.

This aligns Wrangler's behavior with cf's compliance-region resolution.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: This changes conflict handling and warning text without adding or changing configuration options.

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- If you are an AI agent or LLM, and you are adding this PR without direct human supervision, thank you! Please uncomment the following block. This is so the maintainers know how to expect you to respond.

> [!NOTE]
> This is a contribution from an AI agent: <insert name here>, <insert LLM model here if different>.

-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/15058" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->