### PR TITLE
Stop workspace pnpm settings leaking into scaffolded installs

### DIFF
--- a/packages/create-cloudflare/e2e/helpers/spawn.ts
+++ b/packages/create-cloudflare/e2e/helpers/spawn.ts
@@ -1,4 +1,5 @@
 import { stripAnsi } from "@cloudflare/cli-shared-helpers";
+import { overrideConfigEnv } from "@cloudflare/mock-npm-registry/config-env";
 import { spawn } from "cross-spawn";
 import treeKill from "tree-kill";
 import type {
@@ -24,6 +25,12 @@ export const spawnWithLogging = (
 	logStream: Writable
 ) => {
 	const [cmd, ...argv] = args;
+
+	if (overriddenConfigEnv.length > 0) {
+		logStream.write(
+			`\nInherited package manager config overridden: ${overriddenConfigEnv.join(", ")}\n`
+		);
+	}
 
 	logStream.write(`\nRunning command: ${[cmd, ...argv].join(" ")}\n\n`);
 
@@ -111,8 +118,23 @@ export const waitForExit = async (
 	};
 };
 
+// Settings that would otherwise be inherited from the workers-sdk workspace,
+// where they are wrong for the throwaway projects these tests scaffold.
+// `overrideConfigEnv` is used rather than assignment because an inherited
+// variable spelled differently to the override would still win, unpredictably,
+// on Windows.
+const configEnv = overrideConfigEnv(process.env, {
+	// Scaffolded projects intentionally test the latest framework releases.
+	"minimum-release-age": "0",
+	// Give each project its own cache, so parallel installs don't race.
+	cache: "./.npm/cache",
+});
+
+/** Inherited variables dropped above, logged with each test as a breadcrumb. */
+const overriddenConfigEnv = configEnv.removed;
+
 export const testEnv = {
-	...process.env,
+	...configEnv.env,
 	// Strip secrets that should never be accessible to spawned processes.
 	// These tests scaffold third-party framework projects and run their code
 	// (npm install, postinstall scripts, dev servers, etc.) which we do not control.
@@ -128,10 +150,6 @@ export const testEnv = {
 	YARN_CACHE_FOLDER: "./.yarn/cache",
 	YARN_ENABLE_GLOBAL_CACHE: "false",
 	PNPM_HOME: "./.pnpm",
-	npm_config_cache: "./.npm/cache",
-	// Scaffolded projects intentionally test the latest framework releases.
-	npm_config_minimum_release_age: "0",
-	pnpm_config_minimum_release_age: "0",
 	// unset the VITEST env variable as this causes e2e issues with some frameworks
 	VITEST: undefined,
 };

--- a/packages/mock-npm-registry/package.json
+++ b/packages/mock-npm-registry/package.json
@@ -6,11 +6,17 @@
 	"module": "./dist/index.js",
 	"types": "./dist/index.d.ts",
 	"exports": {
-		".": "./dist/index.js"
+		".": "./dist/index.js",
+		"./config-env": {
+			"types": "./dist/config-env.d.ts",
+			"import": "./dist/config-env.js"
+		}
 	},
 	"scripts": {
 		"build": "tsc",
-		"check:types": "tsc"
+		"check:types": "tsc",
+		"test": "vitest",
+		"test:ci": "vitest run"
 	},
 	"devDependencies": {
 		"@cloudflare/workers-utils": "workspace:*",
@@ -20,7 +26,8 @@
 		"tree-kill": "catalog:default",
 		"ts-dedent": "^2.2.0",
 		"typescript": "catalog:default",
-		"verdaccio": "^6.0.5"
+		"verdaccio": "^6.0.5",
+		"vitest": "catalog:default"
 	},
 	"volta": {
 		"extends": "../../package.json"

--- a/packages/mock-npm-registry/src/config-env.ts
+++ b/packages/mock-npm-registry/src/config-env.ts
@@ -1,0 +1,79 @@
+const CONFIG_ENV_PREFIXES = ["npm_config_", "pnpm_config_"];
+
+/**
+ * Reduce a setting name to a spelling-insensitive identity, so that
+ * `minimum-release-age`, `minimum_release_age` and `minimumReleaseAge` all
+ * compare equal.
+ */
+function settingIdentity(name: string): string {
+	return name.toLowerCase().replaceAll(/[-_]/g, "");
+}
+
+/**
+ * The setting an environment variable configures, or `undefined` if it isn't a
+ * package-manager config variable.
+ */
+function settingFromEnvKey(key: string): string | undefined {
+	const lowerCased = key.toLowerCase();
+	const prefix = CONFIG_ENV_PREFIXES.find((candidate) =>
+		lowerCased.startsWith(candidate)
+	);
+
+	if (prefix === undefined) {
+		return undefined;
+	}
+
+	return settingIdentity(lowerCased.slice(prefix.length));
+}
+
+/**
+ * Copy `env`, replacing any inherited spelling of the given settings with a
+ * single canonical variable per package manager.
+ *
+ * Every `pnpm run` script inherits the repository's own pnpm settings via
+ * `npm_config_*` variables, which pnpm matches case-insensitively. Spreading
+ * `process.env` and adding one spelling therefore leaves both in place, and
+ * which one wins depends on the order of the environment block — not stable on
+ * Windows, where it is sorted when a process is created. Removing every
+ * spelling first avoids that.
+ *
+ * Settings are keyed by kebab-case name. Matching is exact but
+ * spelling-insensitive, so overriding `minimum-release-age` leaves
+ * `minimum-release-age-strict` alone; pass such settings explicitly.
+ *
+ * @param env the environment to copy, usually `process.env`
+ * @param overrides settings to apply, keyed by kebab-case setting name
+ * @returns the new environment, and the names of the variables that were removed
+ */
+export function overrideConfigEnv(
+	env: NodeJS.ProcessEnv,
+	overrides: Record<string, string>
+): { env: NodeJS.ProcessEnv; removed: string[] } {
+	const overriddenSettings = new Set(
+		Object.keys(overrides).map((setting) => settingIdentity(setting))
+	);
+
+	const result: NodeJS.ProcessEnv = {};
+	const removed: string[] = [];
+
+	for (const [key, value] of Object.entries(env)) {
+		const setting = settingFromEnvKey(key);
+
+		if (setting !== undefined && overriddenSettings.has(setting)) {
+			removed.push(key);
+			continue;
+		}
+
+		result[key] = value;
+	}
+
+	for (const [setting, value] of Object.entries(overrides)) {
+		// `npm_config_` is read by npm and pnpm 10, `pnpm_config_` by pnpm 11.
+		const envKey = setting.replaceAll("-", "_");
+		for (const prefix of CONFIG_ENV_PREFIXES) {
+			result[`${prefix}${envKey}`] = value;
+		}
+	}
+
+	return { env: result, removed };
+}

--- a/packages/mock-npm-registry/src/index.ts
+++ b/packages/mock-npm-registry/src/index.ts
@@ -9,6 +9,8 @@ import treeKill from "tree-kill";
 import { dedent } from "ts-dedent";
 import { ConfigBuilder } from "verdaccio";
 
+export { overrideConfigEnv } from "./config-env.js";
+
 const debugLog = util.debuglog("mock-npm-registry");
 const repoRoot = path.resolve(__dirname, "../../..");
 
@@ -59,17 +61,17 @@ export async function startMockNpmRegistry(...targetPackages: string[]) {
 	`
 	);
 
-	// pnpm reads array settings such as `minimumReleaseAgeExclude` only from a
-	// config *file* (never from an env var), and the file differs by pnpm major:
-	// pnpm 10 reads the global `<configDir>/rc` (npmrc/INI), while pnpm 11 reads
-	// the global `<configDir>/config.yaml`. `<configDir>` resolves to
-	// `$XDG_CONFIG_HOME/pnpm` on all platforms when XDG_CONFIG_HOME is set, so we
-	// write both files into an isolated config dir and point pnpm at it below.
 	// Freshly-published first-party packages carry a "now" timestamp, so the
-	// inherited `minimumReleaseAge` cooldown (leaked from the workspace via the
-	// `npm_config_minimum_release_age` env var) would otherwise reject them.
-	// Excluding them by name installs their local versions while the cooldown
-	// still applies to third-party deps pulled via the npm uplink.
+	// `minimumReleaseAge` cooldown that `pnpm run` exports from the workspace
+	// would reject them. Excluding them by name installs their local versions
+	// while the cooldown still applies to third-party deps pulled via the npm
+	// uplink. (To change the cooldown itself, use `overrideConfigEnv`.)
+	//
+	// The exclusion is an array, and pnpm only reads those from a config file,
+	// which differs by pnpm major: pnpm 10 reads the global `<configDir>/rc`
+	// (npmrc/INI), pnpm 11 the global `<configDir>/config.yaml`. `<configDir>`
+	// is `$XDG_CONFIG_HOME/pnpm` on all platforms when that is set, so we write
+	// both files into an isolated config dir and point pnpm at it.
 	const configHome = path.join(registryPath, "config");
 	const pnpmConfigDir = path.join(configHome, "pnpm");
 	await fs.mkdir(pnpmConfigDir, { recursive: true });
@@ -120,8 +122,7 @@ export async function startMockNpmRegistry(...targetPackages: string[]) {
 	// `minimumReleaseAgeExclude` list is honored. The scalar
 	// `npm_config_minimum_release_age` inherited from the parent `pnpm run`
 	// still applies to third-party deps; the two settings merge because they are
-	// different keys. (An array cannot be passed via a single env var, and pnpm
-	// only reads this setting from config files — hence the redirect.)
+	// different keys.
 	const revert_XDG_CONFIG_HOME = overrideProcessEnv(
 		"XDG_CONFIG_HOME",
 		configHome

--- a/packages/mock-npm-registry/tests/config-env.test.ts
+++ b/packages/mock-npm-registry/tests/config-env.test.ts
@@ -1,0 +1,143 @@
+import { describe, test } from "vitest";
+import { overrideConfigEnv } from "../src/config-env";
+
+describe("overrideConfigEnv", () => {
+	test("writes a canonical variable for each package manager", ({ expect }) => {
+		const { env, removed } = overrideConfigEnv(
+			{},
+			{ "minimum-release-age": "0" }
+		);
+
+		expect(env).toEqual({
+			npm_config_minimum_release_age: "0",
+			pnpm_config_minimum_release_age: "0",
+		});
+		expect(removed).toEqual([]);
+	});
+
+	test("replaces an inherited value", ({ expect }) => {
+		const { env, removed } = overrideConfigEnv(
+			{ npm_config_minimum_release_age: "1440" },
+			{ "minimum-release-age": "0" }
+		);
+
+		expect(env.npm_config_minimum_release_age).toBe("0");
+		expect(removed).toEqual(["npm_config_minimum_release_age"]);
+	});
+
+	const spellings = {
+		"upper case": "NPM_CONFIG_MINIMUM_RELEASE_AGE",
+		"mixed case": "npm_config_MINIMUM_release_AGE",
+		"camel case": "npm_config_minimumReleaseAge",
+		"pnpm prefix": "pnpm_config_minimum_release_age",
+		"pnpm prefix, upper case": "PNPM_CONFIG_MINIMUM_RELEASE_AGE",
+	};
+
+	for (const [spelling, key] of Object.entries(spellings)) {
+		test(`replaces an inherited value spelled in ${spelling}`, ({ expect }) => {
+			const { env, removed } = overrideConfigEnv(
+				{ [key]: "1440" },
+				{ "minimum-release-age": "0" }
+			);
+
+			expect(removed).toEqual([key]);
+			expect(Object.values(env)).not.toContain("1440");
+			expect(env).toEqual({
+				npm_config_minimum_release_age: "0",
+				pnpm_config_minimum_release_age: "0",
+			});
+		});
+	}
+
+	test("removes every spelling when several are inherited at once", ({
+		expect,
+	}) => {
+		// The case that broke C3's E2E tests on Windows: pnpm reads whichever
+		// spelling the environment block happens to order last.
+		const { env, removed } = overrideConfigEnv(
+			{
+				NPM_CONFIG_MINIMUM_RELEASE_AGE: "1440",
+				npm_config_minimum_release_age: "1440",
+				npm_config_minimumReleaseAge: "1440",
+			},
+			{ "minimum-release-age": "0" }
+		);
+
+		expect(removed).toEqual([
+			"NPM_CONFIG_MINIMUM_RELEASE_AGE",
+			"npm_config_minimum_release_age",
+			"npm_config_minimumReleaseAge",
+		]);
+		expect(env).toEqual({
+			npm_config_minimum_release_age: "0",
+			pnpm_config_minimum_release_age: "0",
+		});
+	});
+
+	test("applies several overrides at once", ({ expect }) => {
+		const { env, removed } = overrideConfigEnv(
+			{
+				NPM_CONFIG_CACHE: "/global/cache",
+				npm_config_minimum_release_age: "1440",
+			},
+			{ "minimum-release-age": "0", cache: "./.npm/cache" }
+		);
+
+		expect(removed).toEqual([
+			"NPM_CONFIG_CACHE",
+			"npm_config_minimum_release_age",
+		]);
+		expect(env).toEqual({
+			npm_config_minimum_release_age: "0",
+			pnpm_config_minimum_release_age: "0",
+			npm_config_cache: "./.npm/cache",
+			pnpm_config_cache: "./.npm/cache",
+		});
+	});
+
+	test("leaves other configuration alone", ({ expect }) => {
+		const { env, removed } = overrideConfigEnv(
+			{
+				PATH: "/usr/bin",
+				npm_config_registry: "http://localhost:1234",
+				NPM_CONFIG_USERCONFIG: "/tmp/.npmrc",
+				npm_config_user_agent: "pnpm/10.33.0",
+			},
+			{ "minimum-release-age": "0" }
+		);
+
+		expect(removed).toEqual([]);
+		expect(env).toMatchObject({
+			PATH: "/usr/bin",
+			npm_config_registry: "http://localhost:1234",
+			NPM_CONFIG_USERCONFIG: "/tmp/.npmrc",
+			npm_config_user_agent: "pnpm/10.33.0",
+		});
+	});
+
+	test("matches settings exactly, not by prefix", ({ expect }) => {
+		// `cache-dir` is a distinct pnpm setting from `cache`, and
+		// `minimum-release-age-strict` from `minimum-release-age`.
+		const { env, removed } = overrideConfigEnv(
+			{
+				npm_config_cache_dir: "/global/pnpm-cache",
+				npm_config_minimum_release_age_strict: "true",
+			},
+			{ "minimum-release-age": "0", cache: "./.npm/cache" }
+		);
+
+		expect(removed).toEqual([]);
+		expect(env).toMatchObject({
+			npm_config_cache_dir: "/global/pnpm-cache",
+			npm_config_minimum_release_age_strict: "true",
+		});
+	});
+
+	test("does not mutate the environment it is given", ({ expect }) => {
+		const original = { npm_config_minimum_release_age: "1440" };
+
+		overrideConfigEnv(original, { "minimum-release-age": "0" });
+
+		expect(original).toEqual({ npm_config_minimum_release_age: "1440" });
+	});
+});

--- a/packages/mock-npm-registry/vitest.config.mts
+++ b/packages/mock-npm-registry/vitest.config.mts
@@ -1,0 +1,11 @@
+import { defineProject, mergeConfig } from "vitest/config";
+import configShared from "../../vitest.shared";
+
+export default mergeConfig(
+	configShared,
+	defineProject({
+		test: {
+			include: ["tests/**/*.test.ts"],
+		},
+	})
+);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2536,6 +2536,9 @@ importers:
       verdaccio:
         specifier: ^6.0.5
         version: 6.0.5(encoding@0.1.13)(typanion@3.14.0)
+      vitest:
+        specifier: catalog:default
+        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@22.15.17)(@vitest/ui@4.1.0)(msw@2.12.4(@types/node@22.15.17)(typescript@5.8.3))(vite@8.2.0(@types/node@22.15.17)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/pages-functions:
     dependencies:


### PR DESCRIPTION
C3's E2E tests intermittently fail on Windows with `ERR_PNPM_NO_MATURE_MATCHING_VERSION` while installing a scaffolded project — for example [this run](https://github.com/cloudflare/workers-sdk/actions/runs/31691728536/job/94420324847#step:10:316), where `@rolldown/binding-linux-s390x-gnu@1.2.4` (23 hours old, and for a platform the runner doesn't even use) failed the workspace's 24-hour `minimumReleaseAge` cooldown.

### Why the cooldown reaches a throwaway project in a temp directory

Every `pnpm run` script inherits the repository's own pnpm settings. pnpm copies the settings from `pnpm-workspace.yaml` into its `rawConfig` kebab-cased, and running a script goes through `@pnpm/npm-lifecycle`, whose `makeEnv` exports every `rawConfig` entry as `npm_config_<setting>`. So `pnpm run test:e2e:c3` hands `npm_config_minimum_release_age=1440` to turbo → vitest → C3 → the scaffolded project's `pnpm install`.

### Why the existing override didn't always win

[#14722](https://github.com/cloudflare/workers-sdk/pull/14722) set `npm_config_minimum_release_age: "0"` on top of a `{...process.env}` spread. That only replaces the inherited variable when it is spelled identically. pnpm matches these case-insensitively (`/^npm_config_/i`, then lower-cased with `_` mapped to `-`), so a differently-cased inherited variable survives alongside the override as a separate key, and which one pnpm honours comes down to the order of the environment block — which is not stable on Windows, where the block is sorted when a process is created. Hence the intermittency, and why Linux stayed green.

Setting the variable at the workflow level does not help either: for pnpm invocations inside the workspace, `pnpm-workspace.yaml` settings are assigned over the env-derived config, so the value is re-clobbered and re-exported.

### The change

- New `overrideConfigEnv` in `@cloudflare/mock-npm-registry`: copies an environment, removes *every* spelling of the requested settings (either prefix, any case, `-`/`_`/camelCase), then writes one canonical variable per package manager. Matching is exact but spelling-insensitive, so overriding `cache` doesn't touch `cache-dir`.
- `testEnv` in C3's E2E helpers is built with it. The overrides themselves are unchanged: `minimum-release-age=0` (scaffolded projects intentionally test the latest framework releases) and `cache=./.npm/cache`. Dropped variables are written to the test log so a recurrence is self-diagnosing in the uploaded artifacts.
- The stale comment in `mock-npm-registry` that described the leak incorrectly is corrected.

### Deliberately not changed

- The workspace keeps `minimumReleaseAge: 1440` for its own installs.
- The `vitest-pool-workers` and `vite-plugin-cloudflare` E2E suites keep the inherited cooldown. Their fixtures depend on caret ranges, so pnpm just resolves to the newest mature version — the setting working as intended, at no cost. Only C3, which scaffolds third-party generators that pin the newest releases, needs the override.

### Verification

Locally, the new log line confirms the leak is real and is now removed rather than shadowed:

```
Inherited package manager config overridden: npm_config_minimum_release_age
```

`E2E_TEST_FILTER=cli pnpm run test:e2e:c3` passes 26/26, including `accepts --variant for React Pages framework without prompting`, the test that failed in the linked run. The ordering hazard itself only manifests on Windows, so the **C3 E2E (pnpm, Windows) - cli** job here is the real signal.


---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: testing change

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- If you are an AI agent or LLM, and you are adding this PR without direct human supervision, thank you! Please uncomment the following block. This is so the maintainers know how to expect you to respond.

> [!NOTE]
> This is a contribution from an AI agent: <insert name here>, <insert LLM model here if different>.

-->
