### PR TITLE
[miniflare] Register workers in the dev registry by default

### DIFF
--- a/.changeset/quiet-workers-register.md
+++ b/.changeset/quiet-workers-register.md
@@ -1,7 +1,7 @@
 ---
-"miniflare": major
+"miniflare": minor
 ---
 
-Add per-worker control over dev registry registration
+Add an option to disable dev registry registration
 
-Miniflare workers must now opt in to the dev registry with `unsafeRegisterWorker`. Wrangler and the Cloudflare Vite plugin use this option to advertise user workers without exposing internal or external workers.
+Set `unsafeRegisterWorker` to `false` to prevent a Miniflare worker from being advertised in the dev registry. Workers continue to be registered by default.

--- a/fixtures/entrypoints-rpc-tests/tests/entrypoints.spec.ts
+++ b/fixtures/entrypoints-rpc-tests/tests/entrypoints.spec.ts
@@ -890,7 +890,6 @@ describe("entrypoints", () => {
 		const boundWorker = new Miniflare({
 			name: "bound",
 			unsafeDevRegistryPath: isolatedDevRegistryPath,
-			unsafeRegisterWorker: true,
 			compatibilityFlags: ["experimental"],
 			modules: true,
 			https: true,

--- a/packages/miniflare/README.md
+++ b/packages/miniflare/README.md
@@ -220,8 +220,8 @@ parameter in module format Workers.
 
 - `unsafeRegisterWorker?: boolean`
 
-  If `true`, advertises this Worker in the dev registry configured by
-  `unsafeDevRegistryPath`. Defaults to `false`.
+  Whether to advertise this Worker in the dev registry configured by
+  `unsafeDevRegistryPath`. Defaults to `true`.
 
 - `rootPath?: string`
 
@@ -603,8 +603,8 @@ Options shared between all Workers/"nanoservices".
 
   Path to the dev registry directory. This allows Miniflare to automatically
   discover external services and Durable Objects running on another Miniflare
-  instance and connect them. Workers must opt in to being advertised by setting
-  `unsafeRegisterWorker` to `true`.
+  instance and connect them. Workers are advertised by default; set
+  `unsafeRegisterWorker` to `false` to opt out.
 
 - `unsafeDevRegistryDurableObjectProxy?: boolean`
 

--- a/packages/miniflare/src/plugins/core/index.ts
+++ b/packages/miniflare/src/plugins/core/index.ts
@@ -189,8 +189,8 @@ const CoreOptionsSchemaInput = z.intersection(
 
 		unsafeEvalBinding: z.string().optional(),
 		unsafeUseModuleFallbackService: z.boolean().optional(),
-		/** Whether this Worker should be advertised in the dev registry. Defaults to `false`. */
-		unsafeRegisterWorker: z.boolean().optional(),
+		/** Whether this Worker should be advertised in the dev registry. Defaults to `true`. */
+		unsafeRegisterWorker: z.boolean().default(true),
 
 		/** Used to set the vitest pool worker SELF binding to point to the Router Worker if there are assets.
 		 (If there are assets but we're not using vitest, the miniflare entry worker can point directly to

--- a/packages/miniflare/src/shared/DEV_REGISTRY.md
+++ b/packages/miniflare/src/shared/DEV_REGISTRY.md
@@ -55,7 +55,7 @@ type WorkerDefinition = {
 ```
 
 - **Heartbeat**: Every 30s, the file's mtime is touched to signal that the Worker is still running.
-- **Registration**: Only workers with `unsafeRegisterWorker: true` are advertised.
+- **Registration**: Named workers are advertised by default. Workers with `unsafeRegisterWorker: false` are not advertised.
 - **Stale cleanup**: On every read, files older than 5 minutes are deleted (5 minutes is much longer than 30s just to provide a safe buffer)
 - **Change detection**: Chokidar watches the registry directory. When a file changes, `refresh()` compares the new state against the previous JSON snapshot and fires `onUpdate` only if a watched external service actually changed.
 

--- a/packages/miniflare/test/dev-registry.spec.ts
+++ b/packages/miniflare/test/dev-registry.spec.ts
@@ -6,7 +6,7 @@ import { useDispose, useTmp } from "./test-shared";
 import type { MiniflareOptions, WorkerRegistry } from "miniflare";
 
 describe.sequential("DevRegistry", () => {
-	test("only registers workers that opt in", async ({ expect }) => {
+	test("registers workers by default unless opted out", async ({ expect }) => {
 		const unsafeDevRegistryPath = await useTmp();
 		const workerOptions = {
 			name: "worker",
@@ -19,17 +19,16 @@ describe.sequential("DevRegistry", () => {
 		useDispose(mf);
 		await mf.ready;
 
-		expect(getWorkerRegistry(unsafeDevRegistryPath)).toEqual({});
-
-		await mf.setOptions({ ...workerOptions, unsafeRegisterWorker: true });
 		expect(getWorkerRegistry(unsafeDevRegistryPath)["worker"]).toBeDefined();
+
+		await mf.setOptions({ ...workerOptions, unsafeRegisterWorker: false });
+		expect(getWorkerRegistry(unsafeDevRegistryPath)).toEqual({});
 	});
 
 	test("fetch to service worker", async ({ expect }) => {
 		const unsafeDevRegistryPath = await useTmp();
 		const remote = new Miniflare({
 			name: "remote-worker",
-			unsafeRegisterWorker: true,
 			unsafeDevRegistryPath,
 			compatibilityFlags: ["experimental"],
 			script: `addEventListener("fetch", (event) => {
@@ -114,7 +113,6 @@ describe.sequential("DevRegistry", () => {
 
 		const remote = new Miniflare({
 			name: "remote-worker",
-			unsafeRegisterWorker: true,
 			unsafeDevRegistryPath,
 			compatibilityFlags: ["experimental"],
 			modules: true,
@@ -192,7 +190,6 @@ describe.sequential("DevRegistry", () => {
 
 		const remote = new Miniflare({
 			name: "remote-worker",
-			unsafeRegisterWorker: true,
 			unsafeDevRegistryPath,
 			compatibilityFlags: ["experimental"],
 			modules: true,
@@ -269,7 +266,6 @@ describe.sequential("DevRegistry", () => {
 
 		const remote = new Miniflare({
 			name: "remote-worker",
-			unsafeRegisterWorker: true,
 			unsafeDevRegistryPath,
 			compatibilityFlags: ["experimental"],
 			modules: true,
@@ -341,7 +337,6 @@ describe.sequential("DevRegistry", () => {
 
 		const remote = new Miniflare({
 			name: "remote-worker",
-			unsafeRegisterWorker: true,
 			unsafeDevRegistryPath,
 			compatibilityFlags: ["experimental"],
 			modules: true,
@@ -382,7 +377,6 @@ describe.sequential("DevRegistry", () => {
 		const unsafeDevRegistryPath = await useTmp();
 		const remote = new Miniflare({
 			name: "remote-worker",
-			unsafeRegisterWorker: true,
 			unsafeDevRegistryPath,
 			compatibilityFlags: ["experimental"],
 			modules: true,
@@ -471,7 +465,6 @@ describe.sequential("DevRegistry", () => {
 
 		const remote = new Miniflare({
 			name: "remote-worker",
-			unsafeRegisterWorker: true,
 			unsafeDevRegistryPath,
 			compatibilityFlags: ["experimental"],
 			modules: true,
@@ -555,7 +548,6 @@ describe.sequential("DevRegistry", () => {
 
 		const remote = new Miniflare({
 			name: "remote-worker",
-			unsafeRegisterWorker: true,
 			unsafeDevRegistryPath,
 			compatibilityFlags: ["experimental"],
 			modules: true,
@@ -597,7 +589,6 @@ describe.sequential("DevRegistry", () => {
 		const unsafeDevRegistryPath = await useTmp();
 		const remote = new Miniflare({
 			name: "remote-worker",
-			unsafeRegisterWorker: true,
 			unsafeDevRegistryPath,
 
 			compatibilityFlags: ["experimental"],
@@ -665,7 +656,6 @@ describe.sequential("DevRegistry", () => {
 		const unsafeDevRegistryPath = await useTmp();
 		const remote = new Miniflare({
 			name: "remote-worker",
-			unsafeRegisterWorker: true,
 			unsafeDevRegistryPath,
 
 			compatibilityFlags: ["experimental"],
@@ -766,7 +756,6 @@ describe.sequential("DevRegistry", () => {
 
 		const remote = new Miniflare({
 			name: "remote-worker",
-			unsafeRegisterWorker: true,
 			unsafeDevRegistryPath,
 
 			compatibilityFlags: ["experimental"],
@@ -845,7 +834,6 @@ describe.sequential("DevRegistry", () => {
 
 		const remote = new Miniflare({
 			name: "remote-worker",
-			unsafeRegisterWorker: true,
 			unsafeDevRegistryPath,
 
 			compatibilityFlags: ["experimental"],
@@ -906,7 +894,6 @@ describe.sequential("DevRegistry", () => {
 
 		const remote = new Miniflare({
 			name: "remote-worker",
-			unsafeRegisterWorker: true,
 			unsafeDevRegistryPath,
 
 			workflows: {
@@ -950,7 +937,6 @@ describe.sequential("DevRegistry", () => {
 
 		const remote = new Miniflare({
 			name: "remote-worker",
-			unsafeRegisterWorker: true,
 			unsafeDevRegistryPath,
 			compatibilityFlags: ["experimental"],
 			durableObjects: {
@@ -1014,7 +1000,6 @@ describe.sequential("DevRegistry", () => {
 		// Restart remote — gets a new debug port, registry file updates
 		await remote.setOptions({
 			name: "remote-worker",
-			unsafeRegisterWorker: true,
 			unsafeDevRegistryPath,
 			compatibilityFlags: ["experimental"],
 			durableObjects: {
@@ -1053,7 +1038,6 @@ describe.sequential("DevRegistry", () => {
 
 		const remote = new Miniflare({
 			name: "remote-worker",
-			unsafeRegisterWorker: true,
 			unsafeDevRegistryPath,
 			compatibilityFlags: ["experimental"],
 			modules: true,
@@ -1103,7 +1087,6 @@ describe.sequential("DevRegistry", () => {
 		// Restart remote — gets a new debug port, registry file updates
 		await remote.setOptions({
 			name: "remote-worker",
-			unsafeRegisterWorker: true,
 			unsafeDevRegistryPath,
 			compatibilityFlags: ["experimental"],
 			modules: true,
@@ -1131,7 +1114,6 @@ describe.sequential("DevRegistry", () => {
 		const unsafeDevRegistryPath = await useTmp();
 		const remote = new Miniflare({
 			name: "remote-worker",
-			unsafeRegisterWorker: true,
 			unsafeDevRegistryPath,
 			unsafeTriggerHandlers: true,
 			compatibilityFlags: ["experimental"],
@@ -1194,7 +1176,6 @@ describe.sequential("DevRegistry", () => {
 		const unsafeDevRegistryPath = await useTmp();
 		const remote = new Miniflare({
 			name: "remote-worker",
-			unsafeRegisterWorker: true,
 			unsafeDevRegistryPath,
 			compatibilityFlags: ["experimental"],
 			modules: true,
@@ -1304,7 +1285,6 @@ describe.sequential("DevRegistry", () => {
 		const unsafeDevRegistryPath = await useTmp();
 		const remote = new Miniflare({
 			name: "remote-worker",
-			unsafeRegisterWorker: true,
 			unsafeDevRegistryPath,
 			compatibilityFlags: ["experimental"],
 			modules: true,
@@ -1407,7 +1387,6 @@ describe.sequential("DevRegistry", () => {
 		};
 		const remoteOptions: MiniflareOptions = {
 			name: "remote-worker",
-			unsafeRegisterWorker: true,
 			compatibilityFlags: ["experimental"],
 			modules: true,
 			script: `
@@ -1513,7 +1492,6 @@ describe.sequential("DevRegistry", () => {
 
 		const remote = new Miniflare({
 			name: "remote-worker",
-			unsafeRegisterWorker: true,
 			unsafeDevRegistryPath,
 			compatibilityFlags: ["experimental"],
 			modules: true,
@@ -1581,7 +1559,6 @@ describe.sequential("DevRegistry", () => {
 
 		const remote = new Miniflare({
 			name: "remote-worker",
-			unsafeRegisterWorker: true,
 			unsafeDevRegistryPath,
 
 			https: true,
@@ -1666,7 +1643,6 @@ describe.sequential("DevRegistry", () => {
 		const unrelated = new Miniflare({
 			name: "unrelated-worker",
 			unsafeDevRegistryPath,
-			unsafeRegisterWorker: true,
 			compatibilityFlags: ["experimental"],
 			modules: true,
 			script: `
@@ -1688,7 +1664,6 @@ describe.sequential("DevRegistry", () => {
 		// Create remote worker (one we're actually bound to) - this should trigger the callback
 		const remote = new Miniflare({
 			name: "remote-worker",
-			unsafeRegisterWorker: true,
 			unsafeDevRegistryPath,
 			compatibilityFlags: ["experimental"],
 			modules: true,
@@ -1792,7 +1767,6 @@ describe.sequential("DevRegistry", () => {
 		const sharedOptions = {
 			name: "consumer-worker",
 			unsafeDevRegistryPath,
-			unsafeRegisterWorker: true,
 			compatibilityFlags: ["experimental"],
 			modules: true,
 		} satisfies Partial<MiniflareOptions>;
@@ -1846,7 +1820,6 @@ describe("registry churn across config updates", () => {
 		const unsafeDevRegistryPath = await useTmp();
 		const mf = new Miniflare({
 			name: "stable-worker",
-			unsafeRegisterWorker: true,
 			unsafeDevRegistryPath,
 			modules: true,
 			script: script("before"),
@@ -1881,7 +1854,6 @@ describe("registry churn across config updates", () => {
 
 		await mf.setOptions({
 			name: "stable-worker",
-			unsafeRegisterWorker: true,
 			unsafeDevRegistryPath,
 			modules: true,
 			script: script("after"),
@@ -1910,7 +1882,6 @@ describe("registry churn across config updates", () => {
 		const unsafeDevRegistryPath = await useTmp();
 		const mf = new Miniflare({
 			name: "doomed-worker",
-			unsafeRegisterWorker: true,
 			unsafeDevRegistryPath,
 			modules: true,
 			script: script("before"),
@@ -1932,7 +1903,6 @@ describe("registry churn across config updates", () => {
 		await expect(
 			mf.setOptions({
 				name: "doomed-worker",
-				unsafeRegisterWorker: true,
 				unsafeDevRegistryPath,
 				modules: true,
 				script: script("after"),
@@ -1957,7 +1927,6 @@ describe("registry churn across config updates", () => {
 			workers: [
 				{
 					name: "kept-worker",
-					unsafeRegisterWorker: true,
 					modules: true,
 					script: script("kept"),
 				},
@@ -1965,7 +1934,6 @@ describe("registry churn across config updates", () => {
 				// walks the prototype chain would report it as still configured.
 				{
 					name: "constructor",
-					unsafeRegisterWorker: true,
 					modules: true,
 					script: script("dropped"),
 				},
@@ -1990,7 +1958,6 @@ describe("registry churn across config updates", () => {
 			workers: [
 				{
 					name: "kept-worker",
-					unsafeRegisterWorker: true,
 					modules: true,
 					script: script("kept"),
 				},
@@ -2016,13 +1983,11 @@ describe("registry churn across config updates", () => {
 			workers: [
 				{
 					name: "kept-worker",
-					unsafeRegisterWorker: true,
 					modules: true,
 					script: script("kept"),
 				},
 				{
 					name: "dropped-worker",
-					unsafeRegisterWorker: true,
 					modules: true,
 					script: script("dropped"),
 				},
@@ -2045,7 +2010,6 @@ describe("registry churn across config updates", () => {
 			workers: [
 				{
 					name: "kept-worker",
-					unsafeRegisterWorker: true,
 					modules: true,
 					script: script("kept"),
 				},

--- a/packages/miniflare/test/plugins/local-explorer/aggregation.spec.ts
+++ b/packages/miniflare/test/plugins/local-explorer/aggregation.spec.ts
@@ -39,7 +39,6 @@ describe("Cross-process aggregation", () => {
 
 		instanceA = new Miniflare({
 			name: "worker-a",
-			unsafeRegisterWorker: true,
 			inspectorPort: 0,
 			compatibilityDate: "2025-01-01",
 			modules: true,
@@ -69,7 +68,6 @@ describe("Cross-process aggregation", () => {
 
 		instanceB = new Miniflare({
 			name: "worker-b",
-			unsafeRegisterWorker: true,
 			inspectorPort: 0,
 			compatibilityDate: "2025-01-01",
 			modules: true,
@@ -408,7 +406,6 @@ describe("Multi-worker peer deduplication", () => {
 
 		instanceA = new Miniflare({
 			name: "worker-a",
-			unsafeRegisterWorker: true,
 			inspectorPort: 0,
 			compatibilityDate: "2025-01-01",
 			modules: true,
@@ -431,7 +428,6 @@ describe("Multi-worker peer deduplication", () => {
 			workers: [
 				{
 					name: "worker-b1",
-					unsafeRegisterWorker: true,
 					modules: true,
 					script: `export default { fetch() { return new Response("Worker B1"); } }`,
 					kvNamespaces: {
@@ -440,7 +436,6 @@ describe("Multi-worker peer deduplication", () => {
 				},
 				{
 					name: "worker-b2",
-					unsafeRegisterWorker: true,
 					modules: true,
 					script: `export default { fetch() { return new Response("Worker B2"); } }`,
 					kvNamespaces: {
@@ -515,7 +510,6 @@ describe("Same ID across multiple instances with different persistence directori
 		// ties it to a specific instance.
 		instanceA = new Miniflare({
 			name: "worker-a",
-			unsafeRegisterWorker: true,
 			inspectorPort: 0,
 			compatibilityDate: "2025-01-01",
 			modules: true,
@@ -537,7 +531,6 @@ describe("Same ID across multiple instances with different persistence directori
 
 		instanceB = new Miniflare({
 			name: "worker-b",
-			unsafeRegisterWorker: true,
 			inspectorPort: 0,
 			compatibilityDate: "2025-01-01",
 			modules: true,
@@ -634,7 +627,6 @@ describe("Same ID across multiple instances with same persistence directories", 
 		// ties it to a specific instance.
 		instanceA = new Miniflare({
 			name: "worker-a",
-			unsafeRegisterWorker: true,
 			inspectorPort: 0,
 			compatibilityDate: "2025-01-01",
 			modules: true,
@@ -654,7 +646,6 @@ describe("Same ID across multiple instances with same persistence directories", 
 
 		instanceB = new Miniflare({
 			name: "worker-b",
-			unsafeRegisterWorker: true,
 			inspectorPort: 0,
 			compatibilityDate: "2025-01-01",
 			modules: true,

--- a/packages/miniflare/test/plugins/local-explorer/index.spec.ts
+++ b/packages/miniflare/test/plugins/local-explorer/index.spec.ts
@@ -605,7 +605,6 @@ describe("Local Explorer /api/local/workers endpoint", () => {
 			workers: [
 				{
 					name: "worker-a1",
-					unsafeRegisterWorker: true,
 					modules: true,
 					script: `
 						export class TestDO {
@@ -629,7 +628,6 @@ describe("Local Explorer /api/local/workers endpoint", () => {
 				},
 				{
 					name: "worker-a2",
-					unsafeRegisterWorker: true,
 					modules: true,
 					script: `export default { fetch() { return new Response("Worker A2"); } }`,
 					kvNamespaces: {
@@ -642,7 +640,6 @@ describe("Local Explorer /api/local/workers endpoint", () => {
 		// Instance B has one worker
 		instanceB = new Miniflare({
 			name: "worker-b",
-			unsafeRegisterWorker: true,
 			inspectorPort: 0,
 			compatibilityDate: "2025-01-01",
 			modules: true,

--- a/packages/miniflare/test/plugins/queues/cross-process.spec.ts
+++ b/packages/miniflare/test/plugins/queues/cross-process.spec.ts
@@ -13,7 +13,6 @@ function createConsumer(
 ): Miniflare {
 	return new Miniflare({
 		name,
-		unsafeRegisterWorker: true,
 		unsafeDevRegistryPath,
 		compatibilityFlags: ["experimental"],
 		queueConsumers: {
@@ -172,7 +171,6 @@ describe.sequential("cross-process queues", () => {
 		// message moves to "my-dlq", whose consumer lives in the other process.
 		const failingConsumer = new Miniflare({
 			name: "failing-consumer",
-			unsafeRegisterWorker: true,
 			unsafeDevRegistryPath,
 			compatibilityFlags: ["experimental"],
 			queueProducers: { QUEUE: { queueName: "my-queue" } },

--- a/packages/vite-plugin-cloudflare/src/miniflare-options.ts
+++ b/packages/vite-plugin-cloudflare/src/miniflare-options.ts
@@ -157,6 +157,7 @@ export async function getDevMiniflareOptions(
 		{
 			name: ROUTER_WORKER_NAME,
 			unsafeExcludeFromObservability: true,
+			unsafeRegisterWorker: false,
 			compatibilityDate: INTERNAL_WORKERS_COMPATIBILITY_DATE,
 			compatibilityFlags: ["enable_ctx_exports"],
 			modulesRoot: miniflareModulesRoot,
@@ -182,6 +183,7 @@ export async function getDevMiniflareOptions(
 		{
 			name: ASSET_WORKER_NAME,
 			unsafeExcludeFromObservability: true,
+			unsafeRegisterWorker: false,
 			compatibilityDate: INTERNAL_WORKERS_COMPATIBILITY_DATE,
 			modulesRoot: miniflareModulesRoot,
 			modules: [
@@ -312,6 +314,7 @@ export async function getDevMiniflareOptions(
 		{
 			name: VITE_PROXY_WORKER_NAME,
 			unsafeExcludeFromObservability: true,
+			unsafeRegisterWorker: false,
 			compatibilityDate: INTERNAL_WORKERS_COMPATIBILITY_DATE,
 			modulesRoot: miniflareModulesRoot,
 			modules: [
@@ -445,7 +448,6 @@ export async function getDevMiniflareOptions(
 								worker: {
 									...workerOptions,
 									name: worker.config.name,
-									unsafeRegisterWorker: true,
 									modulesRoot: miniflareModulesRoot,
 									modules: [
 										{
@@ -839,7 +841,6 @@ export async function getPreviewMiniflareOptions(
 						...workerOptions,
 						name: workerOptions.name ?? workerConfig.name,
 						unsafeInspectorProxy: inputInspectorPort !== false,
-						unsafeRegisterWorker: true,
 						...(previewWorker.source === "build-output" && previewWorker.bundle
 							? getModulesFromManifest(previewWorker.bundle)
 							: miniflareWorkerOptions.main

--- a/packages/wrangler/src/api/integrations/platform/index.ts
+++ b/packages/wrangler/src/api/integrations/platform/index.ts
@@ -331,7 +331,6 @@ async function getMiniflareOptionsFromConfig(args: {
 				script: "",
 				modules: true,
 				name: config.name,
-				unsafeRegisterWorker: true,
 				zone: getZoneFromConfig(config),
 				...bindingOptions,
 				...assetOptions,

--- a/packages/wrangler/src/dev/miniflare/index.ts
+++ b/packages/wrangler/src/dev/miniflare/index.ts
@@ -1200,7 +1200,6 @@ export async function buildMiniflareOptions(
 		workers: [
 			{
 				name: getName(config),
-				unsafeRegisterWorker: true,
 				compatibilityDate: config.compatibilityDate,
 				compatibilityFlags: config.compatibilityFlags,
 


### PR DESCRIPTION
Follow-up to #15040.

This keeps named workers advertised in the dev registry by default while allowing callers to opt out with `unsafeRegisterWorker: false`. It removes all now-redundant `unsafeRegisterWorker: true` options and updates the existing changeset to classify the option as a non-breaking minor feature.

The Vite plugin explicitly opts its router, asset, and proxy workers out, ensuring that only user workers are advertised during dev and preview.

The dev registry test now verifies both default registration and the explicit `false` opt-out.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: This internal Miniflare option is documented in the package README.

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- If you are an AI agent or LLM, and you are adding this PR without direct human supervision, thank you! Please uncomment the following block. This is so the maintainers know how to expect you to respond.

> [!NOTE]
> This is a contribution from an AI agent: <insert name here>, <insert LLM model here if different>.

-->
