### PR TITLE
feat: implement local dev for ctx.access

### DIFF
--- a/.changeset/access-local-dev.md
+++ b/.changeset/access-local-dev.md
@@ -1,0 +1,23 @@
+---
+"miniflare": minor
+"wrangler": minor
+---
+
+Add local dev simulation for Cloudflare Access `ctx.access.getIdentity()`
+
+You can now configure a mock Cloudflare Access identity in `wrangler.json` so that `ctx.access.getIdentity()` returns it during local development.
+
+```jsonc
+// wrangler.json
+{
+	"access": {
+		"dev": {
+			"aud": "my-app-aud-tag",
+			"identity": {
+				"email": "user@example.com",
+				"name": "Test User",
+			},
+		},
+	},
+}
+```

--- a/packages/miniflare/src/config/schema.ts
+++ b/packages/miniflare/src/config/schema.ts
@@ -620,6 +620,13 @@ export const DevConfigSchema = z.strictObject({
 	// Zone to use for the CF-Worker header in outbound fetches. If not
 	// specified, defaults to `${worker-name}.example.com`
 	zone: z.string().optional(),
+	/** Cloudflare Access authentication metadata exposed as `ctx.access` */
+	access: z
+		.strictObject({
+			aud: z.string(),
+			identity: z.record(z.string(), z.unknown()).optional(),
+		})
+		.optional(),
 });
 
 export type DevConfig = z.input<typeof DevConfigSchema>;

