### PR TITLE
fix(wrangler): keep `allowTrailingCommas` off the config schema root `$ref`

### DIFF
--- a/.changeset/nine-jars-shake.md
+++ b/.changeset/nine-jars-shake.md
@@ -4,4 +4,4 @@
 
 Fix spurious `Trailing comma jsonc(519)` warnings for `wrangler.jsonc` in VS Code 1.131+
 
-The generated `config-schema.json` placed the `allowTrailingCommas` hint next to the schema's root `$ref`. VS Code 1.131 updated `vscode-json-languageservice` to a version that treats a draft-07 `$ref` as overriding its sibling keywords, so `allowTrailingCommas` was dropped during resolution and every trailing comma in a `wrangler.jsonc` was flagged, even though Wrangler itself parses those files fine. The root reference now sits inside an `allOf`, which keeps `allowTrailingCommas` on the root schema for both old and new versions of the language service.
+Trailing commas in `wrangler.jsonc` files that reference Wrangler's JSON schema are no longer reported as errors by recent versions of VS Code. Wrangler always accepted these files; only the editor warning was wrong.

--- a/.changeset/nine-jars-shake.md
+++ b/.changeset/nine-jars-shake.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Fix spurious `Trailing comma jsonc(519)` warnings for `wrangler.jsonc` in VS Code 1.131+
+
+The generated `config-schema.json` placed the `allowTrailingCommas` hint next to the schema's root `$ref`. VS Code 1.131 updated `vscode-json-languageservice` to a version that treats a draft-07 `$ref` as overriding its sibling keywords, so `allowTrailingCommas` was dropped during resolution and every trailing comma in a `wrangler.jsonc` was flagged, even though Wrangler itself parses those files fine. The root reference now sits inside an `allOf`, which keeps `allowTrailingCommas` on the root schema for both old and new versions of the language service.

--- a/packages/wrangler/scripts/generate-json-schema.ts
+++ b/packages/wrangler/scripts/generate-json-schema.ts
@@ -11,7 +11,7 @@ const config: Config = {
 	markdownDescription: true,
 };
 
