### PR TITLE
[miniflare] Start runtime disposal before browser/proxy cleanup

### DIFF
--- a/.changeset/fuzzy-cats-dispose.md
+++ b/.changeset/fuzzy-cats-dispose.md
@@ -2,4 +2,4 @@
 "miniflare": patch
 ---
 
-Request workerd termination before independent browser or proxy cleanup and wait for runtime exit before disposal settles.
+Prevent `workerd` from remaining running during Miniflare shutdown when browser or proxy cleanup is slow or fails.

--- a/.changeset/fuzzy-cats-dispose.md
+++ b/.changeset/fuzzy-cats-dispose.md
@@ -1,0 +1,5 @@
+---
+"miniflare": patch
+---
+
+Request workerd termination before independent browser or proxy cleanup and wait for runtime exit before disposal settles.

--- a/packages/miniflare/src/index.ts
+++ b/packages/miniflare/src/index.ts
@@ -3123,70 +3123,106 @@ export class Miniflare {
 		// Note `dispose()`ing the `#proxyClient` implicitly poison's proxies, but
 		// we'd like them to be poisoned synchronously here.
 		this.#proxyClient?.poisonProxies();
+		// Preserve a readiness failure without allowing it to skip teardown.
+		let waitForReadyFailed = false;
+		let waitForReadyError: unknown;
 		try {
 			await this.#waitForReady(/* disposing */ true);
-		} finally {
+		} catch (error) {
+			waitForReadyFailed = true;
+			waitForReadyError = error;
+		}
+
+		// Runtime.dispose() requests workerd termination synchronously before
+		// returning its child-exit promise. Start it before awaiting independent
+		// cleanup so those hooks cannot delay or skip the termination request.
+		let runtimeDisposePromise: Promise<void>;
+		try {
+			runtimeDisposePromise = Promise.resolve(this.#runtime?.dispose());
+		} catch (error) {
+			runtimeDisposePromise = Promise.reject(error);
+		}
+		// Attach a rejection handler immediately so a fast runtime failure cannot
+		// become unhandled while independent cleanup is still pending.
+		const runtimeDisposeOutcome = runtimeDisposePromise.then(
+			() => ({ ok: true as const }),
+			(error: unknown) => ({ ok: false as const, error })
+		);
+
+		// Preserve the existing first cleanup error, while still waiting for the
+		// already-started runtime exit before the outer disposal settles.
+		let independentCleanupFailed = false;
+		let independentCleanupError: unknown;
+		try {
+			// Cleanup as much as possible even if `#init()` threw.
 			await this.#closeBrowserProcesses();
 
 			// Remove exit hook, we're cleaning up what they would've cleaned up now
 			this.#removeExitHook?.();
 
-			// Cleanup as much as possible even if `#init()` threw
 			await this.#proxyClient?.dispose();
-			await this.#runtime?.dispose();
-			// Close the undici Pool used for dispatching fetch requests to the
-			// runtime. This must happen after the runtime is disposed, so that
-			// in-flight connections are broken and close immediately. Without this,
-			// lingering sockets in the Pool can keep the Node.js event loop alive.
-			// The Pool may already be destroyed (e.g., if workerd was SIGKILL'd and
-			// all connections broke), so ignore ClientDestroyedError.
-			try {
-				await this.#runtimeDispatcher?.close();
-			} catch {}
-			// Also close the dev-registry dispatcher (same issue as above).
-			try {
-				await this.#devRegistryDispatcher?.close();
-			} catch {}
-
-			await this.#stopLoopbackServer();
-			// Close the WebSocket server so any connected clients are disconnected
-			// and their sockets don't keep the event loop alive. It uses
-			// `noServer: true` so it doesn't own an HTTP server, but connected
-			// WebSocket clients still hold open sockets.
-			this.#webSocketServer.close();
-			// Best-effort cleanup: on Windows, workerd may not release file handles
-			// immediately after disposal, causing EBUSY errors. The temp directory
-			// lives in os.tmpdir() so the OS will clean it up eventually.
-			removeDir(this.#tmpPath, { fireAndForget: true });
-			// Clean up email session directories in the project temp path. When no
-			// project temp path is supplied, these live inside `#tmpPath` and are
-			// already removed above.
-			const emailPaths = getEmailPathsToClean(
-				this.#sharedOpts.resourceTmpPath,
-				this.#tmpPath
-			);
-			if (emailPaths) {
-				try {
-					await removeDir(emailPaths.sessionDir);
-				} catch (e) {
-					this.#log.debug(
-						`Unable to remove email session directory: ${String(e)}`
-					);
-				}
-			}
-
-			// Close the inspector proxy server if there is one
-			await this.#maybeInspectorProxyController?.dispose();
-			// Unregister workers from dev registry and stop the file watcher
-			await this.#devRegistry.dispose();
-
-			// shutdown hyperdrive proxies if any exist
-			await this.#hyperdriveProxyController.dispose();
-
-			// Remove from instance registry as last step in `finally`, to make sure
-			// all dispose steps complete
-			maybeInstanceRegistry?.delete(this);
+		} catch (error) {
+			independentCleanupFailed = true;
+			independentCleanupError = error;
 		}
+
+		const runtimeCleanupOutcome = await runtimeDisposeOutcome;
+		if (independentCleanupFailed) throw independentCleanupError;
+		if (!runtimeCleanupOutcome.ok) throw runtimeCleanupOutcome.error;
+		// Close the undici Pool used for dispatching fetch requests to the
+		// runtime. This must happen after the runtime is disposed, so that
+		// in-flight connections are broken and close immediately. Without this,
+		// lingering sockets in the Pool can keep the Node.js event loop alive.
+		// The Pool may already be destroyed (e.g., if workerd was SIGKILL'd and
+		// all connections broke), so ignore ClientDestroyedError.
+		try {
+			await this.#runtimeDispatcher?.close();
+		} catch {}
+		// Also close the dev-registry dispatcher (same issue as above).
+		try {
+			await this.#devRegistryDispatcher?.close();
+		} catch {}
+
+		await this.#stopLoopbackServer();
+		// Close the WebSocket server so any connected clients are disconnected
+		// and their sockets don't keep the Node.js event loop alive. It uses
+		// `noServer: true` so it doesn't own an HTTP server, but connected
+		// WebSocket clients still hold open sockets.
+		this.#webSocketServer.close();
+		// Best-effort cleanup: on Windows, workerd may not release file handles
+		// immediately after disposal, causing EBUSY errors. The temp directory
+		// lives in os.tmpdir() so the OS will clean it up eventually.
+		removeDir(this.#tmpPath, { fireAndForget: true });
+		// Clean up email session directories in the project temp path. When no
+		// project temp path is supplied, these live inside `#tmpPath` and are
+		// already removed above.
+		const emailPaths = getEmailPathsToClean(
+			this.#sharedOpts.resourceTmpPath,
+			this.#tmpPath
+		);
+		if (emailPaths) {
+			try {
+				await removeDir(emailPaths.sessionDir);
+			} catch (e) {
+				this.#log.debug(
+					`Unable to remove email session directory: ${String(e)}`
+				);
+			}
+		}
+
+		// Close the inspector proxy server if there is one
+		await this.#maybeInspectorProxyController?.dispose();
+		// Unregister workers from dev registry and stop the file watcher
+		await this.#devRegistry.dispose();
+
+		// shutdown hyperdrive proxies if any exist
+		await this.#hyperdriveProxyController.dispose();
+
+		// Remove from instance registry as last step in disposal, preserving the
+		// existing behavior when an earlier cleanup operation fails.
+		maybeInstanceRegistry?.delete(this);
+
+		if (waitForReadyFailed) throw waitForReadyError;
 	}
 }
 

