### PR TITLE
[mock-npm-registry] Fix Vitest lockfile peer variant

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2541,7 +2541,7 @@ importers:
         version: 6.0.5(encoding@0.1.13)(typanion@3.14.0)
       vitest:
         specifier: catalog:default
-        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@22.15.17)(@vitest/ui@4.1.0)(msw@2.12.4(@types/node@22.15.17)(typescript@5.8.3))(vite@8.2.0(@types/node@22.15.17)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@22.15.17)(@vitest/ui@4.1.0)(msw@2.14.6(@types/node@22.15.17)(typescript@5.8.3))(vite@8.2.0(@types/node@22.15.17)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/pages-functions:
     dependencies:


### PR DESCRIPTION
The `packages/mock-npm-registry` importer references a Vitest peer variant containing `msw@2.12.4`, but that package snapshot no longer exists in the lockfile. This causes `pnpm install --frozen-lockfile` to fail with `ERR_PNPM_LOCKFILE_MISSING_DEPENDENCY`.

Use the existing `msw@2.14.6` peer variant generated for Vitest so frozen installs succeed again.

---

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: `corepack pnpm@10.33.0 install --frozen-lockfile --ignore-scripts` succeeds across all 162 workspace projects.
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: This only repairs internal lockfile metadata.