### PR TITLE
Fix concurrent process race on single-use refresh tokens

### DIFF
--- a/.changeset/fix-concurrent-refresh-token-race.md
+++ b/.changeset/fix-concurrent-refresh-token-race.md
@@ -1,0 +1,9 @@
+---
+"@cloudflare/workers-auth": patch
+---
+
+Fix concurrent process race on single-use refresh tokens
+
+When multiple wrangler processes hit the token expiry window simultaneously, they could all read the same single-use refresh token and race to exchange it. The loser's exchange would fail with `invalid_grant`, potentially killing the refresh chain permanently until interactive re-login.
+
+The refresh operation is now serialized across processes on the same machine using an advisory file lock, and includes a retry-on-`invalid_grant` fallback that re-reads the token from disk in case a sibling process rotated it. Refresh failures are also now logged at warn level (previously debug-only) for easier diagnosis.

--- a/.changeset/fix-concurrent-refresh-token-race.md
+++ b/.changeset/fix-concurrent-refresh-token-race.md
@@ -1,0 +1,7 @@
+---
+"@cloudflare/workers-auth": patch
+---
+
+Fix concurrent process race on single-use refresh tokens
+
+Running several commands at the same time no longer risks invalidating your saved login, so you should no longer be unexpectedly asked to log in again. Refresh failures are now also surfaced as warnings for easier diagnosis.

--- a/packages/workers-auth/src/flow.ts
+++ b/packages/workers-auth/src/flow.ts
@@ -8,8 +8,10 @@ import { getOauthToken } from "./callback-server";
 import { getAPIToken, requireApiToken } from "./credentials";
 import { getOauthTokenViaDeviceFlow } from "./device-flow";
 import { getRevokeUrlFromEnv } from "./env-vars";
+import { ErrorInvalidGrant } from "./errors";
 import { generateAuthUrl as defaultGenerateAuthUrl } from "./generate-auth-url";
 import { generateRandomState as defaultGenerateRandomState } from "./generate-random-state";
+import { withRefreshLock } from "./refresh-lock";
 import { readStoredAuthState, type OAuthFlowState } from "./state";
 import { getOrCreateTemporaryPreviewAccount } from "./temporary";
 import { exchangeRefreshTokenForAccessToken } from "./token-exchange";
