### PR TITLE
[vitest-pool-workers] Cache only per-directory facts when classifying `.js` modules

### DIFF
--- a/.changeset/module-fallback-type-module-cache.md
+++ b/.changeset/module-fallback-type-module-cache.md
@@ -1,0 +1,11 @@
+---
+"@cloudflare/vitest-pool-workers": patch
+---
+
+Stop one `.js` file's ESM/CommonJS classification leaking to every other file in the same package
+
+The module fallback service decides whether a `.js` file is an ES module from its nearest `package.json`, treating it as ESM when `"type": "module"` **or** when the file is that package's `"module"` entry point. That second check depends on the file, but its result was cached per directory, so the first `.js` file resolved out of a package decided the classification handed to `workerd` for every other file in it.
+
+For a dual-format package (`"main": "dist/index.cjs.js"`, `"module": "dist/index.esm.js"`, no `"type"`), whichever file was resolved first won: load the ES module build first and the CommonJS build is subsequently sent to `workerd` as an `esModule`, and vice versa. Which of the two happened depended on import order, so it could differ between runs.
+
+Only `"type"` is cached per directory now; the `"module"` entry-point comparison runs per file.

--- a/.changeset/module-fallback-type-module-cache.md
+++ b/.changeset/module-fallback-type-module-cache.md
@@ -2,10 +2,6 @@
 "@cloudflare/vitest-pool-workers": patch
 ---
 
-Stop one `.js` file's ESM/CommonJS classification leaking to every other file in the same package
+Improve module resolution for dependencies with CommonJS and ES module builds
 
-The module fallback service decides whether a `.js` file is an ES module from its nearest `package.json`, treating it as ESM when `"type": "module"` **or** when the file is that package's `"module"` entry point. That second check depends on the file, but its result was cached per directory, so the first `.js` file resolved out of a package decided the classification handed to `workerd` for every other file in it.
-
-For a dual-format package (`"main": "dist/index.cjs.js"`, `"module": "dist/index.esm.js"`, no `"type"`), whichever file was resolved first won: load the ES module build first and the CommonJS build is subsequently sent to `workerd` as an `esModule`, and vice versa. Which of the two happened depended on import order, so it could differ between runs.
-
-Only `"type"` is cached per directory now; the `"module"` entry-point comparison runs per file.
+These dependencies could previously be loaded with the wrong module type depending on import order, causing syntax errors or missing exports in tests. Each entry point is now loaded using its correct module format.

--- a/packages/vitest-pool-workers/src/pool/module-fallback.ts
+++ b/packages/vitest-pool-workers/src/pool/module-fallback.ts
@@ -90,14 +90,19 @@ function getParentPaths(filePath: string): string[] {
 	}
 }
 
