### PR TITLE
[miniflare] Add experimental retryable hint to Workflows binding errors

### DIFF
--- a/.changeset/workflows-typed-errors-retryable.md
+++ b/.changeset/workflows-typed-errors-retryable.md
@@ -1,0 +1,21 @@
+---
+"miniflare": minor
+---
+
+Add an experimental `retryable` hint to Workflows binding errors in local dev
+
+When the experimental `workflows_typed_errors` compatibility flag is enabled, errors thrown by the Workflows binding methods (`create`, `get`, `createBatch`, etc.) carry a `retryable` boolean classifying whether the failure is safe to retry. This mirrors the behavior in workerd/production and lets you branch on `err.retryable` locally:
+
+```js
+try {
+	await env.MY_WORKFLOW.create({ id });
+} catch (err) {
+	if (err.retryable) {
+		// back off + retry
+	} else {
+		throw err;
+	}
+}
+```
+
+Opt-in and non-breaking: with the flag off, errors are unchanged. `retryable` is only ever `true` for backpressure / rate-limit / temporary-migration signals; every other failure (and any unknown error) is non-retryable. As experimental, the classification may change until the flag is promoted to a default compatibility date.

--- a/packages/miniflare/src/workers/workflows/wrapped-binding.worker.ts
+++ b/packages/miniflare/src/workers/workflows/wrapped-binding.worker.ts
@@ -1,3 +1,4 @@
+import { withRetryableHint } from "@cloudflare/workflows-shared/src/lib/errors";
 import type {
 	WorkflowBinding,
 	WorkflowInstanceRestartOptions,
@@ -5,32 +6,52 @@ import type {
 } from "@cloudflare/workflows-shared/src/binding";
 import type { WorkflowIntrospectionOperation } from "@cloudflare/workflows-shared/src/types";
 
+// Classify here (user's isolate) rather than in the binding: a `retryable`
+// own-property would be dropped crossing the JSRPC boundary, but the message
+// survives. No-op unless `workflows_typed_errors` is enabled.
+async function withTypedErrors<T>(op: () => Promise<T>): Promise<T> {
+	try {
+		return await op();
+	} catch (err) {
+		if (err instanceof Error) {
+			throw withRetryableHint(err);
+		}
+		throw err;
+	}
+}
+
 class WorkflowImpl implements Workflow {
 	constructor(private binding: WorkflowBinding) {}
 
 	async get(id: string): Promise<WorkflowInstance> {
-		const instanceHandle = new InstanceImpl(id, this.binding);
-		// throws instance.not_found if instance doesn't exist
-		// this is needed for backwards compat
-		await instanceHandle.status();
-		return instanceHandle;
+		return withTypedErrors(async () => {
+			const instanceHandle = new InstanceImpl(id, this.binding);
+			// throws instance.not_found if instance doesn't exist
+			// this is needed for backwards compat
+			await instanceHandle.status();
+			return instanceHandle;
+		});
 	}
 
 	async create(
 		options?: WorkflowInstanceCreateOptions
 	): Promise<WorkflowInstance> {
-		using result = (await this.binding.create(options)) as WorkflowInstance &
-			Disposable;
+		return withTypedErrors(async () => {
+			using result = (await this.binding.create(options)) as WorkflowInstance &
+				Disposable;
 
-		return new InstanceImpl(result.id, this.binding);
+			return new InstanceImpl(result.id, this.binding);
+		});
 	}
 
 	async createBatch(
 		options: WorkflowInstanceCreateOptions[]
 	): Promise<WorkflowInstance[]> {
-		const result = await this.binding.createBatch(options);
-		return result.map((res) => {
-			return new InstanceImpl(res.id, this.binding);
+		return withTypedErrors(async () => {
+			const result = await this.binding.createBatch(options);
+			return result.map((res) => {
+				return new InstanceImpl(res.id, this.binding);
+			});
 		});
 	}
 
@@ -96,46 +117,58 @@ class InstanceImpl implements WorkflowInstance {
 	}
 
 	public async pause(): Promise<void> {
-		using instance = await this.getInstance();
-		await instance.pause();
+		return withTypedErrors(async () => {
+			using instance = await this.getInstance();
+			await instance.pause();
+		});
 	}
 
 	public async resume(): Promise<void> {
-		using instance = await this.getInstance();
-		await instance.resume();
+		return withTypedErrors(async () => {
+			using instance = await this.getInstance();
+			await instance.resume();
+		});
 	}
 
 	public async terminate(
 		options?: WorkflowInstanceTerminateOptions
 	): Promise<void> {
-		using instance = await this.getInstance();
-		// TODO(vaish): remove cast once @cloudflare/workers-types ships terminate options
-		await (
-			instance.terminate as (
-				options?: WorkflowInstanceTerminateOptions
-			) => Promise<void>
-		)(options);
+		return withTypedErrors(async () => {
+			using instance = await this.getInstance();
+			// TODO(vaish): remove cast once @cloudflare/workers-types ships terminate options
+			await (
+				instance.terminate as (
+					options?: WorkflowInstanceTerminateOptions
+				) => Promise<void>
+			)(options);
+		});
 	}
 
 	public async restart(
 		options?: WorkflowInstanceRestartOptions
 	): Promise<void> {
-		using instance = await this.getInstance();
-		await instance.restart(options);
+		return withTypedErrors(async () => {
+			using instance = await this.getInstance();
+			await instance.restart(options);
+		});
 	}
 
 	public async status(): Promise<InstanceStatus> {
-		using instance = await this.getInstance();
-		using res = (await instance.status()) as InstanceStatus & Disposable;
-		return structuredClone(res);
+		return withTypedErrors(async () => {
+			using instance = await this.getInstance();
+			using res = (await instance.status()) as InstanceStatus & Disposable;
+			return structuredClone(res);
+		});
 	}
 
 	public async sendEvent(args: {
 		payload: unknown;
 		type: string;
 	}): Promise<void> {
-		using instance = await this.getInstance();
-		await instance.sendEvent(args);
+		return withTypedErrors(async () => {
+			using instance = await this.getInstance();
+			await instance.sendEvent(args);
+		});
 	}
 }
 

--- a/packages/miniflare/test/plugins/workflows/index.spec.ts
+++ b/packages/miniflare/test/plugins/workflows/index.spec.ts
@@ -330,3 +330,73 @@ describe("workflow instance lifecycle methods", () => {
 		expect(finalStatus.output).toBe("workflow-complete");
 	});
 });
+
+// Worker that surfaces a binding error's `retryable` hint to the caller so we can
+// assert the typed-error behavior end-to-end through the real miniflare stack.
+const TYPED_ERROR_WORKFLOW_SCRIPT = () => `
+import { WorkflowEntrypoint } from "cloudflare:workers";
+export class TypedErrorWorkflow extends WorkflowEntrypoint {
+	async run(event, step) {
+		return "done";
+	}
+}
+export default {
+	async fetch(request, env, ctx) {
+		try {
+			// Getting a non-existent instance throws instance.not_found (non-retryable).
+			await env.TYPED_ERROR_WORKFLOW.get("does-not-exist");
+			return Response.json({ threw: false });
+		} catch (err) {
+			return Response.json({
+				threw: true,
+				message: err.message,
+				retryable: err.retryable,
+				hasRetryable: "retryable" in err,
+			});
+		}
+	},
+};`;
+
+function typedErrorMiniflareOpts(
+	tmp: string,
+	extraFlags: string[]
+): MiniflareOptions {
+	return {
+		name: "typed-error-worker",
+		compatibilityDate: "2026-03-09",
+		modules: true,
+		script: TYPED_ERROR_WORKFLOW_SCRIPT(),
+		workflows: {
+			TYPED_ERROR_WORKFLOW: {
+				className: "TypedErrorWorkflow",
+				name: "TYPED_ERROR_WORKFLOW",
+				compatibilityFlags: ["nodejs_compat", "experimental", ...extraFlags],
+			},
+		},
+		resourcePersistencePath: tmp,
+	};
+}
+
+describe("workflows_typed_errors flag", () => {
+	// NOTE: the flag-ON path is covered by the `withRetryableHint` unit tests in
+	// @cloudflare/workflows-shared. It cannot be exercised here until the bundled
+	// `workerd` binary ships the `workflows_typed_errors` compatibility flag —
+	// workerd rejects unknown flags at startup. This test asserts the opt-in
+	// contract: with the flag off, the wrapped binding leaves errors untouched.
+	test("does not set retryable when the flag is off", async ({ expect }) => {
+		const tmp = await useTmp();
+		const mf = new Miniflare(typedErrorMiniflareOpts(tmp, []));
+		useDispose(mf);
+
+		const res = await mf.dispatchFetch("http://localhost");
+		const data = (await res.json()) as {
+			threw: boolean;
+			message: string;
+			hasRetryable: boolean;
+		};
+
+		expect(data.threw).toBe(true);
+		expect(data.message).toBe("instance.not_found");
+		expect(data.hasRetryable).toBe(false);
+	});
+});

--- a/packages/workflows-shared/src/lib/errors.ts
+++ b/packages/workflows-shared/src/lib/errors.ts
@@ -119,6 +119,42 @@ export function shouldPreserveNonRetryableError(): boolean {
 	return getCompatFlag("workflows_preserve_non_retryable_error_message");
 }
 
+export function shouldSetTypedErrors(): boolean {
+	return getCompatFlag("workflows_typed_errors");
+}
+
+// Kept in sync with the workerd table in
+// `workerd/src/cloudflare/internal/workflows-api.ts`.
+const RETRYABLE_CODES: ReadonlySet<string> = new Set([
+	"instance.too_many_queued",
+	"rate_limit.workflow_instance_creation",
+	"rate-limit.workflows_control_plane",
+	"rate_limit.instance_step_output",
+	"migration.in_progress",
+]);
+
+const OVERLOAD_MESSAGE = "too many requests";
+const WORKFLOW_ERROR_CODE_REGEXP = /^\s*\(([a-zA-Z._-]+)\) /;
+
+function classifyRetryable(message: string): boolean {
+	if (message === OVERLOAD_MESSAGE) {
+		return true;
+	}
+	const code = WORKFLOW_ERROR_CODE_REGEXP.exec(message)?.[1];
+	return code !== undefined && RETRYABLE_CODES.has(code);
+}
+
+// Attaches a `retryable` hint when `workflows_typed_errors` is enabled; no-op
+// otherwise. Returns the same error for `throw withRetryableHint(err)` use.
+export function withRetryableHint<T extends Error>(error: T): T {
+	if (shouldSetTypedErrors()) {
+		(error as T & { retryable?: boolean }).retryable = classifyRetryable(
+			error.message
+		);
+	}
+	return error;
+}
+
 export function stepNotFoundError(name: string): WorkflowError {
 	return createWorkflowError(
 		`Step "${name}" not found in execution history`,

--- a/packages/workflows-shared/tests/typed-errors.test.ts
+++ b/packages/workflows-shared/tests/typed-errors.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, describe, it } from "vitest";
+import {
+	stepNotFoundError,
+	WorkflowError,
+	withRetryableHint,
+} from "../src/lib/errors";
+
+// Toggle the flag directly so tests don't depend on the runtime compat date.
+function setTypedErrorsFlag(value: boolean): void {
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- test-only global shim
+	const g = globalThis as any;
+	g.Cloudflare = {
+		...(g.Cloudflare ?? {}),
+		compatibilityFlags: {
+			...(g.Cloudflare?.compatibilityFlags ?? {}),
+			workflows_typed_errors: value,
+		},
+	};
+}
+
+describe("withRetryableHint", () => {
+	afterEach(() => {
+		setTypedErrorsFlag(false);
+	});
+
+	it("does not set retryable when the flag is off", ({ expect }) => {
+		setTypedErrorsFlag(false);
+		const err = withRetryableHint(
+			new WorkflowError("(instance.not_found) nope")
+		);
+		expect(
+			(err as WorkflowError & { retryable?: boolean }).retryable
+		).toBeUndefined();
+		expect(err.message).toBe("(instance.not_found) nope");
+	});
+
+	it("sets retryable=false for non-retryable coded errors", ({ expect }) => {
+		setTypedErrorsFlag(true);
+		const err = withRetryableHint(
+			new WorkflowError("(instance.not_found) nope")
+		);
+		expect((err as WorkflowError & { retryable?: boolean }).retryable).toBe(
+			false
+		);
+	});
+
+	it("sets retryable=true for rate-limit coded errors", ({ expect }) => {
+		setTypedErrorsFlag(true);
+		const err = withRetryableHint(
+			new WorkflowError("(rate-limit.workflows_control_plane) slow down")
+		);
+		expect((err as WorkflowError & { retryable?: boolean }).retryable).toBe(
+			true
+		);
+	});
+
+	it("sets retryable=true for the codeless overload message", ({ expect }) => {
+		setTypedErrorsFlag(true);
+		const err = withRetryableHint(new Error("too many requests"));
+		expect((err as Error & { retryable?: boolean }).retryable).toBe(true);
+	});
+
+	it("sets retryable=false for bare (uncoded) messages", ({ expect }) => {
+		setTypedErrorsFlag(true);
+		const err = withRetryableHint(new Error("instance.not_found"));
+		expect((err as Error & { retryable?: boolean }).retryable).toBe(false);
+	});
+
+	it("ignores a retryable code embedded after the leading code", ({
+		expect,
+	}) => {
+		setTypedErrorsFlag(true);
+		// A message body that tries to smuggle a real retryable code. Only the
+		// leading (non-retryable) code should be classified.
+		const err = withRetryableHint(
+			new WorkflowError(
+				"(instance.not_found) (rate-limit.workflows_control_plane) nope"
+			)
+		);
+		expect((err as WorkflowError & { retryable?: boolean }).retryable).toBe(
+			false
+		);
+	});
+
+	it("ignores a retryable code smuggled through a user step name", ({
+		expect,
+	}) => {
+		setTypedErrorsFlag(true);
+		// stepNotFoundError reflects a user-controlled name into the message body;
+		// the leading (instance.cannot_restart) code must still win.
+		const err = withRetryableHint(
+			stepNotFoundError(") (rate-limit.workflows_control_plane) (")
+		);
+		expect((err as WorkflowError & { retryable?: boolean }).retryable).toBe(
+			false
+		);
+	});
+});


### PR DESCRIPTION
Adds an opt-in `retryable` boolean hint to errors thrown by the Workflows binding methods in local dev (miniflare), gated behind the experimental `workflows_typed_errors` compatibility flag. This mirrors the behavior implemented in workerd/production so `err.retryable` behaves the same locally and in the deployed runtime.

When the flag is enabled, errors from the binding (`create`, `get`, `createBatch`, etc.) carry `retryable: boolean` classifying whether the failure is safe to retry. `retryable` is only ever `true` for backpressure / rate-limit / temporary-migration signals; every other failure (including internal errors and any unknown code) is non-retryable. Opt-in and non-breaking: with the flag off, errors are unchanged.

Classification happens user-side (in the wrapped binding worker) because a `retryable` own-property would be dropped crossing the JSRPC boundary, while the error message survives. The retryable code table is kept in sync with the workerd-owned table.

Security note: the classifier parses the leading `(code)` from the error message. The regex is anchored to the start, and only trusted producers set that leading code (validated against the known code set); retryable codes are backend-state signals, never derived from user input. Adversarial tests cover a fake retryable code embedded later in the message and one smuggled through a user-controlled step name — both correctly classify as non-retryable.

> [!NOTE]
> Depends on the workerd side shipping the `workflows_typed_errors` compatibility flag first. Until a published workerd binary carries the flag, miniflare cannot enable it end-to-end. The corresponding workerd change is tracked separately (internal MR) and will be cross-linked.

---

- Tests
  - [x] Tests included/updated
- Public documentation
  - [x] Documentation not necessary because: the change is an experimental, compatibility-flag-gated internal behavior; it will be documented when the flag is promoted to a default compatibility date.

> [!NOTE]
> This is a contribution from an AI agent: opencode (Claude).

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/15078" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->