### PR TITLE
[wrangler] Omit `mainModule` for build-output entrypoints in `wrangler types`

### DIFF
--- a/.changeset/curvy-moons-listen.md
+++ b/.changeset/curvy-moons-listen.md
@@ -1,0 +1,11 @@
+---
+"wrangler": patch
+---
+
+Omit `mainModule` from generated types when the entrypoint is a framework build artefact
+
+`wrangler types` declared `Cloudflare.GlobalProps.mainModule` as `typeof import("<main>")`. When `main` points into a framework build output directory (for example SvelteKit's `.svelte-kit/cloudflare/_worker.js`), that import made `tsc` and `svelte-check` follow the reference and type-check generated code, producing errors in `worker-configuration.d.ts` on a clean project — or failing outright before the first build had run.
+
+The `mainModule` declaration is now skipped when the entrypoint resolves inside a directory whose name begins with `.`, relative to the Wrangler config. Entrypoints in ordinary directories, and those outside the config directory, are unaffected.
+
+`durableNamespaces` was previously emitted only alongside `mainModule`; it is now declared independently, so Durable Object namespace types survive for these projects.

--- a/packages/wrangler/src/__tests__/type-generation.test.ts
+++ b/packages/wrangler/src/__tests__/type-generation.test.ts
@@ -3793,6 +3793,166 @@ export default { async fetch() { return new Response("ok"); } };`
 			`);
 		});
 	});
