### PR TITLE
[wrangler] Fix local D1 migration parsing after CASE expressions

### DIFF
--- a/.changeset/tidy-d1-trigger-splitting.md
+++ b/.changeset/tidy-d1-trigger-splitting.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Fix local D1 migrations containing `CASE` expressions in triggers
+
+Wrangler now keeps complete SQLite trigger bodies together without interpreting `CASE` expression boundaries. This prevents local migrations from failing when `CASE ... END` is followed by punctuation, while preserving unquoted columns named `begin` or `end`.

--- a/packages/wrangler/src/__tests__/d1/splitter.test.ts
+++ b/packages/wrangler/src/__tests__/d1/splitter.test.ts
@@ -455,4 +455,83 @@ describe("splitSqlQuery()", () => {
 			]
 		`);
 	});
+
+	it("should keep CASE expressions inside trigger bodies", ({ expect }) => {
+		for (const assignment of [
+			"value = CASE WHEN NEW.active THEN 1 ELSE 0 END, other = 2",
+			"value = (CASE WHEN NEW.active THEN 1 ELSE 0 END), other = 2",
+			"value = CASE WHEN NEW.active THEN 1 ELSE 0 END/* note */, other = 2",
+			"value = CASE WHEN NEW.active THEN(1)END, other = 2",
+		]) {
+			const statements = splitSqlQuery(`
+				CREATE TRIGGER update_projection AFTER INSERT ON source BEGIN
+					UPDATE projections SET ${assignment};
+					UPDATE audit SET seen = 1;
+				END;
+				CREATE TABLE after_trigger (id INTEGER PRIMARY KEY);
+			`);
+
+			expect(statements, assignment).toHaveLength(2);
+			expect(statements[0]).toContain("UPDATE audit SET seen = 1;");
+			expect(statements[1]).toBe(
+				"CREATE TABLE after_trigger (id INTEGER PRIMARY KEY)"
+			);
+		}
+	});
+
+	it("should not treat keyword-shaped identifiers as trigger boundaries", ({
+		expect,
+	}) => {
+		expect(
+			splitSqlQuery(`
+				CREATE TABLE source (begin TEXT, start INTEGER, end INTEGER);
+				CREATE TABLE ranges (start INTEGER, end INTEGER);
+				CREATE TRIGGER copy_range AFTER INSERT ON source BEGIN
+					INSERT INTO ranges (start, end) VALUES (NEW.start, NEW.end);
+				END;
+				CREATE TABLE after_trigger (id INTEGER PRIMARY KEY);
+			`)
+		).toEqual([
+			"CREATE TABLE source (begin TEXT, start INTEGER, end INTEGER)",
+			"CREATE TABLE ranges (start INTEGER, end INTEGER)",
+			`CREATE TRIGGER copy_range AFTER INSERT ON source BEGIN
+					INSERT INTO ranges (start, end) VALUES (NEW.start, NEW.end);
+				END`,
+			"CREATE TABLE after_trigger (id INTEGER PRIMARY KEY)",
+		]);
+	});
+
+	it("should recognize trigger boundaries separated by comments", ({
+		expect,
+	}) => {
+		const statements = splitSqlQuery(`
+			CREATE/* before trigger */TRIGGER audit_source AFTER INSERT ON source
+			BEGIN/* body */
+				INSERT INTO audit VALUES (NEW.id);
+			/* before end */END/* after end */;
+			CREATE TABLE after_trigger (id INTEGER PRIMARY KEY);
+		`);
+
+		expect(statements).toHaveLength(2);
+		expect(statements[0]).toContain("INSERT INTO audit VALUES (NEW.id);");
+		expect(statements[1]).toBe(
+			"CREATE TABLE after_trigger (id INTEGER PRIMARY KEY)"
+		);
+	});
+
+	it("should handle temporary triggers", ({ expect }) => {
+		for (const modifier of ["TEMP", "TEMPORARY"]) {
+			const statements = splitSqlQuery(`
+				CREATE ${modifier} TRIGGER audit_source AFTER INSERT ON source BEGIN
+					INSERT INTO audit VALUES (NEW.id);
+				END;
+				CREATE TABLE after_trigger (id INTEGER PRIMARY KEY);
+			`);
+
+			expect(statements, modifier).toHaveLength(2);
+			expect(statements[1]).toBe(
+				"CREATE TABLE after_trigger (id INTEGER PRIMARY KEY)"
+			);
+		}
+	});
 });

--- a/packages/wrangler/src/__tests__/d1/splitter.test.ts
+++ b/packages/wrangler/src/__tests__/d1/splitter.test.ts
@@ -513,7 +513,11 @@ describe("splitSqlQuery()", () => {
 		`);
 
 		expect(statements).toHaveLength(2);
