### PR TITLE
Restore Date and bigint values on forwarded tail events

### DIFF
--- a/.changeset/tail-event-dates.md
+++ b/.changeset/tail-event-dates.md
@@ -3,6 +3,8 @@
 "miniflare": patch
 ---
 
-Restore `Date` values on tail events forwarded to a tail consumer in local dev
+Restore `Date` and `bigint` values on tail events forwarded to a tail consumer in local dev
 
 Tail events are serialized to JSON before being handed to a tail consumer running in another local dev session. `Date` values were flattened to ISO strings on the way through, so a consumer received `event.scheduledTime` as a string and calls such as `event.scheduledTime.getTime()` threw locally while working in production. They are now restored as `Date` objects, matching production.
+
+A `bigint` was worse than lossy in the Vite plugin: `JSON.stringify()` throws on one rather than dropping it, so a single tail event carrying a `bigint` took out the whole forwarding call with `TypeError: Do not know how to serialize a BigInt`. This is reachable today, because `TraceDiagnosticChannelEvent.message` is typed `any` and preserves whatever a worker publishes — `channel("test").publish(5n)` is enough. Miniflare already tagged `bigint` values; the Vite plugin's copy of the same helper did not, and now does.

--- a/.changeset/tail-event-dates.md
+++ b/.changeset/tail-event-dates.md
@@ -1,0 +1,8 @@
+---
+"@cloudflare/vite-plugin": patch
+"miniflare": patch
+---
+
+Restore `Date` values on tail events forwarded to a tail consumer in local dev
+
+Tail events are serialized to JSON before being handed to a tail consumer running in another local dev session. `Date` values were flattened to ISO strings on the way through, so a consumer received `event.scheduledTime` as a string and calls such as `event.scheduledTime.getTime()` threw locally while working in production. They are now restored as `Date` objects, matching production.

--- a/packages/miniflare/src/workers/assets/rpc-proxy.worker.ts
+++ b/packages/miniflare/src/workers/assets/rpc-proxy.worker.ts
@@ -1,8 +1,5 @@
 import { WorkerEntrypoint } from "cloudflare:workers";
-import {
-	tailEventsReplacer,
-	tailEventsReviver,
-} from "../core/dev-registry-proxy-shared.worker";
+import { tailEventsReplacer, tailEventsReviver } from "../core/tail-events";
 import type RouterWorker from "@cloudflare/workers-shared/asset-worker";
 
 interface Env {

--- a/packages/miniflare/src/workers/core/dev-registry-proxy-shared.worker.ts
+++ b/packages/miniflare/src/workers/core/dev-registry-proxy-shared.worker.ts
@@ -259,34 +259,3 @@ export function createProxyDurableObjectClass({
 		}
 	} as unknown as typeof DurableObject;
 }
-
-const SERIALIZED_DATE = "___serialized_date___";
-const SERIALIZED_BIGINT = "___serialized_bigint___";
-
-/**
- * JSON replacer that serializes `Date` and `bigint` values into tagged
- * objects so they survive a JSON round-trip in tail event forwarding.
- */
-export function tailEventsReplacer(_: string, value: any) {
-	if (value instanceof Date) {
-		return { [SERIALIZED_DATE]: value.toISOString() };
-	} else if (typeof value === "bigint") {
-		return { [SERIALIZED_BIGINT]: value.toString() };
-	}
-	return value;
-}
-
-/**
- * JSON reviver that restores `Date` and `bigint` values from the tagged
- * objects produced by {@link tailEventsReplacer}.
- */
-export function tailEventsReviver(_: string, value: any) {
-	if (value && typeof value === "object") {
-		if (SERIALIZED_DATE in value) {
-			return new Date(value[SERIALIZED_DATE]);
-		} else if (SERIALIZED_BIGINT in value) {
-			return BigInt(value[SERIALIZED_BIGINT]);
-		}
-	}
-	return value;
-}

--- a/packages/miniflare/src/workers/core/dev-registry-proxy-shared.worker.ts
+++ b/packages/miniflare/src/workers/core/dev-registry-proxy-shared.worker.ts
@@ -193,34 +193,3 @@ export function createProxyDurableObjectClass({
 		}
 	} as unknown as typeof DurableObject;
 }
