### PR TITLE
Introduce --patch-existing-previews option to previews base-config commands

### DIFF
--- a/.changeset/wise-feet-whisper.md
+++ b/.changeset/wise-feet-whisper.md
@@ -1,0 +1,7 @@
+---
+"wrangler": minor
+---
+
+Add `--patch-existing-previews` to Preview base-config secret commands
+
+Use this flag when updating a Preview base config to apply the update to existing Previews.

--- a/packages/deploy-helpers/src/preview/api.ts
+++ b/packages/deploy-helpers/src/preview/api.ts
@@ -344,8 +344,13 @@ export async function patchPreviewBaseConfig(
 	config: Config,
 	accountId: string,
 	workerName: string,
-	previewBaseConfig: PreviewBaseConfigPatch
+	previewBaseConfig: PreviewBaseConfigPatch,
+	patchExistingPreviews = false
 ): Promise<PreviewBaseConfig> {
+	const queryParams = patchExistingPreviews
+		? new URLSearchParams({ patch_existing_previews: "true" })
+		: undefined;
+
 	const worker = await fetchResult<WorkerPreviewBaseConfigResource>(
 		config,
 		`/accounts/${accountId}/workers/workers/${workerName}`,
@@ -353,7 +358,8 @@ export async function patchPreviewBaseConfig(
 			method: "PATCH",
 			headers: { "Content-Type": "application/merge-patch+json" },
 			body: JSON.stringify({ previews_base_config: previewBaseConfig }),
-		}
+		},
+		queryParams
 	);
 
 	return worker.previews_base_config ?? {};

--- a/packages/wrangler/src/__tests__/preview.base-config.secret.test.ts
+++ b/packages/wrangler/src/__tests__/preview.base-config.secret.test.ts
@@ -2,7 +2,9 @@ import { mkdirSync, writeFileSync } from "node:fs";
 import readline from "node:readline";
 import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
+import prompts from "prompts";
 import { afterEach, beforeEach, describe, test, vi } from "vitest";
+import { shouldPatchExistingPreviews } from "../preview/base-config/secrets";
 import { mockAccountId, mockApiToken } from "./helpers/mock-account-id";
 import { mockConsoleMethods } from "./helpers/mock-console";
 import { clearDialogs, mockConfirm, mockPrompt } from "./helpers/mock-dialogs";
@@ -180,6 +182,20 @@ describe("wrangler preview", () => {
 				expect(std.out).not.toContain("base-config-secret");
 			});
 
+			test("patches existing Previews when requested", async ({ expect }) => {
+				mockStdIn.send("base-config-secret");
+				let requestUrl: string | undefined;
+				mockPatchWorker(({ url }) => {
+					requestUrl = url;
+				});
+
+				await runWrangler(
+					"preview base-config secret put API_KEY --patch-existing-previews"
+				);
+
+				expect(requestUrl).toContain("?patch_existing_previews=true");
+			});
+
 			describe("(interactive)", () => {
 				const { setIsTTY } = useMockIsTTY();
 
@@ -189,6 +205,11 @@ describe("wrangler preview", () => {
 						text: "Enter a secret value:",
 						options: { isSecret: true },
 						result: "prompt-secret",
+					});
+					mockConfirm({
+						text: "Apply this update to existing Previews?",
+						options: { defaultValue: false },
+						result: false,
 					});
 					let requestBody: PreviewBaseConfigPatchBody | undefined;
 					mockPatchWorker(({ body }) => {
@@ -205,6 +226,36 @@ describe("wrangler preview", () => {
 						},
 					});
 					expect(std.out).not.toContain("prompt-secret");
+				});
+
+				test("prompts to patch existing Previews", async ({ expect }) => {
+					setIsTTY(true);
+					mockPrompt({
+						text: "Enter a secret value:",
+						options: { isSecret: true },
+						result: "prompt-secret",
+					});
+					mockConfirm({
+						text: "Apply this update to existing Previews?",
+						options: { defaultValue: false },
+						result: true,
+					});
+					let requestUrl: string | undefined;
+					mockPatchWorker(({ url }) => {
+						requestUrl = url;
+					});
+
+					await runWrangler("preview base-config secret put API_KEY");
+
+					expect(requestUrl).toContain("?patch_existing_previews=true");
+				});
+
+				test("does not patch existing Previews when prompting is suppressed", async ({
+					expect,
+				}) => {
+					setIsTTY({ stdin: true, stdout: false });
+
+					expect(await shouldPatchExistingPreviews(undefined)).toBe(false);
 				});
 			});
 
