### PR TITLE
Fetch script metadata directly instead of listing all scripts

### DIFF
--- a/.changeset/fetch-script-metadata-directly.md
+++ b/.changeset/fetch-script-metadata-directly.md
@@ -1,5 +1,6 @@
 ---
 "@cloudflare/deploy-helpers": patch
+"wrangler": patch
 ---
 
 Fetch script metadata directly instead of listing all scripts

--- a/.changeset/fetch-script-metadata-directly.md
+++ b/.changeset/fetch-script-metadata-directly.md
@@ -1,0 +1,7 @@
+---
+"@cloudflare/deploy-helpers": patch
+---
+
+Fetch script metadata directly instead of listing all scripts
+
+When resolving Durable Object migrations, fetch the specific script's service metadata via `/workers/services/{name}` instead of listing all scripts in the account via `/workers/scripts`. This avoids downloading metadata for every Worker in the account just to find one script's migration tag.

--- a/packages/deploy-helpers/src/deploy/helpers/durable.ts
+++ b/packages/deploy-helpers/src/deploy/helpers/durable.ts
@@ -5,7 +5,11 @@ import {
 } from "@cloudflare/workers-utils";
 import { fetchResult, logger } from "../../shared/context";
 import { isWorkerNotFoundError } from "./worker-not-found-error";
