### PR TITLE
fix(wrangler): match D1 compound END case-insensitively

### DIFF
--- a/packages/wrangler/src/__tests__/d1/splitter.test.ts
+++ b/packages/wrangler/src/__tests__/d1/splitter.test.ts
@@ -326,6 +326,24 @@ describe("splitSqlQuery()", () => {
 				END",
 			]
 		`);
+
+		// Compound END matching must be case-insensitive, like BEGIN/CASE.
+		expect(
+			splitSqlQuery(`
+    CREATE TRIGGER IF NOT EXISTS update_trigger AFTER UPDATE ON items
+    BEGIN
+        DELETE FROM updates WHERE item_id=old.id;
+    end;
+    SELECT 1;`)
+		).toMatchInlineSnapshot(`
+			[
+			  "CREATE TRIGGER IF NOT EXISTS update_trigger AFTER UPDATE ON items
+			    BEGIN
+			        DELETE FROM updates WHERE item_id=old.id;
+			    end",
+			  "SELECT 1",
+			]
+		`);
 	});
 
 	it("should handle compound statements for CASEs", ({ expect }) => {

--- a/packages/wrangler/src/__tests__/d1/splitter.test.ts
+++ b/packages/wrangler/src/__tests__/d1/splitter.test.ts
@@ -326,8 +326,11 @@ describe("splitSqlQuery()", () => {
 				END",
 			]
 		`);
+	});
 
-		// Compound END matching must be case-insensitive, like BEGIN/CASE.
+	it("should treat lowercase end as a compound statement terminator", ({
+		expect,
+	}) => {
 		expect(
 			splitSqlQuery(`
     CREATE TRIGGER IF NOT EXISTS update_trigger AFTER UPDATE ON items

--- a/packages/wrangler/src/d1/splitter.ts
+++ b/packages/wrangler/src/d1/splitter.ts
@@ -166,5 +166,5 @@ function isCompoundStatementStart(str: string) {
  * Returns true if the `str` ends with a compound statement `END` marker.
  */
 function isCompoundStatementEnd(str: string) {
-	return /\sEND[;\s]$/.test(str);
+	return /\sEND[;\s]$/i.test(str);
 }


### PR DESCRIPTION
## Summary
- `isCompoundStatementStart` already matches `BEGIN`/`CASE` case-insensitively, but `isCompoundStatementEnd` required uppercase `END`.
- A lowercase `end;` left the splitter inside a compound statement and broke statement boundaries (e.g. triggers + following SQL).
- Add a regression test for lowercase `end`.

## Test plan
- [x] Added splitter unit coverage for lowercase `end;`
- [ ] CI: `packages/wrangler` d1 splitter tests

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/15091" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->