### PR TITLE
[miniflare] Make dispose idempotent

### DIFF
--- a/.changeset/tidy-pumas-dispose.md
+++ b/.changeset/tidy-pumas-dispose.md
@@ -1,0 +1,7 @@
+---
+"miniflare": patch
+---
+
+Make `Miniflare#dispose()` idempotent for repeated and concurrent calls
+
+Concurrent callers and calls after a successful teardown now reuse the same result, so calling `dispose()` more than once no longer throws. A failed teardown remains retryable.

--- a/packages/miniflare/src/index.ts
+++ b/packages/miniflare/src/index.ts
@@ -979,6 +979,7 @@ export class Miniflare {
 
 	// Aborted when dispose() is called
 	readonly #disposeController: AbortController;
+	#disposePromise?: Promise<void>;
 	#loopbackServer?: StoppableServer;
 	#loopbackHost?: string;
 	readonly #webSocketServer: WebSocketServer;
@@ -1837,11 +1838,17 @@ export class Miniflare {
 		});
 	}
 
-	#stopLoopbackServer(): Promise<void> {
-		return new Promise((resolve, reject) => {
-			assert(this.#loopbackServer !== undefined);
-			this.#loopbackServer.stop((err) => (err ? reject(err) : resolve()));
+	async #stopLoopbackServer(): Promise<void> {
+		const server = this.#loopbackServer;
+		if (server === undefined) {
+			return;
+		}
+		await new Promise<void>((resolve, reject) => {
+			server.stop((error) => (error ? reject(error) : resolve()));
 		});
+		if (this.#loopbackServer === server) {
+			this.#loopbackServer = undefined;
+		}
 	}
 
 	#getSocketAddress(
@@ -3347,7 +3354,15 @@ export class Miniflare {
 		return [...PLUGIN_ENTRIES, ...this.#externalPlugins.entries()];
 	}
 
-	async dispose(): Promise<void> {
+	dispose(): Promise<void> {
+		return (this.#disposePromise ??= this.#dispose().catch((error) => {
+			// A later call must be able to finish any cleanup skipped by a failure.
+			this.#disposePromise = undefined;
+			throw error;
+		}));
+	}
+
+	async #dispose(): Promise<void> {
 		this.#disposeController.abort();
 		// The `ProxyServer` "heap" will be destroyed when `workerd` shuts down,
 		// invalidating all existing native references. Mark all proxies as invalid.

--- a/packages/miniflare/src/plugins/core/inspector-proxy/inspector-proxy-controller.ts
+++ b/packages/miniflare/src/plugins/core/inspector-proxy/inspector-proxy-controller.ts
@@ -22,6 +22,7 @@ export class InspectorProxyController {
 	#proxies: InspectorProxy[] = [];
 
 	#server: Promise<Server>;
+	#disposePromise?: Promise<void>;
 
 	async #getInspectorPort() {
 		const server = await this.#server;
@@ -324,7 +325,14 @@ export class InspectorProxyController {
 		return this.#waitForReady();
 	}
 
-	async dispose(): Promise<void> {
+	dispose(): Promise<void> {
+		return (this.#disposePromise ??= this.#dispose().catch((error) => {
+			this.#disposePromise = undefined;
+			throw error;
+		}));
+	}
+
+	async #dispose(): Promise<void> {
 		await Promise.all(this.#proxies.map((proxy) => proxy.dispose()));
 
 		const server = await this.#server;
@@ -332,9 +340,18 @@ export class InspectorProxyController {
 		// Without this, active HTTP keep-alive or WebSocket connections prevent
 		// the close callback from firing, hanging the dispose.
 		server.closeAllConnections();
-		return new Promise((resolve, reject) => {
-			server.close((err) => (err ? reject(err) : resolve()));
+		const { promise, resolve, reject } = Promise.withResolvers<void>();
+		server.close((error) => {
+			if (
+				error &&
+				(error as NodeJS.ErrnoException).code !== "ERR_SERVER_NOT_RUNNING"
+			) {
+				reject(error);
+			} else {
+				resolve();
+			}
 		});
+		return promise;
 	}
 }
 

--- a/packages/miniflare/test/index.spec.ts
+++ b/packages/miniflare/test/index.spec.ts
@@ -2283,6 +2283,25 @@ test("Miniflare: dispose() immediately after construction", async ({
 	await readyAssertion;
 });
 
+test("Miniflare: dispose() is single-flight and idempotent", async ({
+	expect,
+}) => {
+	const mf = new Miniflare({
+		script: `export default { fetch() { return new Response("ok"); } }`,
+		modules: true,
+	});
+	await mf.ready;
+
+	const firstDispose = mf.dispose();
+	const concurrentDispose = mf.dispose();
+	expect(concurrentDispose).toBe(firstDispose);
+	await firstDispose;
+
+	const subsequentDispose = mf.dispose();
+	expect(subsequentDispose).toBe(firstDispose);
+	await subsequentDispose;
+});
+
 test("Miniflare: getBindings() returns all bindings", async ({
 	expect,
 	onTestFinished,
@@ -2880,6 +2899,17 @@ test("Miniflare: workerd crash during startup => ERR_RUNTIME_FAILURE", async ({
 	await expect(mf.ready).rejects.toMatchObject({
 		code: "ERR_RUNTIME_FAILURE",
 		message: expect.stringContaining("The Workers runtime failed to start."),
+	});
+
+	const firstDispose = mf.dispose();
+	await expect(firstDispose).rejects.toMatchObject({
+		code: "ERR_RUNTIME_FAILURE",
+	});
+
+	const secondDispose = mf.dispose();
+	expect(secondDispose).not.toBe(firstDispose);
+	await expect(secondDispose).rejects.toMatchObject({
+		code: "ERR_RUNTIME_FAILURE",
 	});
 });
 

--- a/packages/miniflare/test/plugins/core/inspector-proxy/index.spec.ts
+++ b/packages/miniflare/test/plugins/core/inspector-proxy/index.spec.ts
@@ -1,9 +1,10 @@
 import events from "node:events";
 import { setTimeout } from "node:timers/promises";
 import getPort from "get-port";
-import { fetch, Miniflare, MiniflareCoreError } from "miniflare";
+import { fetch, Miniflare, MiniflareCoreError, NoOpLog } from "miniflare";
 import { beforeAll, test, vi } from "vitest";
 import WebSocket from "ws";
+import { InspectorProxyController } from "../../../../src/plugins/core/inspector-proxy/inspector-proxy-controller";
 import { useDispose } from "../../../test-shared";
 import type { MiniflareOptions } from "miniflare";
 
@@ -15,6 +16,22 @@ beforeAll(() => {
 	// test the debugging/inspector behavior), so we need to skip the bodies check by
 	// setting process.env.MINIFLARE_ASSERT_BODIES_CONSUMED to undefined
 	process.env.MINIFLARE_ASSERT_BODIES_CONSUMED = undefined;
+});
+
+test("InspectorProxyController: dispose() is single-flight and idempotent", async ({
+	expect,
+}) => {
+	const controller = new InspectorProxyController(
+		0,
+		"127.0.0.1",
+		new NoOpLog(),
+		new Set()
+	);
+
+	const firstDispose = controller.dispose();
+	expect(controller.dispose()).toBe(firstDispose);
+	await firstDispose;
+	expect(controller.dispose()).toBe(firstDispose);
 });
 
 test("InspectorProxy: /json/version should provide details about the inspector version", async ({

--- a/packages/miniflare/test/test-shared/miniflare.ts
+++ b/packages/miniflare/test/test-shared/miniflare.ts
@@ -31,11 +31,6 @@ export async function disposeWithRetry(
 			return;
 		} catch (e) {
 			lastError = e;
-			// Treat "already disposed" as success (idempotent disposal)
-			const message = (e as Error).message;
-			if (message === "Server is not running.") {
-				return;
-			}
 			// Only retry on Windows-specific file locking errors
 			const code = (e as NodeJS.ErrnoException).code;
 			if (


### PR DESCRIPTION
Fixes #15097.

## Summary

- Cache in-flight or successful Miniflare disposal promises so concurrent and later callers do not repeat a completed teardown.
- Clear the cache after a failed teardown so callers such as the existing Windows retry helper can finish cleanup on a later attempt.
- Make both loopback-server and inspector-proxy teardown idempotent, avoiding `ERR_SERVER_NOT_RUNNING` when cleanup is retried.
- Remove the test-helper workaround that matched Node's `Server is not running.` message.

## Regression coverage

- Add a Miniflare lifecycle test that asserts concurrent calls and a later successful call receive the exact same promise.
- Extend the startup-failure regression to prove a rejected disposal is not cached and a second cleanup attempt still reports the original runtime failure rather than a loopback-server error.
- Add an inspector-proxy controller regression proving concurrent and later disposal calls reuse its completed teardown.

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: this fixes lifecycle behavior without adding or changing user-facing configuration.

Validation:
- `pnpm --filter miniflare exec vitest run test/index.spec.ts test/plugins/core/inspector-proxy/index.spec.ts -t '(Miniflare: (dispose\\(\\) is single-flight and idempotent|workerd crash during startup => ERR_RUNTIME_FAILURE)|InspectorProxyController: dispose\\(\\) is single-flight and idempotent)'` (3 tests passed)
- `pnpm --filter miniflare build`
- `pnpm --filter miniflare check:type`
- `pnpm exec oxfmt --check packages/miniflare/src/index.ts packages/miniflare/src/plugins/core/inspector-proxy/inspector-proxy-controller.ts packages/miniflare/test/index.spec.ts packages/miniflare/test/plugins/core/inspector-proxy/index.spec.ts packages/miniflare/test/test-shared/miniflare.ts .changeset/tidy-pumas-dispose.md`

> [!NOTE]
> This is a contribution from an AI agent: OpenAI Codex, GPT-5.6.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/15107" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->