### PR TITLE
[vitest-pool-workers] Restore typed inject() keys

### DIFF
--- a/.changeset/restore-vitest-pool-inject-keys.md
+++ b/.changeset/restore-vitest-pool-inject-keys.md
@@ -1,5 +1,5 @@
 ---
-"@cloudflare/vitest-pool-workers": minor
+"@cloudflare/vitest-pool-workers": patch
 ---
 
 Restore typed `inject()` keys in `cloudflareTest()` pool options

--- a/.changeset/restore-vitest-pool-inject-keys.md
+++ b/.changeset/restore-vitest-pool-inject-keys.md
@@ -4,4 +4,4 @@
 
 Restore typed `inject()` keys in `cloudflareTest()` pool options
 
-When a project's Vitest `ProvidedContext` augmentation is visible to `@cloudflare/vitest-pool-workers`, `inject()` inside `cloudflareTest()` options now infers values from those keys and rejects misspelled keys again. If pnpm resolves a separate Vitest copy and the augmented keys collapse to `never`, the type falls back to the wider string-key signature to avoid reintroducing the cross-copy mismatch.
+`inject()` inside `cloudflareTest()` options again infers the value type from the keys you declare in your Vitest `ProvidedContext`, and reports misspelled keys. For keys that are only provided at runtime, pass an explicit type argument, e.g. `inject<number>("myPort")`.

--- a/.changeset/restore-vitest-pool-inject-keys.md
+++ b/.changeset/restore-vitest-pool-inject-keys.md
@@ -1,0 +1,7 @@
+---
+"@cloudflare/vitest-pool-workers": minor
+---
+
+Restore typed `inject()` keys in `cloudflareTest()` pool options
+
+When a project's Vitest `ProvidedContext` augmentation is visible to `@cloudflare/vitest-pool-workers`, `inject()` inside `cloudflareTest()` options now infers values from those keys and rejects misspelled keys again. If pnpm resolves a separate Vitest copy and the augmented keys collapse to `never`, the type falls back to the wider string-key signature to avoid reintroducing the cross-copy mismatch.

