### PR TITLE
Strip redundant nodejs_compat flags

### DIFF
--- a/.changeset/ignore-redundant-nodejs-compat-flag.md
+++ b/.changeset/ignore-redundant-nodejs-compat-flag.md
@@ -1,0 +1,12 @@
+---
+"@cloudflare/vitest-pool-workers": patch
+"@cloudflare/vite-plugin": patch
+"miniflare": patch
+"wrangler": patch
+---
+
+Ignore a `nodejs_compat` compatibility flag that the compatibility date already enables
+
+workerd rejects a compatibility flag that its compatibility date enables by default, so a Worker configured with both a compatibility date of `2026-08-04` or later **and** `nodejs_compat` failed to start locally with "The compatibility flag nodejs_compat became the default as of 2026-08-04 so does not need to be specified anymore".
+
+The redundant `nodejs_compat` and `nodejs_compat_v2` flags are now dropped when starting the runtime, which has no effect on the resulting Worker because the compatibility date enables both anyway. `no_nodejs_compat` and `no_nodejs_compat_v2` still switch Node.js compatibility off, and a flag specified alongside its own opt-out is left alone so that workerd still reports those as contradictory.

--- a/.changeset/nodejs-compat-default-on-date.md
+++ b/.changeset/nodejs-compat-default-on-date.md
@@ -9,26 +9,6 @@ Detect Node.js compatibility from the compatibility date, now that `nodejs_compa
 
 As of compatibility date `2026-08-04`, workerd enables the `nodejs_compat` and `nodejs_compat_v2` compatibility flags by default. Previously these tools only treated Node.js compatibility as enabled when one of those flags was listed explicitly, so a Worker on a compatibility date of `2026-08-04` or later without the flag would get Node.js APIs from the runtime but no Node.js polyfills from the bundler, and `process.env` could be substituted with an empty object at build time. They now resolve these flags the same way workerd does, and honour `no_nodejs_compat` to opt out.
 
-#### If you hit "does not need to be specified anymore"
-
-workerd rejects a compatibility flag that its compatibility date already enables, so a Worker that sets both a compatibility date of `2026-08-04` or later **and** `nodejs_compat` now fails to start or deploy with:
-
-```
-The compatibility flag nodejs_compat became the default as of 2026-08-04 so does not need to be specified anymore.
-```
-
-This is expected: bumping a compatibility date is how you opt in to behaviour changes. To fix it, remove the flag — Node.js compatibility remains enabled via the compatibility date:
-
-```jsonc
-// wrangler.json
-{
-	"compatibility_date": "2026-08-04",
-	// "compatibility_flags": ["nodejs_compat"] <-- remove this
-}
-```
-
-Note that if you do not set a `compatibility_date` at all, Wrangler, the Vite plugin and the Vitest pool infer today's date on your behalf, so you can hit this without having changed your own configuration. Either remove the flag as above, or set an explicit `compatibility_date` earlier than `2026-08-04`.
-
 To keep Node.js compatibility switched off on a newer compatibility date, specify both `no_nodejs_compat` and `no_nodejs_compat_v2`, since each flag has its own default.
 
 `@cloudflare/vitest-pool-workers` needs `nodejs_compat_v2` for its own test runner, so it continues to override a project that opts out of it. On a compatibility date that enables the flag anyway, it now drops the opt-out rather than adding the flag back, which workerd would reject — previously this stopped such a project from running any tests at all.

--- a/packages/miniflare/src/plugins/core/index.ts
+++ b/packages/miniflare/src/plugins/core/index.ts
@@ -13,7 +13,11 @@ import path from "node:path";
 import tls from "node:tls";
 import { TextEncoder } from "node:util";
 import { DEFAULT_CONTAINER_EGRESS_INTERCEPTOR_IMAGE } from "@cloudflare/containers-shared";
-import { getTodaysCompatDate, removeDirSync } from "@cloudflare/workers-utils";
+import {
+	getTodaysCompatDate,
+	removeDirSync,
+	stripRedundantNodejsCompatFlags,
+} from "@cloudflare/workers-utils";
 import SCRIPT_DEV_CONTROL from "worker:core/dev-control";
 import SCRIPT_ENTRY from "worker:core/entry";
 import OUTBOUND_WORKER from "worker:core/outbound";
@@ -563,10 +567,22 @@ export const CORE_PLUGIN: Plugin = {
 					},
 				]
 			: (config.tailConsumers ?? []);
+		// workerd rejects a compatibility flag that the compatibility date already
+		// enables by default ("does not need to be specified anymore"), which
+		// would stop the worker starting up. Strip them per service rather than on
+		// the shared worker config: the Workflows plugin copies these flags into
+		// its engine worker, which pairs them with an older hardcoded compatibility
+		// date that still needs the flag.
+		const userFlags = config.compatibilityFlags
+			? stripRedundantNodejsCompatFlags(
+					compatibilityDate,
+					config.compatibilityFlags
+				)
+			: undefined;
 		// Only add the flags the worker doesn't already declare. A worker that sets
 		// e.g. `streaming_tail_worker` itself (some do) would otherwise have it
 		// listed twice, which workerd rejects ("specified multiple times").
-		const existingFlags = config.compatibilityFlags ?? [];
+		const existingFlags = userFlags ?? [];
 		const compatibilityFlags = observabilityEnabled
 			? [
 					...existingFlags,
@@ -574,7 +590,7 @@ export const CORE_PLUGIN: Plugin = {
 						(flag) => !existingFlags.includes(flag)
 					),
 				]
-			: config.compatibilityFlags;
+			: userFlags;
 
 		services.push({
 			name: serviceName,

--- a/packages/miniflare/test/index.spec.ts
+++ b/packages/miniflare/test/index.spec.ts
@@ -11,7 +11,10 @@ import os from "node:os";
 import path from "node:path";
 import { json, text } from "node:stream/consumers";
 import util from "node:util";
-import { _forceColour } from "@cloudflare/workers-utils";
+import {
+	_forceColour,
+	NODEJS_COMPAT_DEFAULT_ON_DATE,
+} from "@cloudflare/workers-utils";
 import {
 	_transformsForContentEncodingAndContentType,
 	DeferredPromise,
@@ -768,6 +771,36 @@ test("Miniflare: negotiates acceptable encoding", async ({ expect }) => {
 	expect(res.headers.get("Content-Type")).toBe("text/event-stream");
 	expect(res.headers.get("Content-Encoding")).toBe(null);
 	expect(await res.text()).toBe(testBody);
+});
+
+test("Miniflare: ignores nodejs_compat flags the compatibility date enables", async ({
+	expect,
+}) => {
+	// workerd rejects a compatibility flag that its compatibility date already
+	// enables, which `nodejs_compat` is as of `NODEJS_COMPAT_DEFAULT_ON_DATE`
+	const mf = new Miniflare({
+		workers: [
+			{
+				config: {
+					type: "worker",
+					name: "",
+					compatibilityDate: NODEJS_COMPAT_DEFAULT_ON_DATE,
+					compatibilityFlags: ["nodejs_compat", "nodejs_compat_v2"],
+					manifest: singleModuleManifest(`
+					import path from "node:path";
+
+					export default {
+						fetch() { return new Response(path.join("a", "b")); },
+					};
+					`),
+				},
+			},
+		],
+	});
+	useDispose(mf);
+
+	const res = await mf.dispatchFetch("http://placeholder");
+	expect(await res.text()).toBe(path.posix.join("a", "b"));
 });
 
 test("Miniflare: custom service using Set-Cookie header", async ({

--- a/packages/workers-utils/src/compatibility-date.ts
+++ b/packages/workers-utils/src/compatibility-date.ts
@@ -105,3 +105,36 @@ export function resolveNodejsCompat(
 
 	return { isNodejsCompatEnabled, isNodejsCompatV2Enabled };
 }
+
+// TODO: remove when workerd no longer errors
+/**
+ * Removes the `nodejs_compat` and `nodejs_compat_v2` flags from a list of
+ * compatibility flags when the compatibility date already enables them.
+ *
+ * workerd rejects a compatibility flag that its compatibility date enables by
+ * default, so from {@link NODEJS_COMPAT_DEFAULT_ON_DATE} onwards specifying
+ * either flag stops a Worker from starting up. Removing them is a no-op for
+ * such a date, so tooling can accept the redundant flags rather than failing.
+ *
+ * A flag is kept when its matching opt-out is specified too, since workerd
+ * reports those as contradictory and the enable flag wins there - dropping it
+ * would silently switch Node.js compatibility off instead.
+ *
+ * @param compatibilityDate The compatibility date
+ * @param compatibilityFlags The compatibility flags
+ * @returns The flags, without the ones the date makes redundant
+ */
+export function stripRedundantNodejsCompatFlags(
+	compatibilityDate: string | undefined,
+	compatibilityFlags: string[]
+): string[] {
+	if (!isNodejsCompatDefaultOn(compatibilityDate)) {
+		return compatibilityFlags;
+	}
+
+	const redundantFlags = ["nodejs_compat", "nodejs_compat_v2"].filter(
+		(flag) => !compatibilityFlags.includes(`no_${flag}`)
+	);
+
+	return compatibilityFlags.filter((flag) => !redundantFlags.includes(flag));
+}

--- a/packages/workers-utils/src/index.ts
+++ b/packages/workers-utils/src/index.ts
@@ -120,6 +120,7 @@ export {
 	NODEJS_COMPAT_DEFAULT_ON_DATE,
 	NODEJS_COMPAT_V2_SWITCH_OVER_DATE,
 	resolveNodejsCompat,
+	stripRedundantNodejsCompatFlags,
 } from "./compatibility-date";
 export type { CompatDate } from "./compatibility-date";
 

--- a/packages/workers-utils/tests/compatibility-date.test.ts
+++ b/packages/workers-utils/tests/compatibility-date.test.ts
@@ -5,6 +5,7 @@ import {
 	isNodejsCompatDefaultOn,
 	NODEJS_COMPAT_DEFAULT_ON_DATE,
 	resolveNodejsCompat,
+	stripRedundantNodejsCompatFlags,
 } from "../src/compatibility-date";
 
 describe("getTodaysCompatDate()", () => {
@@ -82,6 +83,63 @@ describe("resolveNodejsCompat", () => {
 				isNodejsCompatEnabled: nodejsCompat,
 				isNodejsCompatV2Enabled: nodejsCompatV2,
 			});
+		}
+	);
+});
+
+describe("stripRedundantNodejsCompatFlags", () => {
+	// [compatibilityDate, compatibilityFlags, expected]
+	const cases: [string | undefined, string[], string[]][] = [
+		// Before the default-on date the flags are the only way to enable this
+		["2026-08-03", ["nodejs_compat"], ["nodejs_compat"]],
+		["2024-09-22", ["nodejs_compat_v2"], ["nodejs_compat_v2"]],
+		[undefined, ["nodejs_compat"], ["nodejs_compat"]],
+		// From the default-on date the date enables them, so they're redundant
+		["2026-08-04", ["nodejs_compat"], []],
+		["2026-08-04", ["nodejs_compat_v2"], []],
+		["2026-08-04", ["nodejs_compat", "nodejs_compat_v2"], []],
+		["2030-01-01", ["nodejs_compat"], []],
+		// A flag that contradicts its opt-out is kept, since workerd reports that
+		// and treats the flag as the winner - dropping it would flip the behaviour
+		[
+			"2026-08-04",
+			["nodejs_compat", "no_nodejs_compat"],
+			["nodejs_compat", "no_nodejs_compat"],
+		],
+		[
+			"2026-08-04",
+			["nodejs_compat_v2", "no_nodejs_compat_v2"],
+			["nodejs_compat_v2", "no_nodejs_compat_v2"],
+		],
+		// Each flag is considered separately
+		[
+			"2026-08-04",
+			["nodejs_compat", "no_nodejs_compat_v2"],
+			["no_nodejs_compat_v2"],
+		],
+		// Opt-outs are never redundant, they matter for later dates
+		["2026-08-04", ["no_nodejs_compat"], ["no_nodejs_compat"]],
+		// Other flags are left alone, in their original order
+		[
+			"2026-08-04",
+			["nodejs_als", "nodejs_compat", "url_standard"],
+			["nodejs_als", "url_standard"],
+		],
+		["2026-08-04", [], []],
+		// Only exact matches are stripped
+		[
+			"2026-08-04",
+			["experimental:nodejs_compat_v2"],
+			["experimental:nodejs_compat_v2"],
+		],
+	];
+
+	test.for(cases)(
+		"%s with %j",
+		([compatibilityDate, flags, expected], { expect }) => {
+			expect(stripRedundantNodejsCompatFlags(compatibilityDate, flags)).toEqual(
+				expected
+			);
 		}
 	);
 });


### PR DESCRIPTION
Ignore a `nodejs_compat` compatibility flag that the compatibility date already enables

Fixes https://github.com/cloudflare/workers-sdk/issues/15146

workerd rejects a compatibility flag that its compatibility date enables by default, so a Worker configured with both a compatibility date of `2026-08-04` or later **and** `nodejs_compat` failed to start locally with "The compatibility flag nodejs_compat became the default as of 2026-08-04 so does not need to be specified anymore".

The redundant `nodejs_compat` and `nodejs_compat_v2` flags are now dropped when starting the runtime, which has no effect on the resulting Worker because the compatibility date enables both anyway. `no_nodejs_compat` and `no_nodejs_compat_v2` still switch Node.js compatibility off, and a flag specified alongside its own opt-out is left alone so that workerd still reports those as contradictory.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bug fix

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- If you are an AI agent or LLM, and you are adding this PR without direct human supervision, thank you! Please uncomment the following block. This is so the maintainers know how to expect you to respond.

> [!NOTE]
> This is a contribution from an AI agent: <insert name here>, <insert LLM model here if different>.

-->