+
+	describe("entrypoints inside framework build output", () => {
+		it("omits `mainModule` when the entrypoint is inside a build output directory", async ({
+			expect,
+		}) => {
+			fs.mkdirSync("./.svelte-kit/cloudflare", { recursive: true });
+			fs.writeFileSync(
+				"./.svelte-kit/cloudflare/_worker.js",
+				`export default { async fetch() { return new Response("ok"); } };`
+			);
+			fs.writeFileSync(
+				"./wrangler.json",
+				JSON.stringify({
+					compatibility_date: "2026-01-01",
+					name: "test-build-output-entrypoint",
+					main: "./.svelte-kit/cloudflare/_worker.js",
+					vars: { myVar: "hello" },
+				}),
+				"utf-8"
+			);
+
+			await runWrangler("types --include-runtime=false");
+
+			// No `GlobalProps` at all: `mainModule` is suppressed and there are no
+			// Durable Objects to declare.
+			expect(std.out).toMatchInlineSnapshot(`
+				"
+				 ⛅️ wrangler x.x.x
+				──────────────────
+				Generating project types...
+
+				interface __BaseEnv_Env {
+					myVar: "hello";
+				}
+				declare namespace Cloudflare {
+					interface Env extends __BaseEnv_Env {}
+				}
+				interface Env extends __BaseEnv_Env {}
+
+				────────────────────────────────────────────────────────────
+				✨ Types written to worker-configuration.d.ts
+
+				📣 Remember to rerun 'wrangler types' after you change your wrangler.json file.
+				"
+			`);
+			expect(std.out).not.toContain("mainModule");
+		});
+
+		it("still declares `durableNamespaces` when `mainModule` is suppressed", async ({
+			expect,
+		}) => {
+			fs.mkdirSync("./.svelte-kit/cloudflare", { recursive: true });
+			fs.writeFileSync(
+				"./.svelte-kit/cloudflare/_worker.js",
+				`import { DurableObject } from "cloudflare:workers";
+export class CounterDO extends DurableObject {}
+export default { async fetch() { return new Response("ok"); } };`
+			);
+			fs.writeFileSync(
+				"./wrangler.json",
+				JSON.stringify({
+					compatibility_date: "2026-01-01",
+					name: "test-build-output-entrypoint-with-do",
+					main: "./.svelte-kit/cloudflare/_worker.js",
+					durable_objects: {
+						bindings: [{ name: "COUNTER", class_name: "CounterDO" }],
+					},
+					exports: {
+						CounterDO: { type: "durable-object", storage: "sqlite" },
+					},
+				}),
+				"utf-8"
+			);
+
+			await runWrangler("types --include-runtime=false");
+
+			// `GlobalProps` must survive without `mainModule`. Note the `COUNTER`
+			// binding still imports from the build output — Durable Object, Service
+			// and Workflow entrypoints fall back to the main entrypoint and are not
+			// covered by this change, because suppressing them would downgrade
+			// `DurableObjectNamespace<...>` to an untyped `DurableObjectNamespace`.
+			expect(std.out).toMatchInlineSnapshot(`
+				"
+				 ⛅️ wrangler x.x.x
+				──────────────────
+				Generating project types...
+
+				interface __BaseEnv_Env {
+					COUNTER: DurableObjectNamespace<import("./.svelte-kit/cloudflare/_worker").CounterDO>;
+				}
+				declare namespace Cloudflare {
+					interface GlobalProps {
+						durableNamespaces: "CounterDO";
+					}
+					interface Env extends __BaseEnv_Env {}
+				}
+				interface Env extends __BaseEnv_Env {}
+
+				────────────────────────────────────────────────────────────
+				✨ Types written to worker-configuration.d.ts
+
+				📣 Remember to rerun 'wrangler types' after you change your wrangler.json file.
+				"
+			`);
+			expect(std.out).not.toContain("mainModule");
+			expect(std.out).toContain('durableNamespaces: "CounterDO";');
+		});
+
+		it("keeps `mainModule` for an entrypoint in a regular nested directory", async ({
+			expect,
+		}) => {
+			fs.mkdirSync("./build", { recursive: true });
+			fs.writeFileSync(
+				"./build/worker.js",
+				`export default { async fetch() { return new Response("ok"); } };`
+			);
+			fs.writeFileSync(
+				"./wrangler.json",
+				JSON.stringify({
+					compatibility_date: "2026-01-01",
+					name: "test-nested-entrypoint",
+					main: "./build/worker.js",
+					vars: { myVar: "hello" },
+				}),
+				"utf-8"
+			);
+
+			await runWrangler("types --include-runtime=false");
+
+			expect(std.out).toContain('mainModule: typeof import("./build/worker");');
+		});
+
+		it("keeps `mainModule` for an entrypoint outside the config directory", async ({
+			expect,
+		}) => {
+			fs.mkdirSync("./worker-config", { recursive: true });
+			fs.writeFileSync(
+				"./index.ts",
+				`export default { async fetch() { return new Response("ok"); } };`
+			);
+			fs.writeFileSync(
+				"./worker-config/wrangler.json",
+				JSON.stringify({
+					compatibility_date: "2026-01-01",
+					name: "test-entrypoint-above-config",
+					main: "../index.ts",
+					vars: { myVar: "hello" },
+				}),
+				"utf-8"
+			);
+
+			await runWrangler(
+				"types --include-runtime=false -c ./worker-config/wrangler.json"
+			);
+
+			// A relative path starting with `..` means the entrypoint merely lives
+			// outside the config directory, which is not a build output directory.
+			expect(std.out).toContain("mainModule: typeof import(");
+		});
+	});
 });
 
 describe("generate types - API", () => {

--- a/packages/wrangler/src/__tests__/type-generation.test.ts
+++ b/packages/wrangler/src/__tests__/type-generation.test.ts
@@ -3925,6 +3925,53 @@ export default { async fetch() { return new Response("ok"); } };`
 			expect(std.out).toContain('mainModule: typeof import("./build/worker");');
 		});
 
+		it("keeps `mainModule` for an entrypoint whose file name starts with a dot", async ({
+			expect,
+		}) => {
+			fs.mkdirSync("./build", { recursive: true });
+			fs.writeFileSync(
+				"./.worker.js",
+				`export default { async fetch() { return new Response("ok"); } };`
+			);
+			fs.writeFileSync(
+				"./build/.worker.js",
+				`export default { async fetch() { return new Response("ok"); } };`
+			);
+			fs.writeFileSync(
+				"./wrangler.json",
+				JSON.stringify({
+					compatibility_date: "2026-01-01",
+					name: "test-dot-prefixed-entrypoint",
+					main: "./.worker.js",
+					vars: { myVar: "hello" },
+				}),
+				"utf-8"
+			);
+
+			await runWrangler("types --include-runtime=false");
+
+			// Only directories are treated as build output, so a hidden file name
+			// keeps its `mainModule` declaration.
+			expect(std.out).toContain('mainModule: typeof import("./.worker");');
+
+			fs.writeFileSync(
+				"./wrangler.json",
+				JSON.stringify({
+					compatibility_date: "2026-01-01",
+					name: "test-dot-prefixed-entrypoint",
+					main: "./build/.worker.js",
+					vars: { myVar: "hello" },
+				}),
+				"utf-8"
+			);
+
+			await runWrangler("types --include-runtime=false");
+
+			expect(std.out).toContain(
+				'mainModule: typeof import("./build/.worker");'
+			);
+		});
+
 		it("keeps `mainModule` for an entrypoint outside the config directory", async ({
 			expect,
 		}) => {

--- a/packages/wrangler/src/type-generation/index.ts
+++ b/packages/wrangler/src/type-generation/index.ts
@@ -795,26 +795,23 @@ export function generateImportSpecifier(from: string, to: string) {
  * Returns true if `entrypointFile` sits inside a framework build output
  * directory, relative to the directory holding the Wrangler config.
  *
- * Any path segment beginning with `.` counts: frameworks consistently write
- * generated output to a hidden directory (`.svelte-kit`, `.next`, `.nuxt`,
- * `.output`). An entrypoint that is merely outside the config directory is not
- * build output, so a relative path starting with `..` is excluded.
+ * Any directory segment beginning with `.` counts: frameworks consistently
+ * write generated output to a hidden directory (`.svelte-kit`, `.next`,
+ * `.nuxt`, `.output`). Only directories are considered — a hidden file name
+ * such as `.worker.js` says nothing about how the file was produced.
+ * An entrypoint that is merely outside the config directory is not build
+ * output, so a relative path that walks up out of it is excluded.
  */
 function isEntrypointInBuildOutputDir(
 	configDir: string,
 	entrypointFile: string
 ): boolean {
-	const relativePath = relative(configDir, entrypointFile);
-	if (relativePath.startsWith("..")) {
+	const segments = relative(configDir, dirname(entrypointFile)).split(sep);
+	if (segments.includes("..")) {
 		return false;
 	}
 
-	return relativePath
-		.split(sep)
-		.some(
-			(segment) =>
-				segment.startsWith(".") && segment !== "." && segment !== ".."
-		);
+	return segments.some((segment) => segment.startsWith("."));
 }
 
 /**

--- a/packages/wrangler/src/type-generation/index.ts
+++ b/packages/wrangler/src/type-generation/index.ts
@@ -1,6 +1,14 @@
 import { createHash } from "node:crypto";
 import * as fs from "node:fs";
-import { basename, dirname, extname, join, relative, resolve } from "node:path";
+import {
+	basename,
+	dirname,
+	extname,
+	join,
+	relative,
+	resolve,
+	sep,
+} from "node:path";
 import { RUNTIME_TYPES_MARKER } from "@cloudflare/runtime-types";
 import {
 	CommandLineArgsError,
@@ -784,6 +792,89 @@ export function generateImportSpecifier(from: string, to: string) {
 }
 
 /**
+ * Returns true if `entrypointFile` sits inside a framework build output
+ * directory, relative to the directory holding the Wrangler config.
+ *
+ * Any path segment beginning with `.` counts: frameworks consistently write
+ * generated output to a hidden directory (`.svelte-kit`, `.next`, `.nuxt`,
+ * `.output`). An entrypoint that is merely outside the config directory is not
+ * build output, so a relative path starting with `..` is excluded.
+ */
+function isEntrypointInBuildOutputDir(
+	configDir: string,
+	entrypointFile: string
+): boolean {
+	const relativePath = relative(configDir, entrypointFile);
+	if (relativePath.startsWith("..")) {
+		return false;
+	}
+
+	return relativePath
+		.split(sep)
+		.some(
+			(segment) =>
+				segment.startsWith(".") && segment !== "." && segment !== ".."
+		);
+}
+
+/**
+ * Computes the `mainModule` import specifier for the entrypoint.
+ *
+ * Returns `undefined` when the entrypoint is a framework build artefact.
+ * `mainModule` is emitted as a `typeof import(...)`, so pointing it at
+ * generated code makes `tsc`/`svelte-check` follow the import and type-check
+ * output that was never meant to be checked. Omitting the declaration is
+ * preferable to breaking the whole generated file.
+ */
+function getEntrypointModule(
+	config: Config,
+	fullOutputPath: string,
+	entrypoint: Entry | undefined
+): string | undefined {
+	if (!entrypoint) {
+		return undefined;
+	}
+
+	const configDir = dirname(config.configPath ?? resolve("wrangler.json"));
+	if (isEntrypointInBuildOutputDir(configDir, entrypoint.file)) {
+		return undefined;
+	}
+
+	return generateImportSpecifier(fullOutputPath, entrypoint.file);
+}
+
+/**
+ * Builds the `Cloudflare.GlobalProps` declaration.
+ *
+ * Each member is independent: a build-output entrypoint yields no `mainModule`
+ * but must still declare `durableNamespaces`, so the interface is emitted
+ * whenever at least one member applies.
+ */
+function generateGlobalPropsContent(
+	entrypointModule: string | undefined,
+	configuredDurableObjects: string[]
+): string {
+	const members: string[] = [];
+
+	if (entrypointModule) {
+		members.push(`\t\tmainModule: typeof import("${entrypointModule}");`);
+	}
+
+	if (configuredDurableObjects.length > 0) {
+		const namespaces = configuredDurableObjects
+			.map((durableObject) => `"${durableObject}"`)
+			.join(" | ");
+		members.push(`\t\tdurableNamespaces: ${namespaces};`);
+	}
+
+	if (members.length === 0) {
+		return "";
+	}
+
+	return `\n\tinterface GlobalProps {\n${members.join("\n")}\n\t}`;
+}
+
+/**
  * Checks whether any config level (top-level or any named environment) declares
  * `secrets`. Used to determine if the project has opted into config-based
  * secret declarations, which replaces `.dev.vars`/`.env` inference for type generation.
@@ -1215,9 +1306,7 @@ async function generateSimpleEnvTypes(
 			stringKeys,
 			config.compatibility_date,
 			config.compatibility_flags,
-			entrypoint
-				? generateImportSpecifier(fullOutputPath, entrypoint.file)
-				: undefined,
+			getEntrypointModule(config, fullOutputPath, entrypoint),
 			[
 				...getDurableObjectClassNameToUseSQLiteMap(
 					config.migrations,
@@ -1673,9 +1762,7 @@ async function generatePerEnvironmentTypes(
 		stringKeys,
 		config.compatibility_date,
 		config.compatibility_flags,
-		entrypoint
-			? generateImportSpecifier(fullOutputPath, entrypoint.file)
-			: undefined,
+		getEntrypointModule(config, fullOutputPath, entrypoint),
 		[
 			...getDurableObjectClassNameToUseSQLiteMap(
 				config.migrations,
@@ -1763,9 +1850,10 @@ function generatePerEnvTypeStrings(
 			.map((b) => `\t${b.key}${b.required ? "" : "?"}: ${b.type};`)
 			.join("\n");
 
-		const globalPropsContent = entrypointModule
-			? `\n\tinterface GlobalProps {\n\t\tmainModule: typeof import("${entrypointModule}");${configuredDurableObjects.length > 0 ? `\n\t\tdurableNamespaces: ${configuredDurableObjects.map((d) => `"${d}"`).join(" | ")};` : ""}\n\t}`
-			: "";
+		const globalPropsContent = generateGlobalPropsContent(
+			entrypointModule,
+			configuredDurableObjects
+		);
 
 		const internalEnvInterface = prefixEnvInterface(envInterface);
 
@@ -1874,7 +1962,12 @@ function generateTypeStrings(
 
 		const internalEnvInterface = prefixEnvInterface(envInterface);
 
-		baseContent = `interface ${internalEnvInterface} {${envTypeStructure.map((value) => `\n\t${value}`).join("")}\n}\ndeclare namespace Cloudflare {${entrypointModule ? `\n\tinterface GlobalProps {\n\t\tmainModule: typeof import("${entrypointModule}");${configuredDurableObjects.length > 0 ? `\n\t\tdurableNamespaces: ${configuredDurableObjects.map((d) => `"${d}"`).join(" | ")};` : ""}\n\t}` : ""}${typeDefsContent ? `\n${typeDefsContent}` : ""}\n\tinterface Env extends ${internalEnvInterface} {}\n}\ninterface ${envInterface} extends ${internalEnvInterface} {}${processEnv}`;
+		const globalPropsContent = generateGlobalPropsContent(
+			entrypointModule,
+			configuredDurableObjects
+		);
+
+		baseContent = `interface ${internalEnvInterface} {${envTypeStructure.map((value) => `\n\t${value}`).join("")}\n}\ndeclare namespace Cloudflare {${globalPropsContent}${typeDefsContent ? `\n${typeDefsContent}` : ""}\n\tinterface Env extends ${internalEnvInterface} {}\n}\ninterface ${envInterface} extends ${internalEnvInterface} {}${processEnv}`;
 	} else {
 		// For service worker format, type definitions still go at the top level since there's no namespace
 		const globalTypeDefsContent =


### PR DESCRIPTION
Fixes #14181.

`wrangler types` declares `Cloudflare.GlobalProps.mainModule` as `typeof import("<main>")`. When `main` points into a framework build output directory — SvelteKit's `.svelte-kit/cloudflare/_worker.js` being the reported case — that import makes `tsc` and `svelte-check` follow the reference and type-check generated code, so a clean checkout reports errors originating from `worker-configuration.d.ts`. Before the first build has run the referenced file does not exist at all.

This skips the `mainModule` declaration when the entrypoint resolves inside a directory whose name begins with `.`, relative to the Wrangler config directory. Frameworks consistently write generated output to a hidden directory (`.svelte-kit`, `.next`, `.nuxt`, `.output`). An entrypoint that is merely *outside* the config directory is not build output, so a relative path starting with `..` is excluded.

`durableNamespaces` was previously only emitted alongside `mainModule` — the interface was generated from a single `entrypointModule ? ... : ""` ternary. Suppressing `mainModule` would therefore have silently dropped `durableNamespaces` too, so `GlobalProps` is now assembled per member and emitted whenever at least one applies. There is a regression test for this.

**Deliberately out of scope:** the Durable Object / Service / Workflow binding types still import from the entrypoint (visible in the second test's snapshot). Those are load-bearing — suppressing them would downgrade `DurableObjectNamespace<CounterDO>` to an untyped `DurableObjectNamespace`, trading a build failure for a silent loss of type safety. Fixing them properly needs a different mechanism than omission, which is worth a follow-up rather than folding into this fix.

Reported by @matingathani in #14336.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: this fixes incorrect output from `wrangler types`; the documented behaviour of `mainModule` is unchanged for supported entrypoint layouts.

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

> [!NOTE]
> This is a contribution from an AI agent: OpenCode, claude-opus-5.