--- a/packages/miniflare/src/config/v4-convert.ts
+++ b/packages/miniflare/src/config/v4-convert.ts
@@ -184,6 +184,7 @@ function convertWorkerOptions(
 	dev.unsafeEphemeralDurableObjects = worker.unsafeEphemeralDurableObjects;
 	dev.stripCfConnectingIp = worker.stripCfConnectingIp;
 	dev.zone = worker.zone;
+	dev.access = worker.access;
 
 	const options: WorkerOptions = { config };
 	if (Object.values(legacy).some((value) => value !== undefined)) {

--- a/packages/miniflare/src/config/v4-schema.ts
+++ b/packages/miniflare/src/config/v4-schema.ts
@@ -373,6 +373,13 @@ const V4WorkerOptionsShapeSchema = z.object({
 	streamingTails: z.array(V4ServiceDesignatorSchema).optional(),
 	stripCfConnectingIp: z.boolean().default(true),
 	zone: z.string().optional(),
+	/** Cloudflare Access authentication metadata exposed as `ctx.access` */
+	access: z
+		.object({
+			aud: z.string(),
+			identity: z.record(z.string(), z.unknown()).optional(),
+		})
+		.optional(),
 	unsafeBindings: z
 		.array(
 			z.object({
@@ -780,6 +787,7 @@ export type V4WorkerOptionsShape = {
 	streamingTails?: V4ServiceDesignator[];
 	stripCfConnectingIp?: boolean;
 	zone?: string;
+	access?: { aud: string; identity?: Record<string, unknown> };
 	unsafeBindings?: Array<{
 		name: string;
 		type: string;

--- a/packages/miniflare/src/plugins/core/index.ts
+++ b/packages/miniflare/src/plugins/core/index.ts
@@ -18,6 +18,7 @@ import {
 	removeDirSync,
 	stripRedundantNodejsCompatFlags,
 } from "@cloudflare/workers-utils";
+import SCRIPT_ACCESS_IDENTITY from "worker:access/access-identity";
 import SCRIPT_DEV_CONTROL from "worker:core/dev-control";
 import SCRIPT_ENTRY from "worker:core/entry";
 import OUTBOUND_WORKER from "worker:core/outbound";
@@ -306,6 +307,10 @@ function getDevControlBindings(
 	}
 
 	return Array.from(bindings.values());
+}
+
+function getAccessIdentityServiceName(workerIndex: number) {
+	return `access-identity:${workerIndex}`;
 }
 
 function getOutboundInterceptorName(workerIndex: number) {
@@ -653,6 +658,14 @@ export const CORE_PLUGIN: Plugin = {
 					.filter((consumer) => consumer.streaming)
 					.map<ServiceDesignator>(getTailServiceDesignator),
 				containerEngine: getContainerEngine(sharedOptions.containerEngine),
+				...(dev?.access
+					? {
+							accessBlobHeader: CoreHeaders.ACCESS_BLOB,
+							accessBindingService: {
+								name: getAccessIdentityServiceName(workerIndex),
+							},
+						}
+					: {}),
 			},
 		});
 
@@ -706,6 +719,26 @@ export const CORE_PLUGIN: Plugin = {
 						WORKER_BINDING_SERVICE_LOOPBACK,
 					],
 					globalOutbound: getGlobalOutbound(workerIndex, config, dev),
+				},
+			});
+		}
+
+		// Access identity binding worker for ctx.access.getIdentity()
+		if (dev?.access) {
+			services.push({
+				name: getAccessIdentityServiceName(workerIndex),
+				worker: {
+					modules: [
+						{
+							name: "index.js",
+							esModule: SCRIPT_ACCESS_IDENTITY(),
+						},
+					],
+					compatibilityDate: "2025-01-01",
+					compatibilityFlags: [
+						"experimental",
+						"service_binding_extra_handlers",
+					],
 				},
 			});
 		}
@@ -857,6 +890,31 @@ export function getGlobalServices({
 			data: encoder.encode(sharedOptions.unsafeProxySharedSecret),
 		});
 	}
+	// Inject per-worker Cloudflare Access blob bindings into the entry worker.
+	// Each worker with dev.access gets its own blob keyed by worker name so the
+	// entry worker can pick the correct one after routing.
+	for (const workerOpt of allWorkerOpts ?? []) {
+		const accessOpts = workerOpt.dev?.access;
+		if (accessOpts) {
+			const accessBlob: {
+				app_aud: string;
+				jwt_claims?: Record<string, unknown>;
+			} = { app_aud: accessOpts.aud };
+			if (accessOpts.identity) {
+				accessBlob.jwt_claims = accessOpts.identity;
+			}
+			serviceEntryBindings.push({
+				name: CoreBindings.JSON_ACCESS_BLOB_PREFIX + workerOpt.config.name,
+				json: JSON.stringify(accessBlob),
+			});
+		}
+	}
+	// Pass the first worker's raw name so the entry worker can look up its
+	// access blob when no route matches (the fallback is always the first worker).
+	serviceEntryBindings.push({
+		name: CoreBindings.TEXT_FALLBACK_WORKER_NAME,
+		text: workerNames[0] ?? "",
+	});
 	const services: Service[] = [
 		{
 			name: SERVICE_LOOPBACK,

--- a/packages/miniflare/src/runtime/config/generated/workerd.ts
+++ b/packages/miniflare/src/runtime/config/generated/workerd.ts
@@ -2608,11 +2608,149 @@ export class Worker_Binding extends $.Struct {
 		return $.utils.getUint16(0, this) as Worker_Binding_Which;
 	}
 }
+export class Worker_DurableObjectNamespace_ContainerOptions_ContainerPrivileges_Device
+	extends $.Struct
+{
+	static readonly _capnp = {
+		displayName: "Device",
+		id: "83f9125afacda809",
+		size: new $.ObjectSize(0, 3),
+	};
+	get pathOnHost(): string {
+		return $.utils.getText(0, this);
+	}
+	set pathOnHost(value: string) {
+		$.utils.setText(0, value, this);
+	}
+	get pathInContainer(): string {
+		return $.utils.getText(1, this);
+	}
+	set pathInContainer(value: string) {
+		$.utils.setText(1, value, this);
+	}
+	get cgroupPermissions(): string {
+		return $.utils.getText(2, this);
+	}
+	set cgroupPermissions(value: string) {
+		$.utils.setText(2, value, this);
+	}
+	toString(): string {
+		return (
+			"Worker_DurableObjectNamespace_ContainerOptions_ContainerPrivileges_Device_" +
+			super.toString()
+		);
+	}
+}
+export class Worker_DurableObjectNamespace_ContainerOptions_ContainerPrivileges
+	extends $.Struct
+{
+	static readonly Device =
+		Worker_DurableObjectNamespace_ContainerOptions_ContainerPrivileges_Device;
+	static readonly _capnp = {
+		displayName: "ContainerPrivileges",
+		id: "ca910fa0c4c988bf",
+		size: new $.ObjectSize(0, 3),
+	};
+	static _Devices: $.ListCtor<Worker_DurableObjectNamespace_ContainerOptions_ContainerPrivileges_Device>;
+	_adoptCapabilities(value: $.Orphan<$.List<string>>): void {
+		$.utils.adopt(value, $.utils.getPointer(0, this));
+	}
+	_disownCapabilities(): $.Orphan<$.List<string>> {
+		return $.utils.disown(this.capabilities);
+	}
+	/**
+	 * Docker HostConfig.CapAdd values.
+	 *
+	 */
+	get capabilities(): $.List<string> {
+		return $.utils.getList(0, $.TextList, this);
+	}
+	_hasCapabilities(): boolean {
+		return !$.utils.isNull($.utils.getPointer(0, this));
+	}
+	_initCapabilities(length: number): $.List<string> {
+		return $.utils.initList(0, $.TextList, length, this);
+	}
+	set capabilities(value: $.List<string>) {
+		$.utils.copyFrom(value, $.utils.getPointer(0, this));
+	}
+	_adoptDevices(
+		value: $.Orphan<
+			$.List<Worker_DurableObjectNamespace_ContainerOptions_ContainerPrivileges_Device>
+		>
+	): void {
+		$.utils.adopt(value, $.utils.getPointer(1, this));
+	}
+	_disownDevices(): $.Orphan<
+		$.List<Worker_DurableObjectNamespace_ContainerOptions_ContainerPrivileges_Device>
+	> {
+		return $.utils.disown(this.devices);
+	}
+	/**
+	 * Docker HostConfig.Devices values.
+	 *
+	 */
+	get devices(): $.List<Worker_DurableObjectNamespace_ContainerOptions_ContainerPrivileges_Device> {
+		return $.utils.getList(
+			1,
+			Worker_DurableObjectNamespace_ContainerOptions_ContainerPrivileges._Devices,
+			this
+		);
+	}
+	_hasDevices(): boolean {
+		return !$.utils.isNull($.utils.getPointer(1, this));
+	}
+	_initDevices(
+		length: number
+	): $.List<Worker_DurableObjectNamespace_ContainerOptions_ContainerPrivileges_Device> {
+		return $.utils.initList(
+			1,
+			Worker_DurableObjectNamespace_ContainerOptions_ContainerPrivileges._Devices,
+			length,
+			this
+		);
+	}
+	set devices(
+		value: $.List<Worker_DurableObjectNamespace_ContainerOptions_ContainerPrivileges_Device>
+	) {
+		$.utils.copyFrom(value, $.utils.getPointer(1, this));
+	}
+	_adoptSecurityOpt(value: $.Orphan<$.List<string>>): void {
+		$.utils.adopt(value, $.utils.getPointer(2, this));
+	}
+	_disownSecurityOpt(): $.Orphan<$.List<string>> {
+		return $.utils.disown(this.securityOpt);
+	}
+	/**
+	 * Docker HostConfig.SecurityOpt values.
+	 *
+	 */
+	get securityOpt(): $.List<string> {
+		return $.utils.getList(2, $.TextList, this);
+	}
+	_hasSecurityOpt(): boolean {
+		return !$.utils.isNull($.utils.getPointer(2, this));
+	}
+	_initSecurityOpt(length: number): $.List<string> {
+		return $.utils.initList(2, $.TextList, length, this);
+	}
+	set securityOpt(value: $.List<string>) {
+		$.utils.copyFrom(value, $.utils.getPointer(2, this));
+	}
+	toString(): string {
+		return (
+			"Worker_DurableObjectNamespace_ContainerOptions_ContainerPrivileges_" +
+			super.toString()
+		);
+	}
+}
 export class Worker_DurableObjectNamespace_ContainerOptions extends $.Struct {
+	static readonly ContainerPrivileges =
+		Worker_DurableObjectNamespace_ContainerOptions_ContainerPrivileges;
 	static readonly _capnp = {
 		displayName: "ContainerOptions",
 		id: "a609621a4d236cd7",
-		size: new $.ObjectSize(0, 1),
+		size: new $.ObjectSize(0, 2),
 	};
 	/**
 	 * Image name to be used to create the container using supported provider.
@@ -2624,6 +2762,44 @@ export class Worker_DurableObjectNamespace_ContainerOptions extends $.Struct {
 	}
 	set imageName(value: string) {
 		$.utils.setText(0, value, this);
+	}
+	_adoptPrivileges(
+		value: $.Orphan<Worker_DurableObjectNamespace_ContainerOptions_ContainerPrivileges>
+	): void {
+		$.utils.adopt(value, $.utils.getPointer(1, this));
+	}
+	_disownPrivileges(): $.Orphan<Worker_DurableObjectNamespace_ContainerOptions_ContainerPrivileges> {
+		return $.utils.disown(this.privileges);
+	}
+	/**
+	 * Extra Docker HostConfig privileges applied when creating the container.
+	 * These fields are passed through to Docker as-is and are empty by default.
+	 * They are not validated or allow-listed. Depending on the values and Docker daemon mode,
+	 * they can expose arbitrary host devices, disable security profiles, or grant capabilities
+	 * such as CAP_SYS_ADMIN that may provide host-level access. Only use trusted configuration.
+	 *
+	 */
+	get privileges(): Worker_DurableObjectNamespace_ContainerOptions_ContainerPrivileges {
+		return $.utils.getStruct(
+			1,
+			Worker_DurableObjectNamespace_ContainerOptions_ContainerPrivileges,
+			this
+		);
+	}
+	_hasPrivileges(): boolean {
+		return !$.utils.isNull($.utils.getPointer(1, this));
+	}
+	_initPrivileges(): Worker_DurableObjectNamespace_ContainerOptions_ContainerPrivileges {
+		return $.utils.initStructAt(
+			1,
+			Worker_DurableObjectNamespace_ContainerOptions_ContainerPrivileges,
+			this
+		);
+	}
+	set privileges(
+		value: Worker_DurableObjectNamespace_ContainerOptions_ContainerPrivileges
+	) {
+		$.utils.copyFrom(value, $.utils.getPointer(1, this));
 	}
 	toString(): string {
 		return "Worker_DurableObjectNamespace_ContainerOptions_" + super.toString();
@@ -2875,7 +3051,7 @@ export class Worker_DurableObjectStorage extends $.Struct {
 	static readonly _capnp = {
 		displayName: "durableObjectStorage",
 		id: "cc72b3faa57827d4",
-		size: new $.ObjectSize(8, 13),
+		size: new $.ObjectSize(8, 15),
 	};
 	get _isNone(): boolean {
 		return $.utils.getUint16(2, this) === 0;
@@ -2940,7 +3116,7 @@ export class Worker_ContainerEngine extends $.Struct {
 	static readonly _capnp = {
 		displayName: "containerEngine",
 		id: "82de68f58dc2eb24",
-		size: new $.ObjectSize(8, 13),
+		size: new $.ObjectSize(8, 15),
 	};
 	get _isNone(): boolean {
 		return $.utils.getUint16(4, this) === 0;
@@ -3037,7 +3213,7 @@ export class Worker extends $.Struct {
 	static readonly _capnp = {
 		displayName: "Worker",
 		id: "acfa77e88fd97d1c",
-		size: new $.ObjectSize(8, 13),
+		size: new $.ObjectSize(8, 15),
 		defaultGlobalOutbound: $.readRawPointer(
 			new Uint8Array([
 				16, 7, 80, 1, 3, 0, 0, 17, 9, 74, 0, 1, 255, 105, 110, 116, 101, 114,
@@ -3354,6 +3530,54 @@ export class Worker extends $.Struct {
 	}
 	_initContainerEngine(): Worker_ContainerEngine {
 		return $.utils.getAs(Worker_ContainerEngine, this);
+	}
+	/**
+	 * Name of the HTTP header carrying per-request Cloudflare Access metadata for local dev.
+	 * When set, the worker reads this header from every incoming request to populate `ctx.access`.
+	 * The header value is a JSON object matching the production Access struct:
+	 *   { "app_aud": "<audience>", "jwt_claims": { ... } }
+	 * `app_aud` (string, required) populates `ctx.access.aud`.
+	 * `jwt_claims` (object, optional) is passed as `ctx.props.jwtClaims` to the access binding
+	 * worker (if configured via `accessBindingService`) when `ctx.access.getIdentity()` is called.
+	 * Requests that carry the header get `ctx.access` populated; requests without it get
+	 * `ctx.access === undefined`.
+	 *
+	 */
+	get accessBlobHeader(): string {
+		return $.utils.getText(13, this);
+	}
+	set accessBlobHeader(value: string) {
+		$.utils.setText(13, value, this);
+	}
+	_adoptAccessBindingService(value: $.Orphan<ServiceDesignator>): void {
+		$.utils.adopt(value, $.utils.getPointer(14, this));
+	}
+	_disownAccessBindingService(): $.Orphan<ServiceDesignator> {
+		return $.utils.disown(this.accessBindingService);
+	}
+	/**
+	 * Names a service that acts as the Cloudflare Access identity binding worker for local dev.
+	 * When `ctx.access.getIdentity()` is called, workerd dispatches a `getIdentity` JS-RPC method
+	 * on this service with per-request `props` set to `{ aud }` or `{ aud, jwtClaims }` (extracted
+	 * from the `accessBlobHeader` HTTP header; `jwtClaims` is included only when the optional
+	 * `jwt_claims` field is present in the header). This mimics the production path where an
+	 * Access binding worker resolves the identity from JWT claims.
+	 *
+	 * If not set, `ctx.access.getIdentity()` resolves to `undefined` (even when `accessBlobHeader`
+	 * is configured and `ctx.access.aud` is available).
+	 *
+	 */
+	get accessBindingService(): ServiceDesignator {
+		return $.utils.getStruct(14, ServiceDesignator, this);
+	}
+	_hasAccessBindingService(): boolean {
+		return !$.utils.isNull($.utils.getPointer(14, this));
+	}
+	_initAccessBindingService(): ServiceDesignator {
+		return $.utils.initStructAt(14, ServiceDesignator, this);
+	}
+	set accessBindingService(value: ServiceDesignator) {
+		$.utils.copyFrom(value, $.utils.getPointer(14, this));
 	}
 	toString(): string {
 		return "Worker_" + super.toString();
@@ -4174,7 +4398,11 @@ export class Extension_Module extends $.Struct {
 		defaultInternal: $.getBitMask(false, 0),
 	};
 	/**
-	 * Full js module name.
+	 * Full js module name. Must be a fully-qualified URL with a non-file: scheme,
+	 * e.g. "my-extension:module". Workers using the new_module_registry
+	 * compatibility flag reject extensions whose module names are not valid URLs;
+	 * the original module registry tolerates any path-like name, but new
+	 * extensions should always use the URL form.
 	 *
 	 */
 	get name(): string {
@@ -4334,6 +4562,10 @@ Config._Services = $.CompositeList(Service);
 Config._Sockets = $.CompositeList(Socket);
 Config._Extensions = $.CompositeList(Extension);
 Worker_Binding_WrappedBinding._InnerBindings = $.CompositeList(Worker_Binding);
+Worker_DurableObjectNamespace_ContainerOptions_ContainerPrivileges._Devices =
+	$.CompositeList(
+		Worker_DurableObjectNamespace_ContainerOptions_ContainerPrivileges_Device
+	);
 Worker._Modules = $.CompositeList(Worker_Module);
 Worker._Bindings = $.CompositeList(Worker_Binding);
 Worker._DurableObjectNamespaces = $.CompositeList(

--- a/packages/miniflare/src/runtime/config/workerd.ts
+++ b/packages/miniflare/src/runtime/config/workerd.ts
@@ -76,6 +76,8 @@ export type Worker = (
 	tails?: ServiceDesignator[];
 	streamingTails?: ServiceDesignator[];
 	containerEngine?: Worker_ContainerEngine;
+	accessBlobHeader?: string;
+	accessBindingService?: ServiceDesignator;
 };
 
 export type Worker_DurableObjectStorage =

--- a/packages/miniflare/src/workers/access/access-identity.worker.ts
+++ b/packages/miniflare/src/workers/access/access-identity.worker.ts
@@ -1,0 +1,22 @@
+// Access identity binding worker for local dev.
+//
+// In production, workerd dispatches `ctx.access.getIdentity()` to an Access
+// binding worker via JS-RPC, passing `{ aud, jwtClaims }` as `ctx.props`.
+// This embedded worker mirrors that interface: it receives `ctx.props` from
+// workerd and returns the `jwtClaims` value as the identity.
+
+import { WorkerEntrypoint } from "cloudflare:workers";
+
+interface Props {
+	aud: string;
+	jwtClaims?: Record<string, unknown>;
+}
+
+export default class AccessIdentityBinding extends WorkerEntrypoint<
+	Record<string, never>,
+	Props
+> {
+	async getIdentity(): Promise<Record<string, unknown> | undefined> {
+		return this.ctx.props.jwtClaims;
+	}
+}

--- a/packages/miniflare/src/workers/core/constants.ts
+++ b/packages/miniflare/src/workers/core/constants.ts
@@ -47,6 +47,7 @@ export const CoreHeaders = {
 	ERROR_STACK_PAYLOAD: "MF-Experimental-Error-Stack-Payload",
 	ROUTE_OVERRIDE: "MF-Route-Override",
 	CF_BLOB: "MF-CF-Blob",
+	ACCESS_BLOB: "MF-Access-Blob",
 	/** Used by the Vite plugin to pass through the original `sec-fetch-mode` header */
 	SEC_FETCH_MODE: "MF-Sec-Fetch-Mode",
 
@@ -95,6 +96,8 @@ export const CoreBindings = {
 	SERVICE_R2_PUBLIC: "MINIFLARE_R2_PUBLIC",
 	SERVICE_R2_S3: "MINIFLARE_R2_S3",
 	SERVICE_OBSERVABILITY_COLLECTOR: "MINIFLARE_OBSERVABILITY_COLLECTOR",
+	JSON_ACCESS_BLOB_PREFIX: "MINIFLARE_ACCESS_BLOB_",
+	TEXT_FALLBACK_WORKER_NAME: "MINIFLARE_FALLBACK_WORKER_NAME",
 } as const;
 
 export const ProxyOps = {

--- a/packages/miniflare/src/workers/core/entry.worker.ts
+++ b/packages/miniflare/src/workers/core/entry.worker.ts
@@ -25,6 +25,7 @@ type Env = {
 	[CoreBindings.TEXT_CUSTOM_SERVICE]: string;
 	[CoreBindings.TEXT_UPSTREAM_URL]?: string;
 	[CoreBindings.JSON_CF_BLOB]: IncomingRequestCfProperties;
+	[CoreBindings.TEXT_FALLBACK_WORKER_NAME]: string;
 	[CoreBindings.JSON_ROUTES]: WorkerRoute[];
 	[CoreBindings.JSON_LOG_LEVEL]: LogLevel;
 	[CoreBindings.DURABLE_OBJECT_NAMESPACE_PROXY]: DurableObjectNamespace;
@@ -36,6 +37,10 @@ type Env = {
 	[K in `${typeof CoreBindings.SERVICE_USER_ROUTE_PREFIX}${string}`]:
 		| Fetcher
 		| undefined; // Won't have a `Fetcher` for every possible `string`
+} & {
+	[K in `${typeof CoreBindings.JSON_ACCESS_BLOB_PREFIX}${string}`]:
+		| { app_aud: string; jwt_claims?: Record<string, unknown> }
+		| undefined;
 };
 
 const encoder = new TextEncoder();
@@ -140,17 +145,25 @@ function getUserRequest(
 	return request;
 }
 
-function getTargetService(request: Request, url: URL, env: Env) {
-	let service: Fetcher | undefined = env[CoreBindings.SERVICE_USER_FALLBACK];
-
+function getTargetService(
+	request: Request,
+	url: URL,
+	env: Env
+): { service: Fetcher | undefined; routeTarget: string } {
 	const override = request.headers.get(CoreHeaders.ROUTE_OVERRIDE);
 	request.headers.delete(CoreHeaders.ROUTE_OVERRIDE);
 
 	const route = override ?? matchRoutes(env[CoreBindings.JSON_ROUTES], url);
 	if (route !== null) {
-		service = env[`${CoreBindings.SERVICE_USER_ROUTE_PREFIX}${route}`];
+		return {
+			service: env[`${CoreBindings.SERVICE_USER_ROUTE_PREFIX}${route}`],
+			routeTarget: route,
+		};
 	}
-	return service;
+	return {
+		service: env[CoreBindings.SERVICE_USER_FALLBACK],
+		routeTarget: env[CoreBindings.TEXT_FALLBACK_WORKER_NAME],
+	};
 }
 
 const LOCALHOST_HOSTNAMES = ["localhost", "127.0.0.1", "[::1]"];
@@ -465,6 +478,11 @@ export default <ExportedHandler<Env>>{
 				};
 		request = new Request(request, { cf });
 
+		// Strip any client-supplied Access blob header early, before branches
+		// that return without calling getUserRequest() (e.g. the magic proxy).
+		// The correct per-worker blob is injected later after routing.
+		request.headers.delete(CoreHeaders.ACCESS_BLOB);
+
 		// Restrict /cdn-cgi/* requests to allowed hostnames.
 		// These endpoints should be served only when the browser-sent Host and
 		// Origin headers match localhost, a configured route, or the configured upstream.
@@ -510,7 +528,7 @@ export default <ExportedHandler<Env>>{
 			throw e;
 		}
 		const url = new URL(request.url);
-		const service = getTargetService(request, url, env);
+		const { service, routeTarget } = getTargetService(request, url, env);
 		if (service === undefined) {
 			return new Response("No entrypoint worker found", { status: 404 });
 		}
@@ -586,6 +604,15 @@ export default <ExportedHandler<Env>>{
 					s3Request.headers.set("Host", originalHostname);
 				}
 				return await r2S3Service.fetch(s3Request);
+			}
+
+			// Inject per-worker Cloudflare Access blob header so workerd populates ctx.access
+			const accessBlob =
+				env[`${CoreBindings.JSON_ACCESS_BLOB_PREFIX}${routeTarget}`];
+			if (accessBlob) {
+				const headers = new Headers(request.headers);
+				headers.set(CoreHeaders.ACCESS_BLOB, JSON.stringify(accessBlob));
+				request = new Request(request, { headers });
 			}
 
 			let response = await service.fetch(request);

--- a/packages/miniflare/test/plugins/core/access.spec.ts
+++ b/packages/miniflare/test/plugins/core/access.spec.ts
@@ -1,0 +1,156 @@
+import { Miniflare, type WorkerOptions } from "miniflare";
+import { describe, test } from "vitest";
+import { singleModuleManifest, useDispose } from "../../test-shared";
+
+// Cloudflare Access local dev wiring.
+//
+// When `dev.access` is configured, Miniflare:
+// 1. Sets `accessBlobHeader` on the user worker so workerd reads a header to
+//    populate `ctx.access`.
+// 2. Injects that header from the entry worker on every incoming request.
+// 3. Creates an embedded access identity binding worker and sets
+//    `accessBindingService` on the user worker so `ctx.access.getIdentity()`
+//    dispatches to it via JS-RPC.
+
+function plainWorker(script: string): WorkerOptions {
+	return {
+		config: {
+			type: "worker",
+			name: "user",
+			compatibilityDate: "2026-06-01",
+			manifest: singleModuleManifest(script),
+		},
+	};
+}
+
+describe("access (wiring)", () => {
+	test("worker with access config boots and serves", async ({ expect }) => {
+		const mf = new Miniflare({
+			workers: [
+				{
+					...plainWorker(
+						`export default { async fetch() { return new Response("ok"); } }`
+					),
+					dev: {
+						access: { aud: "test-aud" },
+					},
+				},
+			],
+		});
+		useDispose(mf);
+
+		// A broken injection (bad service reference or missing compat flags)
+		// would fail to start workerd or to serve.
+		const res = await mf.dispatchFetch("http://localhost/");
+		expect(await res.text()).toBe("ok");
+	});
+
+	test("ctx.access.aud is populated from config", async ({ expect }) => {
+		const mf = new Miniflare({
+			workers: [
+				{
+					...plainWorker(`
+						export default {
+							async fetch(request, env, ctx) {
+								return Response.json({
+									aud: ctx.access?.aud ?? null,
+								});
+							}
+						}
+					`),
+					dev: {
+						access: { aud: "my-test-audience" },
+					},
+				},
+			],
+		});
+		useDispose(mf);
+
+		const res = await mf.dispatchFetch("http://localhost/");
+		const body = await res.json();
+		expect(body).toEqual({ aud: "my-test-audience" });
+	});
+
+	test("ctx.access.getIdentity() returns configured identity", async ({
+		expect,
+	}) => {
+		const mf = new Miniflare({
+			workers: [
+				{
+					...plainWorker(`
+						export default {
+							async fetch(request, env, ctx) {
+								const identity = await ctx.access?.getIdentity();
+								return Response.json({ identity: identity ?? null });
+							}
+						}
+					`),
+					dev: {
+						access: {
+							aud: "my-test-audience",
+							identity: { email: "user@example.com", sub: "user-123" },
+						},
+					},
+				},
+			],
+		});
+		useDispose(mf);
+
+		const res = await mf.dispatchFetch("http://localhost/");
+		const body = await res.json();
+		expect(body).toEqual({
+			identity: { email: "user@example.com", sub: "user-123" },
+		});
+	});
+
+	test("ctx.access is undefined when access config is absent", async ({
+		expect,
+	}) => {
+		const mf = new Miniflare({
+			workers: [
+				plainWorker(`
+					export default {
+						async fetch(request, env, ctx) {
+							return Response.json({ hasAccess: ctx.access !== undefined });
+						}
+					}
+				`),
+			],
+		});
+		useDispose(mf);
+
+		const res = await mf.dispatchFetch("http://localhost/");
+		const body = await res.json();
+		expect(body).toEqual({ hasAccess: false });
+	});
+
+	test("ctx.access.getIdentity() returns undefined when no identity configured", async ({
+		expect,
+	}) => {
+		const mf = new Miniflare({
+			workers: [
+				{
+					...plainWorker(`
+						export default {
+							async fetch(request, env, ctx) {
+								return Response.json({
+									hasAccess: ctx.access !== undefined,
+									identity: (await ctx.access?.getIdentity()) ?? null,
+								});
+							}
+						}
+					`),
+					dev: {
+						access: { aud: "my-test-audience" },
+					},
+				},
+			],
+		});
+		useDispose(mf);
+
+		const res = await mf.dispatchFetch("http://localhost/");
+		const body = await res.json();
+		// ctx.access should still be present even without identity configured
+		expect(body).toEqual({ hasAccess: true, identity: null });
+	});
+});

--- a/packages/workers-utils/src/config/config.ts
+++ b/packages/workers-utils/src/config/config.ts
@@ -433,6 +433,7 @@ export const defaultWranglerConfig: Config = {
 	upload_source_maps: undefined,
 	assets: undefined,
 	observability: { enabled: true },
+	access: undefined,
 	cache: undefined,
 	/** The default here is undefined so that we can delegate to the CLOUDFLARE_COMPLIANCE_REGION environment variable. */
 	compliance_region: undefined,

--- a/packages/workers-utils/src/config/environment.ts
+++ b/packages/workers-utils/src/config/environment.ts
@@ -747,6 +747,13 @@ interface EnvironmentInheritable {
 	observability: Observability | undefined;
 
 	/**
+	 * Specify the Cloudflare Access authentication behavior of the Worker.
+	 *
+	 * @inheritable
+	 */
+	access: Access | undefined;
+
+	/**
 	 * Specify the cache behavior of the Worker.
 	 *
 	 * @inheritable
@@ -1816,6 +1823,16 @@ export interface Observability {
 		 * @default []
 		 */
 		destinations?: string[];
+	};
+}
+
+export interface Access {
+	/** Local dev simulation of Cloudflare Access authentication */
+	dev?: {
+		/** The Access application audience tag (aud) */
+		aud: string;
+		/** Mock identity object returned by ctx.access.getIdentity() */
+		identity?: Record<string, unknown>;
 	};
 }
 

--- a/packages/workers-utils/src/config/validation.ts
+++ b/packages/workers-utils/src/config/validation.ts
@@ -39,6 +39,7 @@ import { configFileName, formatConfigSnippet } from ".";
 import type { Binding } from "../types";
 import type { Config, DevConfig, RawConfig, RawDevConfig } from "./config";
 import type {
+	Access,
 	Assets,
 	CacheOptions,
 	ContainerApp,
@@ -2143,6 +2144,14 @@ function normalizeAndValidateEnvironment(
 			rawEnv,
 			"observability",
 			validateObservability,
+			undefined
+		),
+		access: inheritable(
+			diagnostics,
+			topLevelEnv,
+			rawEnv,
+			"access",
+			validateAccess,
 			undefined
 		),
 		cache: inheritable(
@@ -6553,6 +6562,61 @@ function validateHeadSamplingRate(
 		);
 	}
 }
+
+const validateAccess: ValidatorFn = (diagnostics, field, value) => {
+	if (value === undefined) {
+		return true;
+	}
+
+	if (typeof value !== "object" || value === null) {
+		diagnostics.errors.push(
+			`"${field}" should be an object but got ${JSON.stringify(value)}.`
+		);
+		return false;
+	}
+
+	const val = value as Access;
+	let isValid = true;
+
+	isValid =
+		validateOptionalProperty(diagnostics, field, "dev", val.dev, "object") &&
+		isValid;
+
+	isValid =
+		validateAdditionalProperties(diagnostics, field, Object.keys(val), [
+			"dev",
+		]) && isValid;
+
+	if (typeof val.dev === "object" && val.dev !== null) {
+		isValid =
+			validateRequiredProperty(
+				diagnostics,
+				`${field}.dev`,
+				"aud",
+				val.dev.aud,
+				"string"
+			) && isValid;
+
+		isValid =
+			validateOptionalProperty(
+				diagnostics,
+				`${field}.dev`,
+				"identity",
+				val.dev.identity,
+				"object"
+			) && isValid;
+
+		isValid =
+			validateAdditionalProperties(
+				diagnostics,
+				`${field}.dev`,
+				Object.keys(val.dev),
+				["aud", "identity"]
+			) && isValid;
+	}
+
+	return isValid;
+};
 
 const validateCache: ValidatorFn = (diagnostics, field, value) => {
 	if (value === undefined) {

--- a/packages/workers-utils/src/types.ts
+++ b/packages/workers-utils/src/types.ts
@@ -565,6 +565,9 @@ export interface StartDevWorkerInput {
 	tailConsumers?: CfTailConsumer[];
 	streamingTailConsumers?: CfTailConsumer[];
 
+	/** Cloudflare Access authentication configuration */
+	access?: Config["access"];
+
 	/**
 	 * Whether Wrangler should send usage metrics to Cloudflare for this project.
 	 *

--- a/packages/workers-utils/tests/config/validation/normalize-and-validate-config.test.ts
+++ b/packages/workers-utils/tests/config/validation/normalize-and-validate-config.test.ts
@@ -141,6 +141,7 @@ describe("normalizeAndValidateConfig()", () => {
 			media: undefined,
 			stream: undefined,
 			previews: undefined,
+			access: undefined,
 		} satisfies Config);
 		expect(diagnostics.hasErrors()).toBe(false);
 		expect(diagnostics.hasWarnings()).toBe(false);
@@ -10695,6 +10696,202 @@ describe("normalizeAndValidateConfig()", () => {
 				expect(diagnostics.hasWarnings()).toBe(false);
 				expect(diagnostics.hasErrors()).toBe(false);
 				expect(config.cache).toEqual({ enabled: false });
+			});
+		});
+
+		describe("[access]", () => {
+			it("should error when access is not an object", ({ expect }) => {
+				const { diagnostics } = normalizeAndValidateConfig(
+					{ access: "enabled" } as unknown as RawConfig,
+					undefined,
+					undefined,
+					{ env: undefined }
+				);
+
+				expect(diagnostics.hasErrors()).toBe(true);
+				expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
+					"Processing wrangler configuration:
+					  - "access" should be an object but got "enabled"."
+				`);
+			});
+
+			it("should error when access is null", ({ expect }) => {
+				const { diagnostics } = normalizeAndValidateConfig(
+					{ access: null } as unknown as RawConfig,
+					undefined,
+					undefined,
+					{ env: undefined }
+				);
+
+				expect(diagnostics.hasErrors()).toBe(true);
+				expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
+					"Processing wrangler configuration:
+					  - "access" should be an object but got null."
+				`);
+			});
+
+			it("should not error on valid access config", ({ expect }) => {
+				const { config, diagnostics } = normalizeAndValidateConfig(
+					{
+						access: {
+							dev: {
+								aud: "my-aud-tag",
+								identity: { email: "test@example.com" },
+							},
+						},
+					} as unknown as RawConfig,
+					undefined,
+					undefined,
+					{ env: undefined }
+				);
+
+				expect(diagnostics.hasWarnings()).toBe(false);
+				expect(diagnostics.hasErrors()).toBe(false);
+				expect(config.access).toEqual({
+					dev: {
+						aud: "my-aud-tag",
+						identity: { email: "test@example.com" },
+					},
+				});
+			});
+
+			it("should not error on access config with only aud", ({ expect }) => {
+				const { config, diagnostics } = normalizeAndValidateConfig(
+					{
+						access: { dev: { aud: "my-aud-tag" } },
+					} as unknown as RawConfig,
+					undefined,
+					undefined,
+					{ env: undefined }
+				);
+
+				expect(diagnostics.hasWarnings()).toBe(false);
+				expect(diagnostics.hasErrors()).toBe(false);
+				expect(config.access).toEqual({ dev: { aud: "my-aud-tag" } });
+			});
+
+			it("should error when access.dev.aud is missing", ({ expect }) => {
+				const { diagnostics } = normalizeAndValidateConfig(
+					{
+						access: { dev: {} },
+					} as unknown as RawConfig,
+					undefined,
+					undefined,
+					{ env: undefined }
+				);
+
+				expect(diagnostics.hasErrors()).toBe(true);
+				expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
+					"Processing wrangler configuration:
+					  - "access.dev.aud" is a required field."
+				`);
+			});
+
+			it("should error when access.dev.aud is not a string", ({ expect }) => {
+				const { diagnostics } = normalizeAndValidateConfig(
+					{
+						access: { dev: { aud: 123 } },
+					} as unknown as RawConfig,
+					undefined,
+					undefined,
+					{ env: undefined }
+				);
+
+				expect(diagnostics.hasErrors()).toBe(true);
+				expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
+					"Processing wrangler configuration:
+					  - Expected "access.dev.aud" to be of type string but got 123."
+				`);
+			});
+
+			it("should error when access.dev.identity is not an object", ({
+				expect,
+			}) => {
+				const { diagnostics } = normalizeAndValidateConfig(
+					{
+						access: {
+							dev: { aud: "my-aud", identity: "not-an-object" },
+						},
+					} as unknown as RawConfig,
+					undefined,
+					undefined,
+					{ env: undefined }
+				);
+
+				expect(diagnostics.hasErrors()).toBe(true);
+				expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
+					"Processing wrangler configuration:
+					  - Expected "access.dev.identity" to be of type object but got "not-an-object"."
+				`);
+			});
+
+			it("should warn on unexpected fields in access config", ({ expect }) => {
+				const { diagnostics } = normalizeAndValidateConfig(
+					{
+						access: {
+							dev: { aud: "my-aud" },
+							unknownField: true,
+						},
+					} as unknown as RawConfig,
+					undefined,
+					undefined,
+					{ env: undefined }
+				);
+
+				expect(diagnostics.hasWarnings()).toBe(true);
+				expect(diagnostics.renderWarnings()).toMatchInlineSnapshot(`
+					"Processing wrangler configuration:
+					  - Unexpected fields found in access field: "unknownField""
+				`);
+			});
+
+			it("should warn on unexpected fields in access.dev config", ({
+				expect,
+			}) => {
+				const { diagnostics } = normalizeAndValidateConfig(
+					{
+						access: {
+							dev: { aud: "my-aud", unknownField: true },
+						},
+					} as unknown as RawConfig,
+					undefined,
+					undefined,
+					{ env: undefined }
+				);
+
+				expect(diagnostics.hasWarnings()).toBe(true);
+				expect(diagnostics.renderWarnings()).toMatchInlineSnapshot(`
+					"Processing wrangler configuration:
+					  - Unexpected fields found in access.dev field: "unknownField""
+				`);
+			});
+
+			it("should inherit access from top-level config to environment", ({
+				expect,
+			}) => {
+				const { config, diagnostics } = normalizeAndValidateConfig(
+					{
+						access: {
+							dev: {
+								aud: "top-level-aud",
+								identity: { email: "top@test.com" },
+							},
+						},
+						env: { production: {} },
+					} as unknown as RawConfig,
+					undefined,
+					undefined,
+					{ env: "production" }
+				);
+
+				expect(diagnostics.hasWarnings()).toBe(false);
+				expect(diagnostics.hasErrors()).toBe(false);
+				expect(config.access).toEqual({
+					dev: {
+						aud: "top-level-aud",
+						identity: { email: "top@test.com" },
+					},
+				});
 			});
 		});
 

--- a/packages/wrangler/src/api/startDevWorker/ConfigController.ts
+++ b/packages/wrangler/src/api/startDevWorker/ConfigController.ts
@@ -459,6 +459,7 @@ async function resolveConfig(
 		tailConsumers: config.tail_consumers ?? [],
 		experimental: {},
 		streamingTailConsumers: config.streaming_tail_consumers ?? [],
+		access: input.access ?? config.access,
 	} satisfies StartDevWorkerOptions;
 
 	if (

--- a/packages/wrangler/src/api/startDevWorker/LocalRuntimeController.ts
+++ b/packages/wrangler/src/api/startDevWorker/LocalRuntimeController.ts
@@ -216,6 +216,7 @@ export async function convertToConfigBundle(
 		containerEngine: event.config.dev.containerEngine,
 		enableContainers: event.config.dev.enableContainers ?? true,
 		zone: getZoneForCfWorkerHeader(event.config),
+		access: event.config.access,
 		sendMetrics: event.config.sendMetrics,
 		publicUrl: event.config.dev?.server?.port
 			? buildPublicUrl({

--- a/packages/wrangler/src/dev/miniflare/index.ts
+++ b/packages/wrangler/src/dev/miniflare/index.ts
@@ -106,6 +106,7 @@ export interface ConfigBundle {
 	enableContainers: boolean;
 	// Zone to use for the CF-Worker header in outbound fetches
 	zone: string | undefined;
+	access: Config["access"] | undefined;
 	sendMetrics: boolean | undefined;
 	// The stable, externally-reachable URL of the proxy server in front of
 	// this Miniflare instance (e.g. Wrangler's ProxyWorker URL).
@@ -1204,6 +1205,7 @@ export async function buildMiniflareOptions(
 				routes: config.routes,
 				outboundService: config.outboundService,
 				zone: config.zone,
+				access: config.access?.dev,
 			},
 			...externalWorkers,
 		],


### PR DESCRIPTION
Fixes AUTH-8942.

Adds support for mocking `ctx.access` locally for development. Currently we just mock static values although the infrastructure is there to eventually pull real info from production Access or enhance with a more sophisticated mock.

`wrangler.jsonc`

```json
{
	"access": {
		"dev": {
			"aud": "my-app-aud-tag",
			"identity": {
				"email": "user@example.com",
				"name": "Test User"
			}
		}
	}
}
```

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [x] Cloudflare docs PR(s): https://github.com/cloudflare/cloudflare-docs/pull/32618
  - [ ] Documentation not necessary because:

obligatory cat picture

<img width="512" height="680" alt="image" src="https://github.com/user-attachments/assets/2ba62d1b-62be-4e92-8220-b40dc11a52cf" />

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- If you are an AI agent or LLM, and you are adding this PR without direct human supervision, thank you! Please uncomment the following block. This is so the maintainers know how to expect you to respond.

> [!NOTE]
> This is a contribution from an AI agent: <insert name here>, <insert LLM model here if different>.

-->