--- a/packages/miniflare/src/index.ts
+++ b/packages/miniflare/src/index.ts
@@ -3167,8 +3167,6 @@ export class Miniflare {
 		}
 
 		const runtimeCleanupOutcome = await runtimeDisposeOutcome;
-		if (independentCleanupFailed) throw independentCleanupError;
-		if (!runtimeCleanupOutcome.ok) throw runtimeCleanupOutcome.error;
 		// Close the undici Pool used for dispatching fetch requests to the
 		// runtime. This must happen after the runtime is disposed, so that
 		// in-flight connections are broken and close immediately. Without this,
@@ -3222,6 +3220,8 @@ export class Miniflare {
 		// existing behavior when an earlier cleanup operation fails.
 		maybeInstanceRegistry?.delete(this);
 
+		if (independentCleanupFailed) throw independentCleanupError;
+		if (!runtimeCleanupOutcome.ok) throw runtimeCleanupOutcome.error;
 		if (waitForReadyFailed) throw waitForReadyError;
 	}
 }

--- a/packages/miniflare/test/teardown-lifecycle.spec.ts
+++ b/packages/miniflare/test/teardown-lifecycle.spec.ts
@@ -2,6 +2,7 @@ import childProcess from "node:child_process";
 import path from "node:path";
 import { Miniflare, ProxyClient } from "miniflare";
 import { afterEach, test, vi } from "vitest";
