### PR TITLE
[miniflare] Share local storage across processes

### DIFF
--- a/.changeset/shared-storage-owner.md
+++ b/.changeset/shared-storage-owner.md
@@ -1,0 +1,7 @@
+---
+"miniflare": minor
+---
+
+Add experimental `unsafeSharedStorageOwner` option to share local storage across processes
+
+When several Miniflare instances run with resources with the same resource ID, they will now share the underlying data.

--- a/packages/miniflare/src/config/schema.ts
+++ b/packages/miniflare/src/config/schema.ts
@@ -751,6 +751,8 @@ export const InstanceOptionsSchema = z.strictObject({
 	unsafeTriggerHandlers: z.boolean().optional(),
 	unsafeRuntimeEnv: z.record(z.string(), z.string()).optional(),
 	unsafeLocalExplorer: z.boolean().optional(),
+	unsafeSharedStorageOwner: z.boolean().optional(),
+	unsafeStorageOwnerRole: z.enum(["owner", "client"]).optional(),
 	// Turn on local-dev observability: attach the trace collector to the
 	// user's worker(s) so it receives their tail events.
 	unsafeObservability: z.boolean().optional(),

--- a/packages/miniflare/src/config/v4-convert.ts
+++ b/packages/miniflare/src/config/v4-convert.ts
@@ -66,6 +66,8 @@ function convertSharedOptions(options: ParsedV4MiniflareOptions) {
 		unsafeTriggerHandlers: options.unsafeTriggerHandlers,
 		unsafeRuntimeEnv: options.unsafeRuntimeEnv,
 		unsafeLocalExplorer: options.unsafeLocalExplorer,
+		unsafeSharedStorageOwner: options.unsafeSharedStorageOwner,
+		unsafeStorageOwnerRole: options.unsafeStorageOwnerRole,
 		unsafeObservability: options.unsafeObservability,
 		unsafeInspectDurableObjects: options.unsafeInspectDurableObjects,
 		logRequests: options.logRequests,

--- a/packages/miniflare/src/config/v4-schema.ts
+++ b/packages/miniflare/src/config/v4-schema.ts
@@ -636,6 +636,8 @@ export const V4SharedOptionsSchema = z.object({
 	unsafeTriggerHandlers: z.boolean().optional(),
 	unsafeRuntimeEnv: z.record(z.string(), z.string()).optional(),
 	unsafeLocalExplorer: z.boolean().optional(),
+	unsafeSharedStorageOwner: z.boolean().optional(),
+	unsafeStorageOwnerRole: z.enum(["owner", "client"]).optional(),
 	unsafeObservability: z.boolean().optional(),
 	unsafeInspectDurableObjects: z.boolean().optional(),
 	logRequests: z.boolean().default(true),
@@ -924,6 +926,8 @@ export type V4SharedOptions = {
 	unsafeTriggerHandlers?: boolean;
 	unsafeRuntimeEnv?: Record<string, string>;
 	unsafeLocalExplorer?: boolean;
+	unsafeSharedStorageOwner?: boolean;
+	unsafeStorageOwnerRole?: "owner" | "client";
 	unsafeObservability?: boolean;
 	unsafeInspectDurableObjects?: boolean;
 	logRequests?: boolean;

--- a/packages/miniflare/src/index.ts
+++ b/packages/miniflare/src/index.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert";
+import { spawn } from "node:child_process";
 import crypto from "node:crypto";
 import fs from "node:fs";
 import { mkdir, writeFile } from "node:fs/promises";
@@ -59,13 +60,13 @@ import {
 	QueuesError,
 	R2_PLUGIN_NAME,
 	SECRET_STORE_PLUGIN_NAME,
+	STREAM_PLUGIN_NAME,
 	SERVICE_DEV_REGISTRY_PROXY,
 	SERVICE_ENTRY,
 	SOCKET_DEBUG_PORT,
 	SOCKET_DEV_REGISTRY,
 	SOCKET_ENTRY,
 	SOCKET_ENTRY_LOCAL,
-	STREAM_PLUGIN_NAME,
 	WORKFLOWS_PLUGIN_NAME,
 } from "./plugins";
 import { RPC_PROXY_SERVICE_NAME } from "./plugins/assets/constants";
@@ -98,6 +99,7 @@ import {
 	MiniflareCoreError,
 	NoOpLog,
 	stripAnsi,
+	tryAcquireOwnerSpawnLock,
 } from "./shared";
 import { createDurableObjectStorageHandle } from "./shared/dev-control";
 import { DevRegistry, getWorkerRegistry } from "./shared/dev-registry";
@@ -115,9 +117,12 @@ import {
 	Mutex,
 	SharedHeaders,
 	SiteBindings,
+	STORAGE_OWNER_CLIENT_PRESENCE_PREFIX,
+	STORAGE_OWNER_WORKER_NAME,
 } from "./workers";
 import { ADMIN_API } from "./workers/secrets-store/constants";
 import type {
+	MiniflareBinding,
 	MiniflareOptions,
 	ParsedInstanceOptions,
 	ParsedWorkerOptions,
@@ -130,7 +135,9 @@ import type {
 	PluginServicesOptions,
 	QueueConsumers,
 	QueueProducers,
+	RemoteProxyConnectionString,
 	ReplaceWorkersTypes,
+	StorageOwnerHosting,
 } from "./plugins";
 import type {
 	Config,
@@ -172,6 +179,32 @@ import type { Duplex, Transform, Writable } from "node:stream";
 import type { Dispatcher, Response as UndiciResponse } from "undici";
 
 const DEFAULT_HOST = "127.0.0.1";
+// Detached storage-owner process bootstrap. The owner runs the same built
+// miniflare module (its path handed over via env), so we avoid a second build
+// entry point. Kept as a constant string with no interpolation so it satisfies
+// the no-unsafe-command-execution lint rule.
+const STORAGE_OWNER_BOOTSTRAP =
+	"require(process.env.MINIFLARE_STORAGE_OWNER_MAIN).runStorageOwnerProcess()";
+const ENV_STORAGE_OWNER_MAIN = "MINIFLARE_STORAGE_OWNER_MAIN";
+const ENV_STORAGE_OWNER_CONFIG = "MINIFLARE_STORAGE_OWNER_CONFIG";
+// How long a client waits for a freshly spawned owner to register itself.
+const STORAGE_OWNER_SPAWN_TIMEOUT_MS = 30_000;
+const STORAGE_OWNER_POLL_MS = 50;
+// Owner self-teardown tuning: a startup grace period before the owner is
+// eligible to exit, and a debounce so a transient client gap (e.g. a reload)
+// doesn't tear storage down. Overridable via env (read by the spawned owner
+// process, which inherits the spawner's environment) primarily for tests.
+const STORAGE_OWNER_STARTUP_GRACE_MS =
+	Number(process.env.MINIFLARE_STORAGE_OWNER_GRACE_MS) || 10_000;
+const STORAGE_OWNER_IDLE_CHECK_MS =
+	Number(process.env.MINIFLARE_STORAGE_OWNER_IDLE_CHECK_MS) || 1_000;
+const STORAGE_OWNER_IDLE_DEBOUNCE = 3;
+
+// Distinguishes shared-storage client presence entries when several Miniflare
+// instances live in one process (tests, the Vitest pool) and would otherwise
+// collide on `process.pid`.
+let storageOwnerClientCounter = 0;
+
 function getURLSafeHost(host: string) {
 	return net.isIPv6(host) ? `[${host}]` : host;
 }
@@ -791,6 +824,14 @@ export class Miniflare {
 	readonly #webSocketServer: WebSocketServer;
 	readonly #webSocketExtraHeaders: WeakMap<http.IncomingMessage, Headers>;
 	readonly #devRegistry: DevRegistry;
+
+	// Shared-storage-owner (experimental `unsafeSharedStorageOwner`) client state.
+	// `#storageOwnerRoutingActive` records whether this instance actually routed
+	// its storage to an owner during the last assemble; if so it registers a
+	// presence entry (`#storageOwnerPresenceName`) in the dev registry so the
+	// owner can count live clients and tear itself down when none remain.
+	#storageOwnerRoutingActive = false;
+	readonly #storageOwnerPresenceName = `${STORAGE_OWNER_CLIENT_PRESENCE_PREFIX}${process.pid}-${storageOwnerClientCounter++}`;
 
 	#maybeInspectorProxyController?: InspectorProxyController;
 	#previousRuntimeInspectorPort?: number;
@@ -1749,6 +1790,35 @@ export class Miniflare {
 			? getExternalServiceEntrypoints(allWorkerOpts)
 			: null;
 
+		const storageOwnerHostings = new Map<string, StorageOwnerHosting>();
+		if (
+			this.#storageOwnerPersistRoot() !== undefined &&
+			sharedOpts.unsafeStorageOwnerRole !== "owner"
+		) {
+			for (const [key, plugin] of this.#mergedPluginEntries) {
+				const hosting = plugin.getStorageOwnerHosting?.(allWorkerOpts);
+				if (hosting !== undefined) {
+					storageOwnerHostings.set(key, hosting);
+				}
+			}
+		}
+
+		// As a client, ensure an owner exists (spawning a detached one if needed)
+		// before we resolve routing below.
+		await this.#ensureStorageOwner(storageOwnerHostings);
+
+		// When acting as a shared-storage *client*, resolve the owner so local
+		// storage bindings can be routed to it (and local storage services
+		// skipped). `undefined` => behave normally (owner role, feature off, or
+		// no owner currently published).
+		const storageOwnerRouting = this.#getStorageOwnerRouting();
+		const storageOwnerRoutePlugins = storageOwnerRouting
+			? new Set(storageOwnerHostings.keys())
+			: new Set<string>();
+		// Record whether we're a routing client so `#registerWorkers` publishes a
+		// presence entry the owner can count.
+		this.#storageOwnerRoutingActive = storageOwnerRoutePlugins.size > 0;
+
 		const durableObjectClassNames = getDurableObjectClassNames(allWorkerOpts);
 		const queueProducers = getQueueProducers(allWorkerOpts);
 		const queueConsumers = getQueueConsumers(allWorkerOpts);
@@ -1827,7 +1897,15 @@ export class Miniflare {
 			for (const [key, plugin] of this.#mergedPluginEntries) {
 				const pluginBindings = await plugin.getBindings(workerOpts, i);
 				if (pluginBindings !== undefined) {
-					for (const binding of pluginBindings) {
+					for (const originalBinding of pluginBindings) {
+						// When routing this plugin's storage to a shared owner, let the
+						// plugin repoint its local storage bindings at the storage-owner
+						// client proxy (plugins own the knowledge of their binding shapes;
+						// the proxy resolves the live owner from the dev registry).
+						const binding = storageOwnerRoutePlugins.has(key)
+							? (plugin.routeBindingToStorageOwner?.(originalBinding) ??
+								originalBinding)
+							: originalBinding;
 						// If this is the Workers Sites manifest, we need to add it as a
 						// module for modules workers. For all other bindings, and in
 						// service workers, just add to worker bindings.
@@ -1901,6 +1979,13 @@ export class Miniflare {
 				queueConsumers,
 				devRegistryEnabled,
 				hyperdriveProxyController: this.#hyperdriveProxyController,
+				storageOwnerRoutePlugins,
+				// Plugins not routed to the owner but still disk-backed (Cache,
+				// Durable Objects, Workflows) keep their storage per-instance when
+				// the feature is enabled, so separate processes don't contend on one
+				// database under the shared `resourcePersistencePath`. Applies to every
+				// role (client, fallback-to-local client, and owner).
+				isolateLocalStorage: this.#storageOwnerPersistRoot() !== undefined,
 			};
 			for (const [key, plugin] of this.#mergedPluginEntries) {
 				const pluginServicesExtensions = await plugin.getServices({
@@ -1980,8 +2065,19 @@ export class Miniflare {
 		if (
 			this.#devRegistry.isEnabled() &&
 			externalServices &&
-			(externalServices.size > 0 || hasQueues)
+			(externalServices.size > 0 ||
+				hasQueues ||
+				storageOwnerRoutePlugins.size > 0)
 		) {
+			// When routing storage to a shared owner, watch the owner's well-known
+			// registry name too, so the client's proxy worker is pushed an updated
+			// registry the moment the owner appears (or its debug port changes).
+			if (storageOwnerRoutePlugins.size > 0) {
+				externalServices.set(STORAGE_OWNER_WORKER_NAME, {
+					classNames: new Set(),
+					entrypoints: new Set(),
+				});
+			}
 			await this.#devRegistry.watch(externalServices, hasQueues);
 
 			const externalObjects = Array.from(externalServices).flatMap(
@@ -1996,8 +2092,8 @@ export class Miniflare {
 			// worker has the correct registry from the moment workerd loads it.
 			const initialRegistry = this.#devRegistry.getRegistry();
 			const mainModuleSource = [
-				`import { ExternalQueueProxy, ExternalServiceProxy, setRegistry, createProxyDurableObjectClass } from "./dev-registry-proxy.worker.js";`,
-				`export { ExternalQueueProxy, ExternalServiceProxy };`,
+				`import { ExternalQueueProxy, ExternalServiceProxy, StorageOwnerProxy, setRegistry, createProxyDurableObjectClass } from "./dev-registry-proxy.worker.js";`,
+				`export { ExternalQueueProxy, ExternalServiceProxy, StorageOwnerProxy };`,
 				`setRegistry(${JSON.stringify(initialRegistry)});`,
 				`export default {`,
 				`  async fetch(request, env) {`,
@@ -2088,6 +2184,7 @@ export class Miniflare {
 			proxyBindings,
 			durableObjectClassNames,
 			allWorkerOpts,
+			storageOwnerRoutePlugins,
 		});
 		for (const service of globalServices) {
 			// Global services should all have unique names
@@ -2179,6 +2276,7 @@ export class Miniflare {
 		// This function must be run with `#runtimeMutex` held
 		const initial = !this.#runtimeEntryURL;
 		assert(this.#runtime !== undefined);
+		const runtime = this.#runtime;
 		const configuredHost = this.#sharedOpts.host ?? DEFAULT_HOST;
 		// For internal loopback communication with workerd, always use 127.0.0.1
 		// when localhost is configured. This prevents IPv6/IPv4 mismatch issues
@@ -2262,7 +2360,7 @@ export class Miniflare {
 			onWorkerdCrashRestart: () => this.#handleWorkerdCrash(),
 			runtimeEnv: this.#sharedOpts.unsafeRuntimeEnv,
 		};
-		const maybeSocketPorts = await this.#runtime.updateConfig(
+		const maybeSocketPorts = await runtime.updateConfig(
 			configBuffer,
 			runtimeOpts,
 			this.#workerOpts.map((w) => w.config.name),
@@ -2447,6 +2545,189 @@ export class Miniflare {
 		return new URL(this.#runtimeEntryURL.toString());
 	}
 
+	/**
+	 * The persist root this instance participates in as a shared storage
+	 * owner/client, or `undefined` if the feature is off or there is nothing to
+	 * share (pure in-memory storage).
+	 */
+	#storageOwnerPersistRoot(): string | undefined {
+		if (!this.#sharedOpts.unsafeSharedStorageOwner) {
+			return undefined;
+		}
+		// Discovery + transport ride the dev registry and the debug port, so the
+		// feature is a no-op without a registry.
+		if (!this.#devRegistry.isEnabled()) {
+			return undefined;
+		}
+		return this.#sharedOpts.resourcePersistencePath;
+	}
+
+	/** The current owner's dev registry entry, or `undefined` if none is live. */
+	#readStorageOwnerEntry(): WorkerDefinition | undefined {
+		return this.#devRegistry.getRegistry()[STORAGE_OWNER_WORKER_NAME];
+	}
+
+	/**
+	 * Whether this instance (as a *client*) should route its local storage to the
+	 * shared owner. `false` means behave normally (owner role, feature off, no
+	 * persist root, or no owner currently registered). The owner's live address is
+	 * resolved per-request by `StorageOwnerProxy`, so only its presence matters here.
+	 */
+	#getStorageOwnerRouting(): boolean {
+		const persistRoot = this.#storageOwnerPersistRoot();
+		if (
+			persistRoot === undefined ||
+			this.#sharedOpts.unsafeStorageOwnerRole === "owner"
+		) {
+			return false;
+		}
+
+		if (this.#readStorageOwnerEntry() === undefined) {
+			this.#log.warn(
+				"Shared storage owner enabled but no owner is currently registered — " +
+					"using local storage for this instance"
+			);
+			return false;
+		}
+		return true;
+	}
+
+	/**
+	 * As a client, make sure a storage owner is registered in the dev registry
+	 * before we assemble (and therefore route to it). If none is, elect a single
+	 * spawner via the owner spawn-lock, spawn a detached owner process, and wait
+	 * for it to register itself. Other clients just wait.
+	 *
+	 * Best-effort: on any failure we log and fall back to local storage (the
+	 * client simply won't route), so the feature degrades rather than crashes.
+	 */
+	async #ensureStorageOwner(
+		hostings: Map<string, StorageOwnerHosting>
+	): Promise<void> {
+		const persistRoot = this.#storageOwnerPersistRoot();
+		if (
+			persistRoot === undefined ||
+			this.#sharedOpts.unsafeStorageOwnerRole === "owner" ||
+			hostings.size === 0
+		) {
+			return;
+		}
+		if (this.#readStorageOwnerEntry() !== undefined) {
+			return;
+		}
+
+		let lock: ReturnType<typeof tryAcquireOwnerSpawnLock>;
+		try {
+			lock = tryAcquireOwnerSpawnLock(persistRoot);
+			// Re-check under the lock: another client may have just registered one.
+			if (this.#readStorageOwnerEntry() !== undefined) {
+				return;
+			}
+			if (lock !== undefined) {
+				this.#spawnStorageOwner(persistRoot, hostings);
+			}
+			// Wait for the owner (ours or another client's) to register itself. The
+			// registry watcher refreshes `getRegistry()` as files appear.
+			const deadline = Date.now() + STORAGE_OWNER_SPAWN_TIMEOUT_MS;
+			while (
+				this.#readStorageOwnerEntry() === undefined &&
+				Date.now() < deadline &&
+				!this.#disposeController.signal.aborted
+			) {
+				await new Promise((resolve) =>
+					setTimeout(resolve, STORAGE_OWNER_POLL_MS)
+				);
+			}
+			if (this.#readStorageOwnerEntry() === undefined) {
+				this.#log.warn(
+					"Timed out waiting for the shared storage owner to start — " +
+						"using local storage for this instance"
+				);
+			}
+		} catch (e) {
+			this.#log.warn(`Failed to ensure a shared storage owner: ${String(e)}`);
+		} finally {
+			lock?.release();
+		}
+	}
+
+	/**
+	 * Spawns a detached owner process for the persist root, hosting the storage
+	 * resources this instance uses. The owner runs the same built miniflare
+	 * module, registers itself in the dev registry under `STORAGE_OWNER_WORKER_NAME`,
+	 * and self-terminates once no clients remain (see {@link runStorageOwnerProcess}).
+	 */
+	#spawnStorageOwner(
+		persistRoot: string,
+		hostings: Map<string, StorageOwnerHosting>
+	): void {
+		// Each storage plugin describes the options a spawned owner needs to stand
+		// up its local storage (the union of local, non-remote resources across
+		// this instance's workers). The owner's entry services are generic (keyed
+		// by `idFromName`), so they additionally serve ids declared only by other
+		// clients.
+		const ownerBindings: Record<string, MiniflareBinding> = {};
+		for (const hosting of hostings.values()) {
+			Object.assign(ownerBindings, hosting.ownerBindings);
+		}
+
+		const ownerOptions: MiniflareOptions = {
+			resourcePersistencePath: persistRoot,
+			unsafeDevRegistryPath: this.#sharedOpts.unsafeDevRegistryPath,
+			workers: [
+				{
+					config: {
+						type: "worker",
+						name: STORAGE_OWNER_WORKER_NAME,
+						compatibilityDate: "2025-01-01",
+						compatibilityFlags: ["experimental"],
+						manifest: {
+							mainModule: "index.mjs",
+							modulesRoot: process.cwd(),
+							modules: {
+								"index.mjs": {
+									type: "esm",
+									contents:
+										"export default { fetch() { return new Response('miniflare storage owner', { status: 404 }); } }",
+								},
+							},
+						},
+						env: ownerBindings,
+					},
+					dev: { unsafeRegisterWorker: false },
+				},
+			],
+		};
+
+		const configPath = path.join(
+			persistRoot,
+			`.miniflare-owner-config-${process.pid}.json`
+		);
+		fs.writeFileSync(configPath, JSON.stringify(ownerOptions));
+
+		// The owner is detached and outlives us, so it can't share our stdio.
+		// Redirect its output to a log file in the persist root — otherwise a
+		// crashing or misconfigured owner is invisible and clients just silently
+		// fall back to local storage.
+		const logPath = path.join(persistRoot, ".miniflare-owner.log");
+		const logFd = fs.openSync(logPath, "a");
+		try {
+			const child = spawn(process.execPath, ["-e", STORAGE_OWNER_BOOTSTRAP], {
+				detached: true,
+				stdio: ["ignore", logFd, logFd],
+				env: {
+					...process.env,
+					[ENV_STORAGE_OWNER_MAIN]: __filename,
+					[ENV_STORAGE_OWNER_CONFIG]: configPath,
+				},
+			});
+			child.unref();
+		} finally {
+			// The child has dup'd the fd; close our copy.
+			fs.closeSync(logFd);
+		}
+	}
+
 	async #registerWorkers(): Promise<void> {
 		if (!this.#devRegistry.isEnabled()) {
 			return;
@@ -2501,6 +2782,36 @@ export class Miniflare {
 					defaultEntrypointService,
 					userWorkerService: getUserServiceName(workerName),
 					...(queueConsumers.length > 0 ? { queueConsumers } : {}),
+				},
+			]);
+		}
+
+		// As the shared-storage owner, register under the well-known name so
+		// clients discover our debug port (and reach our storage services over it).
+		// The owner's own worker is a dummy 404, so its default/user service fields
+		// are irrelevant — clients target specific storage services by name.
+		if (this.#sharedOpts.unsafeStorageOwnerRole === "owner") {
+			entries.push([
+				STORAGE_OWNER_WORKER_NAME,
+				{
+					debugPortAddress,
+					defaultEntrypointService: getUserServiceName(),
+					userWorkerService: getUserServiceName(),
+				},
+			]);
+		}
+
+		// As a shared-storage client, publish a presence entry so the owner can
+		// count live clients (from the registry alone) and self-terminate when the
+		// last one leaves. Reserved names are filtered from user-facing registry
+		// enumeration (see `isStorageOwnerRegistryName`).
+		if (this.#storageOwnerRoutingActive) {
+			entries.push([
+				this.#storageOwnerPresenceName,
+				{
+					debugPortAddress,
+					defaultEntrypointService: getUserServiceName(),
+					userWorkerService: getUserServiceName(),
 				},
 			]);
 		}
@@ -3177,7 +3488,8 @@ export class Miniflare {
 
 			// Close the inspector proxy server if there is one
 			await this.#maybeInspectorProxyController?.dispose();
-			// Unregister workers from dev registry and stop the file watcher
+			// Unregister workers from dev registry and stop the file watcher. This
+			// also removes our shared-storage owner/client presence entry, if any.
 			await this.#devRegistry.dispose();
 
 			// shutdown hyperdrive proxies if any exist
@@ -3188,6 +3500,115 @@ export class Miniflare {
 			maybeInstanceRegistry?.delete(this);
 		}
 	}
+}
+
+/**
+ * Entry point for the detached storage-owner process spawned by a client (see
+ * `Miniflare.#spawnStorageOwner`). Reads its config from a temp file named in
+ * the environment, starts a headless owner-role Miniflare, and self-terminates
+ * once no clients have been present for a debounce window (after a startup
+ * grace period), so storage processes don't linger.
+ */
+export async function runStorageOwnerProcess(): Promise<void> {
+	// The owner is detached with its stdio redirected to `.miniflare-owner.log`
+	// in the persist root (see `#spawnStorageOwner`), so these lines are how a
+	// broken owner makes itself heard rather than failing silently. Writes go
+	// straight to the process's own stdout/stderr (there is no host `Log` here).
+	const tag = `[miniflare storage owner ${process.pid}]`;
+	const ownerLog = (message: string) =>
+		process.stdout.write(`${tag} ${message}\n`);
+	const ownerError = (message: string, e: unknown) =>
+		process.stderr.write(
+			`${tag} ${message} ${e instanceof Error ? (e.stack ?? e.message) : String(e)}\n`
+		);
+	// Surface anything that would otherwise kill the process silently.
+	process.on("uncaughtException", (e) => {
+		ownerError("uncaught:", e);
+		process.exit(1);
+	});
+	process.on("unhandledRejection", (e) => {
+		ownerError("unhandled:", e);
+		process.exit(1);
+	});
+
+	const configPath = process.env[ENV_STORAGE_OWNER_CONFIG];
+	assert(configPath !== undefined, `${ENV_STORAGE_OWNER_CONFIG} must be set`);
+	const options = JSON.parse(
+		fs.readFileSync(configPath, "utf8")
+	) as MiniflareOptions;
+	// The config file has served its purpose; remove it.
+	fs.rmSync(configPath, { force: true });
+
+	const persistRoot = options.resourcePersistencePath;
+	assert(
+		persistRoot !== undefined,
+		"storage owner config must set `resourcePersistencePath`"
+	);
+	const registryPath = options.unsafeDevRegistryPath;
+	assert(
+		registryPath !== undefined,
+		"storage owner config must set `unsafeDevRegistryPath`"
+	);
+	ownerLog(`starting for persist root ${persistRoot}`);
+
+	const mf = new Miniflare({
+		...options,
+		unsafeSharedStorageOwner: true,
+		unsafeStorageOwnerRole: "owner",
+	});
+
+	let disposing = false;
+	// Holder so `shutdown` (defined before the interval is created) can clear it.
+	const timers: { idle?: NodeJS.Timeout } = {};
+	const shutdown = async (reason: string) => {
+		if (disposing) {
+			return;
+		}
+		disposing = true;
+		ownerLog(`shutting down (${reason})`);
+		if (timers.idle !== undefined) {
+			clearInterval(timers.idle);
+		}
+		try {
+			await mf.dispose();
+		} finally {
+			process.exit(0);
+		}
+	};
+	process.on("SIGTERM", () => void shutdown("SIGTERM"));
+	process.on("SIGINT", () => void shutdown("SIGINT"));
+
+	try {
+		await mf.ready;
+	} catch (e) {
+		ownerError("failed to start:", e);
+		process.exit(1);
+	}
+	ownerLog("ready");
+
+	// Self-teardown: once past the startup grace, exit after a debounced run of
+	// checks observing zero live clients. A client is any live dev-registry
+	// presence entry (see `#registerWorkers`); the registry's own heartbeat +
+	// staleness reclaim handles crashed clients that never unregistered.
+	const countLiveClients = () =>
+		Object.keys(getWorkerRegistry(registryPath)).filter((name) =>
+			name.startsWith(STORAGE_OWNER_CLIENT_PRESENCE_PREFIX)
+		).length;
+	const startedAt = Date.now();
+	let idleChecks = 0;
+	timers.idle = setInterval(() => {
+		if (Date.now() - startedAt < STORAGE_OWNER_STARTUP_GRACE_MS) {
+			return;
+		}
+		if (countLiveClients() === 0) {
+			idleChecks++;
+			if (idleChecks >= STORAGE_OWNER_IDLE_DEBOUNCE) {
+				void shutdown("no live clients");
+			}
+		} else {
+			idleChecks = 0;
+		}
+	}, STORAGE_OWNER_IDLE_CHECK_MS);
 }
 
 export type { WorkerdStructuredLog } from "./plugins/core";

--- a/packages/miniflare/src/plugins/cache/index.ts
+++ b/packages/miniflare/src/plugins/cache/index.ts
@@ -36,7 +36,13 @@ export const CACHE_PLUGIN: Plugin = {
 	getNodeBindings() {
 		return {};
 	},
-	async getServices({ options, workerIndex, tmpPath, sharedOptions }) {
+	async getServices({
+		options,
+		workerIndex,
+		tmpPath,
+		sharedOptions,
+		isolateLocalStorage,
+	}) {
 		const cache = options.dev?.cacheAPI ?? true;
 
 		let entryWorker: Worker;
@@ -73,10 +79,13 @@ export const CACHE_PLUGIN: Plugin = {
 		if (cache) {
 			const uniqueKey = `miniflare-${CACHE_OBJECT_CLASS_NAME}`;
 
+			// With the shared storage owner enabled, cache stays local to each
+			// instance so each process uses its own `tmpPath` cache and never
+			// contends cross-process.
 			const persistPath = getPersistPath(
 				CACHE_PLUGIN_NAME,
 				tmpPath,
-				sharedOptions.resourcePersistencePath
+				isolateLocalStorage ? undefined : sharedOptions.resourcePersistencePath
 			);
 			await fs.mkdir(persistPath, { recursive: true });
 			const storageService: Service = {

--- a/packages/miniflare/src/plugins/core/index.ts
+++ b/packages/miniflare/src/plugins/core/index.ts
@@ -32,6 +32,7 @@ import { IMAGES_PLUGIN_NAME } from "../images";
 import {
 	getR2PublicService,
 	getR2S3Service,
+	R2_PLUGIN_NAME,
 	R2_PUBLIC_SERVICE_NAME,
 	R2_S3_SERVICE_NAME,
 } from "../r2";
@@ -710,6 +711,8 @@ export interface GlobalServicesOptions {
 	durableObjectClassNames: DurableObjectClassNames;
 	/** All worker options for building per-worker resource bindings */
 	allWorkerOpts?: ParsedWorkerOptions[];
+	/** Storage plugins routed to a shared owner; their global services are skipped. */
+	storageOwnerRoutePlugins?: Set<string>;
 }
 export function getGlobalServices({
 	sharedOptions,
@@ -720,6 +723,7 @@ export function getGlobalServices({
 	proxyBindings,
 	durableObjectClassNames,
 	allWorkerOpts,
+	storageOwnerRoutePlugins,
 }: GlobalServicesOptions): Service[] {
 	// Collect list of workers we could route to, then parse and sort all routes
 	const workerNames = [...allWorkerRoutes.keys()];
@@ -779,12 +783,14 @@ export function getGlobalServices({
 			},
 		});
 	}
-	const streamServiceEnabled = allWorkerOpts?.some((worker) =>
-		getEnvBindingsOfType(worker.config, "stream").some(
-			([, binding]) =>
-				getRemoteProxyConnectionString(binding, worker.dev) === undefined
-		)
-	);
+	const streamServiceEnabled =
+		!storageOwnerRoutePlugins?.has(STREAM_PLUGIN_NAME) &&
+		allWorkerOpts?.some((worker) =>
+			getEnvBindingsOfType(worker.config, "stream").some(
+				([, binding]) =>
+					getRemoteProxyConnectionString(binding, worker.dev) === undefined
+			)
+		);
 	if (streamServiceEnabled) {
 		serviceEntryBindings.push({
 			name: CoreBindings.SERVICE_STREAM,
@@ -794,14 +800,18 @@ export function getGlobalServices({
 			},
 		});
 	}
-	const r2PublicService = getR2PublicService(allWorkerOpts ?? []);
+	const routeR2ToOwner = storageOwnerRoutePlugins?.has(R2_PLUGIN_NAME) === true;
+	const r2PublicService = getR2PublicService(
+		allWorkerOpts ?? [],
+		routeR2ToOwner
+	);
 	if (r2PublicService !== undefined) {
 		serviceEntryBindings.push({
 			name: CoreBindings.SERVICE_R2_PUBLIC,
 			service: { name: R2_PUBLIC_SERVICE_NAME },
 		});
 	}
-	const r2S3Service = getR2S3Service(allWorkerOpts ?? []);
+	const r2S3Service = getR2S3Service(allWorkerOpts ?? [], routeR2ToOwner);
 	if (r2S3Service !== undefined) {
 		serviceEntryBindings.push({
 			name: CoreBindings.SERVICE_R2_S3,

--- a/packages/miniflare/src/plugins/d1/index.ts
+++ b/packages/miniflare/src/plugins/d1/index.ts
@@ -4,6 +4,7 @@ import { SharedBindings } from "../../workers";
 import {
 	buildObjectEntryProps,
 	buildRemoteProxyProps,
+	extractObjectEntryId,
 	getEnvBindingsOfType,
 	getMiniflareObjectBindings,
 	getPersistPath,
@@ -12,22 +13,24 @@ import {
 	ProxyNodeBinding,
 	remoteProxyClientWorker,
 	SERVICE_LOOPBACK,
+	storageOwnerProxyDesignator,
 } from "../shared";
 import type {
 	Service,
 	Worker_Binding,
 	Worker_Binding_DurableObjectNamespaceDesignator,
 } from "../../runtime";
-import type { Plugin } from "../shared";
+import type { MiniflareBinding, Plugin } from "../shared";
 
 export const D1_PLUGIN_NAME = "d1";
 const D1_STORAGE_SERVICE_NAME = `${D1_PLUGIN_NAME}:storage`;
 const D1_DATABASE_SERVICE_PREFIX = `${D1_PLUGIN_NAME}:db`;
 // A single entry service shared by every *local* database. Each database's id is
 // supplied per-binding via `ctx.props`, so one service serves all of them.
-const D1_LOCAL_ENTRY_SERVICE_NAME = `${D1_PLUGIN_NAME}:db:entry`;
+export const D1_LOCAL_ENTRY_SERVICE_NAME = `${D1_PLUGIN_NAME}:db:entry`;
 // One shared remote-proxy service for all remote D1 databases (config via props).
 const D1_REMOTE_SERVICE_NAME = `${D1_PLUGIN_NAME}:db:remote`;
+
 const D1_DATABASE_OBJECT_CLASS_NAME = "D1DatabaseObject";
 const D1_DATABASE_OBJECT: Worker_Binding_DurableObjectNamespaceDesignator = {
 	serviceName: D1_DATABASE_SERVICE_PREFIX,
@@ -80,13 +83,23 @@ export const D1_PLUGIN: Plugin = {
 			])
 		);
 	},
-	async getServices({ options, tmpPath, sharedOptions }) {
+	async getServices({
+		options,
+		tmpPath,
+		sharedOptions,
+		storageOwnerRoutePlugins,
+	}) {
 		const databases = getEnvBindingsOfType(options.config, "d1");
 
 		const services: Service[] = [];
 
+		// When routing local D1 to a shared storage owner, this instance must not
+		// stand up its own D1 storage — its bindings are repointed at the owner
+		// proxy by `Miniflare`.
+		const routeToOwner = storageOwnerRoutePlugins.has(D1_PLUGIN_NAME);
+
 		// One shared entry service for all local databases (id supplied via props).
-		const hasLocal = databases.some(
+		const hasLocal = !routeToOwner && databases.some(
 			([, db]) => getRemoteProxyConnectionString(db, options.dev) === undefined
 		);
 		if (hasLocal) {
@@ -96,7 +109,7 @@ export const D1_PLUGIN: Plugin = {
 			});
 		}
 
-		// One shared proxy service for all remote (mixed-mode) databases.
+		// Remote bindings keep using this instance's per-plugin proxy service.
 		const hasRemote = databases.some(
 			([, db]) => getRemoteProxyConnectionString(db, options.dev) !== undefined
 		);
@@ -106,7 +119,6 @@ export const D1_PLUGIN: Plugin = {
 				worker: remoteProxyClientWorker(),
 			});
 		}
-
 		if (hasLocal) {
 			const uniqueKey = `miniflare-${D1_DATABASE_OBJECT_CLASS_NAME}`;
 			const persistPath = getPersistPath(
@@ -157,5 +169,61 @@ export const D1_PLUGIN: Plugin = {
 		}
 
 		return services;
+	},
+	routeBindingToStorageOwner(binding) {
+		// The owner runs the same D1 plugin code, so its generic entry service is
+		// `D1_LOCAL_ENTRY_SERVICE_NAME`; the id travels as props.
+		const toOwner = (id: string) =>
+			storageOwnerProxyDesignator(D1_LOCAL_ENTRY_SERVICE_NAME, undefined, {
+				[SharedBindings.TEXT_NAMESPACE]: id,
+			});
+		// Pre-Wrangler-3.3 `__D1_BETA__` binding: a bare service designator.
+		if ("service" in binding && binding.service?.name !== undefined) {
+			const id = extractObjectEntryId(binding.service.props?.json);
+			if (id !== undefined) {
+				return {
+					name: binding.name,
+					service: toOwner(id),
+				};
+			}
+		}
+		// Post-3.3 wrapped binding: rewrite the inner fetcher service designator.
+		if ("wrapped" in binding && binding.wrapped?.innerBindings !== undefined) {
+			let rewrote = false;
+			const innerBindings = binding.wrapped.innerBindings.map((inner) => {
+				if ("service" in inner && inner.service?.name !== undefined) {
+					const id = extractObjectEntryId(inner.service.props?.json);
+					if (id !== undefined) {
+						rewrote = true;
+						return {
+							...inner,
+							service: toOwner(id),
+						};
+					}
+				}
+				return inner;
+			});
+			if (rewrote) {
+				return {
+					...binding,
+					wrapped: { ...binding.wrapped, innerBindings },
+				};
+			}
+		}
+		return undefined;
+	},
+	getStorageOwnerHosting(allOptions) {
+		const ownerBindings: Record<string, MiniflareBinding> = {};
+		for (const options of allOptions) {
+			for (const [, binding] of getEnvBindingsOfType(options.config, "d1")) {
+				if (getRemoteProxyConnectionString(binding, options.dev) === undefined) {
+					ownerBindings[`${D1_PLUGIN_NAME}:${binding.id}`] = binding;
+				}
+			}
+		}
+		if (Object.keys(ownerBindings).length === 0) {
+			return undefined;
+		}
+		return { ownerBindings };
 	},
 };

--- a/packages/miniflare/src/plugins/do/index.ts
+++ b/packages/miniflare/src/plugins/do/index.ts
@@ -59,6 +59,7 @@ export const DURABLE_OBJECTS_PLUGIN: Plugin = {
 		sharedOptions,
 		durableObjectClassNames,
 		unsafeEphemeralDurableObjects,
+		isolateLocalStorage,
 	}) {
 		// Check if we even have any Durable Object bindings, if we don't, we can
 		// skip creating the storage directory
@@ -76,10 +77,13 @@ export const DURABLE_OBJECTS_PLUGIN: Plugin = {
 		// don't need to create the storage service at all.
 		if (unsafeEphemeralDurableObjects) return;
 
+		// Durable Objects aren't routed to the shared storage owner (a DO is
+		// single-owner compute, not just storage). When the owner feature is on,
+		// keep DO storage per-instance so separate processes don't contend.
 		const storagePath = getPersistPath(
 			DURABLE_OBJECTS_PLUGIN_NAME,
 			tmpPath,
-			sharedOptions.resourcePersistencePath
+			isolateLocalStorage ? undefined : sharedOptions.resourcePersistencePath
 		);
 		// `workerd` requires the `disk.path` to exist. Setting `recursive: true`
 		// is like `mkdir -p`: it won't fail if the directory already exists, and it
@@ -88,7 +92,7 @@ export const DURABLE_OBJECTS_PLUGIN: Plugin = {
 		return [
 			{
 				// Note this service will be de-duped by name if multiple Workers create
-				// it. Each Worker will have the same `sharedOptions` though, so this
+				// it. Each Worker uses the same resource persistence path, so this
 				// isn't a problem.
 				name: DURABLE_OBJECTS_STORAGE_SERVICE_NAME,
 				disk: { path: storagePath, writable: true },

--- a/packages/miniflare/src/plugins/images/index.ts
+++ b/packages/miniflare/src/plugins/images/index.ts
@@ -14,6 +14,7 @@ import {
 	ProxyNodeBinding,
 	remoteProxyClientWorker,
 	SERVICE_LOOPBACK,
+	storageOwnerProxyDesignator,
 	WORKER_BINDING_SERVICE_LOOPBACK,
 } from "../shared";
 import type { Service } from "../../runtime";
@@ -21,6 +22,8 @@ import type { Plugin } from "../shared";
 
 export const IMAGES_PLUGIN_NAME = "images";
 const IMAGES_REMOTE_SERVICE_NAME = `${IMAGES_PLUGIN_NAME}:remote`;
+const IMAGES_DATA_NAMESPACE = "images-data";
+export const IMAGES_NS_DATA_SERVICE_NAME = `${IMAGES_PLUGIN_NAME}:ns:data`;
 
 export const IMAGES_PLUGIN: Plugin = {
 	bindingTypeDescription: "Images",
@@ -64,12 +67,18 @@ export const IMAGES_PLUGIN: Plugin = {
 			])
 		);
 	},
-	async getServices({ options, tmpPath, sharedOptions }) {
+	async getServices({
+		options,
+		tmpPath,
+		sharedOptions,
+		storageOwnerRoutePlugins,
+	}) {
 		const services: Service[] = [];
 
-		const imagesBindings = getEnvBindingsOfType(options.config, "images");
-
-		for (const [name, binding] of imagesBindings) {
+		for (const [name, binding] of getEnvBindingsOfType(
+			options.config,
+			"images"
+		)) {
 			const remoteProxyConnectionString = getRemoteProxyConnectionString(
 				binding,
 				options.dev
@@ -84,6 +93,31 @@ export const IMAGES_PLUGIN: Plugin = {
 			}
 
 			const serviceName = getUserBindingServiceName(IMAGES_PLUGIN_NAME, name);
+
+			if (storageOwnerRoutePlugins.has(IMAGES_PLUGIN_NAME)) {
+				services.push({
+					name: serviceName,
+					worker: {
+						compatibilityDate: "2025-04-01",
+						modules: [
+							{
+								name: "images.worker.js",
+								esModule: SCRIPT_IMAGES_SERVICE(),
+							},
+						],
+						bindings: [
+							{
+								name: "IMAGES_STORE",
+								kvNamespace: storageOwnerProxyDesignator(
+									IMAGES_NS_DATA_SERVICE_NAME
+								),
+							},
+							WORKER_BINDING_SERVICE_LOOPBACK,
+						],
+					},
+				});
+				continue;
+			}
 
 			const persistPath = getPersistPath(
 				IMAGES_PLUGIN_NAME,
@@ -131,13 +165,13 @@ export const IMAGES_PLUGIN: Plugin = {
 			} satisfies Service;
 
 			const kvNamespaceService = {
-				name: `${IMAGES_PLUGIN_NAME}:ns:data`,
+				name: IMAGES_NS_DATA_SERVICE_NAME,
 				worker: objectEntryWorker(
 					{
 						serviceName: objectService.name,
 						className: KV_NAMESPACE_OBJECT_CLASS_NAME,
 					},
-					"images-data"
+					IMAGES_DATA_NAMESPACE
 				),
 			} satisfies Service;
 
@@ -170,5 +204,21 @@ export const IMAGES_PLUGIN: Plugin = {
 		}
 
 		return services;
+	},
+	getStorageOwnerHosting(allOptions) {
+		const hasLocal = allOptions.some((options) =>
+			getEnvBindingsOfType(options.config, "images").some(
+				([, binding]) =>
+					getRemoteProxyConnectionString(binding, options.dev) === undefined
+			)
+		);
+		if (!hasLocal) {
+			return undefined;
+		}
+		return {
+			ownerBindings: {
+				images: { type: "images" },
+			},
+		};
 	},
 };

--- a/packages/miniflare/src/plugins/kv/index.ts
+++ b/packages/miniflare/src/plugins/kv/index.ts
@@ -2,7 +2,9 @@ import fs from "node:fs/promises";
 import SCRIPT_KV_NAMESPACE_OBJECT from "worker:kv/namespace";
 import { SharedBindings } from "../../workers";
 import {
+	buildObjectEntryProps,
 	buildRemoteProxyProps,
+	extractObjectEntryId,
 	getEnvBindingsOfType,
 	getMiniflareObjectBindings,
 	getPersistPath,
@@ -11,6 +13,7 @@ import {
 	ProxyNodeBinding,
 	remoteProxyClientWorker,
 	SERVICE_LOOPBACK,
+	storageOwnerProxyDesignator,
 } from "../shared";
 import { KV_PLUGIN_NAME } from "./constants";
 import {
@@ -23,13 +26,17 @@ import type {
 	Worker_Binding,
 	Worker_Binding_DurableObjectNamespaceDesignator,
 } from "../../runtime";
-import type { ParsedWorkerOptions, Plugin } from "../shared";
+import type {
+	MiniflareBinding,
+	ParsedWorkerOptions,
+	Plugin,
+} from "../shared";
 import type { SitesOptions } from "./sites";
 
 const SERVICE_NAMESPACE_PREFIX = `${KV_PLUGIN_NAME}:ns`;
 // A single entry service shared by every *local* namespace. Each namespace's id
 // is supplied per-binding via `ctx.props`, so one service serves all of them.
-const KV_LOCAL_ENTRY_SERVICE_NAME = `${KV_PLUGIN_NAME}:ns:entry`;
+export const KV_LOCAL_ENTRY_SERVICE_NAME = `${KV_PLUGIN_NAME}:ns:entry`;
 // One shared remote-proxy service for all remote namespaces (config via props).
 const KV_REMOTE_SERVICE_NAME = `${KV_PLUGIN_NAME}:ns:remote`;
 const KV_STORAGE_SERVICE_NAME = `${KV_PLUGIN_NAME}:storage`;
@@ -72,11 +79,7 @@ export const KV_PLUGIN: Plugin = {
 				name,
 				kvNamespace: {
 					name: KV_LOCAL_ENTRY_SERVICE_NAME,
-					props: {
-						json: JSON.stringify({
-							[SharedBindings.TEXT_NAMESPACE]: id,
-						}),
-					},
+					props: buildObjectEntryProps(id),
 				},
 			};
 		});
@@ -106,13 +109,24 @@ export const KV_PLUGIN: Plugin = {
 		return bindings;
 	},
 
-	async getServices({ options, tmpPath, sharedOptions }) {
+	async getServices({
+		options,
+		tmpPath,
+		sharedOptions,
+		storageOwnerRoutePlugins,
+	}) {
 		const namespaces = getEnvBindingsOfType(options.config, "kv");
 
 		const services: Service[] = [];
 
+		// When routing local KV to a shared storage owner, this instance must not
+		// stand up its own KV storage (disk/DO/migrations) — its bindings are
+		// repointed at the owner proxy by `Miniflare`. Sites are still served
+		// locally as they aren't routed.
+		const routeToOwner = storageOwnerRoutePlugins.has(KV_PLUGIN_NAME);
+
 		// One shared entry service for all local namespaces (id supplied via props).
-		const hasLocalNamespace = namespaces.some(
+		const hasLocalNamespace = !routeToOwner && namespaces.some(
 			([, binding]) => !getRemoteProxyConnectionString(binding, options.dev)
 		);
 		if (hasLocalNamespace) {
@@ -122,7 +136,7 @@ export const KV_PLUGIN: Plugin = {
 			});
 		}
 
-		// One shared proxy service for all remote (mixed-mode) namespaces.
+		// Remote bindings keep using this instance's per-plugin proxy service.
 		const hasRemoteNamespace = namespaces.some(([, binding]) =>
 			getRemoteProxyConnectionString(binding, options.dev)
 		);
@@ -132,7 +146,6 @@ export const KV_PLUGIN: Plugin = {
 				worker: remoteProxyClientWorker(),
 			});
 		}
-
 		if (hasLocalNamespace) {
 			const uniqueKey = `miniflare-${KV_NAMESPACE_OBJECT_CLASS_NAME}`;
 			const persistPath = getPersistPath(
@@ -183,6 +196,41 @@ export const KV_PLUGIN: Plugin = {
 		}
 
 		return services;
+	},
+
+	routeBindingToStorageOwner(binding) {
+		if ("kvNamespace" in binding && binding.kvNamespace?.name !== undefined) {
+			const id = extractObjectEntryId(binding.kvNamespace.props?.json);
+			if (id !== undefined) {
+				return {
+					name: binding.name,
+					// The owner runs the same KV plugin code, so its generic entry
+					// service is `KV_LOCAL_ENTRY_SERVICE_NAME`; the id travels as props
+					// (read by `object-entry.worker.ts` via `ctx.props`).
+					kvNamespace: storageOwnerProxyDesignator(
+						KV_LOCAL_ENTRY_SERVICE_NAME,
+						undefined,
+						{ [SharedBindings.TEXT_NAMESPACE]: id }
+					),
+				};
+			}
+		}
+		return undefined;
+	},
+
+	getStorageOwnerHosting(allOptions) {
+		const ownerBindings: Record<string, MiniflareBinding> = {};
+		for (const options of allOptions) {
+			for (const [, binding] of getEnvBindingsOfType(options.config, "kv")) {
+				if (getRemoteProxyConnectionString(binding, options.dev) === undefined) {
+					ownerBindings[`${KV_PLUGIN_NAME}:${binding.id}`] = binding;
+				}
+			}
+		}
+		if (Object.keys(ownerBindings).length === 0) {
+			return undefined;
+		}
+		return { ownerBindings };
 	},
 };
 

--- a/packages/miniflare/src/plugins/r2/index.ts
+++ b/packages/miniflare/src/plugins/r2/index.ts
@@ -8,6 +8,7 @@ import { R2S3Bindings } from "../../workers/r2/constants";
 import {
 	buildObjectEntryProps,
 	buildRemoteProxyProps,
+	extractObjectEntryId,
 	getEnvBindingsOfType,
 	getMiniflareObjectBindings,
 	getPersistPath,
@@ -16,13 +17,18 @@ import {
 	ProxyNodeBinding,
 	remoteProxyClientWorker,
 	SERVICE_LOOPBACK,
+	storageOwnerProxyDesignator,
 } from "../shared";
 import type {
 	Service,
 	Worker_Binding,
 	Worker_Binding_DurableObjectNamespaceDesignator,
 } from "../../runtime";
-import type { MiniflareBinding, ParsedWorkerOptions, Plugin } from "../shared";
+import type {
+	MiniflareBinding,
+	ParsedWorkerOptions,
+	Plugin,
+} from "../shared";
 
 /** Local-dev S3 credentials, derived from the parsed R2 binding. */
 type R2S3Credentials = NonNullable<
@@ -34,9 +40,10 @@ const R2_STORAGE_SERVICE_NAME = `${R2_PLUGIN_NAME}:storage`;
 const R2_BUCKET_SERVICE_PREFIX = `${R2_PLUGIN_NAME}:bucket`;
 // A single entry service shared by every *local* bucket. Each bucket's id is
 // supplied per-binding via `ctx.props`, so one service serves all of them.
-const R2_LOCAL_ENTRY_SERVICE_NAME = `${R2_PLUGIN_NAME}:bucket:entry`;
+export const R2_LOCAL_ENTRY_SERVICE_NAME = `${R2_PLUGIN_NAME}:bucket:entry`;
 // One shared remote-proxy service for all remote R2 buckets (config via props).
 const R2_REMOTE_SERVICE_NAME = `${R2_PLUGIN_NAME}:bucket:remote`;
+
 export const R2_PUBLIC_SERVICE_NAME = `${R2_PLUGIN_NAME}:public`;
 export const R2_S3_SERVICE_NAME = `${R2_PLUGIN_NAME}:s3`;
 const R2_BUCKET_OBJECT_CLASS_NAME = "R2BucketObject";
@@ -45,8 +52,20 @@ const R2_BUCKET_OBJECT: Worker_Binding_DurableObjectNamespaceDesignator = {
 	className: R2_BUCKET_OBJECT_CLASS_NAME,
 };
 
+function getR2WrapperBucketDesignator(id: string, routeToStorageOwner: boolean) {
+	return routeToStorageOwner
+		? storageOwnerProxyDesignator(R2_LOCAL_ENTRY_SERVICE_NAME, undefined, {
+				[SharedBindings.TEXT_NAMESPACE]: id,
+			})
+		: {
+				name: R2_LOCAL_ENTRY_SERVICE_NAME,
+				props: buildObjectEntryProps(id),
+			};
+}
+
 export function getR2PublicService(
-	allWorkerOpts: ParsedWorkerOptions[]
+	allWorkerOpts: ParsedWorkerOptions[],
+	routeToStorageOwner = false
 ): Service | undefined {
 	const publicBucketIds = new Set<string>();
 	for (const worker of allWorkerOpts) {
@@ -62,10 +81,7 @@ export function getR2PublicService(
 	}
 	const bindings = Array.from(publicBucketIds).map<Worker_Binding>((id) => ({
 		name: id,
-		r2Bucket: {
-			name: R2_LOCAL_ENTRY_SERVICE_NAME,
-			props: buildObjectEntryProps(id),
-		},
+		r2Bucket: getR2WrapperBucketDesignator(id, routeToStorageOwner),
 	}));
 	return {
 		name: R2_PUBLIC_SERVICE_NAME,
@@ -78,7 +94,8 @@ export function getR2PublicService(
 }
 
 export function getR2S3Service(
-	allWorkerOpts: ParsedWorkerOptions[]
+	allWorkerOpts: ParsedWorkerOptions[],
+	routeToStorageOwner = false
 ): Service | undefined {
 	const credentialsById: Record<string, R2S3Credentials> = {};
 	for (const worker of allWorkerOpts) {
@@ -114,10 +131,7 @@ export function getR2S3Service(
 
 	const bindings = bucketIds.map<Worker_Binding>((id) => ({
 		name: `${R2S3Bindings.BUCKET_PREFIX}${id}`,
-		r2Bucket: {
-			name: R2_LOCAL_ENTRY_SERVICE_NAME,
-			props: buildObjectEntryProps(id),
-		},
+		r2Bucket: getR2WrapperBucketDesignator(id, routeToStorageOwner),
 	}));
 	bindings.push({
 		name: R2S3Bindings.JSON_CREDENTIALS,
@@ -168,15 +182,22 @@ export const R2_PLUGIN: Plugin = {
 			])
 		);
 	},
-	async getServices({ options, tmpPath, sharedOptions }) {
+	async getServices({
+		options,
+		tmpPath,
+		sharedOptions,
+		storageOwnerRoutePlugins,
+	}) {
 		const buckets = getEnvBindingsOfType(options.config, "r2");
-
 		const services: Service[] = [];
+		const routeToOwner = storageOwnerRoutePlugins.has(R2_PLUGIN_NAME);
 
-		// One shared entry service for all local buckets (id supplied via props).
-		const hasLocal = buckets.some(
-			([, b]) => getRemoteProxyConnectionString(b, options.dev) === undefined
-		);
+		const hasLocal =
+			!routeToOwner &&
+			buckets.some(
+				([, bucket]) =>
+					getRemoteProxyConnectionString(bucket, options.dev) === undefined
+			);
 		if (hasLocal) {
 			services.push({
 				name: R2_LOCAL_ENTRY_SERVICE_NAME,
@@ -184,9 +205,9 @@ export const R2_PLUGIN: Plugin = {
 			});
 		}
 
-		// One shared proxy service for all remote (mixed-mode) buckets.
 		const hasRemote = buckets.some(
-			([, b]) => getRemoteProxyConnectionString(b, options.dev) !== undefined
+			([, bucket]) =>
+				getRemoteProxyConnectionString(bucket, options.dev) !== undefined
 		);
 		if (hasRemote) {
 			services.push({
@@ -224,9 +245,7 @@ export const R2_PLUGIN: Plugin = {
 							uniqueKey,
 						},
 					],
-					// Store Durable Object SQL databases in persist path
 					durableObjectStorage: { localDisk: R2_STORAGE_SERVICE_NAME },
-					// Bind blob disk directory service to object
 					bindings: [
 						{
 							name: SharedBindings.MAYBE_SERVICE_BLOBS,
@@ -244,5 +263,31 @@ export const R2_PLUGIN: Plugin = {
 		}
 
 		return services;
+	},
+	routeBindingToStorageOwner(binding) {
+		if ("r2Bucket" in binding && binding.r2Bucket?.name !== undefined) {
+			const id = extractObjectEntryId(binding.r2Bucket.props?.json);
+			if (id !== undefined) {
+				return {
+					name: binding.name,
+					r2Bucket: getR2WrapperBucketDesignator(id, true),
+				};
+			}
+		}
+		return undefined;
+	},
+	getStorageOwnerHosting(allOptions) {
+		const ownerBindings: Record<string, MiniflareBinding> = {};
+		for (const options of allOptions) {
+			for (const [, binding] of getEnvBindingsOfType(options.config, "r2")) {
+				if (getRemoteProxyConnectionString(binding, options.dev) === undefined) {
+					ownerBindings[`${R2_PLUGIN_NAME}:${binding.name}`] = binding;
+				}
+			}
+		}
+		if (Object.keys(ownerBindings).length === 0) {
+			return undefined;
+		}
+		return { ownerBindings };
 	},
 };

--- a/packages/miniflare/src/plugins/secret-store/index.ts
+++ b/packages/miniflare/src/plugins/secret-store/index.ts
@@ -12,6 +12,7 @@ import {
 	objectEntryWorker,
 	ProxyNodeBinding,
 	SERVICE_LOOPBACK,
+	storageOwnerProxyDesignator,
 } from "../shared";
 import type { Service, Worker_Binding } from "../../runtime";
 import type { Plugin } from "../shared";
@@ -20,6 +21,7 @@ export const SECRET_STORE_PLUGIN_NAME = "secrets-store";
 // A single entry service shared by every secret store. Each store_id is supplied
 // per-binding via `ctx.props`, so one service serves all of them.
 const SECRET_STORE_LOCAL_ENTRY_SERVICE_NAME = `${SECRET_STORE_PLUGIN_NAME}:ns:entry`;
+export const SECRET_STORE_SECRET_ENTRYPOINT = "SecretsStoreSecret";
 
 export const SECRET_STORE_PLUGIN: Plugin = {
 	bindingTypeDescription: "Secrets Store secret",
@@ -35,7 +37,7 @@ export const SECRET_STORE_PLUGIN: Plugin = {
 						SECRET_STORE_PLUGIN_NAME,
 						`${binding.storeId}:${binding.secretName}`
 					),
-					entrypoint: "SecretsStoreSecret",
+					entrypoint: SECRET_STORE_SECRET_ENTRYPOINT,
 				},
 			};
 		});
@@ -47,13 +49,22 @@ export const SECRET_STORE_PLUGIN: Plugin = {
 			)
 		);
 	},
-	async getServices({ options, tmpPath, sharedOptions }) {
+	async getServices({
+		options,
+		tmpPath,
+		sharedOptions,
+		storageOwnerRoutePlugins,
+	}) {
 		const configs = getEnvBindingsOfType(
 			options.config,
 			"secrets-store-secret"
 		).map(([, binding]) => binding);
 
 		if (configs.length === 0) {
+			return [];
+		}
+
+		if (storageOwnerRoutePlugins.has(SECRET_STORE_PLUGIN_NAME)) {
 			return [];
 		}
 
@@ -140,5 +151,42 @@ export const SECRET_STORE_PLUGIN: Plugin = {
 		}));
 
 		return [...secretServices, entryService, storageService, objectService];
+	},
+	routeBindingToStorageOwner(binding) {
+		if ("service" in binding && binding.service?.name !== undefined) {
+			return {
+				name: binding.name,
+				service: storageOwnerProxyDesignator(
+					binding.service.name,
+					binding.service.entrypoint
+				),
+			};
+		}
+		return undefined;
+	},
+	getStorageOwnerHosting(allOptions) {
+		const secrets = new Map<
+			string,
+			{ type: "secrets-store-secret"; storeId: string; secretName: string }
+		>();
+		for (const options of allOptions) {
+			for (const [, binding] of getEnvBindingsOfType(
+				options.config,
+				"secrets-store-secret"
+			)) {
+				secrets.set(`${binding.storeId}:${binding.secretName}`, binding);
+			}
+		}
+		if (secrets.size === 0) {
+			return undefined;
+		}
+		return {
+			ownerBindings: Object.fromEntries(
+				[...secrets.entries()].map(([resource, binding]) => [
+					`owner:${resource}`,
+					binding,
+				])
+			),
+		};
 	},
 };

--- a/packages/miniflare/src/plugins/shared/constants.ts
+++ b/packages/miniflare/src/plugins/shared/constants.ts
@@ -1,6 +1,11 @@
 import SCRIPT_OBJECT_ENTRY from "worker:shared/object-entry";
 import SCRIPT_REMOTE_PROXY_CLIENT from "worker:shared/remote-proxy-client";
-import { CoreBindings, SharedBindings } from "../../workers";
+import {
+	CoreBindings,
+	SharedBindings,
+	STORAGE_OWNER_CLIENT_ENTRYPOINT,
+} from "../../workers";
+import { getUserServiceName } from "../core/constants";
 import type { RemoteProxyConnectionString } from ".";
 import type {
 	Worker,
@@ -147,6 +152,28 @@ export function buildRemoteProxyProps(
 			binding,
 			cfTraceId: process.env.CF_TRACE_ID,
 		}),
+	};
+}
+
+// Builds a binding designator routing a storage op through the client-side
+// storage-owner proxy (the `StorageOwnerProxy` entrypoint on the dev-registry
+// proxy service). The proxy resolves the owner from the dev registry and, over
+// its debug port, `getEntrypoint`s the named owner service — forwarding
+// `userProps` into the callee's `ctx.props` (e.g. the resource id read by
+// `object-entry.worker.ts`). `ownerService` / `ownerEntrypoint` are the owner's
+// real storage service coordinates (the owner runs the same plugin code, so
+// these names match); the plugin supplies them in `routeBindingToStorageOwner`.
+export function storageOwnerProxyDesignator(
+	ownerService: string,
+	ownerEntrypoint?: string,
+	userProps?: Record<string, unknown>
+): { name: string; entrypoint: string; props: { json: string } } {
+	return {
+		name: getUserServiceName(SERVICE_DEV_REGISTRY_PROXY),
+		entrypoint: STORAGE_OWNER_CLIENT_ENTRYPOINT,
+		props: {
+			json: JSON.stringify({ ownerService, ownerEntrypoint, userProps }),
+		},
 	};
 }
 

--- a/packages/miniflare/src/plugins/shared/index.ts
+++ b/packages/miniflare/src/plugins/shared/index.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { MiniflareCoreError } from "../../shared";
 import type {
+	MiniflareBinding,
 	ParsedInstanceOptions,
 	ParsedWorkerOptions,
 } from "../../config/schema";
@@ -76,11 +77,26 @@ export interface PluginServicesOptions {
 	// messages to a consumer in another `wrangler dev` process.
 	devRegistryEnabled: boolean;
 	hyperdriveProxyController: HyperdriveProxyController;
+	// Plugin names (e.g. "kv") whose *local* storage is being routed to a shared
+	// storage owner process. Plugins listed here should skip standing up their
+	// local storage services (disk/DO/migrations); their bindings are rewritten
+	// to the storage-owner proxy by `Miniflare`.
+	storageOwnerRoutePlugins: Set<string>;
+	// When the shared storage owner feature is enabled, plugins that aren't
+	// routed to the owner but still persist to `resourcePersistencePath` (Cache,
+	// Durable Objects, Workflows) keep their storage per-instance (under
+	// `tmpPath`) instead of the shared root, so separate processes don't contend
+	// on one database.
+	isolateLocalStorage: boolean;
 }
 
 export interface ServicesExtensions {
 	services: Service[];
 	extensions: Extension[];
+}
+
+export interface StorageOwnerHosting {
+	ownerBindings: Record<string, MiniflareBinding>;
 }
 
 /**
@@ -103,6 +119,25 @@ export interface Plugin {
 	getExtensions?(options: {
 		options: ParsedWorkerOptions[];
 	}): Awaitable<Extension[]>;
+	// Shared storage owner (experimental `unsafeSharedStorageOwner`) hooks. Only
+	// implemented by plugins whose local storage can be routed to a single owner
+	// process. `Miniflare` owns the process/presence/routing orchestration; these
+	// let each plugin own the knowledge of its own binding + resource shapes.
+
+	// Rewrite one of this plugin's *local* storage bindings so the op is served by
+	// the owner process (via the client-side storage-owner proxy, which reaches
+	// the owner's storage service over the debug port), or return `undefined` to
+	// leave `binding` unchanged. Called for each binding this plugin emits when
+	// its storage is routed to an owner.
+	routeBindingToStorageOwner?(
+		binding: Worker_Binding
+	): Worker_Binding | undefined;
+	// Given every worker's options for this plugin, describe how a shared owner
+	// should host its local storage, or `undefined` if there's nothing local to
+	// share. Used to configure the spawned owner process.
+	getStorageOwnerHosting?(
+		allOptions: ParsedWorkerOptions[]
+	): StorageOwnerHosting | undefined;
 }
 
 /**

--- a/packages/miniflare/src/plugins/stream/index.ts
+++ b/packages/miniflare/src/plugins/stream/index.ts
@@ -11,6 +11,7 @@ import {
 	getUserBindingServiceName,
 	ProxyNodeBinding,
 	remoteProxyClientWorker,
+	storageOwnerProxyDesignator,
 	WORKER_BINDING_SERVICE_LOOPBACK,
 } from "../shared";
 import type { Service } from "../../runtime";
@@ -21,6 +22,11 @@ const STREAM_REMOTE_SERVICE_NAME = `${STREAM_PLUGIN_NAME}:remote`;
 const STREAM_STORAGE_SERVICE_NAME = `${STREAM_PLUGIN_NAME}:storage`;
 const STREAM_OBJECT_SERVICE_NAME = `${STREAM_PLUGIN_NAME}:object`;
 export const STREAM_OBJECT_CLASS_NAME = "StreamObject";
+export const STREAM_BINDING_SERVICE_NAME = getUserBindingServiceName(
+	STREAM_PLUGIN_NAME,
+	"service"
+);
+export const STREAM_BINDING_ENTRYPOINT = "StreamBinding";
 
 export const STREAM_COMPAT_DATE = "2026-03-23";
 
@@ -41,8 +47,8 @@ export const STREAM_PLUGIN: Plugin = {
 								props: buildRemoteProxyProps(remoteProxyConnectionString, name),
 							}
 						: {
-								name: getUserBindingServiceName(STREAM_PLUGIN_NAME, "service"),
-								entrypoint: "StreamBinding",
+								name: STREAM_BINDING_SERVICE_NAME,
+								entrypoint: STREAM_BINDING_ENTRYPOINT,
 							},
 				};
 			}
@@ -56,7 +62,12 @@ export const STREAM_PLUGIN: Plugin = {
 			])
 		);
 	},
-	async getServices({ options, tmpPath, sharedOptions }) {
+	async getServices({
+		options,
+		tmpPath,
+		sharedOptions,
+		storageOwnerRoutePlugins,
+	}) {
 		const services: Service[] = [];
 
 		for (const [, binding] of getEnvBindingsOfType(options.config, "stream")) {
@@ -70,6 +81,10 @@ export const STREAM_PLUGIN: Plugin = {
 					name: STREAM_REMOTE_SERVICE_NAME,
 					worker: remoteProxyClientWorker(),
 				});
+				continue;
+			}
+
+			if (storageOwnerRoutePlugins.has(STREAM_PLUGIN_NAME)) {
 				continue;
 			}
 
@@ -120,11 +135,7 @@ export const STREAM_PLUGIN: Plugin = {
 
 			// Entrypoint with RPC
 			const bindingService = {
-				name: getUserBindingServiceName(
-					STREAM_PLUGIN_NAME,
-					"service",
-					remoteProxyConnectionString
-				),
+				name: STREAM_BINDING_SERVICE_NAME,
 				worker: {
 					compatibilityDate: STREAM_COMPAT_DATE,
 					compatibilityFlags: ["nodejs_compat", "experimental"],
@@ -154,5 +165,37 @@ export const STREAM_PLUGIN: Plugin = {
 		}
 
 		return services;
+	},
+	routeBindingToStorageOwner(binding) {
+		if (
+			"service" in binding &&
+			binding.service?.name === STREAM_BINDING_SERVICE_NAME &&
+			binding.service.entrypoint === STREAM_BINDING_ENTRYPOINT
+		) {
+			return {
+				name: binding.name,
+				service: storageOwnerProxyDesignator(
+					STREAM_BINDING_SERVICE_NAME,
+					STREAM_BINDING_ENTRYPOINT
+				),
+			};
+		}
+		return undefined;
+	},
+	getStorageOwnerHosting(allOptions) {
+		const hasLocal = allOptions.some((options) =>
+			getEnvBindingsOfType(options.config, "stream").some(
+				([, binding]) =>
+					getRemoteProxyConnectionString(binding, options.dev) === undefined
+			)
+		);
+		if (!hasLocal) {
+			return undefined;
+		}
+		return {
+			ownerBindings: {
+				stream: { type: "stream" },
+			},
+		};
 	},
 };

--- a/packages/miniflare/src/plugins/workflows/index.ts
+++ b/packages/miniflare/src/plugins/workflows/index.ts
@@ -69,16 +69,24 @@ export const WORKFLOWS_PLUGIN: Plugin = {
 		];
 	},
 
-	async getServices({ options, tmpPath, sharedOptions, workerNames }) {
+	async getServices({
+		options,
+		tmpPath,
+		sharedOptions,
+		workerNames,
+		isolateLocalStorage,
+	}) {
 		const workflows = getEnvBindingsOfType(options.config, "workflow");
 		if (workflows.length === 0) {
 			return [];
 		}
 
+		// Workflows aren't routed to the shared storage owner; keep their storage
+		// per-instance when the feature is on so separate processes don't contend.
 		const persistPath = getPersistPath(
 			WORKFLOWS_PLUGIN_NAME,
 			tmpPath,
-			sharedOptions.resourcePersistencePath
+			isolateLocalStorage ? undefined : sharedOptions.resourcePersistencePath
 		);
 		await fs.mkdir(persistPath, { recursive: true });
 		// each workflow should get its own storage service

--- a/packages/miniflare/src/shared/index.ts
+++ b/packages/miniflare/src/shared/index.ts
@@ -2,5 +2,6 @@ export * from "./error";
 export * from "./event";
 export * from "./log";
 export * from "./matcher";
+export * from "./storage-owner";
 export * from "./streams";
 export * from "./types";

--- a/packages/miniflare/src/shared/storage-owner.ts
+++ b/packages/miniflare/src/shared/storage-owner.ts
@@ -1,0 +1,109 @@
+import {
+	mkdirSync,
+	readFileSync,
+	rmSync,
+	statSync,
+	writeFileSync,
+} from "node:fs";
+import path from "node:path";
+
+// Election lock for the shared "central storage owner" feature. Discovery,
+// liveness, and client presence all now ride the dev registry (see
+// `STORAGE_OWNER_WORKER_NAME` and `StorageOwnerProxy`); the only thing the
+// registry can't provide is a mutex, so a single lock file still serialises
+// which client spawns the (one-per-registry) owner process.
+//
+//   <lockDir>/.miniflare-owner.lock   - transient lock serialising owner election
+
+const OWNER_SPAWN_LOCK_FILE = ".miniflare-owner.lock";
+
+// A lock whose mtime is older than this is considered stale and reclaimable.
+export const OWNER_STALE_MS = 30_000;
+const OWNER_LOCK_RETRY_MS = 50;
+
+/**
+ * Returns whether a process with the given pid is currently alive.
+ *
+ * `process.kill(pid, 0)` sends no signal but performs the permission/existence
+ * check: it throws `ESRCH` if the process does not exist, and `EPERM` if it
+ * exists but we lack permission to signal it (still alive).
+ */
+export function isProcessAlive(pid: number): boolean {
+	if (!Number.isInteger(pid) || pid <= 0) {
+		return false;
+	}
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch (e) {
+		return (e as NodeJS.ErrnoException).code === "EPERM";
+	}
+}
+
+function ownerSpawnLockPath(lockDir: string): string {
+	return path.join(lockDir, OWNER_SPAWN_LOCK_FILE);
+}
+
+/** Handle for a held owner-election lock. */
+export interface OwnerSpawnLock {
+	release(): void;
+}
+
+/**
+ * Attempts to acquire the per-registry election lock so that exactly one client
+ * spawns the owner process. `lockDir` should be a directory scoped to the dev
+ * registry but *outside* the watched registry directory (so the registry's own
+ * stale-file cleanup never touches it). Returns a release handle on success, or
+ * `undefined` if another live process currently holds it.
+ *
+ * A lock whose mtime is stale or whose pid is dead is reclaimed.
+ */
+export function tryAcquireOwnerSpawnLock(
+	lockDir: string
+): OwnerSpawnLock | undefined {
+	mkdirSync(lockDir, { recursive: true });
+	const lockPath = ownerSpawnLockPath(lockDir);
+	try {
+		writeFileSync(lockPath, String(process.pid), { flag: "wx" });
+		return { release: () => rmSync(lockPath, { force: true }) };
+	} catch (e) {
+		if ((e as NodeJS.ErrnoException).code !== "EEXIST") {
+			throw e;
+		}
+	}
+	// Lock exists — reclaim if stale or owned by a dead process.
+	if (isOwnerSpawnLockStale(lockPath)) {
+		rmSync(lockPath, { force: true });
+		try {
+			writeFileSync(lockPath, String(process.pid), { flag: "wx" });
+			return { release: () => rmSync(lockPath, { force: true }) };
+		} catch {
+			return undefined;
+		}
+	}
+	return undefined;
+}
+
+function isOwnerSpawnLockStale(lockPath: string): boolean {
+	let stats;
+	try {
+		stats = statSync(lockPath, { throwIfNoEntry: false });
+	} catch {
+		return true;
+	}
+	if (stats === undefined) {
+		return true;
+	}
+	if (stats.mtime.getTime() < Date.now() - OWNER_STALE_MS) {
+		return true;
+	}
+	let pid: number;
+	try {
+		pid = Number(readFileSync(lockPath, { encoding: "utf8" }).trim());
+	} catch {
+		return true;
+	}
+	return !isProcessAlive(pid);
+}
+
+export { OWNER_LOCK_RETRY_MS };

--- a/packages/miniflare/src/workers/core/constants.ts
+++ b/packages/miniflare/src/workers/core/constants.ts
@@ -97,6 +97,35 @@ export const CoreBindings = {
 	SERVICE_OBSERVABILITY_COLLECTOR: "MINIFLARE_OBSERVABILITY_COLLECTOR",
 } as const;
 
+// Shared storage owner (experimental `unsafeSharedStorageOwner`).
+//
+// The detached owner process registers itself in the dev registry under this
+// well-known worker name; clients look it up to find the owner's debug port and
+// reach its storage services over Cap'n Proto RPC (see `StorageOwnerProxy` in
+// `dev-registry-proxy.worker.ts`). Policy is one owner per dev registry.
+export const STORAGE_OWNER_WORKER_NAME = "__miniflare_shared_storage_owner__";
+// Each client routing storage to the owner registers a presence entry under this
+// prefix (+ its pid) so the owner can tell — from the registry alone — when no
+// clients remain and it can tear itself down.
+export const STORAGE_OWNER_CLIENT_PRESENCE_PREFIX =
+	"__miniflare_storage_owner_client__:";
+// Named entrypoint (on the dev-registry-proxy service) that routed storage
+// bindings target; forwards to the owner's storage service via the debug port.
+export const STORAGE_OWNER_CLIENT_ENTRYPOINT = "StorageOwnerProxy";
+
+/**
+ * Whether a dev registry entry name is one of the shared-storage-owner's
+ * internal reservations (the owner itself, or a client presence marker) rather
+ * than a real user worker. Consumers that enumerate the registry as "running
+ * workers" should skip these.
+ */
+export function isStorageOwnerRegistryName(name: string): boolean {
+	return (
+		name === STORAGE_OWNER_WORKER_NAME ||
+		name.startsWith(STORAGE_OWNER_CLIENT_PRESENCE_PREFIX)
+	);
+}
+
 export const ProxyOps = {
 	// Get the target or a property of the target
 	GET: "GET",

--- a/packages/miniflare/src/workers/core/dev-registry-proxy.worker.ts
+++ b/packages/miniflare/src/workers/core/dev-registry-proxy.worker.ts
@@ -1,6 +1,6 @@
 import { WorkerEntrypoint } from "cloudflare:workers";
 import { getQueueServiceName, HEADER_QUEUE_NAME } from "../queues/constants";
-import { CorePaths } from "./constants";
+import { CorePaths, STORAGE_OWNER_WORKER_NAME } from "./constants";
 import {
 	findQueueConsumer,
 	resolveTarget,
@@ -185,5 +185,91 @@ export class ExternalServiceProxy extends WorkerEntrypoint<Env, Props> {
 				}": ${e instanceof Error ? e.message : String(e)}`
 			);
 		}
+	}
+}
+
+/**
+ * Props carried by a storage binding routed to the shared storage owner. The
+ * proxy resolves the owner from the dev registry (by its well-known name) and
+ * `getEntrypoint`s the named owner service over the debug port, forwarding
+ * `userProps` into the callee's `ctx.props` (e.g. the resource id read by
+ * `object-entry.worker.ts`).
+ */
+interface StorageProps {
+	/** The workerd service name on the owner process to target. */
+	ownerService: string;
+	/** Optional named entrypoint of that service (RPC-type resources). */
+	ownerEntrypoint?: string;
+	/** Props forwarded to the owner service as `ctx.props`. */
+	userProps?: Record<string, unknown>;
+}
+
+/**
+ * Client-side proxy for the shared storage owner. Every routed storage binding
+ * (KV / R2 / D1 / Images fetch, Streams / Secrets RPC) points here; the proxy
+ * connects to the owner's debug port and forwards both fetch and arbitrary RPC
+ * calls to the owner's real storage service. Resolved lazily per use so the
+ * owner restarting (new debug port) is picked up automatically.
+ */
+export class StorageOwnerProxy extends WorkerEntrypoint<Env, StorageProps> {
+	_cachedFetcher: Fetcher | undefined;
+	_cachedDebugPortAddress: string | undefined;
+
+	_resolve(): Fetcher | null {
+		const target = resolveTarget(STORAGE_OWNER_WORKER_NAME);
+		if (!target || !target.debugPortAddress) {
+			this._cachedFetcher = undefined;
+			this._cachedDebugPortAddress = undefined;
+			return null;
+		}
+		if (
+			this._cachedFetcher &&
+			target.debugPortAddress === this._cachedDebugPortAddress
+		) {
+			return this._cachedFetcher;
+		}
+		const client = this.env.DEV_REGISTRY_DEBUG_PORT.connect(
+			target.debugPortAddress
+		);
+		const fetcher = client.getEntrypoint(
+			this.ctx.props.ownerService,
+			this.ctx.props.ownerEntrypoint,
+			this.ctx.props.userProps
+		);
+		this._cachedFetcher = fetcher;
+		this._cachedDebugPortAddress = target.debugPortAddress;
+		return fetcher;
+	}
+
+	constructor(ctx: ExecutionContext<StorageProps>, env: Env) {
+		super(ctx, env);
+
+		return new Proxy(this, {
+			get(target, prop) {
+				if (Reflect.has(target, prop)) {
+					return Reflect.get(target, prop);
+				}
+				const fetcher = target._resolve();
+				if (!fetcher) {
+					// Return a function-that-throws rather than throwing in the get
+					// trap: workerd probes properties (fetch, etc.) and throwing here
+					// would crash those internal checks.
+					return () => {
+						throw new Error(workerNotFoundMessage(STORAGE_OWNER_WORKER_NAME));
+					};
+				}
+				return Reflect.get(fetcher, prop);
+			},
+		});
+	}
+
+	fetch(request: Request): Promise<Response> | Response {
+		const fetcher = this._resolve();
+		if (!fetcher) {
+			return new Response(workerNotFoundMessage(STORAGE_OWNER_WORKER_NAME), {
+				status: 503,
+			});
+		}
+		return fetcher.fetch(request);
 	}
 }

--- a/packages/miniflare/src/workers/local-explorer/aggregation.ts
+++ b/packages/miniflare/src/workers/local-explorer/aggregation.ts
@@ -6,7 +6,7 @@
  */
 
 import { env } from "cloudflare:workers";
-import { CorePaths } from "../core";
+import { CorePaths, isStorageOwnerRegistryName } from "../core";
 import type { WorkerRegistry } from "../../shared/dev-registry-types";
 import type { AppContext } from "./common";
 
@@ -28,7 +28,9 @@ function getPeerDebugPortAddresses(
 ): string[] {
 	const selfSet = new Set(selfWorkerNames);
 	const addresses = Object.entries(registry)
-		.filter(([name]) => !selfSet.has(name))
+		// Skip the shared-storage owner + client presence entries — they aren't
+		// real user workers and their debug ports don't serve the explorer API.
+		.filter(([name]) => !selfSet.has(name) && !isStorageOwnerRegistryName(name))
 		.map(([, def]) => def.debugPortAddress)
 		.filter((addr): addr is string => typeof addr === "string");
 	// A single Miniflare process with multiple workers registers multiple

--- a/packages/miniflare/src/workers/shared/object-entry.worker.ts
+++ b/packages/miniflare/src/workers/shared/object-entry.worker.ts
@@ -13,9 +13,11 @@ interface Env {
 
 export default <ExportedHandler<Env, unknown, unknown, Props>>{
 	async fetch(request, env, ctx) {
-		// Prefer the namespace passed at runtime via `ctx.props` (props-based
-		// model: one entry service serves many namespaces). Fall back to the
-		// static binding for callers that still bake the namespace in.
+		// Resolve the namespace, in priority order:
+		//  1. `ctx.props` — props-based model: one entry service serves many
+		//     namespaces. Also how the shared storage owner supplies the resource
+		//     id per-request (forwarded via the debug port's `getEntrypoint` props).
+		//  2. The static binding — legacy per-resource model.
 		const name =
 			ctx.props[SharedBindings.TEXT_NAMESPACE] ??
 			env[SharedBindings.TEXT_NAMESPACE];

--- a/packages/miniflare/test/persist-sharing.spec.ts
+++ b/packages/miniflare/test/persist-sharing.spec.ts
@@ -1,0 +1,187 @@
+import { Miniflare } from "miniflare";
+import { afterEach, describe, test } from "vitest";
+import { singleModuleManifest, useTmp } from "./test-shared";
+import type { MiniflareOptions } from "miniflare";
+
+const SCRIPT = `
+	export default {
+		async fetch(request, env) {
+			const url = new URL(request.url);
+			const key = url.searchParams.get("key") ?? "key";
+
+			if (url.pathname === "/kv") {
+				if (request.method === "PUT") {
+					await env.KV.put(key, await request.text());
+					return new Response("ok");
+				}
+				return new Response((await env.KV.get(key)) ?? "<null>");
+			}
+
+			if (url.pathname === "/r2") {
+				if (request.method === "PUT") {
+					await env.R2.put(key, await request.text());
+					return new Response("ok");
+				}
+				const object = await env.R2.get(key);
+				return new Response(object === null ? "<null>" : await object.text());
+			}
+
+			if (url.pathname === "/d1") {
+				if (request.method === "PUT") {
+					await env.DB.exec("CREATE TABLE IF NOT EXISTS items (value TEXT)");
+					await env.DB.prepare("INSERT INTO items VALUES (?)")
+						.bind(await request.text())
+						.run();
+					return new Response("ok");
+				}
+				try {
+					const { results } = await env.DB.prepare("SELECT value FROM items").all();
+					return Response.json(results);
+				} catch {
+					return Response.json([]);
+				}
+			}
+
+			if (url.pathname === "/cache") {
+				const cacheKey = "http://example.com/value";
+				if (request.method === "PUT") {
+					await caches.default.put(
+						cacheKey,
+						new Response(await request.text(), {
+							headers: { "Cache-Control": "max-age=3600" },
+						})
+					);
+					return new Response("ok");
+				}
+				const response = await caches.default.match(cacheKey);
+				return new Response(response === undefined ? "<null>" : await response.text());
+			}
+
+			return new Response("not found", { status: 404 });
+		}
+	};
+`;
+
+interface MakeOptions {
+	root: string;
+	name: string;
+	kvId?: string;
+	r2Bucket?: string;
+	d1Id?: string;
+}
+
+const instances: Miniflare[] = [];
+
+function make({
+	root,
+	name,
+	kvId = "kv",
+	r2Bucket = "r2",
+	d1Id = "d1",
+}: MakeOptions): Miniflare {
+	const options: MiniflareOptions = {
+		resourcePersistencePath: root,
+		unsafeDevRegistryPath: `${root}/.registry`,
+		unsafeSharedStorageOwner: true,
+		workers: [
+			{
+				config: {
+					type: "worker",
+					name,
+					compatibilityDate: "2024-11-01",
+					manifest: singleModuleManifest(SCRIPT),
+					env: {
+						KV: { type: "kv", id: kvId },
+						R2: { type: "r2", name: r2Bucket },
+						DB: { type: "d1", id: d1Id },
+					},
+				},
+			},
+		],
+	};
+	const instance = new Miniflare(options);
+	instances.push(instance);
+	return instance;
+}
+
+async function text(
+	instance: Miniflare,
+	path: string,
+	init?: RequestInit
+): Promise<string> {
+	return (
+		await instance.dispatchFetch(`http://example.com${path}`, init)
+	).text();
+}
+
+afterEach(async () => {
+	for (const instance of instances.splice(0).reverse()) {
+		await instance.dispose().catch(() => {});
+	}
+});
+
+describe.sequential("shared storage owner persistence", () => {
+	test("instances sharing a persistence root share KV, R2, and D1", async ({
+		expect,
+	}) => {
+		const root = await useTmp();
+		const a = make({ root, name: "a" });
+		const b = make({ root, name: "b" });
+		await Promise.all([a.ready, b.ready]);
+
+		expect(await text(a, "/kv", { method: "PUT", body: "kv-value" })).toBe(
+			"ok"
+		);
+		expect(await text(b, "/kv")).toBe("kv-value");
+
+		expect(await text(a, "/r2", { method: "PUT", body: "r2-value" })).toBe(
+			"ok"
+		);
+		expect(await text(b, "/r2")).toBe("r2-value");
+
+		expect(await text(a, "/d1", { method: "PUT", body: "d1-value" })).toBe(
+			"ok"
+		);
+		expect(await text(b, "/d1")).toBe('[{"value":"d1-value"}]');
+	});
+
+	test("resources with different IDs remain isolated", async ({ expect }) => {
+		const root = await useTmp();
+		const a = make({
+			root,
+			name: "a",
+			kvId: "kv-a",
+			r2Bucket: "r2-a",
+			d1Id: "d1-a",
+		});
+		const b = make({
+			root,
+			name: "b",
+			kvId: "kv-b",
+			r2Bucket: "r2-b",
+			d1Id: "d1-b",
+		});
+		await Promise.all([a.ready, b.ready]);
+
+		await text(a, "/kv", { method: "PUT", body: "kv-value" });
+		await text(a, "/r2", { method: "PUT", body: "r2-value" });
+		await text(a, "/d1", { method: "PUT", body: "d1-value" });
+
+		expect(await text(b, "/kv")).toBe("<null>");
+		expect(await text(b, "/r2")).toBe("<null>");
+		expect(await text(b, "/d1")).toBe("[]");
+	});
+
+	test("cache storage remains local to each instance", async ({ expect }) => {
+		const root = await useTmp();
+		const a = make({ root, name: "a" });
+		const b = make({ root, name: "b" });
+		await Promise.all([a.ready, b.ready]);
+
+		expect(
+			await text(a, "/cache", { method: "PUT", body: "cache-value" })
+		).toBe("ok");
+		expect(await text(a, "/cache")).toBe("cache-value");
+		expect(await text(b, "/cache")).toBe("<null>");
+	});
+});

--- a/packages/miniflare/test/storage-owner.spec.ts
+++ b/packages/miniflare/test/storage-owner.spec.ts
@@ -1,0 +1,702 @@
+import { readFileSync, utimesSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import {
+	getWorkerRegistry,
+	isProcessAlive,
+	Miniflare,
+	OWNER_STALE_MS,
+	STORAGE_OWNER_CLIENT_PRESENCE_PREFIX,
+	STORAGE_OWNER_WORKER_NAME,
+	tryAcquireOwnerSpawnLock,
+} from "miniflare";
+import { describe, it, vi } from "vitest";
+import { singleModuleManifest, useTmp } from "./test-shared";
+import type { MiniflareOptions } from "miniflare";
+
+// A pid that is essentially guaranteed not to exist on the host.
+const DEAD_PID = 0x7fffffff;
+
+/** The live shared-storage owner's dev registry entry, if any. */
+function readOwnerEntry(registryPath: string) {
+	return getWorkerRegistry(registryPath)[STORAGE_OWNER_WORKER_NAME];
+}
+
+/** Number of live shared-storage client presence entries in the registry. */
+function countClientPresence(registryPath: string): number {
+	return Object.keys(getWorkerRegistry(registryPath)).filter((name) =>
+		name.startsWith(STORAGE_OWNER_CLIENT_PRESENCE_PREFIX)
+	).length;
+}
+
+/** Recover the detached owner's pid from its log file (best-effort, tests only). */
+function readOwnerPidFromLog(persistRoot: string): number | undefined {
+	try {
+		const log = readFileSync(
+			path.join(persistRoot, ".miniflare-owner.log"),
+			"utf8"
+		);
+		const match = log.match(/storage owner (\d+)/);
+		return match ? Number(match[1]) : undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+describe("isProcessAlive", () => {
+	it("reports the current process as alive", ({ expect }) => {
+		expect(isProcessAlive(process.pid)).toBe(true);
+	});
+	it("reports a non-existent process as dead", ({ expect }) => {
+		expect(isProcessAlive(DEAD_PID)).toBe(false);
+	});
+	it("treats invalid pids as dead", ({ expect }) => {
+		expect(isProcessAlive(0)).toBe(false);
+		expect(isProcessAlive(-1)).toBe(false);
+	});
+});
+
+describe("owner spawn lock", () => {
+	it("grants the lock to a single acquirer", async ({ expect }) => {
+		const lockDir = await useTmp();
+		const first = tryAcquireOwnerSpawnLock(lockDir);
+		expect(first).toBeDefined();
+		const second = tryAcquireOwnerSpawnLock(lockDir);
+		expect(second).toBeUndefined();
+		first?.release();
+		const third = tryAcquireOwnerSpawnLock(lockDir);
+		expect(third).toBeDefined();
+		third?.release();
+	});
+
+	it("reclaims a lock held by a dead process", async ({ expect }) => {
+		const lockDir = await useTmp();
+		// Simulate a crashed holder by writing a dead pid into the lock file.
+		writeFileSync(
+			path.join(lockDir, ".miniflare-owner.lock"),
+			String(DEAD_PID)
+		);
+		const lock = tryAcquireOwnerSpawnLock(lockDir);
+		expect(lock).toBeDefined();
+		lock?.release();
+	});
+
+	it("reclaims a stale lock", async ({ expect }) => {
+		const lockDir = await useTmp();
+		const lockPath = path.join(lockDir, ".miniflare-owner.lock");
+		writeFileSync(lockPath, String(process.pid));
+		const old = new Date(Date.now() - OWNER_STALE_MS - 60_000);
+		utimesSync(lockPath, old, old);
+		const lock = tryAcquireOwnerSpawnLock(lockDir);
+		expect(lock).toBeDefined();
+		lock?.release();
+	});
+});
+
+describe.sequential("owner presence integration", () => {
+	it("an owner-role instance registers itself in the dev registry and removes it on dispose", async ({
+		expect,
+	}) => {
+		const persistRoot = await useTmp();
+		const registryPath = await useTmp();
+		const owner = new Miniflare({
+			unsafeSharedStorageOwner: true,
+			unsafeStorageOwnerRole: "owner",
+			resourcePersistencePath: persistRoot,
+			unsafeDevRegistryPath: registryPath,
+			workers: [
+				{
+					config: {
+						type: "worker",
+						name: "",
+						compatibilityDate: "2025-05-01",
+						compatibilityFlags: ["experimental"],
+						manifest: singleModuleManifest(
+							"export default { async fetch() { return new Response('owner'); } }"
+						),
+						env: { NS: { type: "kv", id: "NS" } },
+					},
+				},
+			],
+		});
+		await owner.ready;
+
+		const entry = readOwnerEntry(registryPath);
+		expect(entry).toBeDefined();
+		expect(entry?.debugPortAddress).toMatch(/^127\.0\.0\.1:\d+$/);
+
+		await owner.dispose();
+		expect(readOwnerEntry(registryPath)).toBeUndefined();
+	});
+
+	it("a client-role instance registers a presence entry and removes it on dispose", async ({
+		expect,
+	}) => {
+		const persistRoot = await useTmp();
+		const registryPath = await useTmp();
+		const common: MiniflareOptions = {
+			unsafeSharedStorageOwner: true,
+			resourcePersistencePath: persistRoot,
+			unsafeDevRegistryPath: registryPath,
+			workers: [
+				{
+					config: {
+						type: "worker",
+						name: "",
+						compatibilityDate: "2025-01-01",
+						compatibilityFlags: ["experimental"],
+						manifest: singleModuleManifest(
+							"export default { async fetch() { return new Response('ok'); } }"
+						),
+						env: { NS: { type: "kv", id: "NS" } },
+					},
+				},
+			],
+		};
+		const owner = new Miniflare({ ...common, unsafeStorageOwnerRole: "owner" });
+		await owner.ready;
+		const client = new Miniflare({
+			...common,
+			unsafeStorageOwnerRole: "client",
+		});
+
+		try {
+			await client.ready;
+
+			await vi.waitFor(
+				() => expect(countClientPresence(registryPath)).toBe(1),
+				{
+					timeout: 5_000,
+					interval: 100,
+				}
+			);
+
+			await client.dispose();
+			expect(countClientPresence(registryPath)).toBe(0);
+		} finally {
+			await client.dispose().catch(() => {});
+			await owner.dispose();
+		}
+	});
+
+	it("routes a client's KV through the owner so storage is shared", async ({
+		expect,
+	}) => {
+		const persistRoot = await useTmp();
+		const registryPath = await useTmp();
+		const KV_WORKER = `export default {
+			async fetch(request, env) {
+				const url = new URL(request.url);
+				const key = url.searchParams.get("key") ?? "k";
+				if (request.method === "PUT") {
+					await env.NS.put(key, await request.text());
+					return new Response("ok");
+				}
+				const val = await env.NS.get(key);
+				return new Response(val ?? "<null>");
+			}
+		}`;
+		const common: MiniflareOptions = {
+			unsafeSharedStorageOwner: true,
+			resourcePersistencePath: persistRoot,
+			unsafeDevRegistryPath: registryPath,
+			workers: [
+				{
+					config: {
+						type: "worker",
+						name: "",
+						compatibilityDate: "2025-01-01",
+						compatibilityFlags: ["experimental"],
+						manifest: singleModuleManifest(KV_WORKER),
+						env: { NS: { type: "kv", id: "NS" } },
+					},
+				},
+			],
+		};
+
+		const owner = new Miniflare({ ...common, unsafeStorageOwnerRole: "owner" });
+		await owner.ready;
+		const client = new Miniflare({
+			...common,
+			unsafeStorageOwnerRole: "client",
+		});
+
+		try {
+			await client.ready;
+
+			// Write through the client (which routes to the owner).
+			const putRes = await client.dispatchFetch("http://x/?key=greeting", {
+				method: "PUT",
+				body: "hello-from-client",
+			});
+			expect(await putRes.text()).toBe("ok");
+
+			// The owner can read what the client wrote → storage is shared.
+			const ownerRes = await owner.dispatchFetch("http://x/?key=greeting");
+			expect(await ownerRes.text()).toBe("hello-from-client");
+
+			// And the client can read it back through the proxy.
+			const clientRes = await client.dispatchFetch("http://x/?key=greeting");
+			expect(await clientRes.text()).toBe("hello-from-client");
+		} finally {
+			await client.dispose();
+			await owner.dispose();
+		}
+	});
+
+	it("routes a client's R2 and D1 through the owner so storage is shared", async ({
+		expect,
+	}) => {
+		const persistRoot = await useTmp();
+		const registryPath = await useTmp();
+		const WORKER = `export default {
+			async fetch(request, env) {
+				const url = new URL(request.url);
+				const kind = url.searchParams.get("kind");
+				if (kind === "r2") {
+					if (request.method === "PUT") {
+						await env.BUCKET.put("obj", await request.text());
+						return new Response("ok");
+					}
+					const o = await env.BUCKET.get("obj");
+					return new Response(o ? await o.text() : "<null>");
+				}
+				// d1
+				if (request.method === "PUT") {
+					await env.DB.prepare("CREATE TABLE IF NOT EXISTS t(v TEXT)").run();
+					await env.DB.prepare("INSERT INTO t(v) VALUES (?)").bind(await request.text()).run();
+					return new Response("ok");
+				}
+				const { results } = await env.DB.prepare("SELECT v FROM t").all();
+				return new Response(JSON.stringify(results.map((r) => r.v)));
+			}
+		}`;
+		const common: MiniflareOptions = {
+			unsafeSharedStorageOwner: true,
+			resourcePersistencePath: persistRoot,
+			unsafeDevRegistryPath: registryPath,
+			workers: [
+				{
+					config: {
+						type: "worker",
+						name: "",
+						compatibilityDate: "2025-01-01",
+						compatibilityFlags: ["experimental"],
+						manifest: singleModuleManifest(WORKER),
+						env: {
+							BUCKET: { type: "r2", name: "BUCKET" },
+							DB: { type: "d1", id: "DB" },
+						},
+					},
+				},
+			],
+		};
+		const owner = new Miniflare({ ...common, unsafeStorageOwnerRole: "owner" });
+		await owner.ready;
+		const client = new Miniflare({
+			...common,
+			unsafeStorageOwnerRole: "client",
+		});
+
+		try {
+			await client.ready;
+
+			// R2: client write → owner read.
+			expect(
+				await (
+					await client.dispatchFetch("http://x/?kind=r2", {
+						method: "PUT",
+						body: "r2-from-client",
+					})
+				).text()
+			).toBe("ok");
+			expect(
+				await (await owner.dispatchFetch("http://x/?kind=r2")).text()
+			).toBe("r2-from-client");
+
+			// D1: client write → owner read.
+			expect(
+				await (
+					await client.dispatchFetch("http://x/?kind=d1", {
+						method: "PUT",
+						body: "d1-from-client",
+					})
+				).text()
+			).toBe("ok");
+			expect(
+				await (await owner.dispatchFetch("http://x/?kind=d1")).text()
+			).toBe(JSON.stringify(["d1-from-client"]));
+		} finally {
+			await client.dispose();
+			await owner.dispose();
+		}
+	});
+
+	it("routes a client's Stream through the owner over RPC so storage is shared", async ({
+		expect,
+	}) => {
+		const persistRoot = await useTmp();
+		const registryPath = await useTmp();
+		// Exercises the JSRPC path of the owner boundary (native RPC over the debug
+		// port), including nested RpcTargets (`videos.list()`).
+		const WORKER = `export default {
+			async fetch(request, env) {
+				try {
+					if (request.method === "PUT") {
+						const body = new Response(
+							new Uint8Array([0, 1, 2, 3, 4, 5, 6, 7])
+						).body;
+						const video = await env.STREAM.upload(body, {});
+						return Response.json({ id: video.id });
+					}
+					const videos = await env.STREAM.videos.list();
+					return Response.json({ count: videos.length });
+				} catch (e) {
+					return Response.json({ error: String(e && e.stack || e) }, { status: 500 });
+				}
+			}
+		}`;
+		const common: MiniflareOptions = {
+			unsafeSharedStorageOwner: true,
+			resourcePersistencePath: persistRoot,
+			unsafeDevRegistryPath: registryPath,
+			workers: [
+				{
+					config: {
+						type: "worker",
+						name: "",
+						compatibilityDate: "2025-01-01",
+						compatibilityFlags: ["experimental"],
+						manifest: singleModuleManifest(WORKER),
+						env: { STREAM: { type: "stream" } },
+					},
+				},
+			],
+		};
+		const owner = new Miniflare({ ...common, unsafeStorageOwnerRole: "owner" });
+		await owner.ready;
+		const client = new Miniflare({
+			...common,
+			unsafeStorageOwnerRole: "client",
+		});
+
+		try {
+			await client.ready;
+
+			// Client uploads a video (RPC through the owner)...
+			const put = (await (
+				await client.dispatchFetch("http://x/", { method: "PUT" })
+			).json()) as { id: string };
+			expect(put.id).toBeTruthy();
+
+			// ...and the owner sees it (shared store), proving the RPC round-trip
+			// and the shared backing storage.
+			expect(
+				(
+					(await (await owner.dispatchFetch("http://x/")).json()) as {
+						count: number;
+					}
+				).count
+			).toBe(1);
+		} finally {
+			await client.dispose();
+			await owner.dispose();
+		}
+	});
+
+	it("routes a client's Secrets Store secret through the owner over RPC", async ({
+		expect,
+	}) => {
+		const persistRoot = await useTmp();
+		const registryPath = await useTmp();
+		const WORKER = `export default {
+			async fetch(request, env) {
+				try {
+					return new Response(await env.SECRET.get());
+				} catch (e) {
+					return new Response(e.message, { status: 404 });
+				}
+			}
+		}`;
+		const common: MiniflareOptions = {
+			unsafeSharedStorageOwner: true,
+			resourcePersistencePath: persistRoot,
+			unsafeDevRegistryPath: registryPath,
+			workers: [
+				{
+					config: {
+						type: "worker",
+						name: "",
+						compatibilityDate: "2025-01-01",
+						compatibilityFlags: ["experimental"],
+						manifest: singleModuleManifest(WORKER),
+						env: {
+							SECRET: {
+								type: "secrets-store-secret",
+								storeId: "store_a",
+								secretName: "api_key",
+							},
+						},
+					},
+				},
+			],
+		};
+		const owner = new Miniflare({ ...common, unsafeStorageOwnerRole: "owner" });
+		await owner.ready;
+		const client = new Miniflare({
+			...common,
+			unsafeStorageOwnerRole: "client",
+		});
+
+		try {
+			await client.ready;
+
+			// Seed the secret value on the owner (which holds the local store)...
+			await (
+				await owner.getSecretsStoreSecretAPI("SECRET")
+			)().create("super-secret");
+
+			// ...and the client reads it back over the routed RPC binding.
+			expect(await (await client.dispatchFetch("http://x/")).text()).toBe(
+				"super-secret"
+			);
+		} finally {
+			await client.dispose();
+			await owner.dispose();
+		}
+	});
+
+	it("routes a client's Images store to the owner without dangling services", async ({
+		expect,
+	}) => {
+		const persistRoot = await useTmp();
+		const registryPath = await useTmp();
+		const common: MiniflareOptions = {
+			unsafeSharedStorageOwner: true,
+			resourcePersistencePath: persistRoot,
+			unsafeDevRegistryPath: registryPath,
+			workers: [
+				{
+					config: {
+						type: "worker",
+						name: "",
+						compatibilityDate: "2025-01-01",
+						compatibilityFlags: ["experimental"],
+						manifest: singleModuleManifest(
+							"export default { async fetch(_request, env) { return new Response(typeof env.IMAGES.info); } }"
+						),
+						env: { IMAGES: { type: "images" } },
+					},
+				},
+			],
+		};
+		const owner = new Miniflare({ ...common, unsafeStorageOwnerRole: "owner" });
+		const client = new Miniflare({
+			...common,
+			unsafeStorageOwnerRole: "client",
+		});
+		try {
+			// Both reaching `ready` proves the routed client doesn't reference a
+			// local images storage service it no longer stands up (the owner does),
+			// and the transform worker + its routed `IMAGES_STORE` binding resolve.
+			await owner.ready;
+			await client.ready;
+			expect(await (await client.dispatchFetch("http://x/")).text()).toBe(
+				"function"
+			);
+		} finally {
+			await client.dispose();
+			await owner.dispose();
+		}
+	});
+
+	it("auto-spawns a detached owner, routes to it, and tears it down when idle", async ({
+		expect,
+	}) => {
+		const persistRoot = await useTmp();
+		const registryPath = await useTmp();
+		// Shrink the owner's teardown timings (inherited by the spawned process).
+		const prevGrace = process.env.MINIFLARE_STORAGE_OWNER_GRACE_MS;
+		const prevCheck = process.env.MINIFLARE_STORAGE_OWNER_IDLE_CHECK_MS;
+		process.env.MINIFLARE_STORAGE_OWNER_GRACE_MS = "500";
+		process.env.MINIFLARE_STORAGE_OWNER_IDLE_CHECK_MS = "200";
+
+		let ownerPid: number | undefined;
+		const client = new Miniflare({
+			// No role set → behaves as a client and auto-spawns an owner.
+			unsafeSharedStorageOwner: true,
+			resourcePersistencePath: persistRoot,
+			unsafeDevRegistryPath: registryPath,
+			workers: [
+				{
+					config: {
+						type: "worker",
+						name: "",
+						compatibilityDate: "2025-01-01",
+						compatibilityFlags: ["experimental"],
+						manifest: singleModuleManifest(`export default {
+				async fetch(request, env) {
+					if (request.method === "PUT") {
+						await env.NS.put("k", await request.text());
+						return new Response("ok");
+					}
+					return new Response((await env.NS.get("k")) ?? "<null>");
+				}
+			}`),
+						env: { NS: { type: "kv", id: "NS" } },
+					},
+				},
+			],
+		});
+
+		try {
+			await client.ready;
+
+			// An owner was auto-spawned and registered itself in the dev registry.
+			expect(readOwnerEntry(registryPath)).toBeDefined();
+			ownerPid = readOwnerPidFromLog(persistRoot);
+			expect(ownerPid).toBeDefined();
+			expect(ownerPid).not.toBe(process.pid); // a separate process
+
+			// Storage works through the routed proxy.
+			await (
+				await client.dispatchFetch("http://x/", {
+					method: "PUT",
+					body: "via-auto-owner",
+				})
+			).text();
+			const got = await client.dispatchFetch("http://x/");
+			expect(await got.text()).toBe("via-auto-owner");
+
+			// Disposing the only client should let the owner self-terminate.
+			await client.dispose();
+			await vi.waitFor(
+				() => expect(readOwnerEntry(registryPath)).toBeUndefined(),
+				{ timeout: 15_000, interval: 200 }
+			);
+		} finally {
+			await client.dispose().catch(() => {});
+			// Safety net: ensure the detached owner isn't leaked if assertions failed.
+			if (ownerPid !== undefined && isProcessAlive(ownerPid)) {
+				try {
+					process.kill(ownerPid);
+				} catch {}
+			}
+			process.env.MINIFLARE_STORAGE_OWNER_GRACE_MS = prevGrace;
+			process.env.MINIFLARE_STORAGE_OWNER_IDLE_CHECK_MS = prevCheck;
+		}
+	});
+
+	it("lets many client instances write one D1 concurrently without contention", async ({
+		expect,
+	}) => {
+		// This is the scenario that produces cross-process SQLITE_BUSY today: many
+		// processes opening the same SQLite file. With a shared owner, only the
+		// owner opens it, so concurrent writes from all clients succeed.
+		const persistRoot = await useTmp();
+		const registryPath = await useTmp();
+		const prevGrace = process.env.MINIFLARE_STORAGE_OWNER_GRACE_MS;
+		const prevCheck = process.env.MINIFLARE_STORAGE_OWNER_IDLE_CHECK_MS;
+		process.env.MINIFLARE_STORAGE_OWNER_GRACE_MS = "500";
+		process.env.MINIFLARE_STORAGE_OWNER_IDLE_CHECK_MS = "200";
+
+		const N = 3; // client instances
+		const M = 20; // inserts per client
+		const WORKER = `export default {
+			async fetch(request, env) {
+				const url = new URL(request.url);
+				if (url.searchParams.get("init") === "1") {
+					await env.DB.prepare("CREATE TABLE IF NOT EXISTS t(v INTEGER)").run();
+					return new Response("ok");
+				}
+				if (request.method === "PUT") {
+					await env.DB.prepare("INSERT INTO t(v) VALUES (1)").run();
+					return new Response("ok");
+				}
+				const row = await env.DB.prepare("SELECT COUNT(*) AS c FROM t").first();
+				return new Response(String(row.c));
+			}
+		}`;
+		const make = () =>
+			new Miniflare({
+				unsafeSharedStorageOwner: true,
+				resourcePersistencePath: persistRoot,
+				unsafeDevRegistryPath: registryPath,
+				workers: [
+					{
+						config: {
+							type: "worker",
+							name: "",
+							compatibilityDate: "2025-01-01",
+							compatibilityFlags: ["experimental"],
+							manifest: singleModuleManifest(WORKER),
+							env: { DB: { type: "d1", id: "DB" } },
+						},
+					},
+				],
+			});
+
+		const clients = Array.from({ length: N }, make);
+		let ownerPid: number | undefined;
+		try {
+			await Promise.all(clients.map((c) => c.ready));
+			expect(readOwnerEntry(registryPath)).toBeDefined();
+			ownerPid = readOwnerPidFromLog(persistRoot);
+
+			// Create the table once, then hammer it concurrently from every client.
+			await clients[0].dispatchFetch("http://x/?init=1").then((r) => r.text());
+
+			const results = await Promise.all(
+				clients.flatMap((c) =>
+					Array.from({ length: M }, async () => {
+						const r = await c.dispatchFetch("http://x/", { method: "PUT" });
+						await r.text(); // consume body
+						return r.status;
+					})
+				)
+			);
+			// No request failed (e.g. with a 500 from SQLITE_BUSY).
+			expect(results.every((s) => s === 200)).toBe(true);
+
+			// All writes landed — no lost updates, no contention failures.
+			const count = await clients[0]
+				.dispatchFetch("http://x/")
+				.then((r) => r.text());
+			expect(count).toBe(String(N * M));
+		} finally {
+			await Promise.all(clients.map((c) => c.dispose().catch(() => {})));
+			if (ownerPid !== undefined && isProcessAlive(ownerPid)) {
+				try {
+					process.kill(ownerPid);
+				} catch {}
+			}
+			process.env.MINIFLARE_STORAGE_OWNER_GRACE_MS = prevGrace;
+			process.env.MINIFLARE_STORAGE_OWNER_IDLE_CHECK_MS = prevCheck;
+		}
+	});
+
+	it("does nothing when the feature flag is off", async ({ expect }) => {
+		const persistRoot = await useTmp();
+		const registryPath = await useTmp();
+		const mf = new Miniflare({
+			resourcePersistencePath: persistRoot,
+			unsafeDevRegistryPath: registryPath,
+			workers: [
+				{
+					config: {
+						type: "worker",
+						name: "",
+						compatibilityDate: "2025-05-01",
+						compatibilityFlags: ["experimental"],
+						manifest: singleModuleManifest(
+							"export default { async fetch() { return new Response('plain'); } }"
+						),
+					},
+				},
+			],
+		});
+		await mf.ready;
+		expect(readOwnerEntry(registryPath)).toBeUndefined();
+		expect(countClientPresence(registryPath)).toBe(0);
+		await mf.dispose();
+	});
+});


### PR DESCRIPTION
Adds experimental `unsafeSharedStorageOwner` support so Miniflare processes using the same persistence root and resource IDs share KV, R2, D1, Images, Stream, and Secrets Store storage through a single elected owner process. Cache, Durable Objects, and Workflows remain isolated per instance to avoid storage contention.

This PR is stacked on #14994 and ports the original implementation to its v5 configuration model.

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: this is an experimental unsafe Miniflare option.

*A picture of a cute animal (not mandatory, but encouraged)*

> [!NOTE]
> This is a contribution from an AI agent: OpenCode, GPT-5.6 Sol.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/15076" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->