### PR TITLE
WC-5744 [previews] fix: wrangler preview base-config flag inheritance

### DIFF
--- a/.changeset/small-oranges-warn.md
+++ b/.changeset/small-oranges-warn.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Fix `wrangler preview base-config` commands showing an inherited `script` positional

--- a/packages/wrangler/src/__tests__/preview.base-config.secret.test.ts
+++ b/packages/wrangler/src/__tests__/preview.base-config.secret.test.ts
@@ -143,6 +143,18 @@ describe("wrangler preview", () => {
 			}
 		);
 
+		test("does not inherit the preview script positional", async ({ expect }) => {
+			await expect(
+				runWrangler("preview base-config secret put")
+			).rejects.toThrow(/Not enough non-option arguments/);
+			expect(std.out).toContain(
+				"wrangler preview base-config secret put <key>"
+			);
+			expect(std.out).not.toContain(
+				"script  The path to an entry point for your Worker"
+			);
+		});
+
 		describe("put", () => {
 			const mockStdIn = useMockStdin({ isTTY: false });
 

--- a/packages/wrangler/src/__tests__/preview.base-config.secret.test.ts
+++ b/packages/wrangler/src/__tests__/preview.base-config.secret.test.ts
@@ -143,7 +143,9 @@ describe("wrangler preview", () => {
 			}
 		);
 
-		test("does not inherit the preview script positional", async ({ expect }) => {
+		test("does not inherit the preview script positional", async ({
+			expect,
+		}) => {
 			await expect(
 				runWrangler("preview base-config secret put")
 			).rejects.toThrow(/Not enough non-option arguments/);

--- a/packages/wrangler/src/preview/base-config/index.ts
+++ b/packages/wrangler/src/preview/base-config/index.ts
@@ -6,5 +6,6 @@ export const previewBaseConfigNamespace = createNamespace({
 		owner: "Workers: Deploy and Config",
 		category: "Compute & AI",
 		status: "private beta",
+		hideGlobalFlags: ["script"],
 	},
 });


### PR DESCRIPTION
Fixes WC-5744

[private beta] `wrangler preview base-config` commands incorrectly accept `script` as a positional. This results in weird behavior like:
```
✘ [ERROR] Not enough non-option arguments: got 0, need at least 1

wrangler preview base-config secret put <key>

Create or update a secret variable on the Preview base config [private beta]

POSITIONALS
  script  The path to an entry point for your Worker  [string]
  key     The secret name to be accessible in the Worker  [string] [required] 
```

This behavior is only present since we use `wrangler preview <script>` rather than `wrangler preview deploy` - so ignoring this manually.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [X] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [X] Documentation not necessary because: private beta

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- If you are an AI agent or LLM, and you are adding this PR without direct human supervision, thank you! Please uncomment the following block. This is so the maintainers know how to expect you to respond.

> [!NOTE]
> This is a contribution from an AI agent: <insert name here>, <insert LLM model here if different>.

-->