+import { WebSocketServer } from "ws";
 import { singleModuleManifest } from "./test-shared";
 
 async function createReadyMiniflare(): Promise<Miniflare> {
@@ -76,7 +77,7 @@ test("Miniflare: dispose requests workerd termination while proxy cleanup is pen
 	}
 });
 
-test("Miniflare: dispose waits for workerd exit before returning proxy cleanup failure", async ({
+test("Miniflare: dispose waits for workerd exit and continues cleanup before returning proxy cleanup failure", async ({
 	expect,
 }) => {
 	let markRuntimeExitObserved!: () => void;
@@ -114,6 +115,7 @@ test("Miniflare: dispose waits for workerd exit before returning proxy cleanup f
 	const proxyDispose = vi
 		.spyOn(ProxyClient.prototype, "dispose")
 		.mockRejectedValueOnce(new Error("injected proxy cleanup failure"));
+	const webSocketClose = vi.spyOn(WebSocketServer.prototype, "close");
 	const kill = vi.spyOn(childProcess.ChildProcess.prototype, "kill");
 
 	let runtimeExitReleased = false;
@@ -138,6 +140,7 @@ test("Miniflare: dispose waits for workerd exit before returning proxy cleanup f
 		releaseRuntimeExit();
 		runtimeExitReleased = true;
 		const firstDisposeError = await firstDisposeResult;
+		expect(webSocketClose).toHaveBeenCalled();
 		expect(firstDisposeError).toBeInstanceOf(Error);
 		expect((firstDisposeError as Error).message).toContain(
 			"injected proxy cleanup failure"
@@ -146,6 +149,7 @@ test("Miniflare: dispose waits for workerd exit before returning proxy cleanup f
 		if (!runtimeExitReleased) releaseRuntimeExit();
 		emit.mockRestore();
 		proxyDispose.mockRestore();
+		webSocketClose.mockRestore();
 		await firstDisposeResult;
 		await mf.dispose().catch(() => {});
 	}

--- a/packages/miniflare/test/teardown-lifecycle.spec.ts
+++ b/packages/miniflare/test/teardown-lifecycle.spec.ts
@@ -1,0 +1,152 @@
+import childProcess from "node:child_process";
+import path from "node:path";
+import { Miniflare, ProxyClient } from "miniflare";
+import { afterEach, test, vi } from "vitest";
+import { singleModuleManifest } from "./test-shared";
+
+async function createReadyMiniflare(): Promise<Miniflare> {
+	const mf = new Miniflare({
+		workers: [
+			{
+				config: {
+					type: "worker",
+					name: "",
+					compatibilityDate: "2025-05-01",
+					manifest: singleModuleManifest(`export default {
+						fetch() {
+							return new Response("ok");
+						}
+					}`),
+				},
+			},
+		],
+	});
+	await mf.ready;
+	return mf;
+}
+
+function findKilledWorkerd(
+	kill: ReturnType<typeof vi.spyOn>
+): childProcess.ChildProcess | undefined {
+	for (let index = 0; index < kill.mock.calls.length; index++) {
+		const [signal] = kill.mock.calls[index];
+		const child = kill.mock.contexts[index];
+		if (
+			signal === "SIGKILL" &&
+			child instanceof childProcess.ChildProcess &&
+			path.basename(child.spawnfile).toLowerCase().startsWith("workerd")
+		) {
+			return child;
+		}
+	}
+}
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+test("Miniflare: dispose requests workerd termination while proxy cleanup is pending", async ({
+	expect,
+}) => {
+	const mf = await createReadyMiniflare();
+	let markProxyDisposeStarted!: () => void;
+	let releaseProxyDispose!: () => void;
+	const proxyDisposeStarted = new Promise<void>((resolve) => {
+		markProxyDisposeStarted = resolve;
+	});
+	const proxyDisposeBlocked = new Promise<void>((resolve) => {
+		releaseProxyDispose = resolve;
+	});
+	const proxyDispose = vi
+		.spyOn(ProxyClient.prototype, "dispose")
+		.mockImplementationOnce(() => {
+			markProxyDisposeStarted();
+			return proxyDisposeBlocked;
+		});
+	const kill = vi.spyOn(childProcess.ChildProcess.prototype, "kill");
+
+	const disposePromise = mf.dispose();
+	try {
+		await proxyDisposeStarted;
+		expect(findKilledWorkerd(kill)).toBeDefined();
+	} finally {
+		releaseProxyDispose();
+		proxyDispose.mockRestore();
+		await disposePromise;
+	}
+});
+
+test("Miniflare: dispose waits for workerd exit before returning proxy cleanup failure", async ({
+	expect,
+}) => {
+	let markRuntimeExitObserved!: () => void;
+	let releaseRuntimeExit!: () => void;
+	const runtimeExitObserved = new Promise<void>((resolve) => {
+		markRuntimeExitObserved = resolve;
+	});
+	const runtimeExitBlocked = new Promise<void>((resolve) => {
+		releaseRuntimeExit = resolve;
+	});
+	const originalEmit = childProcess.ChildProcess.prototype.emit;
+	let interceptedRuntimeExit = false;
+	const emit = vi
+		.spyOn(childProcess.ChildProcess.prototype, "emit")
+		.mockImplementation(function (
+			this: childProcess.ChildProcess,
+			event: string | symbol,
+			...args: unknown[]
+		) {
+			if (
+				!interceptedRuntimeExit &&
+				event === "exit" &&
+				path.basename(this.spawnfile).toLowerCase().startsWith("workerd")
+			) {
+				interceptedRuntimeExit = true;
+				markRuntimeExitObserved();
+				void runtimeExitBlocked.then(() => {
+					Reflect.apply(originalEmit, this, [event, ...args]);
+				});
+				return true;
+			}
+			return Reflect.apply(originalEmit, this, [event, ...args]) as boolean;
+		});
+	const mf = await createReadyMiniflare();
+	const proxyDispose = vi
+		.spyOn(ProxyClient.prototype, "dispose")
+		.mockRejectedValueOnce(new Error("injected proxy cleanup failure"));
+	const kill = vi.spyOn(childProcess.ChildProcess.prototype, "kill");
+
+	let runtimeExitReleased = false;
+	let firstDisposeSettled = false;
+	const firstDisposeResult = mf.dispose().then(
+		() => {
+			firstDisposeSettled = true;
+			return undefined;
+		},
+		(error: unknown) => {
+			firstDisposeSettled = true;
+			return error;
+		}
+	);
+
+	try {
+		await runtimeExitObserved;
+		await new Promise<void>((resolve) => setImmediate(resolve));
+		expect(firstDisposeSettled).toBe(false);
+		expect(findKilledWorkerd(kill)).toBeDefined();
+
+		releaseRuntimeExit();
+		runtimeExitReleased = true;
+		const firstDisposeError = await firstDisposeResult;
+		expect(firstDisposeError).toBeInstanceOf(Error);
+		expect((firstDisposeError as Error).message).toContain(
+			"injected proxy cleanup failure"
+		);
+	} finally {
+		if (!runtimeExitReleased) releaseRuntimeExit();
+		emit.mockRestore();
+		proxyDispose.mockRestore();
+		await firstDisposeResult;
+		await mf.dispose().catch(() => {});
+	}
+});


### PR DESCRIPTION
Fixes #15085.

`Miniflare.dispose()` currently waits for browser/proxy cleanup before calling `Runtime.dispose()`, so either cleanup can delay or skip the `workerd` termination request.

This starts `Runtime.dispose()` first, which requests `workerd` termination before those cleanup awaits. Browser cleanup → exit-hook removal → proxy cleanup keeps the same order.

If browser/proxy cleanup fails, `Miniflare.dispose()` remembers that error, waits for the already-started runtime exit, continues the remaining cleanup, then returns the cleanup error.

Tests cover:

* requesting `workerd` termination while proxy cleanup is still pending;
* keeping `Miniflare.dispose()` pending on a proxy cleanup failure until the runtime exit settles.
* continuing the remaining cleanup after a proxy cleanup failure.

---

- Tests

  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation

  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: this changes internal teardown ordering without changing the public API.

*A picture of a long-eared jerboa*
<img width="365" height="547" alt="image" src="https://github.com/user-attachments/assets/f5c5f675-2987-4688-a613-1cc40af22659" />
