### PR TITLE
[wrangler] Recognise a lowercase `end` when splitting D1 SQL statements

### DIFF
--- a/.changeset/d1-splitter-lowercase-end.md
+++ b/.changeset/d1-splitter-lowercase-end.md
@@ -1,0 +1,9 @@
+---
+"wrangler": patch
+---
+
+Recognise a lowercase `end` when splitting D1 SQL into statements
+
+`wrangler d1 execute --file` and `wrangler d1 migrations apply` only treated an uppercase `END` as the terminator of a `BEGIN`/`CASE` compound statement, even though the opening `BEGIN`/`CASE` marker is matched case-insensitively. A trigger body closed with `end;` therefore never ended, and every following statement in the file was swallowed into it and executed as one statement.
+
+The closing marker is now matched case-insensitively too.

--- a/packages/wrangler/src/__tests__/d1/splitter.test.ts
+++ b/packages/wrangler/src/__tests__/d1/splitter.test.ts
@@ -328,6 +328,25 @@ describe("splitSqlQuery()", () => {
 		`);
 	});
 
+	it("should handle a lowercase compound statement END", ({ expect }) => {
+		expect(
+			splitSqlQuery(`
+	CREATE TRIGGER IF NOT EXISTS update_trigger AFTER UPDATE ON items
+	begin
+		DELETE FROM updates WHERE item_id=old.id;
+	end;
+	CREATE TABLE tasks (id INTEGER PRIMARY KEY);`)
+		).toMatchInlineSnapshot(`
+			[
+			  "CREATE TRIGGER IF NOT EXISTS update_trigger AFTER UPDATE ON items
+				begin
+					DELETE FROM updates WHERE item_id=old.id;
+				end",
+			  "CREATE TABLE tasks (id INTEGER PRIMARY KEY)",
+			]
+		`);
+	});
+
 	it("should handle compound statements for CASEs", ({ expect }) => {
 		expect(
 			splitSqlQuery(`

--- a/packages/wrangler/src/d1/splitter.ts
+++ b/packages/wrangler/src/d1/splitter.ts
@@ -166,5 +166,5 @@ function isCompoundStatementStart(str: string) {
  * Returns true if the `str` ends with a compound statement `END` marker.
  */
 function isCompoundStatementEnd(str: string) {
-	return /\sEND[;\s]$/.test(str);
+	return /\sEND[;\s]$/i.test(str);
 }


### PR DESCRIPTION
Fixes #15093.

`splitSqlQuery()` matches the opening marker of a compound statement case-insensitively (`/[\s]BEGIN\s*$/i`, `/[\s]CASE\s*$/i`) but matched the closing one case-sensitively (`/\sEND[;\s]$/`). A trigger or `CASE` body closed with a lowercase `end;` therefore never terminated, and every statement after it in the file was swallowed into the compound statement and handed to D1 as one statement — silently dropping the intermediate result sets, with no error and only a wrong `🚣 N commands executed successfully.` count as a hint.

The one-character fix is to match the closing marker case-insensitively too, so the two halves of the pair agree.

The added test covers a trigger body closed with `end;` followed by another statement. It fails on `main` (the two statements come back as one) and passes with the change; the 15 existing `splitSqlQuery()` tests are untouched and still pass.

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: this restores the documented/expected behaviour of SQL splitting; no public API or documented behaviour changes.

> [!NOTE]
> This is a contribution from an AI agent: Claude Code, Claude Opus 5.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/15094" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