-		expect(statements[0]).toContain("INSERT INTO audit VALUES (NEW.id);");
+		expect(statements[0])
+			.toBe(`CREATE TRIGGER audit_source AFTER INSERT ON source
+			BEGIN
+				INSERT INTO audit VALUES (NEW.id);
+			END`);
 		expect(statements[1]).toBe(
 			"CREATE TABLE after_trigger (id INTEGER PRIMARY KEY)"
 		);

--- a/packages/wrangler/src/d1/splitter.ts
+++ b/packages/wrangler/src/d1/splitter.ts
@@ -132,22 +132,75 @@ export function normalizeSqlLineEndings(sql: string): string {
 function splitSqlIntoStatements(sql: string): string[] {
 	const statements: string[] = [];
 	let str = "";
-	const compoundStatementStack: ((s: string) => boolean)[] = [];
+	let word = "";
+	let previousTokenWasSemicolon = false;
+	let statementPrefix: string[] = [];
+	let isTriggerStatement = false;
+	let inTriggerBody = false;
+
+	/**
+	 * Processes the identifier token that has just ended and updates trigger state.
+	 * SQLite requires every command in a trigger body to end with a semicolon, so
+	 * only an `END` after a semicolon closes the trigger. CASE expressions and
+	 * identifiers named BEGIN or END therefore need no special handling.
+	 */
+	function finishWord() {
+		if (word.length === 0) {
+			return;
+		}
+
+		const keyword = word.toUpperCase();
+		if (!isTriggerStatement && statementPrefix.length < 3) {
+			statementPrefix.push(keyword);
+			isTriggerStatement =
+				statementPrefix[0] === "CREATE" &&
+				(statementPrefix[1] === "TRIGGER" ||
+					((statementPrefix[1] === "TEMP" ||
+						statementPrefix[1] === "TEMPORARY") &&
+						statementPrefix[2] === "TRIGGER"));
+		}
+
+		if (isTriggerStatement && keyword === "BEGIN") {
+			inTriggerBody = true;
+		} else if (
+			inTriggerBody &&
+			keyword === "END" &&
+			previousTokenWasSemicolon
+		) {
+			inTriggerBody = false;
+		}
+
+		previousTokenWasSemicolon = false;
+		word = "";
+	}
+
+	/** Resets the parser state that is scoped to a single SQL statement. */
+	function startNextStatement() {
+		statementPrefix = [];
+		isTriggerStatement = false;
+		previousTokenWasSemicolon = false;
+	}
 
 	const iterator = sql[Symbol.iterator]();
 	let next = iterator.next();
 	while (!next.done) {
 		const char = next.value;
 
-		if (compoundStatementStack[0]?.(str + char)) {
-			compoundStatementStack.shift();
+		if (isIdentifierCharacter(char)) {
+			str += char;
+			word += char;
+			next = iterator.next();
+			continue;
 		}
+
+		finishWord();
 
 		switch (char) {
 			case `'`:
 			case `"`:
 			case "`":
 				str += char + consumeUntilMarker(iterator, char);
+				previousTokenWasSemicolon = false;
 				break;
 			case `$`: {
 				const dollarQuote =
@@ -156,6 +209,7 @@ function splitSqlIntoStatements(sql: string): string[] {
 				if (dollarQuote.endsWith("$")) {
 					str += consumeUntilMarker(iterator, dollarQuote);
 				}
+				previousTokenWasSemicolon = false;
 				break;
 			}
 			case `-`:
@@ -168,6 +222,7 @@ function splitSqlIntoStatements(sql: string): string[] {
 					break;
 				} else {
 					str += char;
+					previousTokenWasSemicolon = false;
 					continue;
 				}
 			case `/`:
@@ -178,32 +233,45 @@ function splitSqlIntoStatements(sql: string): string[] {
 					break;
 				} else {
 					str += char;
+					previousTokenWasSemicolon = false;
 					continue;
 				}
 			case `;`:
-				if (compoundStatementStack.length === 0) {
+				if (inTriggerBody) {
+					str += char;
+					previousTokenWasSemicolon = true;
+				} else {
 					statements.push(str);
 					str = "";
-				} else {
-					str += char;
+					startNextStatement();
 				}
 				break;
 			default:
 				str += char;
+				if (!/\s/.test(char)) {
+					previousTokenWasSemicolon = false;
+				}
 				break;
-		}
-
-		if (isCompoundStatementStart(str)) {
-			compoundStatementStack.unshift(isCompoundStatementEnd);
 		}
 
 		next = iterator.next();
 	}
+	finishWord();
 	statements.push(str);
 
 	return statements
 		.map((statement) => statement.trim())
 		.filter((statement) => statement.length > 0);
+}
+
+/**
+ * Checks whether a character can be part of an unquoted SQLite identifier.
+ *
+ * @param char The character to check.
+ * @returns Whether the character is an identifier character.
+ */
+function isIdentifierCharacter(char: string) {
+	return /[0-9_]/.test(char) || char.toLowerCase() !== char.toUpperCase();
 }
 
 /**
@@ -245,18 +313,4 @@ function isDollarQuoteIdentifier(str: string) {
 		(/[0-9_]/i.test(lastChar) ||
 			lastChar.toLowerCase() !== lastChar.toUpperCase())
 	);
-}
-
-/**
- * Returns true if the `str` ends with a compound statement `BEGIN` or `CASE` marker.
- */
-function isCompoundStatementStart(str: string) {
-	return /\s(BEGIN|CASE)\s$/i.test(str);
-}
-
-/**
- * Returns true if the `str` ends with a compound statement `END` marker.
- */
-function isCompoundStatementEnd(str: string) {
-	return /\sEND[;\s]$/i.test(str);
 }

--- a/packages/wrangler/src/d1/splitter.ts
+++ b/packages/wrangler/src/d1/splitter.ts
@@ -137,6 +137,7 @@ function splitSqlIntoStatements(sql: string): string[] {
 	let statementPrefix: string[] = [];
 	let isTriggerStatement = false;
 	let inTriggerBody = false;
+	let blockCommentNeedsWhitespace = false;
 
 	/**
 	 * Processes the identifier token that has just ended and updates trigger state.
@@ -185,6 +186,12 @@ function splitSqlIntoStatements(sql: string): string[] {
 	let next = iterator.next();
 	while (!next.done) {
 		const char = next.value;
+		if (blockCommentNeedsWhitespace) {
+			if (!/\s/.test(char)) {
+				str += " ";
+			}
+			blockCommentNeedsWhitespace = false;
+		}
 
 		if (isIdentifierCharacter(char)) {
 			str += char;
@@ -230,6 +237,7 @@ function splitSqlIntoStatements(sql: string): string[] {
 				if (!next.done && next.value === "*") {
 					// Skip to the end of the comment
 					consumeUntilMarker(iterator, "*/");
+					blockCommentNeedsWhitespace = str.length > 0 && !/\s$/.test(str);
 					break;
 				} else {
 					str += char;


### PR DESCRIPTION
Fixes #15162.

Wrangler splits SQL files on semicolons before sending statements to D1. The previous implementation tried to protect trigger bodies by tracking both `BEGIN` blocks and `CASE` expressions with whitespace-sensitive regular expressions. A `CASE ... END` followed by punctuation could therefore leave the stack unbalanced and combine the rest of a local migration into one query, producing `SQLITE_LOCKED`.

This change tracks SQLite `CREATE [TEMP|TEMPORARY] TRIGGER` bodies directly. SQLite requires every command in a trigger body to end with a semicolon, so the trigger-closing `END` is the one that follows a completed body command. The splitter can keep the trigger intact without interpreting `CASE` expressions or confusing legal identifiers named `begin` and `end` with control-flow markers.

Validation:

- Added regression coverage for `CASE ... END,`, parenthesized and compact CASE expressions, block comments adjacent to boundaries, temporary triggers, and unquoted `begin`/`end` identifiers.
- Rebuilt Wrangler and applied the issue reproduction through local D1/workerd. All five migrations succeed with statement counts `211, 4, 11, 199, 194`, matching remote D1.
- Applied six additional adversarial migrations through `wrangler d1 migrations apply --local`, including unquoted `end` columns and `CASE ... END/* comment */,`.
- Wrangler splitter tests, type-checking, type-aware linting, formatting, and the production build pass locally.

---

<!--
Please do not delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: this corrects internal SQL splitting without changing public APIs or configuration.

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

> [!NOTE]
> This is a contribution from an AI agent: OpenAI Codex, GPT-5.
