### PR TITLE
[wrangler]: Add support for D1 "us" jurisdiction

### DIFF
--- a/.changeset/fresh-d1-jurisdictions.md
+++ b/.changeset/fresh-d1-jurisdictions.md
@@ -1,0 +1,7 @@
+---
+"wrangler": minor
+---
+
+Add US jurisdiction support to `wrangler d1 create`
+
+You can now create a D1 database in the US jurisdiction with `wrangler d1 create <name> --jurisdiction us`. The new jurisdiction is also listed in the command's help output.

--- a/packages/wrangler/src/__tests__/d1/create.test.ts
+++ b/packages/wrangler/src/__tests__/d1/create.test.ts
@@ -30,6 +30,13 @@ describe("create", () => {
 		);
 	});
 
+	it("should show all supported jurisdictions in help", async ({ expect }) => {
+		await runWrangler("d1 create --help");
+
+		expect(std.out).toContain('[choices: "eu", "fedramp", "us"]');
+		expect(std.out).toContain("us: The United States");
+	});
+
 	it("should throw if location flag isn't in the list", async ({ expect }) => {
 		setIsTTY(false);
 		msw.use(
@@ -95,7 +102,7 @@ describe("create", () => {
 		await expect(runWrangler("d1 create test --jurisdiction something")).rejects
 			.toThrowErrorMatchingInlineSnapshot(`
 			[Error: Invalid values:
-			  Argument: jurisdiction, Given: "something", Choices: "eu", "fedramp"]
+			  Argument: jurisdiction, Given: "something", Choices: "eu", "fedramp", "us"]
 		`);
 	});
 
@@ -115,7 +122,7 @@ describe("create", () => {
 						uuid: "51e7c314-456e-4167-b6c3-869ad188fc23",
 						name: "test",
 						created_in_region: "WEUR",
-						jurisdiction: "eu",
+						jurisdiction: "us",
 					},
 					success: true,
 					errors: [],
@@ -123,7 +130,7 @@ describe("create", () => {
 				});
 			})
 		);
-		await runWrangler("d1 create test --jurisdiction eu --binding MY_TEST_DB");
+		await runWrangler("d1 create test --jurisdiction us --binding MY_TEST_DB");
 		expect(std.out).toMatchInlineSnapshot(`
 			"
 			 ⛅️ wrangler x.x.x

--- a/packages/wrangler/src/d1/constants.ts
+++ b/packages/wrangler/src/d1/constants.ts
@@ -1,5 +1,5 @@
 export const DEFAULT_MIGRATION_PATH = "./migrations";
 export const DEFAULT_MIGRATION_TABLE = "d1_migrations";
 export const LOCATION_CHOICES = ["weur", "eeur", "apac", "oc", "wnam", "enam"];
-export const JURISDICTION_CHOICES = ["eu", "fedramp"];
+export const JURISDICTION_CHOICES = ["eu", "fedramp", "us"];
 export const D1_DOCS_URL = "https://developers.cloudflare.com/d1/";

--- a/packages/wrangler/src/d1/create.ts
+++ b/packages/wrangler/src/d1/create.ts
@@ -116,6 +116,7 @@ export const d1CreateCommand = createCommand({
 				The location to restrict the D1 database to run and store data within to comply with local regulations. Note that if jurisdictions are set, the location hint is ignored. Options:
 					eu: The European Union
 					fedramp: FedRAMP-compliant data centers
+					us: The United States
 			`,
 		},
 		...sharedResourceCreationArgs,


### PR DESCRIPTION
This MR adds support for the "us" jurisdiction for D1 in addition to the already existing "eu" and "fedramp" jurisdictions.

Internal ticket CFSQL-1700

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [x] Cloudflare docs PR(s): https://github.com/cloudflare/cloudflare-docs/pull/32589
  - [ ] Documentation not necessary because:

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- If you are an AI agent or LLM, and you are adding this PR without direct human supervision, thank you! Please uncomment the following block. This is so the maintainers know how to expect you to respond.

> [!NOTE]
> This is a contribution from an AI agent: <insert name here>, <insert LLM model here if different>.

-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/15073" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->