### PR TITLE
[workers-auth] Avoid stale Access service-token headers

### DIFF
--- a/.changeset/quiet-access-caches.md
+++ b/.changeset/quiet-access-caches.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/workers-auth": patch
+---
+
+Use the current Cloudflare Access service-token credentials after environment variables change. Interactive Access cookie caching is unchanged.

--- a/packages/workers-auth/src/access.ts
+++ b/packages/workers-auth/src/access.ts
@@ -110,12 +110,10 @@ export async function getAccessHeaders(
 
 	if (clientId && clientSecret) {
 		logger.debug("Using Access Service Token headers for domain:", domain);
-		const headers = {
+		return {
 			"CF-Access-Client-Id": clientId,
 			"CF-Access-Client-Secret": clientSecret,
 		};
-		headersCache[domain] = headers;
-		return headers;
 	}
 
 	// Warn if only one of the two env vars is set

--- a/packages/workers-auth/tests/access.test.ts
+++ b/packages/workers-auth/tests/access.test.ts
@@ -67,6 +67,7 @@ const msw = setupServer();
 
 beforeAll(() => msw.listen({ onUnhandledRequest: "error" }));
 afterEach(() => {
+	vi.unstubAllEnvs();
 	msw.restoreHandlers();
 	msw.resetHandlers();
 });
@@ -84,6 +85,7 @@ const isNonInteractiveOrCI = () => true;
 
 describe("access", () => {
 	beforeEach(() => {
+		vi.unstubAllEnvs();
 		clearAccessCaches();
 		silentLogger.warn = vi.fn();
 		msw.use(...mswAccessHandlers);
@@ -168,6 +170,77 @@ describe("access", () => {
 					"CF-Access-Client-Secret": "test-client-secret",
 				});
 				expect(silentLogger.warn).not.toHaveBeenCalled();
+			});
+
+			it("should not reuse service token headers after the env vars are unset", async ({
+				expect,
+			}) => {
+				vi.stubEnv("CLOUDFLARE_ACCESS_CLIENT_ID", "first-client-id.access");
+				vi.stubEnv("CLOUDFLARE_ACCESS_CLIENT_SECRET", "first-client-secret");
+				await getAccessHeaders("access-protected.com", {
+					logger: silentLogger,
+					isNonInteractiveOrCI,
+				});
+
+				vi.stubEnv("CLOUDFLARE_ACCESS_CLIENT_ID", undefined);
+				vi.stubEnv("CLOUDFLARE_ACCESS_CLIENT_SECRET", undefined);
+
+				await expect(
+					getAccessHeaders("access-protected.com", {
+						logger: silentLogger,
+						isNonInteractiveOrCI,
+					})
+				).rejects.toThrow("no Access Service Token credentials were found");
+			});
+
+			it("should not reuse service token headers when only CLOUDFLARE_ACCESS_CLIENT_ID remains", async ({
+				expect,
+			}) => {
+				vi.stubEnv("CLOUDFLARE_ACCESS_CLIENT_ID", "first-client-id.access");
+				vi.stubEnv("CLOUDFLARE_ACCESS_CLIENT_SECRET", "first-client-secret");
+				await getAccessHeaders("access-protected.com", {
+					logger: silentLogger,
+					isNonInteractiveOrCI,
+				});
+
+				vi.stubEnv("CLOUDFLARE_ACCESS_CLIENT_ID", "second-client-id.access");
+				vi.stubEnv("CLOUDFLARE_ACCESS_CLIENT_SECRET", undefined);
+
+				await expect(
+					getAccessHeaders("access-protected.com", {
+						logger: silentLogger,
+						isNonInteractiveOrCI,
+					})
+				).rejects.toThrow("no Access Service Token credentials were found");
+				expect(silentLogger.warn).toHaveBeenCalledWith(
+					expect.stringContaining("Only CLOUDFLARE_ACCESS_CLIENT_ID was found")
+				);
+			});
+
+			it("should not reuse service token headers when only CLOUDFLARE_ACCESS_CLIENT_SECRET remains", async ({
+				expect,
+			}) => {
+				vi.stubEnv("CLOUDFLARE_ACCESS_CLIENT_ID", "first-client-id.access");
+				vi.stubEnv("CLOUDFLARE_ACCESS_CLIENT_SECRET", "first-client-secret");
+				await getAccessHeaders("access-protected.com", {
+					logger: silentLogger,
+					isNonInteractiveOrCI,
+				});
+
+				vi.stubEnv("CLOUDFLARE_ACCESS_CLIENT_ID", undefined);
+				vi.stubEnv("CLOUDFLARE_ACCESS_CLIENT_SECRET", "second-client-secret");
+
+				await expect(
+					getAccessHeaders("access-protected.com", {
+						logger: silentLogger,
+						isNonInteractiveOrCI,
+					})
+				).rejects.toThrow("no Access Service Token credentials were found");
+				expect(silentLogger.warn).toHaveBeenCalledWith(
+					expect.stringContaining(
+						"Only CLOUDFLARE_ACCESS_CLIENT_SECRET was found"
+					)
+				);
 			});
 
 			it("should warn when only CLOUDFLARE_ACCESS_CLIENT_ID is set", async ({
@@ -295,6 +368,35 @@ See https://developers.cloudflare.com/cloudflare-one/access-controls/service-cre
 					["access", "login", "access-protected.com"],
 					{ signal: undefined }
 				);
+			});
+
+			it("should reuse the cached CF_Authorization cookie header", async ({
+				expect,
+			}) => {
+				const fake = createFakeProcess();
+				vi.mocked(spawn).mockReturnValueOnce(fake.child);
+
+				const firstHeaders = getAccessHeaders("access-protected.com", {
+					logger: silentLogger,
+					isNonInteractiveOrCI: () => false,
+				});
+				await vi.waitFor(() => {
+					expect(spawn).toHaveBeenCalledOnce();
+				});
+				fake.complete("fetched your token:\n\ntest-access-token\n");
+
+				await expect(firstHeaders).resolves.toEqual({
+					Cookie: "CF_Authorization=test-access-token",
+				});
+				await expect(
+					getAccessHeaders("access-protected.com", {
+						logger: silentLogger,
+						isNonInteractiveOrCI: () => false,
+					})
+				).resolves.toEqual({
+					Cookie: "CF_Authorization=test-access-token",
+				});
+				expect(spawn).toHaveBeenCalledOnce();
 			});
 
 			it("should kill a still-pending cloudflared when the process exits", async ({


### PR DESCRIPTION
Fixes #15070

`getAccessHeaders()` stored Access service-token headers in the domain cache. If the current `CLOUDFLARE_ACCESS_CLIENT_ID` / `CLOUDFLARE_ACCESS_CLIENT_SECRET` pair was later removed or became incomplete, a later call for the same domain could reuse the earlier complete pair.

This change returns service-token headers directly from the current environment instead of storing them in the domain cache. Interactive CF_Authorization cookie caching is unchanged.

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: this only corrects reuse of existing Access service-token environment variables and does not add or change user-facing configuration.

*Japanese dwarf flying squirrel peeking out of tree:*
<img width="547" height="365" alt="image" src="https://github.com/user-attachments/assets/5febb287-5f32-45c3-b790-86aed51475d4" />

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/15080" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->