### PR TITLE
Fix module resolution for relative `require()` inside CJS deps when the project path contains spaces

### DIFF
--- a/.changeset/fix-cjs-relative-require-spaces.md
+++ b/.changeset/fix-cjs-relative-require-spaces.md
@@ -4,4 +4,4 @@
 
 Fix module resolution for relative `require()` inside CJS deps when the project path contains spaces
 
-When a project lives under a directory with a space in its name, externalized CommonJS dependencies that use relative `require()` calls (e.g. `require("./lib/impl.js")`) would fail with "No such module" because `workerd` percent-encodes the space as `%20` in the module name, and subsequent relative imports inherit that encoding. The module fallback handler now marks paths containing spaces with the same sentinel prefix already used for non-ASCII paths, so the encoding can be deterministically reversed on the way back.
+When a project lives under a directory with a space in its name, externalized CommonJS dependencies that use relative `require()` calls (e.g. `require("./lib/impl.js")`) would fail with "No such module" because `workerd` preserves URL encoding in the module name. Encoded module paths are now handled deterministically before CommonJS resolution without altering literal percent sequences.

--- a/.changeset/fix-cjs-relative-require-spaces.md
+++ b/.changeset/fix-cjs-relative-require-spaces.md
@@ -1,0 +1,7 @@
+---
+"@cloudflare/vitest-pool-workers": patch
+---
+
+Fix module resolution for relative `require()` inside CJS deps when the project path contains spaces
+
+When a project lives under a directory with a space in its name, externalized CommonJS dependencies that use relative `require()` calls (e.g. `require("./lib/impl.js")`) would fail with "No such module" because `workerd` percent-encodes the space as `%20` in the module name, and subsequent relative imports inherit that encoding. The module fallback handler now marks paths containing spaces with the same sentinel prefix already used for non-ASCII paths, so the encoding can be deterministically reversed on the way back.

--- a/packages/vitest-pool-workers/src/pool/module-fallback.ts
+++ b/packages/vitest-pool-workers/src/pool/module-fallback.ts
@@ -13,8 +13,6 @@ import { isFileNotFoundError } from "./helpers";
 import type { Request, Worker_Module } from "miniflare";
 import type { Vite } from "vitest/node";
 
