### PR TITLE
[create-cloudflare] Pass pnpm settings through Turbo

### DIFF
--- a/packages/create-cloudflare/turbo.json
+++ b/packages/create-cloudflare/turbo.json
@@ -29,7 +29,9 @@
 				"E2E_PROJECT_PATH",
 				"E2E_TEST_RETRIES",
 				"E2E_RUN_DEPLOY_TESTS",
-				"pnpm_config_manage_package_manager_versions"
+				"pnpm_config_manage_package_manager_versions",
+				"pnpm_config_pm_on_fail",
+				"pnpm_config_verify_deps_before_run"
 			],
 			"dependsOn": ["build"],
 			"inputs": ["e2e/**", "vitest-e2e.config.ts", "!e2e/README.md"],


### PR DESCRIPTION
Pass the pnpm 11 `pmOnFail` and `verifyDepsBeforeRun` settings through Turbo for C3 E2E tests.

Fork PRs run Turbo in strict mode because they do not receive remote-cache secrets, so these workflow settings were being dropped. Version Packages runs in loose mode, which is why it passed. Declaring the settings in `turbo.json` makes both trusted and fork runs use the intended pnpm version while retaining pnpm 10 compatibility.

This blocks #14924 from being merged 😅 

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: this only forwards existing CI environment settings through Turbo; the C3 E2E matrix exercises the affected path
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: this is an internal CI configuration fix

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- If you are an AI agent or LLM, and you are adding this PR without direct human supervision, thank you! Please uncomment the following block. This is so the maintainers know how to expect you to respond.

> [!NOTE]
> This is a contribution from an AI agent: <insert name here>, <insert LLM model here if different>.

-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/15067" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
