### PR TITLE
Treat 502/503/504 as gateway errors during asset upload retries

### DIFF
--- a/.changeset/pages-upload-gateway-backoff.md
+++ b/.changeset/pages-upload-gateway-backoff.md
@@ -5,6 +5,4 @@
 
 Treat 502, 503, and 504 as gateway errors during asset upload retries
 
-`APIError.isGatewayError()` previously matched only Cloudflare's 524 timeout. Pages and Workers asset uploads use that helper to drop upload concurrency and wait longer before retrying, so a `502 Bad Gateway` HTML response from `POST /pages/assets/upload` was retried with the short backoff path and counted against `MAX_UPLOAD_ATTEMPTS` immediately.
-
-Those HTTP gateway statuses now take the same backoff path as 524.
+Pages and Workers asset uploads now retry more patiently when the Cloudflare API responds with a 502, 503 or 504 gateway error, reducing concurrency and waiting longer between attempts instead of failing the deploy quickly.

--- a/.changeset/pages-upload-gateway-backoff.md
+++ b/.changeset/pages-upload-gateway-backoff.md
@@ -1,0 +1,10 @@
+---
+"@cloudflare/workers-utils": patch
+"wrangler": patch
+---
+
+Treat 502, 503, and 504 as gateway errors during asset upload retries
+
+`APIError.isGatewayError()` previously matched only Cloudflare's 524 timeout. Pages and Workers asset uploads use that helper to drop upload concurrency and wait longer before retrying, so a `502 Bad Gateway` HTML response from `POST /pages/assets/upload` was retried with the short backoff path and counted against `MAX_UPLOAD_ATTEMPTS` immediately.
+
+Those HTTP gateway statuses now take the same backoff path as 524.

--- a/packages/workers-utils/src/parse.ts
+++ b/packages/workers-utils/src/parse.ts
@@ -84,7 +84,6 @@ export class APIError extends ParseError {
 
 	isGatewayError() {
 		if (this.#status !== undefined) {
-			// HTTP gateway failures plus Cloudflare's 524 timeout.
 			// Pages/Workers asset upload uses this to drop concurrency and back off longer.
 			return [502, 503, 504, 524].includes(this.#status);
 		}

--- a/packages/workers-utils/src/parse.ts
+++ b/packages/workers-utils/src/parse.ts
@@ -84,7 +84,9 @@ export class APIError extends ParseError {
 
 	isGatewayError() {
 		if (this.#status !== undefined) {
-			return [524].includes(this.#status);
+			// HTTP gateway failures plus Cloudflare's 524 timeout.
+			// Pages/Workers asset upload uses this to drop concurrency and back off longer.
+			return [502, 503, 504, 524].includes(this.#status);
 		}
 		return false;
 	}

--- a/packages/workers-utils/tests/parse.test.ts
+++ b/packages/workers-utils/tests/parse.test.ts
@@ -411,18 +411,31 @@ describe("APIError.isGatewayError", () => {
 		expect,
 	}) => {
 		for (const status of [502, 503, 504, 524]) {
-			expect(new APIError({ text: "gateway", status }).isGatewayError()).toBe(
-				true
-			);
+			expect(
+				new APIError({
+					text: "gateway",
+					status,
+					telemetryMessage: false,
+				}).isGatewayError()
+			).toBe(true);
 		}
 	});
 
 	it("does not treat other statuses as gateway errors", ({ expect }) => {
-		expect(new APIError({ text: "no status" }).isGatewayError()).toBe(false);
+		expect(
+			new APIError({
+				text: "no status",
+				telemetryMessage: false,
+			}).isGatewayError()
+		).toBe(false);
 		for (const status of [200, 400, 401, 404, 429, 500]) {
-			expect(new APIError({ text: "other", status }).isGatewayError()).toBe(
-				false
-			);
+			expect(
+				new APIError({
+					text: "other",
+					status,
+					telemetryMessage: false,
+				}).isGatewayError()
+			).toBe(false);
 		}
 	});
 });

--- a/packages/workers-utils/tests/parse.test.ts
+++ b/packages/workers-utils/tests/parse.test.ts
@@ -1,5 +1,6 @@
 import { describe, it } from "vitest";
 import {
+	APIError,
 	indexLocation,
 	parseByteSize,
 	parseJSON,
@@ -402,5 +403,26 @@ describe("parseByteSize", () => {
 		expect(parseByteSize(".B")).toBeNaN();
 		expect(parseByteSize("3iB")).toBeNaN();
 		expect(parseByteSize("3ib")).toBeNaN();
+	});
+});
+
+describe("APIError.isGatewayError", () => {
+	it("treats HTTP gateway statuses and Cloudflare 524 as gateway errors", ({
+		expect,
+	}) => {
+		for (const status of [502, 503, 504, 524]) {
+			expect(new APIError({ text: "gateway", status }).isGatewayError()).toBe(
+				true
+			);
+		}
+	});
+
+	it("does not treat other statuses as gateway errors", ({ expect }) => {
+		expect(new APIError({ text: "no status" }).isGatewayError()).toBe(false);
+		for (const status of [200, 400, 401, 404, 429, 500]) {
+			expect(new APIError({ text: "other", status }).isGatewayError()).toBe(
+				false
+			);
+		}
 	});
 });


### PR DESCRIPTION
## What

`APIError.isGatewayError()` now matches HTTP 502, 503, and 504 in addition to Cloudflare's 524 timeout.

Pages and Workers asset upload use that helper to drop concurrency and wait longer before retrying. A `502 Bad Gateway` HTML page from `POST /pages/assets/upload` previously took the short backoff path and counted against `MAX_UPLOAD_ATTEMPTS` immediately.

## Why

Hit this class of failure on `wrangler@4.118.0 pages deploy` for a small static site (~26KB). `POST /pages/assets/upload` returned an HTML 5xx; `--skip-caching` did not help; `wrangler@3.114.15 pages publish` succeeded.

Related: https://github.com/cloudflare/workers-sdk/issues/14021 (502 HTML on the same endpoint; retries visible in debug logs).

500 is left out of `isGatewayError()` on purpose — it is not a gateway status. Those responses remain retryable via `isRetryable()`.

## Tests

Unit tests for `APIError.isGatewayError` in `packages/workers-utils/tests/parse.test.ts`.

- [x] Tests included/updated
- [x] Documentation not necessary because: this only changes retry backoff for existing HTTP gateway statuses; no user-facing docs or CLI flags changed