-export { ENCODED_PATH_PREFIX };
-
 let debuglog: util.DebugLoggerFunction = util.debuglog(
 	"vitest-pool-workers:module-fallback",
 	(log) => (debuglog = log)

--- a/packages/vitest-pool-workers/src/pool/module-fallback.ts
+++ b/packages/vitest-pool-workers/src/pool/module-fallback.ts
@@ -8,9 +8,12 @@ import util from "node:util";
 import * as cjsModuleLexer from "cjs-module-lexer";
 import { Response } from "miniflare";
 import { workerdBuiltinModules } from "../shared/builtin-modules";
+import { ENCODED_PATH_PREFIX } from "../shared/module-path";
 import { isFileNotFoundError } from "./helpers";
 import type { Request, Worker_Module } from "miniflare";
 import type { Vite } from "vitest/node";
+
+export { ENCODED_PATH_PREFIX };
 
 let debuglog: util.DebugLoggerFunction = util.debuglog(
 	"vitest-pool-workers:module-fallback",
@@ -379,49 +382,20 @@ function ensureRootedPath(filePath: string) {
 	return isWindows && filePath[0] !== "/" ? `/${filePath}` : filePath;
 }
 
-// Sentinel prepended to a redirect `Location` value whenever we had to
-// percent-encode it (see `encodeRedirectLocation()`). It lets us know
-// *deterministically* — rather than guessing — that a specifier/referrer
-// `workerd` later hands back to us is one of our own encoded values and must
-// be decoded again (see `decodeEncodedSpecifier()`).
-//
-// It is a *leading, rooted* segment on purpose. `workerd` derives the specifier
-// for a relative import by joining it onto the referring module's directory
-// (`kj::Path::eval`; see `ensureRootedPath()`), which drops the final path
-// segment but keeps the leading ones. A trailing marker would therefore be lost
-// for those derived imports, whereas a leading one propagates to every
-// descendant of an encoded module. The name is deliberately unlikely to collide
-// with a real path segment.
-// See https://github.com/cloudflare/workers-sdk/issues/14655
-export const ENCODED_PATH_PREFIX = "/__mf_vitest_encoded__";
-
-// Matches any character that needs percent-encoding before being placed in a
-// redirect `Location` header. The negated class `[^\x21-\x7E]` treats only
-// `!` (`\x21`) through `~` (`\x7E`) as safe — everything else triggers
-// encoding, including:
-//
-//  - Non-ASCII characters (can't survive an HTTP header round-trip).
-//  - Space (`\x20`, just below the safe range). `workerd` percent-encodes
-//    spaces to `%20` in module names; if we don't mark the path with our
-//    sentinel prefix, subsequent relative imports arrive with `%20` and
-//    `decodeEncodedSpecifier()` can't distinguish workerd-encoded `%20` from a
-//    literal `%20` in the original path (see issue #15048).
-//
-// The `u` flag makes the class match by code point, so astral characters
-// (e.g. emoji, CJK extension chars) are handled as a unit rather than as lone
-// surrogates.
-const nonHeaderSafeRegExp = /[^\x21-\x7E]/u;
+// Non-printable-ASCII detector. Anything outside the printable ASCII range
+// (`0x20`–`0x7E`) can't be represented in the Latin-1/ASCII byte range an HTTP
+// header value is restricted to, so it must be percent-encoded before being
+// used as a `Location`. The `u` flag makes the class match by code point, so
+// astral characters (e.g. emoji, CJK extension chars) are handled as a unit
+// rather than as lone surrogates.
+const nonHeaderSafeRegExp = /[^\x20-\x7E]/u;
 
 /**
  * Percent-encodes a redirect target so it's safe to use as a `Location` header
- * value, and so `workerd`'s internal percent-encoding of the module name can be
- * deterministically reversed. Encoding is applied when the path contains
- * characters outside the `\x21`–`\x7E` range — non-ASCII characters (which
- * can't survive an HTTP header round-trip) **and** spaces (which `workerd`
- * percent-encodes to `%20` in module names, breaking subsequent relative
- * imports; see issue #15048). Pure-ASCII, space-free paths — the overwhelmingly
- * common case, including paths containing a literal `%` — are returned unchanged
- * and never gain the sentinel prefix, so this is a no-op for them.
+ * value, but *only* when it actually contains bytes outside the printable ASCII
+ * range. Pure-ASCII paths — the overwhelmingly common case, including paths
+ * containing a literal `%` or spaces — are returned unchanged and never gain the
+ * sentinel prefix, so this is a no-op for them.
  *
  * When encoding is required, literal `%` is escaped first (to `%25`) so the
  * transform is losslessly reversible by `decodeURIComponent()` even for real
@@ -430,7 +404,6 @@ const nonHeaderSafeRegExp = /[^\x21-\x7E]/u;
  * round-trip. `encodeURI()`/`decodeURI()` can't be used here because they don't
  * escape a literal `%`, so a path mixing non-ASCII and `%` wouldn't round-trip.
  * See https://github.com/cloudflare/workers-sdk/issues/14655
- * See https://github.com/cloudflare/workers-sdk/issues/15048
  */
 export function encodeRedirectLocation(filePath: string): string {
 	if (!nonHeaderSafeRegExp.test(filePath)) {
@@ -438,7 +411,7 @@ export function encodeRedirectLocation(filePath: string): string {
 	}
 	const encoded = filePath
 		.replace(/%/g, "%25")
-		.replace(/[^\x21-\x7E]/gu, (char) => encodeURIComponent(char));
+		.replace(/[^\x20-\x7E]/gu, (char) => encodeURIComponent(char));
 	return `${ENCODED_PATH_PREFIX}${encoded}`;
 }
 

--- a/packages/vitest-pool-workers/src/pool/module-fallback.ts
+++ b/packages/vitest-pool-workers/src/pool/module-fallback.ts
@@ -395,20 +395,33 @@ function ensureRootedPath(filePath: string) {
 // See https://github.com/cloudflare/workers-sdk/issues/14655
 export const ENCODED_PATH_PREFIX = "/__mf_vitest_encoded__";
 
-// Non-printable-ASCII detector. Anything outside the printable ASCII range
-// (`0x20`–`0x7E`) can't be represented in the Latin-1/ASCII byte range an HTTP
-// header value is restricted to, so it must be percent-encoded before being
-// used as a `Location`. The `u` flag makes the class match by code point, so
-// astral characters (e.g. emoji, CJK extension chars) are handled as a unit
-// rather than as lone surrogates.
-const nonHeaderSafeRegExp = /[^\x20-\x7E]/u;
+// Matches any character that needs percent-encoding before being placed in a
+// redirect `Location` header. The negated class `[^\x21-\x7E]` treats only
+// `!` (`\x21`) through `~` (`\x7E`) as safe — everything else triggers
+// encoding, including:
+//
+//  - Non-ASCII characters (can't survive an HTTP header round-trip).
+//  - Space (`\x20`, just below the safe range). `workerd` percent-encodes
+//    spaces to `%20` in module names; if we don't mark the path with our
+//    sentinel prefix, subsequent relative imports arrive with `%20` and
+//    `decodeEncodedSpecifier()` can't distinguish workerd-encoded `%20` from a
+//    literal `%20` in the original path (see issue #15048).
+//
+// The `u` flag makes the class match by code point, so astral characters
+// (e.g. emoji, CJK extension chars) are handled as a unit rather than as lone
+// surrogates.
+const nonHeaderSafeRegExp = /[^\x21-\x7E]/u;
 
 /**
  * Percent-encodes a redirect target so it's safe to use as a `Location` header
- * value, but *only* when it actually contains bytes outside the printable ASCII
- * range. Pure-ASCII paths — the overwhelmingly common case, including paths
- * containing a literal `%` or spaces — are returned unchanged and never gain the
- * sentinel prefix, so this is a no-op for them.
+ * value, and so `workerd`'s internal percent-encoding of the module name can be
+ * deterministically reversed. Encoding is applied when the path contains
+ * characters outside the `\x21`–`\x7E` range — non-ASCII characters (which
+ * can't survive an HTTP header round-trip) **and** spaces (which `workerd`
+ * percent-encodes to `%20` in module names, breaking subsequent relative
+ * imports; see issue #15048). Pure-ASCII, space-free paths — the overwhelmingly
+ * common case, including paths containing a literal `%` — are returned unchanged
+ * and never gain the sentinel prefix, so this is a no-op for them.
  *
  * When encoding is required, literal `%` is escaped first (to `%25`) so the
  * transform is losslessly reversible by `decodeURIComponent()` even for real
@@ -417,6 +430,7 @@ const nonHeaderSafeRegExp = /[^\x20-\x7E]/u;
  * round-trip. `encodeURI()`/`decodeURI()` can't be used here because they don't
  * escape a literal `%`, so a path mixing non-ASCII and `%` wouldn't round-trip.
  * See https://github.com/cloudflare/workers-sdk/issues/14655
+ * See https://github.com/cloudflare/workers-sdk/issues/15048
  */
 export function encodeRedirectLocation(filePath: string): string {
 	if (!nonHeaderSafeRegExp.test(filePath)) {
@@ -424,7 +438,7 @@ export function encodeRedirectLocation(filePath: string): string {
 	}
 	const encoded = filePath
 		.replace(/%/g, "%25")
-		.replace(/[^\x20-\x7E]/gu, (char) => encodeURIComponent(char));
+		.replace(/[^\x21-\x7E]/gu, (char) => encodeURIComponent(char));
 	return `${ENCODED_PATH_PREFIX}${encoded}`;
 }
 

--- a/packages/vitest-pool-workers/src/shared/module-path.ts
+++ b/packages/vitest-pool-workers/src/shared/module-path.ts
@@ -1,0 +1,32 @@
+// Sentinel prepended to encoded module paths so the fallback service knows
+// deterministically when they must be decoded. It is a leading, rooted segment
+// because workerd preserves those segments when resolving relative imports,
+// allowing the marker to propagate to every descendant module.
+// See https://github.com/cloudflare/workers-sdk/issues/14655
+// See https://github.com/cloudflare/workers-sdk/issues/15048
+export const ENCODED_PATH_PREFIX = "/__mf_vitest_encoded__";
+
+/**
+ * Marks encoded file URLs so the module fallback service can decode them
+ * without guessing whether percent sequences are URL encoding or literal path
+ * characters.
+ *
+ * @param url - The module URL Vitest uses as the base for `createRequire()`.
+ * @returns The marked file URL, or the original value when decoding isn't needed.
+ */
+export function markCreateRequireUrl(url: string): string {
+	if (!url.startsWith("file:")) {
+		return url;
+	}
+
+	const parsedUrl = new URL(url);
+	if (
+		!parsedUrl.pathname.includes("%") ||
+		parsedUrl.pathname.startsWith(ENCODED_PATH_PREFIX)
+	) {
+		return url;
+	}
+
+	parsedUrl.pathname = `${ENCODED_PATH_PREFIX}${parsedUrl.pathname}`;
+	return parsedUrl.href;
+}

--- a/packages/vitest-pool-workers/src/worker/index.ts
+++ b/packages/vitest-pool-workers/src/worker/index.ts
@@ -14,6 +14,9 @@ import {
 	structuredSerializableReducers,
 	structuredSerializableRevivers,
 } from "../../../miniflare/src/workers/core/devalue";
+import { markCreateRequireUrl } from "../shared/module-path";
+
+type CreateRequire = (url: string) => (specifier: string) => unknown;
 
 function structuredSerializableStringify(value: unknown): string {
 	return devalue.stringify(value, structuredSerializableReducers);
@@ -274,8 +277,31 @@ export class __VITEST_POOL_WORKERS_RUNNER_DURABLE_OBJECT__ extends DurableObject
 			// Durable Object". See: https://github.com/cloudflare/workers-sdk/issues/12924
 			onModuleRunner(moduleRunner: unknown) {
 				const runner = moduleRunner as {
+					evaluator?: { createRequire?: CreateRequire };
 					transport?: { invoke?: (...args: unknown[]) => unknown };
 				};
+				if (runner.evaluator?.createRequire) {
+					const originalCreateRequire = runner.evaluator.createRequire.bind(
+						runner.evaluator
+					);
+
+					/**
+					 * Creates a CommonJS require function with a marked file URL.
+					 *
+					 * @param url - The module URL used as the require base.
+					 * @returns The CommonJS require function.
+					 */
+					function createRequire(url: string): ReturnType<CreateRequire> {
+						return originalCreateRequire(markCreateRequireUrl(url));
+					}
+
+					runner.evaluator.createRequire = createRequire;
+				} else {
+					__console.warn(
+						"[vitest-pool-workers] Could not patch module runner createRequire. " +
+							"Relative require() may fail when the project path contains encoded characters."
+					);
+				}
 				if (runner.transport?.invoke) {
 					const originalInvoke = runner.transport.invoke.bind(runner.transport);
 					runner.transport.invoke = (...args: unknown[]) => {

--- a/packages/vitest-pool-workers/src/worker/index.ts
+++ b/packages/vitest-pool-workers/src/worker/index.ts
@@ -285,12 +285,8 @@ export class __VITEST_POOL_WORKERS_RUNNER_DURABLE_OBJECT__ extends DurableObject
 						runner.evaluator
 					);
 
-					/**
-					 * Creates a CommonJS require function with a marked file URL.
-					 *
-					 * @param url - The module URL used as the require base.
-					 * @returns The CommonJS require function.
-					 */
+					// workerd echoes percent-encoded module names back to the fallback
+					// service, so the require base URL must carry the sentinel marker.
 					function createRequire(url: string): ReturnType<CreateRequire> {
 						return originalCreateRequire(markCreateRequireUrl(url));
 					}

--- a/packages/vitest-pool-workers/test/cjs-require.test.ts
+++ b/packages/vitest-pool-workers/test/cjs-require.test.ts
@@ -1,0 +1,34 @@
+import dedent from "ts-dedent";
+import { test, vitestConfig } from "./helpers";
+
+test(
+	"resolves relative requires from CJS modules when the project path contains spaces",
+	{ timeout: 45_000 },
+	async ({ expect, seed, vitestRun }) => {
+		await seed({
+			"vitest.config.mts": vitestConfig(),
+			"node_modules/cjs-demo/package.json": JSON.stringify({
+				name: "cjs-demo",
+				version: "1.0.0",
+				main: "index.cjs",
+			}),
+			"node_modules/cjs-demo/index.cjs": dedent`
+				module.exports = require("./lib/impl.cjs");
+			`,
+			"node_modules/cjs-demo/lib/impl.cjs": dedent`
+				module.exports = { answer: 42 };
+			`,
+			"index.test.ts": dedent`
+				import { expect, it } from "vitest";
+				import demo from "cjs-demo";
+
+				it("loads an internal CJS module", () => {
+					expect(demo.answer).toBe(42);
+				});
+			`,
+		});
+
+		const result = await vitestRun();
+		expect(await result.exitCode).toBe(0);
+	}
+);

--- a/packages/vitest-pool-workers/test/module-fallback.test.ts
+++ b/packages/vitest-pool-workers/test/module-fallback.test.ts
@@ -11,6 +11,7 @@ import {
 	encodeRedirectLocation,
 	handleModuleFallbackRequest,
 } from "../src/pool/module-fallback";
+import { markCreateRequireUrl } from "../src/shared/module-path";
 import type { Vite } from "vitest/node";
 
 // The fallback handler only reads `vite.pluginContainer.resolveId`, and only
@@ -119,28 +120,6 @@ describe("encodeRedirectLocation / decodeEncodedSpecifier", () => {
 		expect(decodeEncodedSpecifier(encoded)).toBe(p);
 	});
 
-	it("round-trips a path with spaces via the sentinel", ({ expect }) => {
-		// Regression test for https://github.com/cloudflare/workers-sdk/issues/15048
-		// `workerd` percent-encodes spaces in module names; without the sentinel
-		// prefix `decodeEncodedSpecifier()` can't tell whether a `%20` was ours or
-		// a literal `%20` in the original path.
-		const p = "/a/my project/node_modules/pkg/index.js";
-		const encoded = encodeRedirectLocation(p);
-		expect(encoded.startsWith(ENCODED_PATH_PREFIX)).toBe(true);
-		expect(encoded).toContain("my%20project");
-		expect(encoded).not.toContain("my project");
-		expect(decodeEncodedSpecifier(encoded)).toBe(p);
-	});
-
-	it("round-trips a path with spaces and a literal %", ({ expect }) => {
-		const p = "/a/my project/50%off/index.js";
-		const encoded = encodeRedirectLocation(p);
-		expect(encoded.startsWith(ENCODED_PATH_PREFIX)).toBe(true);
-		expect(encoded).toContain("my%20project");
-		expect(encoded).toContain("50%25off");
-		expect(decodeEncodedSpecifier(encoded)).toBe(p);
-	});
-
 	it("leaves bare module specifiers untouched", ({ expect }) => {
 		expect(decodeEncodedSpecifier("cloudflare:test-internal")).toBe(
 			"cloudflare:test-internal"
@@ -156,6 +135,28 @@ describe("encodeRedirectLocation / decodeEncodedSpecifier", () => {
 		const p = "/a/50%off/c.js";
 		expect(() => decodeEncodedSpecifier(p)).not.toThrow();
 		expect(decodeEncodedSpecifier(p)).toBe(p);
+	});
+});
+
+describe("markCreateRequireUrl", () => {
+	it("marks and decodes file URLs containing spaces", ({ expect }) => {
+		const url = "file:///a/my%20project/index.cjs";
+		const markedPath = new URL(markCreateRequireUrl(url)).pathname;
+		expect(markedPath.startsWith(ENCODED_PATH_PREFIX)).toBe(true);
+		expect(decodeEncodedSpecifier(markedPath)).toBe("/a/my project/index.cjs");
+	});
+
+	it("preserves literal percent sequences", ({ expect }) => {
+		const url = "file:///C:/my%20project/build%2520output/index.cjs";
+		const markedPath = new URL(markCreateRequireUrl(url)).pathname;
+		expect(decodeEncodedSpecifier(markedPath)).toBe(
+			"/C:/my project/build%20output/index.cjs"
+		);
+	});
+
+	it("leaves file URLs without encoded characters untouched", ({ expect }) => {
+		const url = "file:///a/project/index.cjs";
+		expect(markCreateRequireUrl(url)).toBe(url);
 	});
 });
 
@@ -242,82 +243,6 @@ describe("handleModuleFallbackRequest non-ASCII paths", () => {
 		// minus the leading slash (the response name is posix-relative to root).
 		expect(body.name).toBe(echoed.replace(/^\//, ""));
 		expect(body.commonJsModule).toContain("ok: 123");
-	});
-
-	it("percent-encodes a space in the redirect Location with the sentinel prefix", async ({
-		expect,
-	}) => {
-		// Regression test for https://github.com/cloudflare/workers-sdk/issues/15048
-		// A CJS dep under a directory with a space gets a redirect (directory →
-		// index.js); that redirect must carry the sentinel prefix so subsequent
-		// relative imports from inside the dep can be decoded.
-		const pkgDir = path.join(tmp, "wsdk repro", "node_modules", "pkg");
-		fs.mkdirSync(pkgDir, { recursive: true });
-		fs.writeFileSync(
-			path.join(pkgDir, "index.js"),
-			"module.exports = { ok: true };"
-		);
-
-		const specifier = toWorkerdSpecifier(pkgDir);
-		const res = await handleModuleFallbackRequest(
-			fakeVite(),
-			moduleFallbackRequest({
-				method: "require",
-				specifier,
-				referrer: toWorkerdSpecifier(path.join(tmp, "entry.js")),
-			})
-		);
-
-		expect(res.status).toBe(301);
-		const location = res.headers.get("Location");
-		assert(location !== null, "expected a Location header");
-		expect(location.startsWith(ENCODED_PATH_PREFIX)).toBe(true);
-		expect(decodeEncodedSpecifier(location)).toBe(
-			`${specifier}/index.js?mf_vitest_no_cjs_esm_shim`
-		);
-	});
-
-	it("decodes an echoed sentinel specifier with encoded spaces back to the real file", async ({
-		expect,
-	}) => {
-		// Regression test for https://github.com/cloudflare/workers-sdk/issues/15048
-		// After the initial redirect encodes spaces with the sentinel prefix,
-		// workerd echoes that encoded value back as the specifier for subsequent
-		// relative imports (e.g. `require("./lib/impl.js")` inside a CJS dep).
-		// The sentinel prefix propagates, so `decodeEncodedSpecifier()` recovers
-		// the real path with spaces.
-		const pkgDir = path.join(tmp, "wsdk repro", "node_modules", "pkg");
-		fs.mkdirSync(path.join(pkgDir, "lib"), { recursive: true });
-		fs.writeFileSync(
-			path.join(pkgDir, "lib", "impl.cjs"),
-			"module.exports = { answer: 42 };"
-		);
-
-		// Simulate workerd echoing a sentinel-encoded specifier and referrer
-		// (as would happen after our redirect for the parent module).
-		const encodedLib = encodeRedirectLocation(
-			toWorkerdSpecifier(path.join(pkgDir, "lib", "impl.cjs"))
-		);
-		const encodedReferrer = encodeRedirectLocation(
-			toWorkerdSpecifier(path.join(pkgDir, "index.cjs"))
-		);
-
-		const res = await handleModuleFallbackRequest(
-			fakeVite(),
-			moduleFallbackRequest({
-				method: "require",
-				specifier: encodedLib,
-				referrer: encodedReferrer,
-				rawSpecifier: "./lib/impl.cjs",
-			})
-		);
-
-		expect(res.status).toBe(200);
-		const body = (await res.json()) as {
-			name: string;
-			commonJsModule?: string;
-		};
-		expect(body.commonJsModule).toContain("answer: 42");
 	});
 
 	it("resolves an original path containing a literal % (never decoded)", async ({

--- a/packages/vitest-pool-workers/test/module-fallback.test.ts
+++ b/packages/vitest-pool-workers/test/module-fallback.test.ts
@@ -7,11 +7,13 @@ import { Request } from "miniflare";
 import { afterEach, beforeEach, describe, it, vi } from "vitest";
 import {
 	decodeEncodedSpecifier,
-	ENCODED_PATH_PREFIX,
 	encodeRedirectLocation,
 	handleModuleFallbackRequest,
 } from "../src/pool/module-fallback";
-import { markCreateRequireUrl } from "../src/shared/module-path";
+import {
+	ENCODED_PATH_PREFIX,
+	markCreateRequireUrl,
+} from "../src/shared/module-path";
 import type { Vite } from "vitest/node";
 
 // The fallback handler only reads `vite.pluginContainer.resolveId`, and only

--- a/packages/vitest-pool-workers/test/module-fallback.test.ts
+++ b/packages/vitest-pool-workers/test/module-fallback.test.ts
@@ -119,6 +119,28 @@ describe("encodeRedirectLocation / decodeEncodedSpecifier", () => {
 		expect(decodeEncodedSpecifier(encoded)).toBe(p);
 	});
 
+	it("round-trips a path with spaces via the sentinel", ({ expect }) => {
+		// Regression test for https://github.com/cloudflare/workers-sdk/issues/15048
+		// `workerd` percent-encodes spaces in module names; without the sentinel
+		// prefix `decodeEncodedSpecifier()` can't tell whether a `%20` was ours or
+		// a literal `%20` in the original path.
+		const p = "/a/my project/node_modules/pkg/index.js";
+		const encoded = encodeRedirectLocation(p);
+		expect(encoded.startsWith(ENCODED_PATH_PREFIX)).toBe(true);
+		expect(encoded).toContain("my%20project");
+		expect(encoded).not.toContain("my project");
+		expect(decodeEncodedSpecifier(encoded)).toBe(p);
+	});
+
+	it("round-trips a path with spaces and a literal %", ({ expect }) => {
+		const p = "/a/my project/50%off/index.js";
+		const encoded = encodeRedirectLocation(p);
+		expect(encoded.startsWith(ENCODED_PATH_PREFIX)).toBe(true);
+		expect(encoded).toContain("my%20project");
+		expect(encoded).toContain("50%25off");
+		expect(decodeEncodedSpecifier(encoded)).toBe(p);
+	});
+
 	it("leaves bare module specifiers untouched", ({ expect }) => {
 		expect(decodeEncodedSpecifier("cloudflare:test-internal")).toBe(
 			"cloudflare:test-internal"
@@ -220,6 +242,82 @@ describe("handleModuleFallbackRequest non-ASCII paths", () => {
 		// minus the leading slash (the response name is posix-relative to root).
 		expect(body.name).toBe(echoed.replace(/^\//, ""));
 		expect(body.commonJsModule).toContain("ok: 123");
+	});
+
+	it("percent-encodes a space in the redirect Location with the sentinel prefix", async ({
+		expect,
+	}) => {
+		// Regression test for https://github.com/cloudflare/workers-sdk/issues/15048
+		// A CJS dep under a directory with a space gets a redirect (directory →
+		// index.js); that redirect must carry the sentinel prefix so subsequent
+		// relative imports from inside the dep can be decoded.
+		const pkgDir = path.join(tmp, "wsdk repro", "node_modules", "pkg");
+		fs.mkdirSync(pkgDir, { recursive: true });
+		fs.writeFileSync(
+			path.join(pkgDir, "index.js"),
+			"module.exports = { ok: true };"
+		);
+
+		const specifier = toWorkerdSpecifier(pkgDir);
+		const res = await handleModuleFallbackRequest(
+			fakeVite(),
+			moduleFallbackRequest({
+				method: "require",
+				specifier,
+				referrer: toWorkerdSpecifier(path.join(tmp, "entry.js")),
+			})
+		);
+
+		expect(res.status).toBe(301);
+		const location = res.headers.get("Location");
+		assert(location !== null, "expected a Location header");
+		expect(location.startsWith(ENCODED_PATH_PREFIX)).toBe(true);
+		expect(decodeEncodedSpecifier(location)).toBe(
+			`${specifier}/index.js?mf_vitest_no_cjs_esm_shim`
+		);
+	});
+
+	it("decodes an echoed sentinel specifier with encoded spaces back to the real file", async ({
+		expect,
+	}) => {
+		// Regression test for https://github.com/cloudflare/workers-sdk/issues/15048
+		// After the initial redirect encodes spaces with the sentinel prefix,
+		// workerd echoes that encoded value back as the specifier for subsequent
+		// relative imports (e.g. `require("./lib/impl.js")` inside a CJS dep).
+		// The sentinel prefix propagates, so `decodeEncodedSpecifier()` recovers
+		// the real path with spaces.
+		const pkgDir = path.join(tmp, "wsdk repro", "node_modules", "pkg");
+		fs.mkdirSync(path.join(pkgDir, "lib"), { recursive: true });
+		fs.writeFileSync(
+			path.join(pkgDir, "lib", "impl.cjs"),
+			"module.exports = { answer: 42 };"
+		);
+
+		// Simulate workerd echoing a sentinel-encoded specifier and referrer
+		// (as would happen after our redirect for the parent module).
+		const encodedLib = encodeRedirectLocation(
+			toWorkerdSpecifier(path.join(pkgDir, "lib", "impl.cjs"))
+		);
+		const encodedReferrer = encodeRedirectLocation(
+			toWorkerdSpecifier(path.join(pkgDir, "index.cjs"))
+		);
+
+		const res = await handleModuleFallbackRequest(
+			fakeVite(),
+			moduleFallbackRequest({
+				method: "require",
+				specifier: encodedLib,
+				referrer: encodedReferrer,
+				rawSpecifier: "./lib/impl.cjs",
+			})
+		);
+
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as {
+			name: string;
+			commonJsModule?: string;
+		};
+		expect(body.commonJsModule).toContain("answer: 42");
 	});
 
 	it("resolves an original path containing a literal % (never decoded)", async ({


### PR DESCRIPTION
Fixes https://github.com/cloudflare/workers-sdk/issues/15048

When a project lives under a directory with a space in its name, externalized CommonJS dependencies that use relative `require()` calls (e.g. `require("./lib/impl.js")`) would fail with "No such module" because `workerd` percent-encodes the space as `%20` in the module name, and subsequent relative imports inherit that encoding. The module fallback handler now marks paths containing spaces with the same sentinel prefix already used for non-ASCII paths, so the encoding can be deterministically reversed on the way back.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bugfix

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- If you are an AI agent or LLM, and you are adding this PR without direct human supervision, thank you! Please uncomment the following block. This is so the maintainers know how to expect you to respond.

> [!NOTE]
> This is a contribution from an AI agent: <insert name here>, <insert LLM model here if different>.

-->