-const applyFormattingRules = ({ $ref, ...schema }: Schema) => {
+function applyFormattingRules({ $ref, ...schema }: Schema) {
 	// `allowTrailingCommas` is a VS Code extension to JSON Schema. In draft-07 a
 	// `$ref` overrides its sibling keywords, so editors discard `allowTrailingCommas`
 	// when it sits next to the root `$ref`, and every trailing comma in a
@@ -22,7 +22,7 @@ const applyFormattingRules = ({ $ref, ...schema }: Schema) => {
 		allowTrailingCommas: true,
 		...($ref === undefined ? {} : { allOf: [{ $ref }] }),
 	};
-};
+}
 
 const schema = applyFormattingRules(
 	createGenerator(config).createSchema(config.type)

--- a/packages/wrangler/scripts/generate-json-schema.ts
+++ b/packages/wrangler/scripts/generate-json-schema.ts
@@ -11,8 +11,17 @@ const config: Config = {
 	markdownDescription: true,
 };
 
-const applyFormattingRules = (schema: Schema) => {
-	return { ...schema, allowTrailingCommas: true };
+const applyFormattingRules = ({ $ref, ...schema }: Schema) => {
+	// `allowTrailingCommas` is a VS Code extension to JSON Schema. In draft-07 a
+	// `$ref` overrides its sibling keywords, so editors discard `allowTrailingCommas`
+	// when it sits next to the root `$ref`, and every trailing comma in a
+	// `wrangler.jsonc` is reported as `jsonc(519)`. Moving the reference into an
+	// `allOf` keeps both.
+	return {
+		...schema,
+		allowTrailingCommas: true,
+		...($ref === undefined ? {} : { allOf: [{ $ref }] }),
+	};
 };
 
 const schema = applyFormattingRules(

--- a/packages/wrangler/src/__tests__/config-schema.test.ts
+++ b/packages/wrangler/src/__tests__/config-schema.test.ts
@@ -1,0 +1,29 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, it } from "vitest";
+
+type WranglerSchema = {
+	$ref?: string;
+	allOf?: { $ref: string }[];
+	allowTrailingCommas?: boolean;
+};
+
+function readSchema(): WranglerSchema {
+	const schemaFile = path.join(__dirname, "../../config-schema.json");
+	return JSON.parse(fs.readFileSync(schemaFile, "utf-8")) as WranglerSchema;
+}
+
+describe("config schema", () => {
+	it("keeps allowTrailingCommas off the root $ref", ({ expect }) => {
+		const schema = readSchema();
+
+		// `allowTrailingCommas` is a VS Code extension to JSON Schema. In draft-07 a
+		// `$ref` overrides its sibling keywords, so an editor resolving a root `$ref`
+		// discards anything next to it — which would make every trailing comma in a
+		// `wrangler.jsonc` report a spurious `jsonc(519)` warning. Keeping the
+		// reference inside `allOf` leaves `allowTrailingCommas` on the root.
+		expect(schema.allowTrailingCommas).toBe(true);
+		expect(schema).not.toHaveProperty("$ref");
+		expect(schema.allOf).toEqual([{ $ref: "#/definitions/RawConfig" }]);
+	});
+});


### PR DESCRIPTION
Fixes #14927

## Problem

Since VS Code 1.131, every trailing comma in a `wrangler.jsonc` that points at Wrangler's generated schema is flagged:

```
Trailing comma jsonc(519)
```

Wrangler itself parses the file fine and builds succeed — the warning is editor-only, but it fires on every trailing comma in the file.

## Root cause

`packages/wrangler/scripts/generate-json-schema.ts:14-16` (on `main`) attaches the `allowTrailingCommas` hint to the root of the schema produced by `ts-json-schema-generator`:

```ts
const applyFormattingRules = (schema: Schema) => {
	return { ...schema, allowTrailingCommas: true };
};
```

That root object also carries `"$ref": "#/definitions/RawConfig"`, so the generated `config-schema.json` root is:

```json
["$schema", "$ref", "definitions", "allowTrailingCommas"]
```

`allowTrailingCommas` is a VS Code extension to JSON Schema, and it is a **sibling of the root `$ref`**. `vscode-json-languageservice` 6.0.0-next.2 ([PR #308](https://github.com/microsoft/vscode-json-languageservice/pull/308)) changed draft-04..draft-07 resolution so a `$ref` *overrides* its sibling keywords instead of merging with them. `allowTrailingCommas` is therefore discarded while the schema is resolved, the default trailing-comma severity applies, and the parser's `ErrorCode.TrailingComma` (519) surfaces.

VS Code 1.131 picked that version up in [microsoft/vscode@49715cf](https://github.com/microsoft/vscode/commit/49715cfcdb76296719952c994010ac27a18653d9). I confirmed that commit bumps `extensions/json-language-features` from `^6.0.0-next.1` to `^6.0.0-next.2`, and that `git compare 49715cf...1.131.0` reports `ahead`, i.e. the bump is an ancestor of the 1.131.0 tag.

## Fix

Lift the root `$ref` out and re-attach it under `allOf`, so `allowTrailingCommas` is no longer a `$ref` sibling. The language service's `schemaAllowsTrailingCommas` recurses into `allOf`, and older versions merged siblings anyway, so both old and new resolve correctly. This is the shape the reporter proposed.

Generated root keys become:

```json
["$schema", "definitions", "allowTrailingCommas", "allOf"]
```

with `allOf: [{ "$ref": "#/definitions/RawConfig" }]`.

`config-schema.json` itself is gitignored and regenerated by the build, so the diff is only the generator, a test, and a changeset.

## Before/after evidence

Driven from Node against the exact library version VS Code 1.131 bundles, using the reporter's `wrangler.jsonc` verbatim and the **real** generated `config-schema.json`. The schema is fetched by URI through a `schemaRequestService` and associated with the document, the same path a `"$schema"` pointer takes.

`vscode-json-languageservice@6.0.0-next.2`:

```
=== 1. trailing comma (the reported bug) ===
BEFORE: ["519: Trailing comma"]
AFTER : []
```

The full BEFORE diagnostic, verbatim:

```json
[{ "range": {"start":{"line":4,"character":35},"end":{"line":4,"character":36}},
   "message": "Trailing comma", "severity": 1, "code": 519, "source": "jsonc" }]
```

Version control — the same baseline schema on `6.0.0-next.1` (VS Code 1.130) reports `[]`, so the trigger really is the `$ref`-sibling change, not a Wrangler-only defect. After the fix, `next.1` still reports `[]`.

No editor regression, measured BEFORE vs AFTER on the real schema on `next.2`:

```
=== 2. diagnostics on an INVALID config (must be unchanged) ===
BEFORE: ["Incorrect type. Expected \"string\".","Property unknown_key is not allowed."]
AFTER : ["Incorrect type. Expected \"string\".","Property unknown_key is not allowed."]  -> SAME

=== 3. completions inside the object ===
BEFORE count: 88 | first 6: $schema, env, name, account_id, compatibility_date, compatibility_flags
AFTER  count: 88 | first 6: $schema, env, name, account_id, compatibility_date, compatibility_flags  -> SAME

=== 4. hover on a property ===
BEFORE: "A date in the form yyyy-mm-dd, which will be used to determine\nwhich version of the Workers runti…"
AFTER :  (identical)  -> SAME
```

So invalid configs are still rejected identically, and completions/hovers are untouched.

## Test

New `packages/wrangler/src/__tests__/config-schema.test.ts`, modelled on the existing `src/__tests__/containers/schema.test.ts`, which already asserts against the generated `config-schema.json`.

Verified against a true baseline — `git show origin/main:packages/wrangler/scripts/generate-json-schema.ts`, then re-running `generate-json-schema` so the artifact comes from the unfixed script. Baseline script contains 0 occurrences of `allOf`; baseline artifact root is `["$schema","$ref","definitions","allowTrailingCommas"]`.

```
BASELINE: Test Files 1 failed | 1 passed (2) ; Tests 1 failed | 2 passed (3)
          FAIL src/__tests__/config-schema.test.ts > keeps allowTrailingCommas off the root $ref
          AssertionError: expected { …(4) } to not have property "$ref"
WITH FIX: Test Files 2 passed (2) ; Tests 3 passed (3)
```

## What I ran

- `pnpm install --frozen-lockfile`, `npx turbo build --filter=wrangler...` — both exit 0
- Config + containers suites: **18 files, 253 passed, 1 skipped, exit 0**
- Full `vitest run` for `wrangler`: **248/251 files passed, 4904 passed, 27 failed, exit 1**
- `oxfmt --check` repo-wide: clean across 4826 files
- `oxlint --deny-warnings --type-aware` on the changed areas: 0 warnings, 0 errors
- `tsc -p ./tsconfig.json`, `tsc -p ./templates/tsconfig.json`, `tsc -p ./src/__tests__/tsconfig.json` — all exit 0

The 27 full-suite failures are **pre-existing and unrelated**. I re-ran the same three files on an untouched `main` (`e5d56e9`, `git diff origin/main` empty) and got the identical set — `diff` of the sorted `FAIL` lines between baseline and this branch is empty, 27 vs 27:

```
src/__tests__/tail.test.ts                       (16 failed)
src/__tests__/pages/pages-deployment-tail.test.ts (10 failed)
src/__tests__/dev/remote-bindings.test.ts         (1 failed)
```

They are environmental: 27 of them are `Error: The snapshot state for '…tail.test.ts' is not found. Did you call 'SnapshotClient.setup()'?`, and the remote-bindings one is `Address already in use (127.0.0.1:8787)`.

## What I could NOT verify

- I did not test inside a real VS Code 1.131 window. The behavioural proof is against `vscode-json-languageservice@6.0.0-next.2` driven from Node — the exact library version that commit pins — not the editor itself.
- I did not run the e2e suites (`test:e2e`).
- The three pre-existing failing files fail in my local environment for the reasons above; I have not checked whether they pass in CI.


---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: this fixes an editor-only diagnostic regression in the generated `config-schema.json`. The schema's shape is an internal build artifact, no documented Wrangler behaviour, config key, or public API changes, and users see only the disappearance of a spurious `jsonc(519)` warning.