-
-const SERIALIZED_DATE = "___serialized_date___";
-const SERIALIZED_BIGINT = "___serialized_bigint___";
-
-/**
- * JSON replacer that serializes `Date` and `bigint` values into tagged
- * objects so they survive a JSON round-trip in tail event forwarding.
- */
-export function tailEventsReplacer(_: string, value: any) {
-	if (value instanceof Date) {
-		return { [SERIALIZED_DATE]: value.toISOString() };
-	} else if (typeof value === "bigint") {
-		return { [SERIALIZED_BIGINT]: value.toString() };
-	}
-	return value;
-}
-
-/**
- * JSON reviver that restores `Date` and `bigint` values from the tagged
- * objects produced by {@link tailEventsReplacer}.
- */
-export function tailEventsReviver(_: string, value: any) {
-	if (value && typeof value === "object") {
-		if (SERIALIZED_DATE in value) {
-			return new Date(value[SERIALIZED_DATE]);
-		} else if (SERIALIZED_BIGINT in value) {
-			return BigInt(value[SERIALIZED_BIGINT]);
-		}
-	}
-	return value;
-}

--- a/packages/miniflare/src/workers/core/dev-registry-proxy.worker.ts
+++ b/packages/miniflare/src/workers/core/dev-registry-proxy.worker.ts
@@ -6,10 +6,9 @@ import {
 	openDebugPortClient,
 	resolveSharedStorageOwner,
 	resolveTarget,
-	tailEventsReplacer,
-	tailEventsReviver,
 	workerNotFoundMessage,
 } from "./dev-registry-proxy-shared.worker";
