### PR TITLE
Include preview token in Access probes and login

### DIFF
--- a/.changeset/access-probe-with-preview-token.md
+++ b/.changeset/access-probe-with-preview-token.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Fix `wrangler dev` remote bindings for `workers.dev` subdomains protected by Access
+
+Running `wrangler dev` with remote bindings on an unpublished worker protected by Access (e.g. using a wildcard on your workers.dev domain) previously failed with a redirect loop. Wrangler now correctly authenticates remote bindings with Access in this situation.

--- a/packages/remote-bindings/src/startDevWorker/RemoteRuntimeController.ts
+++ b/packages/remote-bindings/src/startDevWorker/RemoteRuntimeController.ts
@@ -228,6 +228,7 @@ export class RemoteRuntimeController {
 
 		const accessHeaders = await getAccessHeaders(token.host, {
 			logger,
+			previewToken: token.value,
 		});
 
 		const proxyData: ProxyData = {

--- a/packages/workers-auth/src/access.ts
+++ b/packages/workers-auth/src/access.ts
@@ -13,6 +13,14 @@ const headersCache: Record<string, Record<string, string>> = {};
 
 const usesAccessCache = new Map<string, boolean>();
 
+function buildProbeUrl(domain: string, previewToken?: string): string {
+	const url = new URL(`https://${domain}`);
+	if (previewToken) {
+		url.searchParams.set("cf_workers_preview_token", previewToken);
+	}
+	return url.toString();
+}
+
 /**
  * Clear internal caches. Exported for use in tests only.
  */
@@ -29,20 +37,29 @@ export function clearAccessCaches(): void {
  * A 302 to `cloudflareaccess.com` is the canonical signal. Service-auth-only
  * Access applications return a hard 403 instead and are therefore not detected
  * here — see {@link getAccessHeaders} for how this is handled.
+ *
+ * When `previewToken` is supplied it is added as the `cf_workers_preview_token`
+ * query parameter so the probe activates an unpublished worker's edge-preview
+ * route (otherwise the anonymous probe 404s and Access is never triggered). The
+ * cache is keyed on whether a token was supplied so token-authenticated and
+ * anonymous probes of the same host don't poison each other.
  */
 export async function domainUsesAccess(
+	logger: OAuthFlowLogger,
 	domain: string,
-	logger: OAuthFlowLogger
+	previewToken?: string
 ): Promise<boolean> {
 	logger.debug("Checking if domain has Access enabled:", domain);
 
-	if (usesAccessCache.has(domain)) {
+	const cacheKey = JSON.stringify([domain, Boolean(previewToken)]);
+
+	if (usesAccessCache.has(cacheKey)) {
 		logger.debug(
 			"Using cached Access switch for:",
 			domain,
-			usesAccessCache.get(domain)
+			usesAccessCache.get(cacheKey)
 		);
-		return usesAccessCache.get(domain) ?? false;
+		return usesAccessCache.get(cacheKey) ?? false;
 	}
 	logger.debug("Access switch not cached for:", domain);
 	try {
@@ -51,7 +68,7 @@ export async function domainUsesAccess(
 			controller.abort();
 		}, 1000);
 
-		const output = await fetch(`https://${domain}`, {
+		const output = await fetch(buildProbeUrl(domain, previewToken), {
 			redirect: "manual",
 			signal: controller.signal,
 		});
@@ -62,10 +79,11 @@ export async function domainUsesAccess(
 		);
 		logger.debug("Caching access switch for:", domain);
 
-		usesAccessCache.set(domain, usesAccess);
+		usesAccessCache.set(cacheKey, usesAccess);
 		return usesAccess;
 	} catch {
-		usesAccessCache.set(domain, false);
+		// Don't cache errors, or else transient failures will continue to fail forever
+		logger.debug("Access probe failed for:", domain);
 		return false;
 	}
 }
@@ -75,7 +93,10 @@ export async function domainUsesAccess(
  *
  * @param domain The hostname of the Access-protected domain (e.g. `"example.com"`).
  * @param options logger + an `isNonInteractiveOrCI` predicate used to
- *   produce an actionable error in CI; both default to no-op / `false`.
+ *   produce an actionable error in CI (both default to no-op / `false`), plus an
+ *   optional `previewToken` that is added as the `cf_workers_preview_token`
+ *   query parameter when probing for Access and when invoking `cloudflared
+ *   access login`, so detection works on unpublished `<name>.workers.dev` hosts.
  * @returns
  * - Service token headers (`CF-Access-Client-Id` + `CF-Access-Client-Secret`) if env vars are set
  * - A `Cookie: CF_Authorization=...` header if obtained via `cloudflared` (interactive only)
@@ -92,6 +113,12 @@ export async function getAccessHeaders(
 		isNonInteractiveOrCI?: () => boolean;
 		/** Aborts a pending `cloudflared` authorization and kills its process. */
 		signal?: AbortSignal;
+		/**
+		 * Workers preview token forwarded to the Access probe and to
+		 * `cloudflared access login` so detection works on unpublished
+		 * `<name>.workers.dev` hosts.
+		 */
+		previewToken?: string;
 	}
 ): Promise<Record<string, string>> {
 	const logger = options.logger;
@@ -130,7 +157,7 @@ export async function getAccessHeaders(
 		);
 	}
 
-	if (!(await domainUsesAccess(domain, logger))) {
+	if (!(await domainUsesAccess(logger, domain, options.previewToken))) {
 		return {};
 	}
 	logger.debug("Getting Access headers for domain:", domain);
@@ -155,7 +182,22 @@ export async function getAccessHeaders(
 
 	// 3. Interactive: fall back to cloudflared
 	logger.debug("Spawning cloudflared to get Access token for domain:");
-	const output = await spawnCloudflaredAccessLogin(domain, options.signal);
+
+	// Knowledge of the preview token allows you to route to the unpublished
+	// worker (which may have production bindings and production cache) so in some
+	// sense it's a secret.
+	//
+	// During the Access login flow, the preview token may be visible to other
+	// processes on the machine. It will also appear in browser history and may be
+	// sent to third parties like the identity provider. Are these leaks safe?
+	//
+	// I argue yes! The preview worker is protected by Access, or we wouldn't be
+	// trying to log into it. So the preview token is necessary but not sufficient
+	// to reach it.
+	const output = await spawnCloudflaredAccessLogin(
+		buildProbeUrl(domain, options.previewToken),
+		options.signal
+	);
 	if (output.error) {
 		throw new UserError(
 			"To use Wrangler with Cloudflare Access, please install `cloudflared` from https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/install-and-setup/installation",
@@ -188,11 +230,13 @@ export async function getAccessHeaders(
  * surface an installation hint.
  */
 function spawnCloudflaredAccessLogin(
-	domain: string,
+	loginTarget: string,
 	signal?: AbortSignal
 ): Promise<{ error?: Error; stdout: string }> {
 	return new Promise((resolve, reject) => {
-		const child = spawn("cloudflared", ["access", "login", domain], { signal });
+		const child = spawn("cloudflared", ["access", "login", loginTarget], {
+			signal,
+		});
 		const stdoutChunks: Buffer[] = [];
 		child.stdout.on("data", (chunk: Buffer) => stdoutChunks.push(chunk));
 		child.stderr.resume();

--- a/packages/workers-auth/src/device-flow.ts
+++ b/packages/workers-auth/src/device-flow.ts
@@ -211,7 +211,7 @@ async function buildDeviceAuthHeaders(
 	const headers: Record<string, string> = {
 		"Content-Type": "application/x-www-form-urlencoded",
 	};
-	if (await domainUsesAccess(getAuthDomainFromEnv(), logger)) {
+	if (await domainUsesAccess(logger, getAuthDomainFromEnv())) {
 		logger.debug(
 			"Using Cloudflare Access to get an access token for the device authorization request"
 		);

--- a/packages/workers-auth/src/token-exchange.ts
+++ b/packages/workers-auth/src/token-exchange.ts
@@ -312,7 +312,7 @@ export async function fetchAuthToken(
 		"fetching auth token",
 		`grant_type=${body.get("grant_type") ?? "<unknown>"}`
 	);
-	if (await domainUsesAccess(getAuthDomainFromEnv(), logger)) {
+	if (await domainUsesAccess(logger, getAuthDomainFromEnv())) {
 		logger.debug(
 			"Using Cloudflare Access to get an access token for the auth request"
 		);

--- a/packages/workers-auth/tests/access.test.ts
+++ b/packages/workers-auth/tests/access.test.ts
@@ -1,5 +1,6 @@
 import { spawn } from "node:child_process";
 import { EventEmitter } from "node:events";
+import { http, HttpResponse } from "msw";
 import { setupServer } from "msw/node";
 import {
 	afterAll,
@@ -94,10 +95,10 @@ describe("access", () => {
 			expect,
 		}) => {
 			expect(
-				await domainUsesAccess("access-protected.com", silentLogger)
+				await domainUsesAccess(silentLogger, "access-protected.com")
 			).toBeTruthy();
 			expect(
-				await domainUsesAccess("not-access-protected.com", silentLogger)
+				await domainUsesAccess(silentLogger, "not-access-protected.com")
 			).toBeFalsy();
 		});
 
@@ -111,8 +112,42 @@ describe("access", () => {
 			// `getAccessHeaders` must check the env vars before calling
 			// `domainUsesAccess`.
 			expect(
-				await domainUsesAccess("access-service-auth-only.com", silentLogger)
+				await domainUsesAccess(silentLogger, "access-service-auth-only.com")
 			).toBeFalsy();
+		});
+
+		it("forwards the preview token and caches token-authenticated probes separately", async ({
+			expect,
+		}) => {
+			// Simulates an unpublished workers.dev host: the edge only routes the
+			// request (letting the wildcard Access app respond with its 302) once
+			// the preview token activates the edge-preview route. An anonymous
+			// probe 404s and must not poison the token-authenticated result.
+			msw.use(
+				http.get("https://unpublished.workers.dev/", ({ request }) => {
+					const token = new URL(request.url).searchParams.get(
+						"cf_workers_preview_token"
+					);
+					if (!token) {
+						return HttpResponse.json(null, { status: 404 });
+					}
+					return HttpResponse.json(null, {
+						status: 302,
+						headers: { location: "unpublished.cloudflareaccess.com" },
+					});
+				})
+			);
+
+			expect(
+				await domainUsesAccess(silentLogger, "unpublished.workers.dev")
+			).toBeFalsy();
+			expect(
+				await domainUsesAccess(
+					silentLogger,
+					"unpublished.workers.dev",
+					"preview-token"
+				)
+			).toBeTruthy();
 		});
 	});
 
@@ -292,7 +327,37 @@ See https://developers.cloudflare.com/cloudflare-one/access-controls/service-cre
 				});
 				expect(spawn).toHaveBeenCalledWith(
 					"cloudflared",
-					["access", "login", "access-protected.com"],
+					["access", "login", "https://access-protected.com/"],
+					{ signal: undefined }
+				);
+			});
+
+			it("should forward the preview token to cloudflared as a query parameter", async ({
+				expect,
+			}) => {
+				const fake = createFakeProcess();
+				vi.mocked(spawn).mockReturnValueOnce(fake.child);
+
+				const pendingHeaders = getAccessHeaders("access-protected.com", {
+					logger: silentLogger,
+					isNonInteractiveOrCI: () => false,
+					previewToken: "preview-token",
+				});
+				await vi.waitFor(() => {
+					expect(spawn).toHaveBeenCalledOnce();
+				});
+				fake.complete("fetched your token:\n\ntest-access-token\n");
+
+				await expect(pendingHeaders).resolves.toEqual({
+					Cookie: "CF_Authorization=test-access-token",
+				});
+				expect(spawn).toHaveBeenCalledWith(
+					"cloudflared",
+					[
+						"access",
+						"login",
+						"https://access-protected.com/?cf_workers_preview_token=preview-token",
+					],
 					{ signal: undefined }
 				);
 			});

--- a/packages/wrangler/src/api/startDevWorker/RemoteRuntimeController.ts
+++ b/packages/wrangler/src/api/startDevWorker/RemoteRuntimeController.ts
@@ -324,6 +324,7 @@ export class RemoteRuntimeController extends RuntimeController {
 
 		const accessHeaders = await getAccessHeaders(
 			token.host,
+			token.value,
 			this.#abortController.signal
 		);
 

--- a/packages/wrangler/src/user/access.ts
+++ b/packages/wrangler/src/user/access.ts
@@ -14,16 +14,18 @@ export function clearAccessCaches(): void {
 }
 
 export async function domainUsesAccess(domain: string): Promise<boolean> {
-	return packageDomainUsesAccess(domain, logger);
+	return packageDomainUsesAccess(logger, domain);
 }
 
 export async function getAccessHeaders(
 	domain: string,
+	previewToken?: string,
 	signal?: AbortSignal
 ): Promise<Record<string, string>> {
 	return packageGetAccessHeaders(domain, {
 		logger,
 		isNonInteractiveOrCI,
+		previewToken,
 		signal,
 	});
 }


### PR DESCRIPTION
When wrangler dev uses remote bindings, the Access detection probe sent an anonymous GET to the edge-preview hostname. For an unpublished worker that hostname has no public route at the edge, so the probe returned 404 and wrangler concluded the host was not behind Access. So it skipped attaching a CF_Authorization cookie, even though a wildcard Access app covered it. The actual preview-token traffic later did trigger Access, producing a 302 redirect loop with no clear error.

The probe now adds the preview token as a cf_workers_preview_token query parameter, which activates the edge-preview route and lets Access respond with its expected 302. The same token-bearing URL is passed to 'cloudflared access login' so it is carried through the login flow.

Fixes AUTH-8704

This depends on some Access changes that are still rolling out, to support the `cf_workers_preview_token` query parameter.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [X] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [X] Documentation not necessary because: it fixes a regression