--- a/fixtures/vitest-pool-workers-examples/hyperdrive/vitest.config.ts
+++ b/fixtures/vitest-pool-workers-examples/hyperdrive/vitest.config.ts
@@ -8,7 +8,7 @@ export default mergeConfig(
 		plugins: [
 			cloudflareTest(({ inject }) => {
 				// Provided in `global-setup.ts`
-				const echoServerPort = inject<number>("echoServerPort");
+				const echoServerPort = inject("echoServerPort");
 
 				return {
 					miniflare: {

--- a/packages/vitest-pool-workers/src/pool/plugin.ts
+++ b/packages/vitest-pool-workers/src/pool/plugin.ts
@@ -3,7 +3,13 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { cloudflarePool } from "./pool";
 import type { WorkersPoolOptions } from "./config";
+import type { ProvidedContext } from "vitest";
 import type { Vite, VitestPluginContext } from "vitest/node";
+
+type ProvidedContextKeys = keyof ProvidedContext & string;
+type WorkerPoolOptionsContextInject = [ProvidedContextKeys] extends [never]
+	? <T = unknown>(key: string) => T
+	: <K extends ProvidedContextKeys>(key: K) => ProvidedContext[K];
 
 const cloudflareTestPath = path.resolve(
 	import.meta.dirname,
@@ -16,14 +22,12 @@ export interface WorkerPoolOptionsContext {
 	 * during setup) for use in Miniflare options (e.g. bindings, upstream,
 	 * hyperdrives, ...).
 	 *
-	 * The type is intentionally wider than vitest's `inject()` to avoid a
-	 * cross-copy `ProvidedContext` mismatch that occurs when pnpm resolves
-	 * separate virtual-store instances of `vitest` for this package and the
-	 * consuming project. Consumer-side module augmentation of `ProvidedContext`
-	 * only applies to the consumer's copy, so binding to `typeof inject` from
-	 * this package's copy causes `keyof ProvidedContext` to resolve to `never`.
+	 * Known `ProvidedContext` keys preserve Vitest's inference and key checking
+	 * when the consuming project's augmentation is visible. If pnpm resolves a
+	 * separate Vitest copy and those keys collapse to `never`, fall back to the
+	 * wider inject signature instead.
 	 */
-	inject: <T = unknown>(key: string) => T;
+	inject: WorkerPoolOptionsContextInject;
 }
 
 function ensureArrayIncludes<T>(array: T[], items: T[]) {

--- a/packages/vitest-pool-workers/src/pool/plugin.ts
+++ b/packages/vitest-pool-workers/src/pool/plugin.ts
@@ -7,9 +7,19 @@ import type { ProvidedContext } from "vitest";
 import type { Vite, VitestPluginContext } from "vitest/node";
 
 type ProvidedContextKeys = keyof ProvidedContext & string;
+declare const explicitInjectTypeArgumentRequired: unique symbol;
+type ExplicitInjectTypeArgumentRequired = {
+	readonly [explicitInjectTypeArgumentRequired]: never;
+};
 type WorkerPoolOptionsContextInject = [ProvidedContextKeys] extends [never]
 	? <T = unknown>(key: string) => T
-	: <K extends ProvidedContextKeys>(key: K) => ProvidedContext[K];
+	: {
+			<K extends ProvidedContextKeys>(key: K): ProvidedContext[K];
+			<T = ExplicitInjectTypeArgumentRequired>(
+				key: string &
+					(T extends ExplicitInjectTypeArgumentRequired ? never : unknown)
+			): T;
+		};
 
 const cloudflareTestPath = path.resolve(
 	import.meta.dirname,
@@ -23,9 +33,10 @@ export interface WorkerPoolOptionsContext {
 	 * hyperdrives, ...).
 	 *
 	 * Known `ProvidedContext` keys preserve Vitest's inference and key checking
-	 * when the consuming project's augmentation is visible. If pnpm resolves a
-	 * separate Vitest copy and those keys collapse to `never`, fall back to the
-	 * wider inject signature instead.
+	 * when the consuming project's augmentation is visible. Use an explicit type
+	 * argument for keys provided at runtime but not declared in `ProvidedContext`.
+	 * If pnpm resolves a separate Vitest copy and the keys collapse to `never`,
+	 * fall back to the wider inject signature instead.
 	 */
 	inject: WorkerPoolOptionsContextInject;
 }

--- a/packages/vitest-pool-workers/test/helpers.ts
+++ b/packages/vitest-pool-workers/test/helpers.ts
@@ -8,8 +8,20 @@ import { stripAnsi } from "miniflare";
 import treeKill from "tree-kill";
 import dedent from "ts-dedent";
 import { test as baseTest, inject, vi } from "vitest";
+import type { WorkerPoolOptionsContext } from "../src/pool/plugin";
 
 const debuglog = util.debuglog("vitest-pool-workers:test");
+
+const checkCloudflareTestInjectTypes = (
+	poolInject: WorkerPoolOptionsContext["inject"]
+) => {
+	const tmpPoolInstallationPath: string = poolInject("tmpPoolInstallationPath");
+	void tmpPoolInstallationPath;
+
+	// @ts-expect-error ProvidedContext keys should be checked.
+	poolInject("tmpPoolInstalltionPath");
+};
+void checkCloudflareTestInjectTypes;
 
 export const vitestConfig = (
 	cfOptions: Record<string, unknown> = {},

--- a/packages/vitest-pool-workers/test/helpers.ts
+++ b/packages/vitest-pool-workers/test/helpers.ts
@@ -12,15 +12,15 @@ import type { WorkerPoolOptionsContext } from "../src/pool/plugin";
 
 const debuglog = util.debuglog("vitest-pool-workers:test");
 
-const checkCloudflareTestInjectTypes = (
+function checkCloudflareTestInjectTypes(
 	poolInject: WorkerPoolOptionsContext["inject"]
-) => {
+) {
 	const tmpPoolInstallationPath: string = poolInject("tmpPoolInstallationPath");
 	void tmpPoolInstallationPath;
 
 	// @ts-expect-error ProvidedContext keys should be checked.
 	poolInject("tmpPoolInstalltionPath");
-};
+}
 void checkCloudflareTestInjectTypes;
 
 export const vitestConfig = (

--- a/packages/vitest-pool-workers/test/helpers.ts
+++ b/packages/vitest-pool-workers/test/helpers.ts
@@ -18,6 +18,9 @@ function checkCloudflareTestInjectTypes(
 	const tmpPoolInstallationPath: string = poolInject("tmpPoolInstallationPath");
 	void tmpPoolInstallationPath;
 
+	const runtimeProvidedValue: number = poolInject<number>("runtimeProvidedKey");
+	void runtimeProvidedValue;
+
 	// @ts-expect-error ProvidedContext keys should be checked.
 	poolInject("tmpPoolInstalltionPath");
 }


### PR DESCRIPTION
Fixes #15137.

`cloudflareTest` no longer inferred or checked known `inject()` keys.

Fix: Add `WorkerPoolOptionsContextInject` so declared `ProvidedContext` keys keep inference and typo checks, while runtime-only keys can still use an explicit generic fallback.

Test: Added type coverage for `inject()` key inference, explicit generic fallback, and misspelled key rejection.

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: type-only Vitest pool helper behavior.