+import { tailEventsReplacer, tailEventsReviver } from "./tail-events";
 import type {
 	RegistryEntry,
 	WorkerdDebugPortConnector,

--- a/packages/miniflare/src/workers/core/dev-registry-proxy.worker.ts
+++ b/packages/miniflare/src/workers/core/dev-registry-proxy.worker.ts
@@ -4,10 +4,9 @@ import { CorePaths } from "./constants";
 import {
 	findQueueConsumer,
 	resolveTarget,
-	tailEventsReplacer,
-	tailEventsReviver,
 	workerNotFoundMessage,
 } from "./dev-registry-proxy-shared.worker";
+import { tailEventsReplacer, tailEventsReviver } from "./tail-events";
 import type { WorkerdDebugPortConnector } from "./dev-registry-proxy-shared.worker";
 
 export {

--- a/packages/miniflare/src/workers/core/tail-events.ts
+++ b/packages/miniflare/src/workers/core/tail-events.ts
@@ -1,0 +1,41 @@
+const SERIALIZED_DATE = "___serialized_date___";
+const SERIALIZED_BIGINT = "___serialized_bigint___";
+
+/**
+ * JSON replacer that serializes `Date` and `bigint` values into tagged
+ * objects so they survive a JSON round-trip in tail event forwarding.
+ */
+export function tailEventsReplacer(this: any, key: string, value: any) {
+	// `JSON.stringify()` calls `Date.prototype.toJSON()` before handing a value
+	// to the replacer, so a real `Date` arrives here already flattened to an ISO
+	// string. Read the untouched value back off the holder to catch those. The
+	// `instanceof` check below still matters for values a custom `toJSON()`
+	// returns, which reach the replacer unconverted.
+	if (typeof value === "string") {
+		const original = this[key];
+		if (original instanceof Date) {
+			return { [SERIALIZED_DATE]: original.toISOString() };
+		}
+	}
+	if (value instanceof Date) {
+		return { [SERIALIZED_DATE]: value.toISOString() };
+	} else if (typeof value === "bigint") {
+		return { [SERIALIZED_BIGINT]: value.toString() };
+	}
+	return value;
+}
+
+/**
+ * JSON reviver that restores `Date` and `bigint` values from the tagged
+ * objects produced by {@link tailEventsReplacer}.
+ */
+export function tailEventsReviver(_: string, value: any) {
+	if (value && typeof value === "object") {
+		if (SERIALIZED_DATE in value) {
+			return new Date(value[SERIALIZED_DATE]);
+		} else if (SERIALIZED_BIGINT in value) {
+			return BigInt(value[SERIALIZED_BIGINT]);
+		}
+	}
+	return value;
+}

--- a/packages/miniflare/src/workers/core/tail-events.ts
+++ b/packages/miniflare/src/workers/core/tail-events.ts
@@ -34,7 +34,15 @@ export function tailEventsReviver(_: string, value: any) {
 		if (SERIALIZED_DATE in value) {
 			return new Date(value[SERIALIZED_DATE]);
 		} else if (SERIALIZED_BIGINT in value) {
-			return BigInt(value[SERIALIZED_BIGINT]);
+			try {
+				return BigInt(value[SERIALIZED_BIGINT]);
+			} catch {
+				// `BigInt()` throws on a string that isn't an integer, unlike
+				// `new Date()`. A payload that merely happens to carry the tag would
+				// otherwise fail the parse it is meant to survive, so leave it as the
+				// plain object it already is.
+				return value;
+			}
 		}
 	}
 	return value;

--- a/packages/miniflare/test/workers/core/tail-events.spec.ts
+++ b/packages/miniflare/test/workers/core/tail-events.spec.ts
@@ -1,0 +1,85 @@
+import { describe, test } from "vitest";
+import {
+	tailEventsReplacer,
+	tailEventsReviver,
+} from "../../../src/workers/core/tail-events";
+
+// Mirrors how tail events are forwarded between dev sessions.
+function roundTrip<T>(value: unknown): T {
+	return JSON.parse(
+		JSON.stringify(value, tailEventsReplacer),
+		tailEventsReviver
+	);
+}
+
+describe("tail event serialization", () => {
+	test("restores a Date", ({ expect }) => {
+		const scheduledTime = new Date("2025-05-01T12:34:56.000Z");
+
+		const result = roundTrip<{ event: { scheduledTime: Date } }>({
+			event: { scheduledTime },
+		});
+
+		expect(result.event.scheduledTime).toBeInstanceOf(Date);
+		expect(result.event.scheduledTime.getTime()).toBe(scheduledTime.getTime());
+	});
+
+	test("restores a Date nested in an array", ({ expect }) => {
+		const date = new Date("2025-05-01T12:34:56.000Z");
+
+		const [item] = roundTrip<[{ date: Date }]>([{ date }]);
+
+		expect(item.date).toBeInstanceOf(Date);
+		expect(item.date.getTime()).toBe(date.getTime());
+	});
+
+	test("restores a Date returned by a custom toJSON()", ({ expect }) => {
+		const date = new Date("2025-05-01T12:34:56.000Z");
+
+		const result = roundTrip<{ value: Date }>({
+			value: {
+				toJSON() {
+					return date;
+				},
+			},
+		});
+
+		expect(result.value).toBeInstanceOf(Date);
+		expect(result.value.getTime()).toBe(date.getTime());
+	});
+
+	test("restores a bigint", ({ expect }) => {
+		const result = roundTrip<{ cpuTime: bigint }>({
+			cpuTime: 9007199254740993n,
+		});
+
+		expect(result.cpuTime).toBe(9007199254740993n);
+	});
+
+	test("leaves a date-like string alone", ({ expect }) => {
+		const result = roundTrip<{ message: string }>({
+			message: "2025-05-01T12:34:56.000Z",
+		});
+
+		expect(result.message).toBe("2025-05-01T12:34:56.000Z");
+	});
+
+	test("does not throw on an invalid Date", ({ expect }) => {
+		const result = roundTrip<{ scheduledTime: null }>({
+			scheduledTime: new Date(NaN),
+		});
+
+		expect(result.scheduledTime).toBe(null);
+	});
+
+	test("revives a payload that already contains the date tag", ({ expect }) => {
+		// The tag is a plain object key, so a payload that happens to contain it
+		// is indistinguishable from a serialized Date. Pinned here so the
+		// collision stays a known trade-off.
+		const result = roundTrip<{ logged: Date }>({
+			logged: { ___serialized_date___: "2025-05-01T12:34:56.000Z" },
+		});
+
+		expect(result.logged).toBeInstanceOf(Date);
+	});
+});

--- a/packages/miniflare/test/workers/core/tail-events.spec.ts
+++ b/packages/miniflare/test/workers/core/tail-events.spec.ts
@@ -49,11 +49,24 @@ describe("tail event serialization", () => {
 	});
 
 	test("restores a bigint", ({ expect }) => {
-		const result = roundTrip<{ cpuTime: bigint }>({
-			cpuTime: 9007199254740993n,
+		const result = roundTrip<{ value: bigint }>({
+			value: 9007199254740993n,
 		});
 
-		expect(result.cpuTime).toBe(9007199254740993n);
+		expect(result.value).toBe(9007199254740993n);
+	});
+
+	test("restores a bigint published on a diagnostics channel", ({ expect }) => {
+		// `TraceDiagnosticChannelEvent.message` is typed `any`, so anything a
+		// worker publishes lands here — including a bigint, which
+		// `JSON.stringify()` throws on rather than dropping.
+		const result = roundTrip<{
+			diagnosticsChannelEvents: { channel: string; message: bigint }[];
+		}>({
+			diagnosticsChannelEvents: [{ channel: "test", message: 5n }],
+		});
+
+		expect(result.diagnosticsChannelEvents[0].message).toBe(5n);
 	});
 
 	test("leaves a date-like string alone", ({ expect }) => {
@@ -81,5 +94,26 @@ describe("tail event serialization", () => {
 		});
 
 		expect(result.logged).toBeInstanceOf(Date);
+	});
+
+	test("revives a payload that already contains the bigint tag", ({
+		expect,
+	}) => {
+		// Same known trade-off as the date tag above.
+		const result = roundTrip<{ logged: bigint }>({
+			logged: { ___serialized_bigint___: "5" },
+		});
+
+		expect(result.logged).toBe(5n);
+	});
+
+	test("leaves a malformed bigint tag alone", ({ expect }) => {
+		// `BigInt("not a number")` throws, so the tag has to be tolerated rather
+		// than trusted — otherwise reviving is itself a way to fail the parse.
+		const result = roundTrip<{ logged: Record<string, string> }>({
+			logged: { ___serialized_bigint___: "not a number" },
+		});
+
+		expect(result.logged).toEqual({ ___serialized_bigint___: "not a number" });
 	});
 });

--- a/packages/miniflare/test/workers/core/tail-events.spec.ts
+++ b/packages/miniflare/test/workers/core/tail-events.spec.ts
@@ -61,7 +61,7 @@ describe("tail event serialization", () => {
 		// worker publishes lands here — including a bigint, which
 		// `JSON.stringify()` throws on rather than dropping.
 		const result = roundTrip<{
-			diagnosticsChannelEvents: { channel: string; message: bigint }[];
+			diagnosticsChannelEvents: [{ channel: string; message: bigint }];
 		}>({
 			diagnosticsChannelEvents: [{ channel: "test", message: 5n }],
 		});

--- a/packages/vite-plugin-cloudflare/src/workers/vite-proxy-worker/__tests__/tail-events.spec.ts
+++ b/packages/vite-plugin-cloudflare/src/workers/vite-proxy-worker/__tests__/tail-events.spec.ts
@@ -45,6 +45,27 @@ describe("tail event serialization", () => {
 		expect(result.value.getTime()).toBe(date.getTime());
 	});
 
+	test("restores a bigint", ({ expect }) => {
+		const result = roundTrip<{ value: bigint }>({
+			value: 9007199254740993n,
+		});
+
+		expect(result.value).toBe(9007199254740993n);
+	});
+
+	test("restores a bigint published on a diagnostics channel", ({ expect }) => {
+		// `TraceDiagnosticChannelEvent.message` is typed `any`, so anything a
+		// worker publishes lands here — including a bigint, which
+		// `JSON.stringify()` throws on rather than dropping.
+		const result = roundTrip<{
+			diagnosticsChannelEvents: { channel: string; message: bigint }[];
+		}>({
+			diagnosticsChannelEvents: [{ channel: "test", message: 5n }],
+		});
+
+		expect(result.diagnosticsChannelEvents[0].message).toBe(5n);
+	});
+
 	test("leaves a date-like string alone", ({ expect }) => {
 		const result = roundTrip<{ message: string }>({
 			message: "2025-05-01T12:34:56.000Z",
@@ -70,5 +91,26 @@ describe("tail event serialization", () => {
 		});
 
 		expect(result.logged).toBeInstanceOf(Date);
+	});
+
+	test("revives a payload that already contains the bigint tag", ({
+		expect,
+	}) => {
+		// Same known trade-off as the date tag above.
+		const result = roundTrip<{ logged: bigint }>({
+			logged: { ___serialized_bigint___: "5" },
+		});
+
+		expect(result.logged).toBe(5n);
+	});
+
+	test("leaves a malformed bigint tag alone", ({ expect }) => {
+		// `BigInt("not a number")` throws, so the tag has to be tolerated rather
+		// than trusted — otherwise reviving is itself a way to fail the parse.
+		const result = roundTrip<{ logged: Record<string, string> }>({
+			logged: { ___serialized_bigint___: "not a number" },
+		});
+
+		expect(result.logged).toEqual({ ___serialized_bigint___: "not a number" });
 	});
 });

--- a/packages/vite-plugin-cloudflare/src/workers/vite-proxy-worker/__tests__/tail-events.spec.ts
+++ b/packages/vite-plugin-cloudflare/src/workers/vite-proxy-worker/__tests__/tail-events.spec.ts
@@ -1,0 +1,74 @@
+import { describe, test } from "vitest";
+import { tailEventsReplacer, tailEventsReviver } from "../tail-events";
+
+// Mirrors how tail events are forwarded to the user worker.
+function roundTrip<T>(value: unknown): T {
+	return JSON.parse(
+		JSON.stringify(value, tailEventsReplacer),
+		tailEventsReviver
+	);
+}
+
+describe("tail event serialization", () => {
+	test("restores a Date", ({ expect }) => {
+		const scheduledTime = new Date("2025-05-01T12:34:56.000Z");
+
+		const result = roundTrip<{ event: { scheduledTime: Date } }>({
+			event: { scheduledTime },
+		});
+
+		expect(result.event.scheduledTime).toBeInstanceOf(Date);
+		expect(result.event.scheduledTime.getTime()).toBe(scheduledTime.getTime());
+	});
+
+	test("restores a Date nested in an array", ({ expect }) => {
+		const date = new Date("2025-05-01T12:34:56.000Z");
+
+		const [item] = roundTrip<[{ date: Date }]>([{ date }]);
+
+		expect(item.date).toBeInstanceOf(Date);
+		expect(item.date.getTime()).toBe(date.getTime());
+	});
+
+	test("restores a Date returned by a custom toJSON()", ({ expect }) => {
+		const date = new Date("2025-05-01T12:34:56.000Z");
+
+		const result = roundTrip<{ value: Date }>({
+			value: {
+				toJSON() {
+					return date;
+				},
+			},
+		});
+
+		expect(result.value).toBeInstanceOf(Date);
+		expect(result.value.getTime()).toBe(date.getTime());
+	});
+
+	test("leaves a date-like string alone", ({ expect }) => {
+		const result = roundTrip<{ message: string }>({
+			message: "2025-05-01T12:34:56.000Z",
+		});
+
+		expect(result.message).toBe("2025-05-01T12:34:56.000Z");
+	});
+
+	test("does not throw on an invalid Date", ({ expect }) => {
+		const result = roundTrip<{ scheduledTime: null }>({
+			scheduledTime: new Date(NaN),
+		});
+
+		expect(result.scheduledTime).toBe(null);
+	});
+
+	test("revives a payload that already contains the date tag", ({ expect }) => {
+		// The tag is a plain object key, so a payload that happens to contain it
+		// is indistinguishable from a serialized Date. Pinned here so the
+		// collision stays a known trade-off.
+		const result = roundTrip<{ logged: Date }>({
+			logged: { ___serialized_date___: "2025-05-01T12:34:56.000Z" },
+		});
+
+		expect(result.logged).toBeInstanceOf(Date);
+	});
+});

--- a/packages/vite-plugin-cloudflare/src/workers/vite-proxy-worker/__tests__/tail-events.spec.ts
+++ b/packages/vite-plugin-cloudflare/src/workers/vite-proxy-worker/__tests__/tail-events.spec.ts
@@ -58,7 +58,7 @@ describe("tail event serialization", () => {
 		// worker publishes lands here — including a bigint, which
 		// `JSON.stringify()` throws on rather than dropping.
 		const result = roundTrip<{
-			diagnosticsChannelEvents: { channel: string; message: bigint }[];
+			diagnosticsChannelEvents: [{ channel: string; message: bigint }];
 		}>({
 			diagnosticsChannelEvents: [{ channel: "test", message: 5n }],
 		});

--- a/packages/vite-plugin-cloudflare/src/workers/vite-proxy-worker/index.ts
+++ b/packages/vite-plugin-cloudflare/src/workers/vite-proxy-worker/index.ts
@@ -1,4 +1,5 @@
 import { WorkerEntrypoint } from "cloudflare:workers";
+import { tailEventsReplacer, tailEventsReviver } from "./tail-events";
 
 interface Env {
 	ENTRY_USER_WORKER: Service<WorkerEntrypoint>;
@@ -37,28 +38,4 @@ export default class ViteProxyWorker extends WorkerEntrypoint<Env> {
 			JSON.parse(JSON.stringify(events, tailEventsReplacer), tailEventsReviver)
 		);
 	}
-}
-
-const serializedDate = "___serialized_date___";
-
-function tailEventsReplacer(_: string, value: unknown) {
-	// The tail events might contain Date objects which will not be restored directly
-	if (value instanceof Date) {
-		return { [serializedDate]: value.toISOString() };
-	}
-	return value;
-}
-
-function tailEventsReviver(_: string, value: unknown) {
-	// To restore Date objects from the serialized events
-	if (
-		value &&
-		typeof value === "object" &&
-		serializedDate in value &&
-		typeof value[serializedDate] === "string"
-	) {
-		return new Date(value[serializedDate]);
-	}
-
-	return value;
 }

--- a/packages/vite-plugin-cloudflare/src/workers/vite-proxy-worker/tail-events.ts
+++ b/packages/vite-plugin-cloudflare/src/workers/vite-proxy-worker/tail-events.ts
@@ -1,0 +1,34 @@
+const serializedDate = "___serialized_date___";
+
+export function tailEventsReplacer(this: unknown, key: string, value: unknown) {
+	// The tail events might contain Date objects which will not be restored directly.
+	// `JSON.stringify()` calls `Date.prototype.toJSON()` before handing a value to
+	// the replacer, so a real `Date` arrives here already flattened to an ISO
+	// string. Read the untouched value back off the holder to catch those. The
+	// `instanceof` check below still matters for values a custom `toJSON()`
+	// returns, which reach the replacer unconverted.
+	if (typeof value === "string") {
+		const original = (this as Record<string, unknown>)[key];
+		if (original instanceof Date) {
+			return { [serializedDate]: original.toISOString() };
+		}
+	}
+	if (value instanceof Date) {
+		return { [serializedDate]: value.toISOString() };
+	}
+	return value;
+}
+
+export function tailEventsReviver(_: string, value: unknown) {
+	// To restore Date objects from the serialized events
+	if (
+		value &&
+		typeof value === "object" &&
+		serializedDate in value &&
+		typeof value[serializedDate] === "string"
+	) {
+		return new Date(value[serializedDate]);
+	}
+
+	return value;
+}

--- a/packages/vite-plugin-cloudflare/src/workers/vite-proxy-worker/tail-events.ts
+++ b/packages/vite-plugin-cloudflare/src/workers/vite-proxy-worker/tail-events.ts
@@ -1,4 +1,5 @@
 const serializedDate = "___serialized_date___";
+const serializedBigint = "___serialized_bigint___";
 
 export function tailEventsReplacer(this: unknown, key: string, value: unknown) {
 	// The tail events might contain Date objects which will not be restored directly.
@@ -16,18 +17,34 @@ export function tailEventsReplacer(this: unknown, key: string, value: unknown) {
 	if (value instanceof Date) {
 		return { [serializedDate]: value.toISOString() };
 	}
+	// A bigint makes `JSON.stringify()` throw rather than dropping the value, so
+	// leaving it untagged takes out the whole forwarding call.
+	if (typeof value === "bigint") {
+		return { [serializedBigint]: value.toString() };
+	}
 	return value;
 }
 
 export function tailEventsReviver(_: string, value: unknown) {
-	// To restore Date objects from the serialized events
-	if (
-		value &&
-		typeof value === "object" &&
-		serializedDate in value &&
-		typeof value[serializedDate] === "string"
-	) {
-		return new Date(value[serializedDate]);
+	// To restore Date and bigint values from the serialized events
+	if (value && typeof value === "object") {
+		if (serializedDate in value && typeof value[serializedDate] === "string") {
+			return new Date(value[serializedDate]);
+		}
+		if (
+			serializedBigint in value &&
+			typeof value[serializedBigint] === "string"
+		) {
+			try {
+				return BigInt(value[serializedBigint]);
+			} catch {
+				// `BigInt()` throws on a string that isn't an integer, unlike
+				// `new Date()`. A payload that merely happens to carry the tag would
+				// otherwise fail the parse it is meant to survive, so leave it as the
+				// plain object it already is.
+				return value;
+			}
+		}
 	}
 
 	return value;


### PR DESCRIPTION
Fixes #15180
Fixes #15249

Tail events are handed to a tail consumer as JSON — `JSON.stringify(events, tailEventsReplacer)` and then `JSON.parse(..., tailEventsReviver)`. The replacer is supposed to tag `Date` values so the reviver can rebuild them, but `JSON.stringify()` applies `Date.prototype.toJSON()` **before** it calls the replacer, so a real `Date` reaches the replacer already flattened to an ISO string. `value instanceof Date` is therefore false, the `___serialized_date___` tag is never written, and the reviver has nothing to restore.

The consumer ends up with a `string` where the types promise a `Date` (`TraceItemAlarmEventInfo.scheduledTime` is typed `Date`), so `event.scheduledTime.getTime()` throws in local dev while the same code works in production. I reproduced this end to end for tail events forwarded between two local dev sessions through the dev registry (`packages/miniflare/src/workers/core/dev-registry-proxy.worker.ts`). It's a local-dev fidelity bug — dev diverges from production — not a production issue.

The fix reads the untouched value back off the holder that `JSON.stringify()` passes as `this`, and only when the value arrived as a string, so it costs one property read per string rather than one per key. The existing `instanceof` branch is kept rather than replaced: a value returned by a custom `toJSON()` *does* reach the replacer as a `Date`, and that case already worked — dropping the branch would regress it to `{}`. There's a test for that specifically.

`packages/vite-plugin-cloudflare`'s proxy worker has its own copy of the pair with the same `Date` defect. Both copies moved into a small `tail-events` module so they can be unit tested without importing a worker entry (which pulls in `cloudflare:workers`), following the existing `runner-worker/env.ts` + `__tests__/env.spec.ts` pattern. Aside from the fix, the moved code is unchanged.

One thing worth noting: an invalid `Date` doesn't hit the new branch at all, because `Date.prototype.toJSON()` returns `null` rather than a string for those, so it still serialises to `null` exactly as before. There's a test pinning that too.

## `bigint` (#15249)

The two copies of the helper had also drifted: miniflare tagged `bigint` values, the Vite plugin's copy did not. That asymmetry is worse than lossy, because `JSON.stringify()` **throws** on a `bigint` rather than dropping it, so a single tail event carrying one takes out the entire forwarding call with `TypeError: Do not know how to serialize a BigInt`.

I originally raised that separately because I couldn't establish whether a real `TraceItem` can actually carry a `bigint` — `TraceMetrics.cpuTime` is typed `number`, so my first guess was wrong. @edmundhung confirmed the reachable path in #15249: `TraceDiagnosticChannelEvent.message` is typed `any` and preserves whatever a worker publishes, so

```ts
import { channel } from "node:diagnostics_channel";
channel("test").publish(5n);
```

is enough to hit it. That makes it live rather than latent, so it's folded in here as he suggested.

One wrinkle worth flagging, because it applies to the miniflare side that already shipped in this PR: `BigInt()` **throws** on a string that isn't an integer, where `new Date()` merely returns an Invalid Date. So a payload that happens to carry `___serialized_bigint___` with non-numeric content would have failed the very `JSON.parse()` the helper exists to survive. Both revivers now tolerate the tag instead of trusting it, and there's a test for that in each package.

The two specs are now mirror images of each other — the drift between them is what produced this bug in the first place, so it seemed worth closing that gap rather than just the behavioural one.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: this restores the already-documented shape of a tail event (`TraceItemAlarmEventInfo.scheduledTime` is typed `Date`); no public API or documented behaviour changes.

<!-- devin-review-badge-begin -->

---

<a href="https://cloudflare.devinenterprise.com/review/cloudflare/workers-sdk/pull/15181" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->