### PR TITLE
[wrangler] Paginate R2 bucket listings

### DIFF
--- a/.changeset/calm-cursors-list.md
+++ b/.changeset/calm-cursors-list.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Return every R2 bucket from `wrangler r2 bucket list`
+
+`wrangler r2 bucket list` no longer stops after the first handful of buckets — it now lists every bucket in your account, including when a jurisdiction is specified.

--- a/packages/wrangler/src/__tests__/r2/bucket.test.ts
+++ b/packages/wrangler/src/__tests__/r2/bucket.test.ts
@@ -139,6 +139,134 @@ describe("r2", () => {
 				`);
 			});
 
+			it("paginates buckets through the SDK and preserves request headers", async ({
+				expect,
+			}) => {
+				const firstPage = Array.from({ length: 100 }, (_, index) => ({
+					name: `bucket-${String(index + 1).padStart(3, "0")}`,
+					creation_date: "01-01-2001",
+				}));
+				const secondPage = Array.from({ length: 100 }, (_, index) => ({
+					name: `bucket-${index + 101}`,
+					creation_date: "02-01-2001",
+				}));
+				const requests: Array<{
+					startAfter: string | null;
+					jurisdiction: string | null;
+				}> = [];
+				function getPage(startAfter: string | null) {
+					switch (startAfter) {
+						case null:
+							return firstPage;
+						case "bucket-100":
+							return secondPage;
+						case "bucket-200":
+							return [];
+						default:
+							throw new Error(`Unexpected start_after: ${startAfter}`);
+					}
+				}
+				msw.use(
+					http.get(
+						"*/accounts/:accountId/r2/buckets",
+						({ request, params }) => {
+							const url = new URL(request.url);
+							const startAfter = url.searchParams.get("start_after");
+							const jurisdiction = request.headers.get("cf-r2-jurisdiction");
+							const buckets = getPage(startAfter);
+
+							expect(params.accountId).toEqual("some-account-id");
+							expect(Object.fromEntries(url.searchParams)).toEqual({
+								direction: "asc",
+								order: "name",
+								per_page: "100",
+								...(startAfter === null ? {} : { start_after: startAfter }),
+							});
+							expect(jurisdiction).toEqual("eu");
+							requests.push({ startAfter, jurisdiction });
+
+							return HttpResponse.json(createFetchResult({ buckets }));
+						}
+					)
+				);
+
+				await runWrangler("r2 bucket list --jurisdiction eu");
+
+				expect(requests).toEqual([
+					{ startAfter: null, jurisdiction: "eu" },
+					{ startAfter: "bucket-100", jurisdiction: "eu" },
+					{ startAfter: "bucket-200", jurisdiction: "eu" },
+				]);
+				expect(std.out).toContain("name:           bucket-001");
+				expect(std.out).toContain("name:           bucket-200");
+				expect(std.out.match(/creation_date:/g)).toHaveLength(200);
+			});
+
+			it("paginates through null and empty result_info", async ({ expect }) => {
+				const firstPage = Array.from({ length: 100 }, (_, index) => ({
+					name: `bucket-${String(index + 1).padStart(3, "0")}`,
+					creation_date: "01-01-2001",
+				}));
+				const requests: Array<Record<string, string>> = [];
+				msw.use(
+					http.get(
+						"*/accounts/:accountId/r2/buckets",
+						({ request, params }) => {
+							const query = Object.fromEntries(
+								new URL(request.url).searchParams
+							);
+							requests.push(query);
+							expect(params.accountId).toEqual("some-account-id");
+
+							const buckets =
+								query.start_after === undefined
+									? firstPage
+									: [{ name: "bucket-101", creation_date: "02-01-2001" }];
+							return HttpResponse.json({
+								...createFetchResult({ buckets }),
+								result_info: query.start_after === undefined ? null : {},
+							});
+						}
+					)
+				);
+
+				await runWrangler("r2 bucket list");
+
+				expect(requests).toEqual([
+					{ direction: "asc", order: "name", per_page: "100" },
+					{
+						direction: "asc",
+						order: "name",
+						per_page: "100",
+						start_after: "bucket-100",
+					},
+				]);
+				expect(std.out).toContain("name:           bucket-001");
+				expect(std.out).toContain("name:           bucket-101");
+				expect(std.out.match(/creation_date:/g)).toHaveLength(101);
+			});
+
+			it("reports when SDK pagination does not advance", async ({ expect }) => {
+				const page = Array.from({ length: 100 }, (_, index) => ({
+					name: `bucket-${String(index + 1).padStart(3, "0")}`,
+					creation_date: "01-01-2001",
+				}));
+				let requests = 0;
+				msw.use(
+					http.get("*/accounts/:accountId/r2/buckets", () => {
+						requests++;
+						return HttpResponse.json(createFetchResult({ buckets: page }));
+					})
+				);
+
+				await expect(
+					runWrangler("r2 bucket list")
+				).rejects.toThrowErrorMatchingInlineSnapshot(
+					`[Error: Unable to list every R2 bucket because API pagination did not advance. Retry the command.]`
+				);
+				expect(requests).toBe(2);
+			});
+
 			it("should list buckets even if the local wrangler config is invalid", async () => {
 				writeWranglerConfig(
 					{

--- a/packages/wrangler/src/ai-search/create.ts
+++ b/packages/wrangler/src/ai-search/create.ts
@@ -330,7 +330,7 @@ export const aiSearchCreateCommand = createCommand({
 		},
 	},
 	positionalArgs: ["name"],
-	async handler(args, { config }) {
+	async handler(args, { config, sdk }) {
 		// Get accountId early — needed for listing R2 buckets and zones
 		const accountId = await requireAuth(config);
 
@@ -560,7 +560,7 @@ export const aiSearchCreateCommand = createCommand({
 			const effectiveJurisdiction = sourceJurisdiction?.trim() || undefined;
 			// 3.1 R2: list buckets and let user pick, with "Create new" option
 			const buckets = await listR2Buckets(
-				config,
+				sdk,
 				accountId,
 				effectiveJurisdiction
 			);

--- a/packages/wrangler/src/r2/bucket.ts
+++ b/packages/wrangler/src/r2/bucket.ts
@@ -202,12 +202,12 @@ export const r2BucketListCommand = createCommand({
 			type: "string",
 		},
 	},
-	async handler(args, { config }) {
+	async handler(args, { config, sdk }) {
 		const accountId = await requireAuth(config);
 
 		logger.log(`Listing buckets...`);
 
-		const buckets = await listR2Buckets(config, accountId, args.jurisdiction);
+		const buckets = await listR2Buckets(sdk, accountId, args.jurisdiction);
 		const tableOutput = tableFromR2BucketsListResponse(buckets);
 		logger.log(tableOutput.map((x) => formatLabelledValues(x)).join("\n\n"));
 	},

--- a/packages/wrangler/src/r2/helpers/bucket.ts
+++ b/packages/wrangler/src/r2/helpers/bucket.ts
@@ -1,6 +1,7 @@
 import prettyBytes from "pretty-bytes";
 import { fetchGraphqlResult, fetchResult } from "../../cfetch";
 import type { ComplianceConfig } from "@cloudflare/workers-utils";
+import type Cloudflare from "cloudflare";
 import type { HeadersInit } from "undici";
 
 /**
@@ -35,24 +36,53 @@ export interface R2BucketMetricsGraphQLResponse {
 }
 
 /**
- * Fetch a list of all the buckets under the given `accountId`.
+ * Fetch every bucket under the given `accountId` through the Cloudflare SDK.
  *
- * Keep in sync with the local provisioning copy in
- * packages/deploy-helpers/src/deploy/helpers/provision-bindings.ts.
+ * The SDK returns one page at a time, so continue from the last bucket name
+ * until the API returns a partial page.
  */
 export async function listR2Buckets(
-	complianceConfig: ComplianceConfig,
+	sdk: Cloudflare,
 	accountId: string,
 	jurisdiction?: string
 ): Promise<R2BucketInfo[]> {
-	const headers: HeadersInit = {};
-	if (jurisdiction !== undefined) {
-		headers["cf-r2-jurisdiction"] = jurisdiction;
+	const pageSize = 100;
+	const results: R2BucketInfo[] = [];
+	let startAfter: string | undefined;
+	const requestOptions =
+		jurisdiction === undefined
+			? undefined
+			: { headers: { "cf-r2-jurisdiction": jurisdiction } };
+
+	while (true) {
+		const response = await sdk.r2.buckets.list(
+			{
+				account_id: accountId,
+				direction: "asc",
+				order: "name",
+				per_page: pageSize,
+				start_after: startAfter,
+			},
+			requestOptions
+		);
+		const buckets = response.buckets;
+		if (buckets === undefined || buckets.length === 0) {
+			return results;
+		}
+
+		results.push(...(buckets as R2BucketInfo[]));
+		if (buckets.length < pageSize) {
+			return results;
+		}
+
+		const nextStartAfter = buckets.at(-1)?.name;
+		if (nextStartAfter === undefined || nextStartAfter === startAfter) {
+			throw new Error(
+				"Unable to list every R2 bucket because API pagination did not advance. Retry the command."
+			);
+		}
+		startAfter = nextStartAfter;
 	}
-	const results = await fetchResult<{
-		buckets: R2BucketInfo[];
-	}>(complianceConfig, `/accounts/${accountId}/r2/buckets`, { headers });
-	return results.buckets;
 }
 
 export function tableFromR2BucketsListResponse(buckets: R2BucketInfo[]): {


### PR DESCRIPTION
## Summary

- Route R2 bucket listing through the injected Cloudflare TypeScript SDK instead of the raw `cfetch` REST helper.
- Request stable 100-bucket pages ordered by name and continue with the SDK's typed `start_after` parameter until every page is returned, preserving jurisdiction headers.
- Use the same SDK-backed helper from both `wrangler r2 bucket list` and the interactive AI Search R2 bucket picker; report an unexpected service failure if a response cannot advance pagination.

## Regression coverage

- Verify two full 100-bucket SDK pages plus an empty terminal page, including exact query parameters, jurisdiction headers, request count, and all 200 output buckets.
- Verify null and empty outer `result_info` values do not truncate a 101-bucket listing.
- Verify a repeated full page fails after two requests with a regular tracked error instead of looping or silently returning an incomplete list.
- Exercise the AI Search interactive R2 bucket picker through the migrated SDK helper.

Fixes #15103.

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: this fixes existing bucket-list completeness without changing commands, flags, or configuration.

Validation:
- `pnpm --filter wrangler exec vitest run src/__tests__/r2/bucket.test.ts -t 'SDK|result_info'` (3 tests passed)
- `pnpm --filter wrangler exec vitest run src/__tests__/ai-search.test.ts -t 'should list buckets in the chosen jurisdiction'` (1 test passed)
- `pnpm --filter @cloudflare/workers-utils build`
- `pnpm --filter @cloudflare/workers-utils check:type`
- `pnpm --filter wrangler check:type`
- `pnpm exec oxfmt --check packages/wrangler/src/r2/helpers/bucket.ts packages/wrangler/src/r2/bucket.ts packages/wrangler/src/ai-search/create.ts packages/wrangler/src/__tests__/r2/bucket.test.ts .changeset/calm-cursors-list.md`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/15108" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->