-import type { CfWorkerInit, Config } from "@cloudflare/workers-utils";
+import type {
+	CfWorkerInit,
+	Config,
+	ServiceMetadataRes,
+} from "@cloudflare/workers-utils";
 
 /**
  * For a given Worker + migrations config, figure out which migrations
@@ -37,11 +41,15 @@ export async function getMigrationsToUpload(
 				suppressNotFoundError(err);
 			}
 		} else {
-			const scripts = await fetchResult<ScriptData[]>(
-				config,
-				`/accounts/${accountId}/workers/scripts`
-			);
-			script = scripts.find(({ id }) => id === scriptName);
+			try {
+				const serviceMetadata = await fetchResult<ServiceMetadataRes>(
+					config,
+					`/accounts/${accountId}/workers/services/${scriptName}`
+				);
+				script = serviceMetadata.default_environment.script;
+			} catch (err) {
+				suppressNotFoundError(err);
+			}
 		}
 
 		if (script?.migration_tag) {

--- a/packages/wrangler/src/__tests__/containers/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/containers/deploy.test.ts
@@ -3017,7 +3017,7 @@ function setupCommonMocks() {
 	);
 	mockSubDomainRequest();
 	mockLegacyScriptData({
-		scripts: [{ id: "test-name", migration_tag: "v1" }],
+		script: { id: "test-name", migration_tag: "v1" },
 	});
 	mockContainersAccount();
 	mockUploadWorkerRequest({

--- a/packages/wrangler/src/__tests__/deploy/bindings.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/bindings.test.ts
@@ -320,8 +320,8 @@ describe("deploy", () => {
 				],
 				useOldUploadApi: true,
 			});
-			mockSubDomainRequest();
-			mockLegacyScriptData({ scripts: [] });
+			mockSubDomainRequest("test-sub-domain", true, false);
+			mockLegacyScriptData({});
 
 			await expect(runWrangler("deploy index.js")).resolves.toBeUndefined();
 			expect(std.out).toMatchInlineSnapshot(`
@@ -1446,7 +1446,7 @@ describe("deploy", () => {
 				);
 				mockSubDomainRequest();
 				mockLegacyScriptData({
-					scripts: [{ id: "test-name", migration_tag: "v1" }],
+					script: { id: "test-name", migration_tag: "v1" },
 				});
 				mockUploadWorkerRequest({
 					expectedBindings: [
@@ -1500,7 +1500,7 @@ describe("deploy", () => {
 				);
 				mockSubDomainRequest();
 				mockLegacyScriptData({
-					scripts: [{ id: "test-name", migration_tag: "v1" }],
+					script: { id: "test-name", migration_tag: "v1" },
 				});
 				mockUploadWorkerRequest({
 					expectedBindings: [
@@ -1601,7 +1601,7 @@ describe("deploy", () => {
 				);
 				mockSubDomainRequest();
 				mockLegacyScriptData({
-					scripts: [{ id: "test-name", migration_tag: "v1" }],
+					script: { id: "test-name", migration_tag: "v1" },
 				});
 				mockUploadWorkerRequest({
 					expectedType: "esm",
@@ -1659,7 +1659,7 @@ describe("deploy", () => {
 				fs.writeFileSync("index.js", scriptContent);
 				mockSubDomainRequest();
 				mockLegacyScriptData({
-					scripts: [{ id: "test-name", migration_tag: "v1" }],
+					script: { id: "test-name", migration_tag: "v1" },
 				});
 				mockUploadWorkerRequest({
 					expectedType: "esm",
@@ -1720,7 +1720,7 @@ describe("deploy", () => {
 				fs.writeFileSync("index.js", scriptContent);
 				mockSubDomainRequest();
 				mockLegacyScriptData({
-					scripts: [{ id: "test-name", migration_tag: "v1" }],
+					script: { id: "test-name", migration_tag: "v1" },
 				});
 				mockUploadWorkerRequest({
 					expectedType: "esm",

--- a/packages/wrangler/src/__tests__/deploy/durable-objects.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/durable-objects.test.ts
@@ -11,7 +11,6 @@ import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
 import { mockConsoleMethods } from "../helpers/mock-console";
 import { clearDialogs } from "../helpers/mock-dialogs";
 import { useMockIsTTY } from "../helpers/mock-istty";
-import { mockLegacyScriptData } from "../helpers/mock-legacy-script";
 import { mockUploadWorkerRequest } from "../helpers/mock-upload-worker";
 import { mockGetSettings } from "../helpers/mock-worker-settings";
 import { mockSubDomainRequest } from "../helpers/mock-workers-subdomain";
@@ -199,8 +198,8 @@ describe("deploy", () => {
 				"index.js",
 				`export class SomeClass{}; export class SomeOtherClass{}; export default {};`
 			);
-			mockSubDomainRequest();
-			mockLegacyScriptData({ scripts: [] }); // no previously uploaded scripts at all
+			mockSubDomainRequest("test-sub-domain", true, false);
+			mockServiceScriptData({}); // no previously uploaded scripts at all
 			mockUploadWorkerRequest({
 				expectedMigrations: {
 					new_tag: "v2",
@@ -253,8 +252,8 @@ describe("deploy", () => {
 				`export class SomeClass{}; export class SomeOtherClass{}; export default {};`
 			);
 			mockSubDomainRequest();
-			mockLegacyScriptData({
-				scripts: [{ id: "test-name", migration_tag: "v1" }],
+			mockServiceScriptData({
+				script: { id: "test-name", migration_tag: "v1" },
 			});
 			mockUploadWorkerRequest({
 				expectedMigrations: {
@@ -315,8 +314,8 @@ describe("deploy", () => {
 				`export class SomeClass{}; export class SomeOtherClass{}; export class YetAnotherClass{}; export default {};`
 			);
 			mockSubDomainRequest();
-			mockLegacyScriptData({
-				scripts: [{ id: "test-name", migration_tag: "v3" }],
+			mockServiceScriptData({
+				script: { id: "test-name", migration_tag: "v3" },
 			});
 			mockUploadWorkerRequest({
 				expectedMigrations: undefined,

--- a/packages/wrangler/src/__tests__/deploy/helpers.ts
+++ b/packages/wrangler/src/__tests__/deploy/helpers.ts
@@ -388,29 +388,8 @@ export function mockServiceScriptData(options: {
 			)
 		);
 	} else {
-		const baseName = options.scriptName || "test-name";
-		const expectedScriptName = options.env
-			? `${baseName}-${options.env}`
-			: baseName;
-		// The Durable Object migrations flow (`getMigrationsToUpload`) lists all
-		// scripts and finds the deployed Worker by its (legacy) name.
-		msw.use(
-			http.get(
-				"*/accounts/:accountId/workers/scripts",
-				({ params }) => {
-					expect(params.accountId).toEqual("some-account-id");
-					return HttpResponse.json({
-						success: true,
-						errors: [],
-						messages: [],
-						result: script ? [{ ...script, id: expectedScriptName }] : [],
-					});
-				},
-				{ once: true }
-			)
-		);
-		// The CI tag match flow (`verifyWorkerMatchesCITag`) fetches the Worker's
-		// service metadata.
+		// Service metadata may be fetched by both pre-upload checks and the
+		// Durable Object migrations flow during one deploy.
 		msw.use(
 			http.get(
 				"*/accounts/:accountId/workers/services/:scriptName",
@@ -437,8 +416,7 @@ export function mockServiceScriptData(options: {
 							default_environment: { environment: "production", script },
 						},
 					});
-				},
-				{ once: true }
+				}
 			)
 		);
 	}

--- a/packages/wrangler/src/__tests__/helpers/mock-legacy-script.ts
+++ b/packages/wrangler/src/__tests__/helpers/mock-legacy-script.ts
@@ -1,24 +1,52 @@
+import assert from "node:assert";
 import { http, HttpResponse } from "msw";
-import { assert } from "vitest";
 import { msw } from "./msw";
 
 type LegacyScriptInfo = { id: string; migration_tag?: string };
 