@@ -322,40 +324,143 @@ export function createOAuthFlow(ctx: OAuthFlowContext): OAuthFlowAPI {
 	}
 
 	async function refreshToken(profile?: string): Promise<boolean> {
-		// `exchangeRefreshTokenForAccessToken` reads the refresh token fresh from
-		// disk on every call, so we always pick up the latest rotation written by a
-		// sibling Wrangler process. Refresh tokens are single-use, so a long-lived
-		// process such as `wrangler dev` would otherwise send a stale value and get
-		// a 401 from the token endpoint.
 		const storage = getStorage(profile);
+		const lockDir = storage.path() + ".refresh-lock";
 
-		try {
-			const {
-				token: { value: oauth_token, expiry: expiration_time } = {
-					value: "",
-					expiry: "",
-				},
-				refreshToken: { value: refresh_token } = {},
-				scopes,
-			} = await exchangeRefreshTokenForAccessToken(
-				ctx.logger,
-				ctx.isNonInteractiveOrCI,
-				getClientId(),
-				storage
-			);
-			storage.write({
-				oauth_token,
-				expiration_time,
-				refresh_token,
-				scopes,
+		return withRefreshLock(lockDir, async () => {
+			// After acquiring the lock, re-read the auth state — a sibling
+			// process may have already completed the refresh while we waited.
+			const postLockState = readStoredAuthState({
+				warningLogger: ctx.logger,
+				storage,
 			});
+			if (
+				postLockState.accessToken &&
+				new Date() < new Date(postLockState.accessToken.expiry)
+			) {
+				return true;
+			}
+
+			// Snapshot the refresh token we're about to send so the retry
+			// logic can detect whether a sibling rotated it on disk.
+			const sentRefreshToken = postLockState.refreshToken?.value;
+
+			try {
+				return await doExchange(storage);
+			} catch (e) {
+				if (isInvalidGrantError(e)) {
+					return handleInvalidGrant(storage, sentRefreshToken, e);
+				}
+				ctx.logger.warn(
+					`Token refresh failed: ${e instanceof Error ? e.message : String(e)}`
+				);
+				return false;
+			}
+		});
+	}
+
+	/**
+	 * Execute the refresh-token exchange and persist the result.
+	 *
+	 * @param storage - The auth config storage to read from and write to.
+	 * @returns `true` on success.
+	 */
+	async function doExchange(storage: AuthConfigStorage): Promise<boolean> {
+		const {
+			token: { value: oauth_token, expiry: expiration_time } = {
+				value: "",
+				expiry: "",
+			},
+			refreshToken: { value: refresh_token } = {},
+			scopes,
+		} = await exchangeRefreshTokenForAccessToken(
+			ctx.logger,
+			ctx.isNonInteractiveOrCI,
+			getClientId(),
+			storage
+		);
+		storage.write({
+			oauth_token,
+			expiration_time,
+			refresh_token,
+			scopes,
+		});
+		return true;
+	}
+
+	/**
+	 * Handle an `invalid_grant` error from the token endpoint by checking
+	 * whether a sibling process has already rotated the refresh token on
+	 * disk. If so, either the sibling's refresh already produced a fresh
+	 * access token (skip) or the on-disk refresh token differs and we can
+	 * retry the exchange once with the new value.
+	 *
+	 * @param storage - The auth config storage.
+	 * @param sentRefreshToken - The refresh token value that was sent in the
+	 *   failed exchange, so we can detect on-disk rotation.
+	 * @param originalError - The original error for logging.
+	 * @returns `true` if the refresh ultimately succeeded, `false` otherwise.
+	 */
+	async function handleInvalidGrant(
+		storage: AuthConfigStorage,
+		sentRefreshToken: string | undefined,
+		originalError: unknown
+	): Promise<boolean> {
+		const freshState = readStoredAuthState({
+			warningLogger: ctx.logger,
+			storage,
+		});
+
+		if (
+			freshState.accessToken &&
+			new Date() < new Date(freshState.accessToken.expiry)
+		) {
 			return true;
-		} catch (e) {
-			ctx.logger.debug(
-				`Token refresh failed: ${e instanceof Error ? e.message : String(e)}`
-			);
-			return false;
 		}
+
+		if (
+			freshState.refreshToken?.value &&
+			freshState.refreshToken.value !== sentRefreshToken
+		) {
+			try {
+				return await doExchange(storage);
+			} catch (retryErr) {
+				ctx.logger.warn(
+					`Token refresh retry failed: ${retryErr instanceof Error ? retryErr.message : String(retryErr)}`
+				);
+				return false;
+			}
+		}
+
+		ctx.logger.warn(
+			`Token refresh failed: ${originalError instanceof Error ? originalError.message : String(originalError)}`
+		);
+		return false;
+	}
+
+	/**
+	 * Detect an `invalid_grant` error regardless of its shape.
+	 *
+	 * `exchangeRefreshTokenForAccessToken` can throw either:
+	 * - An `ErrorInvalidGrant` instance (structured error from `toErrorClass`)
+	 * - A plain object `{ error: "invalid_grant" }` (raw JSON from a >= 400 response)
+	 *
+	 * @param e - The caught error value.
+	 * @returns `true` if the error represents an `invalid_grant` OAuth error.
+	 */
+	function isInvalidGrantError(e: unknown): boolean {
+		if (e instanceof ErrorInvalidGrant) {
+			return true;
+		}
+		if (
+			typeof e === "object" &&
+			e !== null &&
+			"error" in e &&
+			(e as { error: unknown }).error === "invalid_grant"
+		) {
+			return true;
+		}
+		return false;
 	}
 
 	async function loginOrRefreshIfRequired(

--- a/packages/workers-auth/src/flow.ts
+++ b/packages/workers-auth/src/flow.ts
@@ -8,8 +8,10 @@ import { getOauthToken } from "./callback-server";
 import { getAPIToken, requireApiToken } from "./credentials";
 import { getOauthTokenViaDeviceFlow } from "./device-flow";
 import { getRevokeUrlFromEnv } from "./env-vars";
+import { ErrorInvalidGrant } from "./errors";
 import { generateAuthUrl as defaultGenerateAuthUrl } from "./generate-auth-url";
 import { generateRandomState as defaultGenerateRandomState } from "./generate-random-state";
+import { withRefreshLock } from "./refresh-lock";
 import { readStoredAuthState, type OAuthFlowState } from "./state";
 import { getOrCreateTemporaryPreviewAccount } from "./temporary";
 import { exchangeRefreshTokenForAccessToken } from "./token-exchange";
@@ -218,6 +220,16 @@ export function createOAuthFlow(ctx: OAuthFlowContext): OAuthFlowAPI {
 
 	let activeProfile = "default";
 
+	/**
+	 * In-flight refresh promises keyed by storage path, used to deduplicate
+	 * concurrent `refreshToken` calls within the same process. Without this,
+	 * two parallel API requests that both see an expired token would each try
+	 * to acquire the file lock — and because the lock is held by the same PID,
+	 * the second caller would wait out the full retry budget (~30 s) before
+	 * proceeding.
+	 */
+	const inflightRefreshes = new Map<string, Promise<boolean>>();
+
 	function getStorage(profile?: string): AuthConfigStorage {
 		return ctx.storageFactory(profile ?? activeProfile);
 	}
@@ -322,40 +334,207 @@ export function createOAuthFlow(ctx: OAuthFlowContext): OAuthFlowAPI {
 	}
 
 	async function refreshToken(profile?: string): Promise<boolean> {
-		// `exchangeRefreshTokenForAccessToken` reads the refresh token fresh from
-		// disk on every call, so we always pick up the latest rotation written by a
-		// sibling Wrangler process. Refresh tokens are single-use, so a long-lived
-		// process such as `wrangler dev` would otherwise send a stale value and get
-		// a 401 from the token endpoint.
 		const storage = getStorage(profile);
+		const storagePath = storage.path();
 
-		try {
-			const {
-				token: { value: oauth_token, expiry: expiration_time } = {
-					value: "",
-					expiry: "",
-				},
-				refreshToken: { value: refresh_token } = {},
-				scopes,
-			} = await exchangeRefreshTokenForAccessToken(
-				ctx.logger,
-				ctx.isNonInteractiveOrCI,
-				getClientId(),
-				storage
-			);
-			storage.write({
-				oauth_token,
-				expiration_time,
-				refresh_token,
-				scopes,
-			});
-			return true;
-		} catch (e) {
-			ctx.logger.debug(
-				`Token refresh failed: ${e instanceof Error ? e.message : String(e)}`
-			);
-			return false;
+		const existing = inflightRefreshes.get(storagePath);
+		if (existing) {
+			return existing;
 		}
+
+		const promise = doRefreshToken(storage);
+		inflightRefreshes.set(storagePath, promise);
+		try {
+			return await promise;
+		} finally {
+			inflightRefreshes.delete(storagePath);
+		}
+	}
+
+	/**
+	 * Perform the actual token refresh, serialized behind an advisory file lock.
+	 *
+	 * Callers should go through {@link refreshToken} which deduplicates
+	 * concurrent in-process calls.
+	 *
+	 * @param storage - The auth config storage to refresh against.
+	 * @returns `true` if the refresh succeeded, `false` otherwise.
+	 */
+	async function doRefreshToken(storage: AuthConfigStorage): Promise<boolean> {
+		const lockDir = storage.path() + ".refresh-lock";
+
+		return withRefreshLock(lockDir, async () => {
+			// After acquiring the lock, re-read the auth state — a sibling
+			// process may have already completed the refresh while we waited.
+			const postLockState = readStoredAuthState({
+				warningLogger: ctx.logger,
+				storage,
+			});
+			if (
+				postLockState.accessToken &&
+				new Date() < new Date(postLockState.accessToken.expiry)
+			) {
+				return true;
+			}
+
+			// Use the refresh token we just read so the same value is both sent
+			// to the server and compared in the retry logic — avoids a TOCTOU
+			// race where a sibling rotates the on-disk value between this read
+			// and the exchange function's independent read.
+			const sentRefreshToken = postLockState.refreshToken?.value;
+
+			try {
+				return await doExchange(storage, sentRefreshToken);
+			} catch (e) {
+				if (isInvalidGrantError(e)) {
+					return handleInvalidGrant(storage, sentRefreshToken, e);
+				}
+				ctx.logger.warn(`Token refresh failed: ${describeError(e)}`);
+				return false;
+			}
+		});
+	}
+
+	/**
+	 * Execute the refresh-token exchange and persist the result.
+	 *
+	 * @param storage - The auth config storage to write to.
+	 * @param refreshTokenValue - The refresh token value to send. Passing it
+	 *   explicitly avoids a second disk read inside
+	 *   `exchangeRefreshTokenForAccessToken` that could race with a sibling
+	 *   process rotating the on-disk value.
+	 * @returns `true` on success.
+	 */
+	async function doExchange(
+		storage: AuthConfigStorage,
+		refreshTokenValue?: string
+	): Promise<boolean> {
+		const {
+			token: { value: oauth_token, expiry: expiration_time } = {
+				value: "",
+				expiry: "",
+			},
+			refreshToken: { value: refresh_token } = {},
+			scopes,
+		} = await exchangeRefreshTokenForAccessToken(
+			ctx.logger,
+			ctx.isNonInteractiveOrCI,
+			getClientId(),
+			storage,
+			refreshTokenValue
+		);
+		storage.write({
+			oauth_token,
+			expiration_time,
+			refresh_token,
+			scopes,
+		});
+		return true;
+	}
+
+	/**
+	 * Handle an `invalid_grant` error from the token endpoint by checking
+	 * whether a sibling process has already rotated the refresh token on
+	 * disk. If so, either the sibling's refresh already produced a fresh
+	 * access token (skip) or the on-disk refresh token differs and we can
+	 * retry the exchange once with the new value.
+	 *
+	 * @param storage - The auth config storage.
+	 * @param sentRefreshToken - The refresh token value that was sent in the
+	 *   failed exchange, so we can detect on-disk rotation.
+	 * @param originalError - The original error for logging.
+	 * @returns `true` if the refresh ultimately succeeded, `false` otherwise.
+	 */
+	async function handleInvalidGrant(
+		storage: AuthConfigStorage,
+		sentRefreshToken: string | undefined,
+		originalError: unknown
+	): Promise<boolean> {
+		const freshState = readStoredAuthState({
+			warningLogger: ctx.logger,
+			storage,
+		});
+
+		if (
+			freshState.accessToken &&
+			new Date() < new Date(freshState.accessToken.expiry)
+		) {
+			return true;
+		}
+
+		if (
+			freshState.refreshToken?.value &&
+			freshState.refreshToken.value !== sentRefreshToken
+		) {
+			try {
+				return await doExchange(storage, freshState.refreshToken.value);
+			} catch (retryErr) {
+				ctx.logger.warn(
+					`Token refresh retry failed: ${describeError(retryErr)}`
+				);
+				return false;
+			}
+		}
+
+		ctx.logger.warn(`Token refresh failed: ${describeError(originalError)}`);
+		return false;
+	}
+
+	/**
+	 * Extract a human-readable message from an unknown thrown value.
+	 *
+	 * `exchangeRefreshTokenForAccessToken` can throw plain objects (the raw
+	 * parsed JSON body for >= 400 responses, e.g. `{ error: "invalid_grant",
+	 * error_description: "..." }`), `Error` instances, or strings. Using
+	 * `String()` on a plain object produces the unhelpful `"[object Object]"`,
+	 * so this helper prefers the OAuth `error` / `error_description` fields
+	 * when available.
+	 *
+	 * @param e - The caught error value.
+	 * @returns A readable string suitable for a user-facing warning.
+	 */
+	function describeError(e: unknown): string {
+		if (e instanceof Error) {
+			return e.message;
+		}
+		if (typeof e === "string") {
+			return e;
+		}
+		if (typeof e === "object" && e !== null) {
+			const obj = e as Record<string, unknown>;
+			if (typeof obj.error === "string") {
+				return obj.error_description
+					? `${obj.error}: ${obj.error_description}`
+					: obj.error;
+			}
+			return JSON.stringify(e);
+		}
+		return String(e);
+	}
+
+	/**
+	 * Detect an `invalid_grant` error regardless of its shape.
+	 *
+	 * `exchangeRefreshTokenForAccessToken` can throw either:
+	 * - An `ErrorInvalidGrant` instance (structured error from `toErrorClass`)
+	 * - A plain object `{ error: "invalid_grant" }` (raw JSON from a >= 400 response)
+	 *
+	 * @param e - The caught error value.
+	 * @returns `true` if the error represents an `invalid_grant` OAuth error.
+	 */
+	function isInvalidGrantError(e: unknown): boolean {
+		if (e instanceof ErrorInvalidGrant) {
+			return true;
+		}
+		if (
+			typeof e === "object" &&
+			e !== null &&
+			"error" in e &&
+			(e as { error: unknown }).error === "invalid_grant"
+		) {
+			return true;
+		}
+		return false;
 	}
 
 	async function loginOrRefreshIfRequired(

--- a/packages/workers-auth/src/refresh-lock.ts
+++ b/packages/workers-auth/src/refresh-lock.ts
@@ -1,0 +1,235 @@
+import { mkdirSync, statSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { readFileSync, removeDirSync } from "@cloudflare/workers-utils";
+
+interface LockInfo {
+	pid: number;
+	timestamp: number;
+}
+
+/**
+ * Maximum age (in ms) before a lock held by a **dead** process is considered
+ * stale. A healthy refresh spans one network round-trip (~500 ms), but a slow
+ * connection or a debugger-paused process could take longer.
+ */
+const STALE_THRESHOLD_MS = 30_000;
+
+/**
+ * Grace period (in ms) for a lock directory whose `info.json` is missing.
+ * Between `mkdirSync` and `writeLockInfo` there is a brief window where the
+ * directory exists but the info file does not. Treating that as immediately
+ * stale would let a sibling break the lock out from under the acquirer
+ * (TOCTOU). We give the acquirer this much time to finish writing.
+ */
+const LOCK_GRACE_MS = 5_000;
+
+/** How many times to retry lock acquisition before giving up. */
+const MAX_RETRIES = 5;
+
+/** Delay (ms) between retry attempts. */
+const RETRY_DELAY_MS = 200;
+
+/**
+ * Name of the file written inside the lock directory to record the
+ * owning process.
+ */
+const LOCK_INFO_FILE = "info.json";
+
+/**
+ * @param ms - The number of milliseconds to sleep.
+ * @returns A promise that resolves after the given delay.
+ */
+function sleep(ms: number): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Read the lock-info file inside an existing lock directory.
+ *
+ * @param lockDir - Path to the lock directory.
+ * @returns The parsed lock info, or `undefined` if the file is missing/corrupt.
+ */
+function readLockInfo(lockDir: string): LockInfo | undefined {
+	const infoPath = path.join(lockDir, LOCK_INFO_FILE);
+	try {
+		const raw = readFileSync(infoPath);
+		return JSON.parse(raw) as LockInfo;
+	} catch {
+		return undefined;
+	}
+}
+
+/**
+ * Write the lock-info file into an already-created lock directory.
+ *
+ * @param lockDir - Path to the lock directory.
+ */
+function writeLockInfo(lockDir: string): void {
+	const info: LockInfo = { pid: process.pid, timestamp: Date.now() };
+	writeFileSync(
+		path.join(lockDir, LOCK_INFO_FILE),
+		JSON.stringify(info),
+		"utf-8"
+	);
+}
+
+/**
+ * Check whether a given PID corresponds to a running process.
+ *
+ * @param pid - The process ID to check.
+ * @returns `true` if the process is alive, `false` otherwise.
+ */
+function isProcessAlive(pid: number): boolean {
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Determine whether an existing lock is stale.
+ *
+ * A lock is stale when:
+ * - The info file exists and the owning process is dead.
+ * - The info file exists, the process is dead, and the lock has aged past
+ *   {@link STALE_THRESHOLD_MS}.
+ * - The info file is missing and the directory is older than
+ *   {@link LOCK_GRACE_MS} (the acquirer had enough time to write it).
+ *
+ * A lock is **not** stale when:
+ * - The info file is missing but the directory was created recently (the
+ *   acquirer is mid-write — breaking it would be a TOCTOU race).
+ * - The info file exists and the owning process is alive (even if the lock
+ *   is old — a slow but legitimate refresh should not be evicted).
+ *
+ * @param lockDir - Path to the lock directory.
+ * @returns `true` if the lock should be broken, `false` if it is still valid.
+ */
+function isLockStale(lockDir: string): boolean {
+	const info = readLockInfo(lockDir);
+	if (!info) {
+		// No info file — could be a sibling mid-acquisition (dir created,
+		// info.json not yet written). Only treat as stale if the directory
+		// itself is older than the grace period.
+		return isDirOlderThan(lockDir, LOCK_GRACE_MS);
+	}
+	if (!isProcessAlive(info.pid)) {
+		return true;
+	}
+	// The holder is alive — don't evict it. A slow-but-legitimate refresh
+	// (debugger-paused, slow network, suspended laptop) should keep its
+	// lock. The invalid_grant retry in the caller is the safety net.
+	return false;
+}
+
+/**
+ * Check whether a directory's mtime is older than a given threshold.
+ *
+ * @param dirPath - Path to the directory.
+ * @param thresholdMs - Age threshold in milliseconds.
+ * @returns `true` if the directory is older than the threshold, or if the
+ *   stat fails (directory may have been removed).
+ */
+function isDirOlderThan(dirPath: string, thresholdMs: number): boolean {
+	try {
+		const stats = statSync(dirPath);
+		return Date.now() - stats.mtimeMs > thresholdMs;
+	} catch {
+		return true;
+	}
+}
+
+/**
+ * Forcibly remove a stale lock directory.
+ *
+ * @param lockDir - Path to the lock directory to break.
+ */
+function breakLock(lockDir: string): void {
+	removeDirSync(lockDir);
+}
+
+/**
+ * Try to acquire the advisory lock once.
+ *
+ * @param lockDir - Path to the lock directory.
+ * @returns `true` if the lock was acquired, `false` if it is held by another process.
+ */
+function tryAcquire(lockDir: string): boolean {
+	try {
+		mkdirSync(lockDir);
+		writeLockInfo(lockDir);
+		return true;
+	} catch (e: unknown) {
+		if ((e as NodeJS.ErrnoException).code === "EEXIST") {
+			if (isLockStale(lockDir)) {
+				breakLock(lockDir);
+				try {
+					mkdirSync(lockDir);
+					writeLockInfo(lockDir);
+					return true;
+				} catch {
+					return false;
+				}
+			}
+			return false;
+		}
+		throw e;
+	}
+}
+
+/**
+ * Release the advisory lock by removing the lock directory.
+ *
+ * @param lockDir - Path to the lock directory.
+ */
+function releaseLock(lockDir: string): void {
+	removeDirSync(lockDir);
+}
+
+/**
+ * Acquire an advisory file lock, execute `fn`, and release the lock.
+ *
+ * The lock serializes the OAuth token refresh across sibling wrangler
+ * processes on the same machine. If the lock cannot be acquired after
+ * {@link MAX_RETRIES} attempts (e.g. a sibling is legitimately mid-refresh),
+ * `fn` is executed without the lock — the retry-on-`invalid_grant` logic in
+ * the caller provides a safety net.
+ *
+ * @param lockDir - Path to use as the lock directory (e.g. `storage.path() + '.refresh-lock'`).
+ * @param fn - The async function to execute while holding the lock.
+ * @returns The return value of `fn`.
+ */
+export async function withRefreshLock<T>(
+	lockDir: string,
+	fn: () => Promise<T>
+): Promise<T> {
+	let acquired = false;
+	for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
+		if (tryAcquire(lockDir)) {
+			acquired = true;
+			break;
+		}
+		await sleep(RETRY_DELAY_MS);
+	}
+
+	try {
+		return await fn();
+	} finally {
+		if (acquired) {
+			releaseLock(lockDir);
+		}
+	}
+}
+
+/**
+ * Visible for testing only — the constants governing lock behaviour.
+ */
+export const _TEST_CONSTANTS = {
+	STALE_THRESHOLD_MS,
+	LOCK_GRACE_MS,
+	MAX_RETRIES,
+	RETRY_DELAY_MS,
+	LOCK_INFO_FILE,
+} as const;

--- a/packages/workers-auth/src/refresh-lock.ts
+++ b/packages/workers-auth/src/refresh-lock.ts
@@ -1,0 +1,256 @@
+import { mkdirSync, statSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { readFileSync, removeDirSync } from "@cloudflare/workers-utils";
+
+interface LockInfo {
+	pid: number;
+}
+
+/**
+ * Grace period (in ms) for a lock directory whose `info.json` is missing.
+ * Between `mkdirSync` and `writeLockInfo` there is a brief window where the
+ * directory exists but the info file does not. Treating that as immediately
+ * stale would let a sibling break the lock out from under the acquirer
+ * (TOCTOU). We give the acquirer this much time to finish writing.
+ */
+const LOCK_GRACE_MS = 5_000;
+
+/** How many times to retry lock acquisition before giving up. */
+const MAX_RETRIES = 15;
+
+/** Delay (ms) between retry attempts. */
+const RETRY_DELAY_MS = 2_000;
+
+/**
+ * Name of the file written inside the lock directory to record the
+ * owning process.
+ */
+const LOCK_INFO_FILE = "info.json";
+
+/**
+ * @param ms - The number of milliseconds to sleep.
+ * @returns A promise that resolves after the given delay.
+ */
+function sleep(ms: number): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Read the lock-info file inside an existing lock directory.
+ *
+ * @param lockDir - Path to the lock directory.
+ * @returns The parsed lock info, or `undefined` if the file is missing/corrupt.
+ */
+function readLockInfo(lockDir: string): LockInfo | undefined {
+	const infoPath = path.join(lockDir, LOCK_INFO_FILE);
+	try {
+		const raw = readFileSync(infoPath);
+		return JSON.parse(raw) as LockInfo;
+	} catch {
+		return undefined;
+	}
+}
+
+/**
+ * Write the lock-info file into an already-created lock directory.
+ *
+ * @param lockDir - Path to the lock directory.
+ */
+function writeLockInfo(lockDir: string): void {
+	const info: LockInfo = { pid: process.pid };
+	writeFileSync(
+		path.join(lockDir, LOCK_INFO_FILE),
+		JSON.stringify(info),
+		"utf-8"
+	);
+}
+
+/**
+ * Check whether a given PID corresponds to a running process.
+ *
+ * @param pid - The process ID to check.
+ * @returns `true` if the process is alive, `false` otherwise.
+ */
+function isProcessAlive(pid: number): boolean {
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Determine whether an existing lock is stale.
+ *
+ * A lock is stale when:
+ * - The info file exists and the owning process is dead.
+ * - The info file is missing and the directory is older than
+ *   {@link LOCK_GRACE_MS} (the acquirer had enough time to write it).
+ *
+ * A lock is **not** stale when:
+ * - The info file is missing but the directory was created recently (the
+ *   acquirer is mid-write — breaking it would be a TOCTOU race).
+ * - The info file exists and the owning process is alive (even if the lock
+ *   is old — a slow but legitimate refresh should not be evicted).
+ *
+ * @param lockDir - Path to the lock directory.
+ * @returns `true` if the lock should be broken, `false` if it is still valid.
+ */
+function isLockStale(lockDir: string): boolean {
+	const info = readLockInfo(lockDir);
+	if (!info) {
+		// No info file — could be a sibling mid-acquisition (dir created,
+		// info.json not yet written). Only treat as stale if the directory
+		// itself is older than the grace period.
+		return isDirOlderThan(lockDir, LOCK_GRACE_MS);
+	}
+	if (!isProcessAlive(info.pid)) {
+		return true;
+	}
+	// The holder is alive — don't evict it. A slow-but-legitimate refresh
+	// (debugger-paused, slow network, suspended laptop) should keep its
+	// lock. The invalid_grant retry in the caller is the safety net.
+	return false;
+}
+
+/**
+ * Check whether a directory's mtime is older than a given threshold.
+ *
+ * @param dirPath - Path to the directory.
+ * @param thresholdMs - Age threshold in milliseconds.
+ * @returns `true` if the directory is older than the threshold, or if the
+ *   stat fails (directory may have been removed).
+ */
+function isDirOlderThan(dirPath: string, thresholdMs: number): boolean {
+	try {
+		const stats = statSync(dirPath);
+		return Date.now() - stats.mtimeMs > thresholdMs;
+	} catch {
+		return true;
+	}
+}
+
+/**
+ * Forcibly remove a stale lock directory.
+ *
+ * @param lockDir - Path to the lock directory to break.
+ */
+function breakLock(lockDir: string): void {
+	removeDirSync(lockDir);
+}
+
+/**
+ * Result of a single lock-acquisition attempt.
+ *
+ * - `"acquired"` — the lock was successfully taken.
+ * - `"contended"` — another process holds the lock (`EEXIST`); retrying may succeed.
+ * - `"unavailable"` — a permanent filesystem error (e.g. `EACCES`, `ENOENT`);
+ *   retrying will not help.
+ */
+type AcquireResult = "acquired" | "contended" | "unavailable";
+
+/**
+ * Try to acquire the advisory lock once.
+ *
+ * @param lockDir - Path to the lock directory.
+ * @returns The acquisition result.
+ */
+function tryAcquire(lockDir: string): AcquireResult {
+	try {
+		mkdirSync(lockDir);
+		try {
+			writeLockInfo(lockDir);
+		} catch {
+			// Created the directory but failed to write the owner record — clean
+			// up so siblings aren't blocked by a lock nobody holds.
+			breakLock(lockDir);
+			return "unavailable";
+		}
+		return "acquired";
+	} catch (e: unknown) {
+		if ((e as NodeJS.ErrnoException).code === "EEXIST") {
+			if (isLockStale(lockDir)) {
+				breakLock(lockDir);
+				try {
+					mkdirSync(lockDir);
+					writeLockInfo(lockDir);
+					return "acquired";
+				} catch {
+					return "contended";
+				}
+			}
+			return "contended";
+		}
+		// Any other filesystem error (EACCES, EROFS, ENOSPC, etc.) means we
+		// cannot take the lock; retrying will not help.
+		return "unavailable";
+	}
+}
+
+/**
+ * Release the advisory lock by removing the lock directory.
+ *
+ * @param lockDir - Path to the lock directory.
+ */
+function releaseLock(lockDir: string): void {
+	removeDirSync(lockDir);
+}
+
+/**
+ * Acquire an advisory file lock, execute `fn`, and release the lock.
+ *
+ * The lock serializes the OAuth token refresh across sibling wrangler
+ * processes on the same machine. If the lock cannot be acquired after
+ * {@link MAX_RETRIES} attempts (e.g. a sibling is legitimately mid-refresh),
+ * `fn` is executed without the lock — the retry-on-`invalid_grant` logic in
+ * the caller provides a safety net.
+ *
+ * @param lockDir - Path to use as the lock directory (e.g. `storage.path() + '.refresh-lock'`).
+ * @param fn - The async function to execute while holding the lock.
+ * @param options - Optional overrides for retry behaviour (test-only).
+ * @param options.maxRetries - Number of lock-acquisition attempts.
+ * @param options.retryDelayMs - Delay between attempts in milliseconds.
+ * @returns The return value of `fn`.
+ */
+export async function withRefreshLock<T>(
+	lockDir: string,
+	fn: () => Promise<T>,
+	options?: { maxRetries?: number; retryDelayMs?: number }
+): Promise<T> {
+	const maxRetries = options?.maxRetries ?? MAX_RETRIES;
+	const retryDelayMs = options?.retryDelayMs ?? RETRY_DELAY_MS;
+
+	let acquired = false;
+	for (let attempt = 0; attempt < maxRetries; attempt++) {
+		const result = tryAcquire(lockDir);
+		if (result === "acquired") {
+			acquired = true;
+			break;
+		}
+		if (result === "unavailable") {
+			break;
+		}
+		if (attempt < maxRetries - 1) {
+			await sleep(retryDelayMs);
+		}
+	}
+
+	try {
+		return await fn();
+	} finally {
+		if (acquired) {
+			releaseLock(lockDir);
+		}
+	}
+}
+
+/**
+ * Visible for testing only — the constants governing lock behaviour.
+ */
+export const _TEST_CONSTANTS = {
+	LOCK_GRACE_MS,
+	MAX_RETRIES,
+	RETRY_DELAY_MS,
+	LOCK_INFO_FILE,
+} as const;

--- a/packages/workers-auth/src/token-exchange.ts
+++ b/packages/workers-auth/src/token-exchange.ts
@@ -130,19 +130,32 @@ export async function getAuthURL(
 
 /**
  * Refresh an access token from the remote service.
+ *
+ * @param logger - Logger for diagnostics.
+ * @param isNonInteractiveOrCI - Whether the environment is non-interactive.
+ * @param clientId - The OAuth client ID.
+ * @param storage - Auth config storage to read the refresh token from (used
+ *   only when `refreshToken` is not supplied).
+ * @param refreshToken - When provided, this value is sent instead of
+ *   re-reading from storage. Callers that already hold a snapshot of the
+ *   token should pass it here to avoid a TOCTOU race where a sibling
+ *   rotates the on-disk value between the caller's read and this function's
+ *   independent read.
+ * @returns The access context containing the new access token.
  */
 export async function exchangeRefreshTokenForAccessToken(
 	logger: OAuthFlowContext["logger"],
 	isNonInteractiveOrCI: OAuthFlowContext["isNonInteractiveOrCI"],
 	clientId: string,
-	storage: AuthConfigStorage
+	storage: AuthConfigStorage,
+	refreshToken?: string
 ): Promise<AccessContext> {
-	// Read the refresh token fresh from disk on every call so we always pick up
-	// the latest rotation written by a sibling Wrangler process.
-	const storedRefreshToken = readStoredAuthState({
-		warningLogger: logger,
-		storage,
-	}).refreshToken;
+	const storedRefreshToken = refreshToken
+		? { value: refreshToken }
+		: readStoredAuthState({
+				warningLogger: logger,
+				storage,
+			}).refreshToken;
 	if (!storedRefreshToken) {
 		logger.warn("No refresh token is present.");
 	}

--- a/packages/workers-auth/tests/flow-refresh.test.ts
+++ b/packages/workers-auth/tests/flow-refresh.test.ts
@@ -1,0 +1,383 @@
+import os from "node:os";
+import path from "node:path";
+import { http, HttpResponse } from "msw";
+import { setupServer } from "msw/node";
+import {
+	afterAll,
+	afterEach,
+	beforeAll,
+	beforeEach,
+	describe,
+	it,
+} from "vitest";
+import { clearAccessCaches } from "../src/access";
+import { createOAuthFlow } from "../src/flow";
+import type {
+	AuthConfigStorage,
+	UserAuthConfig,
+} from "../src/config-file/auth";
+import type { OAuthFlowContext } from "../src/context";
+import type { ComplianceConfig } from "@cloudflare/workers-utils";
+
+const msw = setupServer();
+
+beforeAll(() => msw.listen({ onUnhandledRequest: "error" }));
+afterEach(() => {
+	msw.restoreHandlers();
+	msw.resetHandlers();
+});
+afterAll(() => msw.close());
+
+const COMPLIANCE_CONFIG: ComplianceConfig = { compliance_region: undefined };
+
+const PAST_DATE = new Date(Date.now() - 100_000_000).toISOString();
+const FUTURE_DATE = new Date(Date.now() + 100_000_000).toISOString();
+
+/**
+ * Create a test context wired to an in-memory storage backend.
+ *
+ * @returns The context, the logs array, and a handle to the storage so
+ *   tests can manipulate the "on-disk" state between calls.
+ */
+function createTestContext(): {
+	ctx: OAuthFlowContext;
+	logs: { level: string; message: string }[];
+	storage: AuthConfigStorage;
+} {
+	const logs: { level: string; message: string }[] = [];
+	let stored: UserAuthConfig | undefined;
+
+	const storage: AuthConfigStorage = {
+		read: () => stored,
+		write: (config: UserAuthConfig) => {
+			stored = config;
+		},
+		clear: () => {
+			const existed = stored !== undefined;
+			stored = undefined;
+			return existed;
+		},
+		path: () => path.join(os.tmpdir(), "workers-auth-test-config"),
+	};
+
+	const logger: OAuthFlowContext["logger"] = {
+		debug: (...args: unknown[]) => {
+			logs.push({ level: "debug", message: args.join(" ") });
+		},
+		info: (...args: unknown[]) => {
+			logs.push({ level: "info", message: args.join(" ") });
+		},
+		log: (...args: unknown[]) => {
+			logs.push({ level: "log", message: args.join(" ") });
+		},
+		warn: (...args: unknown[]) => {
+			logs.push({ level: "warn", message: args.join(" ") });
+		},
+		error: (...args: unknown[]) => {
+			logs.push({ level: "error", message: args.join(" ") });
+		},
+	};
+
+	return {
+		logs,
+		storage,
+		ctx: {
+			logger,
+			isNonInteractiveOrCI: () => true,
+			openInBrowser: async () => {},
+			hasEnvCredentials: () => false,
+			clientId: "test-client-id",
+			consent: {
+				granted: { url: "https://example.com/granted" },
+				denied: {
+					url: "https://example.com/denied",
+					error: "consent denied",
+				},
+			},
+			displayName: "TestCLI",
+			deviceLoginCommand: "testcli auth login --device",
+			redirectUri: "http://localhost:9999/oauth/callback",
+			storageFactory: () => storage,
+			allowGlobalAuthKey: true,
+			temporary: undefined,
+		},
+	};
+}
+
+/** Handle the Cloudflare Access probe. */
+function mockAccessProbe() {
+	return http.get(
+		"https://dash.cloudflare.com/",
+		() => new HttpResponse(null, { status: 200 })
+	);
+}
+
+/**
+ * Return an MSW handler that always succeeds for the token endpoint.
+ *
+ * @param overrides - Optional overrides for the response body.
+ * @returns An MSW handler for `POST *​/oauth2/token`.
+ */
+function mockTokenSuccess(overrides: Record<string, unknown> = {}) {
+	return http.post("*/oauth2/token", () =>
+		HttpResponse.json({
+			access_token: "fresh-access-token",
+			expires_in: 3600,
+			refresh_token: "RT_NEXT",
+			scope: "account:read",
+			token_type: "bearer",
+			...overrides,
+		})
+	);
+}
+
+describe("refreshToken (via loginOrRefreshIfRequired)", () => {
+	beforeEach(() => {
+		clearAccessCaches();
+	});
+
+	it("refreshes an expired token and persists the result", async ({
+		expect,
+	}) => {
+		const { ctx, storage } = createTestContext();
+		storage.write({
+			oauth_token: "expired-access",
+			refresh_token: "RT_A",
+			expiration_time: PAST_DATE,
+			scopes: ["account:read"],
+		});
+
+		msw.use(mockAccessProbe(), mockTokenSuccess());
+
+		const flow = createOAuthFlow(ctx);
+		const result = await flow.loginOrRefreshIfRequired({
+			complianceConfig: COMPLIANCE_CONFIG,
+			scopes: ["account:read"],
+		});
+
+		expect(result).toEqual({ loggedIn: true });
+		const written = storage.read();
+		expect(written?.oauth_token).toBe("fresh-access-token");
+		expect(written?.refresh_token).toBe("RT_NEXT");
+	});
+
+	it("skips the exchange when the token is already fresh after lock acquisition", async ({
+		expect,
+	}) => {
+		const { ctx, storage } = createTestContext();
+		// Token is not expired — no exchange should happen.
+		storage.write({
+			oauth_token: "still-valid",
+			refresh_token: "RT_A",
+			expiration_time: FUTURE_DATE,
+			scopes: ["account:read"],
+		});
+
+		// No MSW handler for token endpoint — if an exchange is attempted,
+		// the test will fail with "unhandled request".
+		msw.use(mockAccessProbe());
+
+		const flow = createOAuthFlow(ctx);
+		const result = await flow.loginOrRefreshIfRequired({
+			complianceConfig: COMPLIANCE_CONFIG,
+			scopes: ["account:read"],
+		});
+
+		expect(result).toEqual({ loggedIn: true });
+	});
+
+	it("retries on invalid_grant when a sibling rotated the refresh token", async ({
+		expect,
+	}) => {
+		const { ctx, storage } = createTestContext();
+		storage.write({
+			oauth_token: "expired-access",
+			refresh_token: "RT_A",
+			expiration_time: PAST_DATE,
+			scopes: ["account:read"],
+		});
+
+		let callCount = 0;
+		msw.use(
+			mockAccessProbe(),
+			http.post("*/oauth2/token", async ({ request }) => {
+				callCount++;
+				const body = new URLSearchParams(await request.text());
+				const rt = body.get("refresh_token");
+
+				if (rt === "RT_A") {
+					// Simulate the first exchange failing because a sibling
+					// already consumed RT_A. Before the retry, we also update
+					// the "disk" to simulate the sibling's write.
+					storage.write({
+						oauth_token: "expired-access",
+						refresh_token: "RT_B",
+						expiration_time: PAST_DATE,
+						scopes: ["account:read"],
+					});
+					return HttpResponse.json({ error: "invalid_grant" }, { status: 400 });
+				}
+				// RT_B succeeds.
+				return HttpResponse.json({
+					access_token: "fresh-from-retry",
+					expires_in: 3600,
+					refresh_token: "RT_C",
+					scope: "account:read",
+					token_type: "bearer",
+				});
+			})
+		);
+
+		const flow = createOAuthFlow(ctx);
+		const result = await flow.loginOrRefreshIfRequired({
+			complianceConfig: COMPLIANCE_CONFIG,
+			scopes: ["account:read"],
+		});
+
+		expect(result).toEqual({ loggedIn: true });
+		expect(callCount).toBe(2);
+		const written = storage.read();
+		expect(written?.oauth_token).toBe("fresh-from-retry");
+		expect(written?.refresh_token).toBe("RT_C");
+	});
+
+	it("succeeds without retry when a sibling already completed the refresh", async ({
+		expect,
+	}) => {
+		const { ctx, storage } = createTestContext();
+		storage.write({
+			oauth_token: "expired-access",
+			refresh_token: "RT_A",
+			expiration_time: PAST_DATE,
+			scopes: ["account:read"],
+		});
+
+		let callCount = 0;
+		msw.use(
+			mockAccessProbe(),
+			http.post("*/oauth2/token", async () => {
+				callCount++;
+				// Before returning the error, simulate the sibling having
+				// completed a full refresh (fresh access token on disk).
+				storage.write({
+					oauth_token: "sibling-refreshed-token",
+					refresh_token: "RT_B",
+					expiration_time: FUTURE_DATE,
+					scopes: ["account:read"],
+				});
+				return HttpResponse.json({ error: "invalid_grant" }, { status: 400 });
+			})
+		);
+
+		const flow = createOAuthFlow(ctx);
+		const result = await flow.loginOrRefreshIfRequired({
+			complianceConfig: COMPLIANCE_CONFIG,
+			scopes: ["account:read"],
+		});
+
+		expect(result).toEqual({ loggedIn: true });
+		// Only one call — no retry needed because the sibling already
+		// wrote a fresh access token.
+		expect(callCount).toBe(1);
+	});
+
+	it("gives up when invalid_grant and the on-disk token hasn't changed", async ({
+		expect,
+	}) => {
+		const { ctx, storage } = createTestContext();
+		storage.write({
+			oauth_token: "expired-access",
+			refresh_token: "RT_A",
+			expiration_time: PAST_DATE,
+			scopes: ["account:read"],
+		});
+
+		msw.use(
+			mockAccessProbe(),
+			http.post("*/oauth2/token", async () => {
+				return HttpResponse.json({ error: "invalid_grant" }, { status: 400 });
+			})
+		);
+
+		const flow = createOAuthFlow(ctx);
+		const result = await flow.loginOrRefreshIfRequired({
+			complianceConfig: COMPLIANCE_CONFIG,
+			scopes: ["account:read"],
+		});
+
+		// Non-interactive, so it can't fall back to login.
+		expect(result).toEqual({
+			loggedIn: false,
+			reason: "token-expired-non-interactive",
+		});
+	});
+
+	it("logs refresh failures at warn level", async ({ expect }) => {
+		const { ctx, storage, logs } = createTestContext();
+		storage.write({
+			oauth_token: "expired-access",
+			refresh_token: "RT_A",
+			expiration_time: PAST_DATE,
+			scopes: ["account:read"],
+		});
+
+		msw.use(
+			mockAccessProbe(),
+			http.post("*/oauth2/token", async () => {
+				return HttpResponse.json({ error: "invalid_grant" }, { status: 400 });
+			})
+		);
+
+		const flow = createOAuthFlow(ctx);
+		await flow.loginOrRefreshIfRequired({
+			complianceConfig: COMPLIANCE_CONFIG,
+			scopes: ["account:read"],
+		});
+
+		const warnLogs = logs.filter((l) => l.level === "warn");
+		expect(
+			warnLogs.some((l) => l.message.includes("Token refresh failed"))
+		).toBe(true);
+	});
+
+	it("logs at warn when retry also fails", async ({ expect }) => {
+		const { ctx, storage, logs } = createTestContext();
+		storage.write({
+			oauth_token: "expired-access",
+			refresh_token: "RT_A",
+			expiration_time: PAST_DATE,
+			scopes: ["account:read"],
+		});
+
+		let callCount = 0;
+		msw.use(
+			mockAccessProbe(),
+			http.post("*/oauth2/token", async () => {
+				callCount++;
+				if (callCount === 1) {
+					// First call fails; simulate sibling writing a different RT.
+					storage.write({
+						oauth_token: "expired-access",
+						refresh_token: "RT_B",
+						expiration_time: PAST_DATE,
+						scopes: ["account:read"],
+					});
+				}
+				// Both calls fail with invalid_grant.
+				return HttpResponse.json({ error: "invalid_grant" }, { status: 400 });
+			})
+		);
+
+		const flow = createOAuthFlow(ctx);
+		await flow.loginOrRefreshIfRequired({
+			complianceConfig: COMPLIANCE_CONFIG,
+			scopes: ["account:read"],
+		});
+
+		expect(callCount).toBe(2);
+		const warnLogs = logs.filter((l) => l.level === "warn");
+		expect(
+			warnLogs.some((l) => l.message.includes("Token refresh retry failed"))
+		).toBe(true);
+	});
+});

--- a/packages/workers-auth/tests/flow-refresh.test.ts
+++ b/packages/workers-auth/tests/flow-refresh.test.ts
@@ -1,0 +1,484 @@
+import os from "node:os";
+import path from "node:path";
+import { http, HttpResponse } from "msw";
+import { setupServer } from "msw/node";
+import {
+	afterAll,
+	afterEach,
+	beforeAll,
+	beforeEach,
+	describe,
+	it,
+} from "vitest";
+import { clearAccessCaches } from "../src/access";
+import { createOAuthFlow } from "../src/flow";
+import type {
+	AuthConfigStorage,
+	UserAuthConfig,
+} from "../src/config-file/auth";
+import type { OAuthFlowContext } from "../src/context";
+import type { ComplianceConfig } from "@cloudflare/workers-utils";
+
+const msw = setupServer();
+
+beforeAll(() => msw.listen({ onUnhandledRequest: "error" }));
+afterEach(() => {
+	msw.restoreHandlers();
+	msw.resetHandlers();
+});
+afterAll(() => msw.close());
+
+const COMPLIANCE_CONFIG: ComplianceConfig = { compliance_region: undefined };
+
+const PAST_DATE = new Date(Date.now() - 100_000_000).toISOString();
+const FUTURE_DATE = new Date(Date.now() + 100_000_000).toISOString();
+
+/**
+ * Create a test context wired to an in-memory storage backend.
+ *
+ * @returns The context, the logs array, and a handle to the storage so
+ *   tests can manipulate the "on-disk" state between calls.
+ */
+function createTestContext(): {
+	ctx: OAuthFlowContext;
+	logs: { level: string; message: string }[];
+	storage: AuthConfigStorage;
+} {
+	const logs: { level: string; message: string }[] = [];
+	let stored: UserAuthConfig | undefined;
+
+	const storage: AuthConfigStorage = {
+		read: () => stored,
+		write: (config: UserAuthConfig) => {
+			stored = config;
+		},
+		clear: () => {
+			const existed = stored !== undefined;
+			stored = undefined;
+			return existed;
+		},
+		path: () => path.join(os.tmpdir(), "workers-auth-test-config"),
+	};
+
+	const logger: OAuthFlowContext["logger"] = {
+		debug: (...args: unknown[]) => {
+			logs.push({ level: "debug", message: args.join(" ") });
+		},
+		info: (...args: unknown[]) => {
+			logs.push({ level: "info", message: args.join(" ") });
+		},
+		log: (...args: unknown[]) => {
+			logs.push({ level: "log", message: args.join(" ") });
+		},
+		warn: (...args: unknown[]) => {
+			logs.push({ level: "warn", message: args.join(" ") });
+		},
+		error: (...args: unknown[]) => {
+			logs.push({ level: "error", message: args.join(" ") });
+		},
+	};
+
+	return {
+		logs,
+		storage,
+		ctx: {
+			logger,
+			isNonInteractiveOrCI: () => true,
+			openInBrowser: async () => {},
+			hasEnvCredentials: () => false,
+			clientId: "test-client-id",
+			consent: {
+				granted: { url: "https://example.com/granted" },
+				denied: {
+					url: "https://example.com/denied",
+					error: "consent denied",
+				},
+			},
+			displayName: "TestCLI",
+			deviceLoginCommand: "testcli auth login --device",
+			redirectUri: "http://localhost:9999/oauth/callback",
+			storageFactory: () => storage,
+			allowGlobalAuthKey: true,
+			temporary: undefined,
+		},
+	};
+}
+
+/** Handle the Cloudflare Access probe. */
+function mockAccessProbe() {
+	return http.get(
+		"https://dash.cloudflare.com/",
+		() => new HttpResponse(null, { status: 200 })
+	);
+}
+
+/**
+ * Return an MSW handler that always succeeds for the token endpoint.
+ *
+ * @param overrides - Optional overrides for the response body.
+ * @returns An MSW handler for `POST *​/oauth2/token`.
+ */
+function mockTokenSuccess(overrides: Record<string, unknown> = {}) {
+	return http.post("*/oauth2/token", () =>
+		HttpResponse.json({
+			access_token: "fresh-access-token",
+			expires_in: 3600,
+			refresh_token: "RT_NEXT",
+			scope: "account:read",
+			token_type: "bearer",
+			...overrides,
+		})
+	);
+}
+
+describe("refreshToken (via loginOrRefreshIfRequired)", () => {
+	beforeEach(() => {
+		clearAccessCaches();
+	});
+
+	it("refreshes an expired token and persists the result", async ({
+		expect,
+	}) => {
+		const { ctx, storage } = createTestContext();
+		storage.write({
+			oauth_token: "expired-access",
+			refresh_token: "RT_A",
+			expiration_time: PAST_DATE,
+			scopes: ["account:read"],
+		});
+
+		msw.use(mockAccessProbe(), mockTokenSuccess());
+
+		const flow = createOAuthFlow(ctx);
+		const result = await flow.loginOrRefreshIfRequired({
+			complianceConfig: COMPLIANCE_CONFIG,
+			scopes: ["account:read"],
+		});
+
+		expect(result).toEqual({ loggedIn: true });
+		const written = storage.read();
+		expect(written?.oauth_token).toBe("fresh-access-token");
+		expect(written?.refresh_token).toBe("RT_NEXT");
+	});
+
+	it("skips the exchange when the token is already fresh after lock acquisition", async ({
+		expect,
+	}) => {
+		const { ctx, storage } = createTestContext();
+		// Token is not expired — no exchange should happen.
+		storage.write({
+			oauth_token: "still-valid",
+			refresh_token: "RT_A",
+			expiration_time: FUTURE_DATE,
+			scopes: ["account:read"],
+		});
+
+		// No MSW handler for token endpoint — if an exchange is attempted,
+		// the test will fail with "unhandled request".
+		msw.use(mockAccessProbe());
+
+		const flow = createOAuthFlow(ctx);
+		const result = await flow.loginOrRefreshIfRequired({
+			complianceConfig: COMPLIANCE_CONFIG,
+			scopes: ["account:read"],
+		});
+
+		expect(result).toEqual({ loggedIn: true });
+	});
+
+	it("retries on invalid_grant when a sibling rotated the refresh token", async ({
+		expect,
+	}) => {
+		const { ctx, storage } = createTestContext();
+		storage.write({
+			oauth_token: "expired-access",
+			refresh_token: "RT_A",
+			expiration_time: PAST_DATE,
+			scopes: ["account:read"],
+		});
+
+		let callCount = 0;
+		msw.use(
+			mockAccessProbe(),
+			http.post("*/oauth2/token", async ({ request }) => {
+				callCount++;
+				const body = new URLSearchParams(await request.text());
+				const rt = body.get("refresh_token");
+
+				if (rt === "RT_A") {
+					// Simulate the first exchange failing because a sibling
+					// already consumed RT_A. Before the retry, we also update
+					// the "disk" to simulate the sibling's write.
+					storage.write({
+						oauth_token: "expired-access",
+						refresh_token: "RT_B",
+						expiration_time: PAST_DATE,
+						scopes: ["account:read"],
+					});
+					return HttpResponse.json({ error: "invalid_grant" }, { status: 400 });
+				}
+				// RT_B succeeds.
+				return HttpResponse.json({
+					access_token: "fresh-from-retry",
+					expires_in: 3600,
+					refresh_token: "RT_C",
+					scope: "account:read",
+					token_type: "bearer",
+				});
+			})
+		);
+
+		const flow = createOAuthFlow(ctx);
+		const result = await flow.loginOrRefreshIfRequired({
+			complianceConfig: COMPLIANCE_CONFIG,
+			scopes: ["account:read"],
+		});
+
+		expect(result).toEqual({ loggedIn: true });
+		expect(callCount).toBe(2);
+		const written = storage.read();
+		expect(written?.oauth_token).toBe("fresh-from-retry");
+		expect(written?.refresh_token).toBe("RT_C");
+	});
+
+	it("succeeds without retry when a sibling already completed the refresh", async ({
+		expect,
+	}) => {
+		const { ctx, storage } = createTestContext();
+		storage.write({
+			oauth_token: "expired-access",
+			refresh_token: "RT_A",
+			expiration_time: PAST_DATE,
+			scopes: ["account:read"],
+		});
+
+		let callCount = 0;
+		msw.use(
+			mockAccessProbe(),
+			http.post("*/oauth2/token", async () => {
+				callCount++;
+				// Before returning the error, simulate the sibling having
+				// completed a full refresh (fresh access token on disk).
+				storage.write({
+					oauth_token: "sibling-refreshed-token",
+					refresh_token: "RT_B",
+					expiration_time: FUTURE_DATE,
+					scopes: ["account:read"],
+				});
+				return HttpResponse.json({ error: "invalid_grant" }, { status: 400 });
+			})
+		);
+
+		const flow = createOAuthFlow(ctx);
+		const result = await flow.loginOrRefreshIfRequired({
+			complianceConfig: COMPLIANCE_CONFIG,
+			scopes: ["account:read"],
+		});
+
+		expect(result).toEqual({ loggedIn: true });
+		// Only one call — no retry needed because the sibling already
+		// wrote a fresh access token.
+		expect(callCount).toBe(1);
+	});
+
+	it("gives up when invalid_grant and the on-disk token hasn't changed", async ({
+		expect,
+	}) => {
+		const { ctx, storage } = createTestContext();
+		storage.write({
+			oauth_token: "expired-access",
+			refresh_token: "RT_A",
+			expiration_time: PAST_DATE,
+			scopes: ["account:read"],
+		});
+
+		msw.use(
+			mockAccessProbe(),
+			http.post("*/oauth2/token", async () => {
+				return HttpResponse.json({ error: "invalid_grant" }, { status: 400 });
+			})
+		);
+
+		const flow = createOAuthFlow(ctx);
+		const result = await flow.loginOrRefreshIfRequired({
+			complianceConfig: COMPLIANCE_CONFIG,
+			scopes: ["account:read"],
+		});
+
+		// Non-interactive, so it can't fall back to login.
+		expect(result).toEqual({
+			loggedIn: false,
+			reason: "token-expired-non-interactive",
+		});
+	});
+
+	it("logs refresh failures at warn level", async ({ expect }) => {
+		const { ctx, storage, logs } = createTestContext();
+		storage.write({
+			oauth_token: "expired-access",
+			refresh_token: "RT_A",
+			expiration_time: PAST_DATE,
+			scopes: ["account:read"],
+		});
+
+		msw.use(
+			mockAccessProbe(),
+			http.post("*/oauth2/token", async () => {
+				return HttpResponse.json({ error: "invalid_grant" }, { status: 400 });
+			})
+		);
+
+		const flow = createOAuthFlow(ctx);
+		await flow.loginOrRefreshIfRequired({
+			complianceConfig: COMPLIANCE_CONFIG,
+			scopes: ["account:read"],
+		});
+
+		const warnLogs = logs.filter((l) => l.level === "warn");
+		expect(
+			warnLogs.some((l) => l.message.includes("Token refresh failed"))
+		).toBe(true);
+		expect(warnLogs.some((l) => l.message.includes("invalid_grant"))).toBe(
+			true
+		);
+	});
+
+	it("logs at warn when retry also fails", async ({ expect }) => {
+		const { ctx, storage, logs } = createTestContext();
+		storage.write({
+			oauth_token: "expired-access",
+			refresh_token: "RT_A",
+			expiration_time: PAST_DATE,
+			scopes: ["account:read"],
+		});
+
+		let callCount = 0;
+		msw.use(
+			mockAccessProbe(),
+			http.post("*/oauth2/token", async () => {
+				callCount++;
+				if (callCount === 1) {
+					// First call fails; simulate sibling writing a different RT.
+					storage.write({
+						oauth_token: "expired-access",
+						refresh_token: "RT_B",
+						expiration_time: PAST_DATE,
+						scopes: ["account:read"],
+					});
+				}
+				// Both calls fail with invalid_grant.
+				return HttpResponse.json({ error: "invalid_grant" }, { status: 400 });
+			})
+		);
+
+		const flow = createOAuthFlow(ctx);
+		await flow.loginOrRefreshIfRequired({
+			complianceConfig: COMPLIANCE_CONFIG,
+			scopes: ["account:read"],
+		});
+
+		expect(callCount).toBe(2);
+		const warnLogs = logs.filter((l) => l.level === "warn");
+		expect(
+			warnLogs.some((l) => l.message.includes("Token refresh retry failed"))
+		).toBe(true);
+		expect(warnLogs.some((l) => l.message.includes("invalid_grant"))).toBe(
+			true
+		);
+	});
+
+	it("sends the post-lock snapshot token, not a re-read from disk", async ({
+		expect,
+	}) => {
+		const { ctx, storage } = createTestContext();
+		storage.write({
+			oauth_token: "expired-access",
+			refresh_token: "RT_A",
+			expiration_time: PAST_DATE,
+			scopes: ["account:read"],
+		});
+
+		const sentTokens: string[] = [];
+		msw.use(
+			mockAccessProbe(),
+			http.post("*/oauth2/token", async ({ request }) => {
+				const body = new URLSearchParams(await request.text());
+				const rt = body.get("refresh_token") ?? "";
+				sentTokens.push(rt);
+
+				// Simulate a sibling writing RT_B to disk between the post-lock
+				// read and the exchange. Without the fix, the exchange would
+				// re-read disk and send RT_B; with the fix it sends RT_A.
+				storage.write({
+					oauth_token: "expired-access",
+					refresh_token: "RT_B",
+					expiration_time: PAST_DATE,
+					scopes: ["account:read"],
+				});
+
+				return HttpResponse.json({
+					access_token: "fresh-access-token",
+					expires_in: 3600,
+					refresh_token: "RT_NEXT",
+					scope: "account:read",
+					token_type: "bearer",
+				});
+			})
+		);
+
+		const flow = createOAuthFlow(ctx);
+		const result = await flow.loginOrRefreshIfRequired({
+			complianceConfig: COMPLIANCE_CONFIG,
+			scopes: ["account:read"],
+		});
+
+		expect(result).toEqual({ loggedIn: true });
+		// The exchange should have used RT_A (the post-lock snapshot), not
+		// RT_B (the value a sibling wrote to disk mid-exchange).
+		expect(sentTokens).toEqual(["RT_A"]);
+	});
+
+	it("deduplicates concurrent in-process refreshes (single-flight)", async ({
+		expect,
+	}) => {
+		const { ctx, storage } = createTestContext();
+		storage.write({
+			oauth_token: "expired-access",
+			refresh_token: "RT_A",
+			expiration_time: PAST_DATE,
+			scopes: ["account:read"],
+		});
+
+		let callCount = 0;
+		msw.use(
+			mockAccessProbe(),
+			http.post("*/oauth2/token", async () => {
+				callCount++;
+				return HttpResponse.json({
+					access_token: "fresh-access-token",
+					expires_in: 3600,
+					refresh_token: "RT_NEXT",
+					scope: "account:read",
+					token_type: "bearer",
+				});
+			})
+		);
+
+		const flow = createOAuthFlow(ctx);
+		const [r1, r2] = await Promise.all([
+			flow.loginOrRefreshIfRequired({
+				complianceConfig: COMPLIANCE_CONFIG,
+				scopes: ["account:read"],
+			}),
+			flow.loginOrRefreshIfRequired({
+				complianceConfig: COMPLIANCE_CONFIG,
+				scopes: ["account:read"],
+			}),
+		]);
+
+		expect(r1).toEqual({ loggedIn: true });
+		expect(r2).toEqual({ loggedIn: true });
+		// Only one token exchange should have been made.
+		expect(callCount).toBe(1);
+	});
+});

--- a/packages/workers-auth/tests/refresh-lock.test.ts
+++ b/packages/workers-auth/tests/refresh-lock.test.ts
@@ -1,0 +1,139 @@
+import { existsSync, mkdirSync, utimesSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
+import { describe, it } from "vitest";
+import { withRefreshLock, _TEST_CONSTANTS } from "../src/refresh-lock";
+
+describe("withRefreshLock", () => {
+	runInTempDir();
+
+	function lockDir(): string {
+		return path.join(process.cwd(), "test.lock");
+	}
+
+	it("acquires and releases the lock around fn", async ({ expect }) => {
+		const result = await withRefreshLock(lockDir(), async () => {
+			expect(existsSync(lockDir())).toBe(true);
+			return 42;
+		});
+		expect(result).toBe(42);
+		expect(existsSync(lockDir())).toBe(false);
+	});
+
+	it("releases the lock when fn throws", async ({ expect }) => {
+		await expect(
+			withRefreshLock(lockDir(), async () => {
+				throw new Error("boom");
+			})
+		).rejects.toThrow("boom");
+		expect(existsSync(lockDir())).toBe(false);
+	});
+
+	it("breaks a stale lock held by a dead process", async ({ expect }) => {
+		const dir = lockDir();
+		mkdirSync(dir);
+		writeFileSync(
+			path.join(dir, _TEST_CONSTANTS.LOCK_INFO_FILE),
+			JSON.stringify({ pid: 999999999, timestamp: Date.now() }),
+			"utf-8"
+		);
+
+		const result = await withRefreshLock(dir, async () => "acquired");
+		expect(result).toBe("acquired");
+		expect(existsSync(dir)).toBe(false);
+	});
+
+	it("breaks a lock that has aged past the stale threshold from a dead process", async ({
+		expect,
+	}) => {
+		const dir = lockDir();
+		mkdirSync(dir);
+		writeFileSync(
+			path.join(dir, _TEST_CONSTANTS.LOCK_INFO_FILE),
+			JSON.stringify({
+				pid: 999999999,
+				timestamp: Date.now() - _TEST_CONSTANTS.STALE_THRESHOLD_MS - 1000,
+			}),
+			"utf-8"
+		);
+
+		const result = await withRefreshLock(dir, async () => "acquired");
+		expect(result).toBe("acquired");
+	});
+
+	it("does not evict an alive process even if the lock is old", async ({
+		expect,
+	}) => {
+		const dir = lockDir();
+		mkdirSync(dir);
+		writeFileSync(
+			path.join(dir, _TEST_CONSTANTS.LOCK_INFO_FILE),
+			JSON.stringify({
+				pid: process.pid,
+				timestamp: Date.now() - _TEST_CONSTANTS.STALE_THRESHOLD_MS - 1000,
+			}),
+			"utf-8"
+		);
+
+		// Lock held by a live process — should NOT be broken, so fn runs
+		// without the lock after retries exhaust.
+		const result = await withRefreshLock(dir, async () => "ran-unlocked");
+		expect(result).toBe("ran-unlocked");
+	});
+
+	it("proceeds without the lock when acquisition fails after retries", async ({
+		expect,
+	}) => {
+		const dir = lockDir();
+		mkdirSync(dir);
+		// Lock held by the current process with a fresh timestamp — not stale,
+		// so all retry attempts will fail.
+		writeFileSync(
+			path.join(dir, _TEST_CONSTANTS.LOCK_INFO_FILE),
+			JSON.stringify({ pid: process.pid, timestamp: Date.now() }),
+			"utf-8"
+		);
+
+		const result = await withRefreshLock(dir, async () => "ran-unlocked");
+		expect(result).toBe("ran-unlocked");
+	});
+
+	it("serializes two sequential callers on the same lock", async ({
+		expect,
+	}) => {
+		const order: string[] = [];
+		await withRefreshLock(lockDir(), async () => {
+			order.push("first");
+		});
+		await withRefreshLock(lockDir(), async () => {
+			order.push("second");
+		});
+		expect(order).toEqual(["first", "second"]);
+	});
+
+	it("breaks a lock directory with no info file after grace period", async ({
+		expect,
+	}) => {
+		const dir = lockDir();
+		mkdirSync(dir);
+		// Backdate the directory mtime past the grace period so it's treated
+		// as stale (the acquirer had enough time to write info.json but didn't).
+		const past = new Date(Date.now() - _TEST_CONSTANTS.LOCK_GRACE_MS - 1000);
+		utimesSync(dir, past, past);
+
+		const result = await withRefreshLock(dir, async () => "acquired");
+		expect(result).toBe("acquired");
+	});
+
+	it("does not break a fresh lock directory with no info file", async ({
+		expect,
+	}) => {
+		const dir = lockDir();
+		mkdirSync(dir);
+		// No info file and the directory was just created — within the grace
+		// period, so the lock is treated as held by a sibling mid-acquisition.
+
+		const result = await withRefreshLock(dir, async () => "ran-unlocked");
+		expect(result).toBe("ran-unlocked");
+	});
+});

--- a/packages/workers-auth/tests/refresh-lock.test.ts
+++ b/packages/workers-auth/tests/refresh-lock.test.ts
@@ -1,0 +1,180 @@
+import fs from "node:fs";
+import { existsSync, mkdirSync, utimesSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
+import { describe, it, vi } from "vitest";
+import { withRefreshLock, _TEST_CONSTANTS } from "../src/refresh-lock";
+
+const FAST_RETRIES = { maxRetries: 3, retryDelayMs: 10 };
+
+describe("withRefreshLock", () => {
+	runInTempDir();
+
+	function lockDir(): string {
+		return path.join(process.cwd(), "test.lock");
+	}
+
+	it("acquires and releases the lock around fn", async ({ expect }) => {
+		const result = await withRefreshLock(lockDir(), async () => {
+			expect(existsSync(lockDir())).toBe(true);
+			return 42;
+		});
+		expect(result).toBe(42);
+		expect(existsSync(lockDir())).toBe(false);
+	});
+
+	it("releases the lock when fn throws", async ({ expect }) => {
+		await expect(
+			withRefreshLock(lockDir(), async () => {
+				throw new Error("boom");
+			})
+		).rejects.toThrow("boom");
+		expect(existsSync(lockDir())).toBe(false);
+	});
+
+	it("breaks a lock held by a dead process", async ({ expect }) => {
+		const dir = lockDir();
+		mkdirSync(dir);
+		writeFileSync(
+			path.join(dir, _TEST_CONSTANTS.LOCK_INFO_FILE),
+			JSON.stringify({ pid: 999999999 }),
+			"utf-8"
+		);
+
+		const result = await withRefreshLock(dir, async () => "acquired");
+		expect(result).toBe("acquired");
+		expect(existsSync(dir)).toBe(false);
+	});
+
+	it("does not evict an alive process", async ({ expect }) => {
+		const dir = lockDir();
+		mkdirSync(dir);
+		writeFileSync(
+			path.join(dir, _TEST_CONSTANTS.LOCK_INFO_FILE),
+			JSON.stringify({ pid: process.pid }),
+			"utf-8"
+		);
+
+		// Lock held by a live process — should NOT be broken, so fn runs
+		// without the lock after retries exhaust.
+		const result = await withRefreshLock(
+			dir,
+			async () => "ran-unlocked",
+			FAST_RETRIES
+		);
+		expect(result).toBe("ran-unlocked");
+	});
+
+	it("proceeds without the lock when acquisition fails after retries", async ({
+		expect,
+	}) => {
+		const dir = lockDir();
+		mkdirSync(dir);
+		// Lock held by the current process — not stale, so all retry
+		// attempts will fail.
+		writeFileSync(
+			path.join(dir, _TEST_CONSTANTS.LOCK_INFO_FILE),
+			JSON.stringify({ pid: process.pid }),
+			"utf-8"
+		);
+
+		const result = await withRefreshLock(
+			dir,
+			async () => "ran-unlocked",
+			FAST_RETRIES
+		);
+		expect(result).toBe("ran-unlocked");
+	});
+
+	it("serializes two sequential callers on the same lock", async ({
+		expect,
+	}) => {
+		const order: string[] = [];
+		await withRefreshLock(lockDir(), async () => {
+			order.push("first");
+		});
+		await withRefreshLock(lockDir(), async () => {
+			order.push("second");
+		});
+		expect(order).toEqual(["first", "second"]);
+	});
+
+	it("breaks a lock directory with no info file after grace period", async ({
+		expect,
+	}) => {
+		const dir = lockDir();
+		mkdirSync(dir);
+		// Backdate the directory mtime past the grace period so it's treated
+		// as stale (the acquirer had enough time to write info.json but didn't).
+		const past = new Date(Date.now() - _TEST_CONSTANTS.LOCK_GRACE_MS - 1000);
+		utimesSync(dir, past, past);
+
+		const result = await withRefreshLock(dir, async () => "acquired");
+		expect(result).toBe("acquired");
+	});
+
+	it("proceeds without the lock on non-EEXIST filesystem errors", async ({
+		expect,
+	}) => {
+		// Use a lock path under a non-existent parent to trigger ENOENT from
+		// mkdirSync. The function should degrade gracefully (run fn without
+		// the lock) rather than propagating the error, and should return
+		// immediately without burning through the full retry budget.
+		const badLockDir = path.join(
+			process.cwd(),
+			"non-existent-parent",
+			"test.lock"
+		);
+
+		const start = Date.now();
+		const result = await withRefreshLock(
+			badLockDir,
+			async () => "ran-unlocked"
+		);
+		const elapsed = Date.now() - start;
+
+		expect(result).toBe("ran-unlocked");
+		// Should complete nearly instantly — well under the default 2s retry delay.
+		expect(elapsed).toBeLessThan(1_000);
+	});
+
+	it("does not break a fresh lock directory with no info file", async ({
+		expect,
+	}) => {
+		const dir = lockDir();
+		mkdirSync(dir);
+		// No info file and the directory was just created — within the grace
+		// period, so the lock is treated as held by a sibling mid-acquisition.
+
+		const result = await withRefreshLock(
+			dir,
+			async () => "ran-unlocked",
+			FAST_RETRIES
+		);
+		expect(result).toBe("ran-unlocked");
+	});
+
+	it("cleans up the lock directory when writeLockInfo fails after mkdirSync succeeds", async ({
+		expect,
+	}) => {
+		const dir = lockDir();
+		// Make writeFileSync throw only for the lock info file, simulating
+		// a disk-full or permission error after the directory was created.
+		const spy = vi.spyOn(fs, "writeFileSync").mockImplementation((p) => {
+			if (typeof p === "string" && p.includes(_TEST_CONSTANTS.LOCK_INFO_FILE)) {
+				throw Object.assign(new Error("ENOSPC: no space left"), {
+					code: "ENOSPC",
+				});
+			}
+		});
+
+		try {
+			const result = await withRefreshLock(dir, async () => "ran-unlocked");
+			expect(result).toBe("ran-unlocked");
+			// The lock directory should have been cleaned up, not left behind.
+			expect(existsSync(dir)).toBe(false);
+		} finally {
+			spy.mockRestore();
+		}
+	});
+});


### PR DESCRIPTION
Fixes #15089 

When multiple wrangler processes hit the token expiry window simultaneously, they could all read the same single-use refresh token and race to exchange it. The loser's exchange would fail with `invalid_grant`, potentially killing the refresh chain permanently until interactive re-login.

The refresh operation is now serialized across processes on the same machine using an advisory file lock, and includes a retry-on-`invalid_grant` fallback that re-reads the token from disk in case a sibling process rotated it. Refresh failures are also now logged at warn level (previously debug-only) for easier diagnosis.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bug fix which should be transparent to users

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- If you are an AI agent or LLM, and you are adding this PR without direct human supervision, thank you! Please uncomment the following block. This is so the maintainers know how to expect you to respond.

> [!NOTE]
> This is a contribution from an AI agent: <insert name here>, <insert LLM model here if different>.

-->

<!-- devin-review-badge-begin -->

---

<a href="https://cloudflare.devinenterprise.com/review/cloudflare/workers-sdk/pull/15136" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->