-const dirPathTypeModuleCache = new Map<string, boolean>();
+// Note the cached value must stay file-independent: it is keyed by directory
+// and reused for every file resolved out of that directory. Only `type` is a
+// property of the package; whether a file is the `module` entry point is not,
+// so that comparison happens per call against the cached path.
+type DirPathPackageInfo = { typeModule: boolean; modulePath: string };
+const dirPathPackageCache = new Map<string, DirPathPackageInfo>();
 function isWithinTypeModuleContext(filePath: string): boolean {
 	const parentPaths = getParentPaths(filePath);
 
 	for (const parentPath of parentPaths) {
-		const cache = dirPathTypeModuleCache.get(parentPath);
-		if (cache !== undefined) {
-			return cache;
+		const cached = dirPathPackageCache.get(parentPath);
+		if (cached !== undefined) {
+			return cached.typeModule || cached.modulePath === filePath;
 		}
 	}
 
@@ -106,12 +111,12 @@ function isWithinTypeModuleContext(filePath: string): boolean {
 			const pkgPath = posixPath.join(parentPath, "package.json");
 			const pkgJson = fs.readFileSync(pkgPath, "utf8");
 			const pkg = JSON.parse(pkgJson);
-			const maybeModulePath = pkg.module
-				? posixPath.join(parentPath, pkg.module)
-				: "";
-			const cache = pkg.type === "module" || maybeModulePath === filePath;
-			dirPathTypeModuleCache.set(parentPath, cache);
-			return cache;
+			const info: DirPathPackageInfo = {
+				typeModule: pkg.type === "module",
+				modulePath: pkg.module ? posixPath.join(parentPath, pkg.module) : "",
+			};
+			dirPathPackageCache.set(parentPath, info);
+			return info.typeModule || info.modulePath === filePath;
 		} catch (e: unknown) {
 			if (!isFileNotFoundError(e)) {
 				throw e;

--- a/packages/vitest-pool-workers/test/module-fallback.test.ts
+++ b/packages/vitest-pool-workers/test/module-fallback.test.ts
@@ -256,3 +256,58 @@ describe("handleModuleFallbackRequest non-ASCII paths", () => {
 		}
 	});
 });
+
+describe("handleModuleFallbackRequest dual-format packages", () => {
+	let tmp: string;
+
+	beforeEach(() => {
+		tmp = fs.realpathSync(
+			fs.mkdtempSync(path.join(os.tmpdir(), "mf-fallback-dual-"))
+		);
+	});
+
+	afterEach(() => {
+		removeDirSync(tmp);
+	});
+
+	it("keeps a package's CommonJS entry CommonJS after its ES module entry is loaded", async ({
+		expect,
+	}) => {
+		// A dual-format package with no `type` field: `module` points at the ESM
+		// build, `main` at the CommonJS one, both `.js` and in the same directory.
+		const pkgDir = path.join(tmp, "node_modules", "dual-pkg");
+		fs.mkdirSync(path.join(pkgDir, "dist"), { recursive: true });
+		fs.writeFileSync(
+			path.join(pkgDir, "package.json"),
+			JSON.stringify({
+				name: "dual-pkg",
+				main: "dist/index.cjs.js",
+				module: "dist/index.esm.js",
+			})
+		);
+		fs.writeFileSync(
+			path.join(pkgDir, "dist", "index.esm.js"),
+			"export const value = 1;"
+		);
+		fs.writeFileSync(
+			path.join(pkgDir, "dist", "index.cjs.js"),
+			"module.exports = { value: 1 };"
+		);
+
+		const referrer = toWorkerdSpecifier(path.join(tmp, "entry.js"));
+		const load = async (fileName: string) =>
+			await (
+				await handleModuleFallbackRequest(
+					fakeVite(),
+					moduleFallbackRequest({
+						method: "require",
+						specifier: toWorkerdSpecifier(path.join(pkgDir, "dist", fileName)),
+						referrer,
+					})
+				)
+			).json();
+
+		expect(await load("index.esm.js")).toHaveProperty("esModule");
+		expect(await load("index.cjs.js")).toHaveProperty("commonJsModule");
+	});
+});


### PR DESCRIPTION
Fixes #15095.

`isWithinTypeModuleContext()` folds two different kinds of fact into one cached boolean:

- `pkg.type === "module"` — a property of the **package**, so safe to cache per directory.
- `maybeModulePath === filePath` — a property of the **file being resolved**, so not safe to cache per directory.

Both were stored under a directory key, so the first `.js` file resolved out of a package decided the classification `workerd` was given for every other file in it. A dual-format package (`"main": "dist/index.cjs.js"`, `"module": "dist/index.esm.js"`, no `"type"`) therefore got its module type from import order: load the ES module build first and the CommonJS build is subsequently returned as an `esModule`; load the CommonJS build first and the ES module build is returned as a `commonJsModule`.

This change caches only `{ typeModule, modulePath }` — both package-level facts — and runs the entry-point comparison against `filePath` on every call. The lookup stays one `Map` hit per parent directory, so no extra `package.json` reads are introduced.

The added test resolves both entries of a dual-format package in one order and asserts each gets its own correct type. It fails on `main` with `expected { …(2) } to have property "commonJsModule"` and passes with the change. The 12 existing tests in the file are untouched and still pass, and `pnpm -F @cloudflare/vitest-pool-workers check:type` is clean.

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: internal module-resolution fix, no public API or documented behaviour changes.

> [!NOTE]
> This is a contribution from an AI agent: Claude Code, Claude Opus 5.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/15096" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->