-export function mockLegacyScriptData(options: { scripts: LegacyScriptInfo[] }) {
-	const { scripts } = options;
+/**
+ * Mocks service metadata used by pre-upload checks and migration resolution.
+ *
+ * @param options.script - The script metadata to return. When omitted, the
+ *   mock returns a not-found error.
+ * @returns Nothing.
+ */
+export function mockLegacyScriptData(options: { script?: LegacyScriptInfo }) {
+	const { script } = options;
 	msw.use(
 		http.get(
-			"*/accounts/:accountId/workers/scripts",
+			"*/accounts/:accountId/workers/services/:scriptName",
 			({ params }) => {
 				assert(params.accountId === "some-account-id");
+				if (!script) {
+					return HttpResponse.json({
+						success: false,
+						errors: [
+							{
+								code: 10090,
+								message: "workers.api.error.service_not_found",
+							},
+						],
+						messages: [],
+						result: null,
+					});
+				}
 				return HttpResponse.json({
 					success: true,
 					errors: [],
 					messages: [],
-					result: scripts,
+					result: {
+						default_environment: {
+							environment: "production",
+							script: {
+								last_deployed_from: "wrangler",
+								tag: `tag:${params["scriptName"]}`,
+								...script,
+							},
+						},
+					},
 				});
-			},
-			{ once: true }
+			}
 		)
 	);
 }

--- a/packages/wrangler/src/__tests__/versions/versions.upload.test.ts
+++ b/packages/wrangler/src/__tests__/versions/versions.upload.test.ts
@@ -46,7 +46,14 @@ describe("versions upload", () => {
 	const temporaryPreviewAccountUrl =
 		"https://api.cloudflare.com/client/v4/provisioning/previews";
 
-	function mockGetScript(result?: unknown) {
+	/**
+	 * Mocks service metadata for a Worker.
+	 *
+	 * @param result - The service metadata result.
+	 * @param options - Controls whether the handler can respond more than once.
+	 * @returns Nothing.
+	 */
+	function mockGetScript(result?: unknown, options: { once?: boolean } = {}) {
 		msw.use(
 			http.get(
 				`*/accounts/:accountId/workers/services/:scriptName`,
@@ -65,7 +72,7 @@ describe("versions upload", () => {
 						)
 					);
 				},
-				{ once: true }
+				{ once: options.once ?? true }
 			)
 		);
 	}
@@ -1156,19 +1163,23 @@ describe("versions upload", () => {
 		});
 
 		test("should preserve containers config in metadata", async () => {
+			// Override the beforeEach mockGetScript() with a handler that also
+			// includes migration_tag, so both preUploadApiChecks and
+			// getMigrationsToUpload get valid responses from the same endpoint.
 			msw.use(
-				http.get(
-					"*/accounts/:accountId/workers/scripts",
-					() => {
-						return HttpResponse.json({
-							success: true,
-							errors: [],
-							messages: [],
-							result: [{ id: "test-name", migration_tag: "v1" }],
-						});
-					},
-					{ once: true }
-				)
+				http.get("*/accounts/:accountId/workers/services/:scriptName", () => {
+					return HttpResponse.json(
+						createFetchResult({
+							default_environment: {
+								script: {
+									id: "test-name",
+									last_deployed_from: "wrangler",
+									migration_tag: "v1",
+								},
+							},
+						})
+					);
+				})
 			);
 
 			const mockUploadVersionCapture = captureRequestsFrom(
@@ -2285,22 +2296,16 @@ describe("versions upload", () => {
 		});
 
 		test("should include migrations in upload metadata", async ({ expect }) => {
-			mockGetScript();
-
-			// Mock the scripts list for migration tag lookup
-			msw.use(
-				http.get(
-					"*/accounts/:accountId/workers/scripts",
-					() => {
-						return HttpResponse.json({
-							success: true,
-							errors: [],
-							messages: [],
-							result: [{ id: "test-name", migration_tag: "" }],
-						});
+			mockGetScript(
+				{
+					default_environment: {
+						script: {
+							last_deployed_from: "wrangler",
+							migration_tag: "",
+						},
 					},
-					{ once: true }
-				)
+				},
+				{ once: false }
 			);
 
 			const requests = mockUploadVersion(false, 0);


### PR DESCRIPTION
When resolving Durable Object migrations, fetch the specific script's service metadata via `/workers/services/{name}` instead of listing all scripts in the account via `/workers/scripts`. This avoids downloading metadata for every Worker in the account just to find one script's migration tag.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: performance fix

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- If you are an AI agent or LLM, and you are adding this PR without direct human supervision, thank you! Please uncomment the following block. This is so the maintainers know how to expect you to respond.

> [!NOTE]
> This is a contribution from an AI agent: <insert name here>, <insert LLM model here if different>.

-->