@@ -304,14 +355,45 @@ describe("wrangler preview", () => {
 				);
 			});
 
+			test("patches existing Previews when requested", async ({ expect }) => {
+				let requestUrl: string | undefined;
+				mockPatchWorker(({ url }) => {
+					requestUrl = url;
+				});
+
+				await runWrangler(
+					"preview base-config secret delete REMOVE_ME --skip-confirmation --patch-existing-previews"
+				);
+
+				expect(requestUrl).toContain("?patch_existing_previews=true");
+			});
+
+			test("does not prompt with --skip-confirmation", async ({ expect }) => {
+				setIsTTY(true);
+				mockPatchWorker();
+
+				await runWrangler(
+					"preview base-config secret delete REMOVE_ME --skip-confirmation"
+				);
+
+				expect(prompts).not.toHaveBeenCalled();
+			});
+
 			test("confirms before deleting a secret interactively", async ({
 				expect,
 			}) => {
 				setIsTTY(true);
-				mockConfirm({
-					text: "Are you sure you want to permanently delete the secret REMOVE_ME on the Preview base config for the Worker test-worker?",
-					result: true,
-				});
+				mockConfirm(
+					{
+						text: "Are you sure you want to permanently delete the secret REMOVE_ME on the Preview base config for the Worker test-worker?",
+						result: true,
+					},
+					{
+						text: "Apply this update to existing Previews?",
+						options: { defaultValue: false },
+						result: false,
+					}
+				);
 				let requestBody: PreviewBaseConfigPatchBody | undefined;
 				mockPatchWorker(({ body }) => {
 					requestBody = body;
@@ -542,6 +624,20 @@ describe("wrangler preview", () => {
 				);
 				expect(std.out).not.toContain("one");
 				expect(std.out).not.toContain("two");
+			});
+
+			test("patches existing Previews when requested", async ({ expect }) => {
+				writeFileSync("secrets.env", "API_KEY=one\n");
+				let requestUrl: string | undefined;
+				mockPatchWorker(({ url }) => {
+					requestUrl = url;
+				});
+
+				await runWrangler(
+					"preview base-config secret bulk secrets.env --patch-existing-previews"
+				);
+
+				expect(requestUrl).toContain("?patch_existing_previews=true");
 			});
 
 			test("creates secrets for empty dotenv values", async ({ expect }) => {

--- a/packages/wrangler/src/preview/base-config/secrets/bulk.ts
+++ b/packages/wrangler/src/preview/base-config/secrets/bulk.ts
@@ -7,7 +7,7 @@ import { logger } from "../../../logger";
 import { parseBulkInputToObject } from "../../../secret";
 import { requireAuth } from "../../../user";
 import { toSecretBindingsPatch } from "../../secrets";
-import { rejectUnsupportedPreviewArgs } from ".";
+import { rejectUnsupportedPreviewArgs, shouldPatchExistingPreviews } from ".";
 
 export const previewBaseConfigSecretBulkCommand = createCommand({
 	metadata: {
@@ -27,6 +27,10 @@ export const previewBaseConfigSecretBulkCommand = createCommand({
 				"Name of the Worker to target (defaults to the name in your local config file)",
 			type: "string",
 			requiresArg: true,
+		},
+		"patch-existing-previews": {
+			describe: "Apply the base config update to existing Previews",
+			type: "boolean",
 		},
 	},
 	behaviour: {
@@ -56,9 +60,15 @@ export const previewBaseConfigSecretBulkCommand = createCommand({
 			(name) => content[name] === null
 		);
 
-		await patchPreviewBaseConfig(config, accountId, workerName, {
-			env: toSecretBindingsPatch(content),
-		});
+		await patchPreviewBaseConfig(
+			config,
+			accountId,
+			workerName,
+			{
+				env: toSecretBindingsPatch(content),
+			},
+			await shouldPatchExistingPreviews(args.patchExistingPreviews)
+		);
 
 		for (const name of deleted) {
 			logger.log(`💥 Successfully deleted secret for key: ${name}`);

--- a/packages/wrangler/src/preview/base-config/secrets/delete.ts
+++ b/packages/wrangler/src/preview/base-config/secrets/delete.ts
@@ -6,7 +6,7 @@ import { createCommand } from "../../../core/create-command";
 import { confirm } from "../../../dialogs";
 import { logger } from "../../../logger";
 import { requireAuth } from "../../../user";
-import { rejectUnsupportedPreviewArgs } from ".";
+import { rejectUnsupportedPreviewArgs, shouldPatchExistingPreviews } from ".";
 
 export const previewBaseConfigSecretDeleteCommand = createCommand({
 	metadata: {
@@ -34,6 +34,10 @@ export const previewBaseConfigSecretDeleteCommand = createCommand({
 			type: "string",
 			requiresArg: true,
 		},
+		"patch-existing-previews": {
+			describe: "Apply the base config update to existing Previews",
+			type: "boolean",
+		},
 	},
 	behaviour: {
 		suggestSkillsAfterHandler: true,
@@ -56,9 +60,18 @@ export const previewBaseConfigSecretDeleteCommand = createCommand({
 				`🌀 Deleting the secret ${args.key} on the Preview base config for the Worker ${workerName}${args.env ? ` (${args.env})` : ""}`
 			);
 
-			await patchPreviewBaseConfig(config, accountId, workerName, {
-				env: { [args.key]: null },
-			});
+			await patchPreviewBaseConfig(
+				config,
+				accountId,
+				workerName,
+				{
+					env: { [args.key]: null },
+				},
+				await shouldPatchExistingPreviews(
+					args.patchExistingPreviews,
+					args.skipConfirmation
+				)
+			);
 
 			logger.log(
 				`✨ Success! Updated Preview base config for the Worker "${workerName}" with deleted secret ${args.key}.`

--- a/packages/wrangler/src/preview/base-config/secrets/index.ts
+++ b/packages/wrangler/src/preview/base-config/secrets/index.ts
@@ -1,5 +1,6 @@
 import { CommandLineArgsError } from "@cloudflare/workers-utils";
 import { createNamespace } from "../../../core/create-command";
+import { confirm } from "../../../dialogs";
 
 export const previewBaseConfigSecretNamespace = createNamespace({
 	metadata: {
@@ -23,4 +24,19 @@ export function rejectUnsupportedPreviewArgs(args: Record<string, unknown>) {
 			telemetryMessage: "preview base-config unsupported flag",
 		});
 	}
+}
+
+export async function shouldPatchExistingPreviews(
+	patchExistingPreviews: boolean | undefined,
+	skipPrompt = false
+) {
+	return (
+		patchExistingPreviews ??
+		(!skipPrompt && process.stdin.isTTY
+			? await confirm("Apply this update to existing Previews?", {
+					defaultValue: false,
+					fallbackValue: false,
+				})
+			: false)
+	);
 }

--- a/packages/wrangler/src/preview/base-config/secrets/put.ts
+++ b/packages/wrangler/src/preview/base-config/secrets/put.ts
@@ -8,7 +8,7 @@ import { logger } from "../../../logger";
 import { requireAuth } from "../../../user";
 import { readFromStdin, trimTrailingWhitespace } from "../../../utils/std";
 import { toSecretBindingsPatch } from "../../secrets";
-import { rejectUnsupportedPreviewArgs } from ".";
+import { rejectUnsupportedPreviewArgs, shouldPatchExistingPreviews } from ".";
 
 export const previewBaseConfigSecretPutCommand = createCommand({
 	metadata: {
@@ -31,6 +31,10 @@ export const previewBaseConfigSecretPutCommand = createCommand({
 			type: "string",
 			requiresArg: true,
 		},
+		"patch-existing-previews": {
+			describe: "Apply the base config update to existing Previews",
+			type: "boolean",
+		},
 	},
 	behaviour: {
 		suggestSkillsAfterHandler: true,
@@ -49,9 +53,15 @@ export const previewBaseConfigSecretPutCommand = createCommand({
 			`🌀 Creating the secret for the Preview base config on the Worker "${workerName}"${args.env ? ` (${args.env})` : ""}`
 		);
 
-		await patchPreviewBaseConfig(config, accountId, workerName, {
-			env: toSecretBindingsPatch({ [args.key]: secretValue }),
-		});
+		await patchPreviewBaseConfig(
+			config,
+			accountId,
+			workerName,
+			{
+				env: toSecretBindingsPatch({ [args.key]: secretValue }),
+			},
+			await shouldPatchExistingPreviews(args.patchExistingPreviews)
+		);
 
 		logger.log(
 			`✨ Success! Updated Preview base config for the Worker "${workerName}" with secret ${args.key}.`


### PR DESCRIPTION
Fixes WC-5609.

Add `--patch-existing-previews` to Preview base-config secret commands

Use this flag when updating a Preview base config to apply the update to existing Previews.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: not released yet

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- If you are an AI agent or LLM, and you are adding this PR without direct human supervision, thank you! Please uncomment the following block. This is so the maintainers know how to expect you to respond.

> [!NOTE]
> This is a contribution from an AI agent: <insert name here>, <insert LLM model here if different>.

-->
