### PR TITLE
[wrangler] Fix kv bulk put corrupting binary values in local mode

### DIFF
--- a/.changeset/kv-bulk-put-local-base64-binary.md
+++ b/.changeset/kv-bulk-put-local-base64-binary.md
@@ -1,0 +1,9 @@
+---
+"wrangler": patch
+---
+
+Fixes `kv bulk put` corrupting binary values written to local KV
+
+Values marked `base64: true` were stored incorrectly whenever they contained bytes that do not form valid UTF-8, which covers images, compressed data and most other binary payloads. A Worker reading such a key back under `wrangler dev` got a different, longer value than the one that was written: a 12 byte PNG header came back as 20 bytes.
+
+`kv bulk put` writes to local KV by default, so the plain command was the affected one. Remote writes were never affected, and neither were entries without `base64` or values written with `kv key put`.

--- a/packages/wrangler/src/__tests__/kv/local.test.ts
+++ b/packages/wrangler/src/__tests__/kv/local.test.ts
@@ -238,7 +238,6 @@ describe("kv", () => {
 			await runWrangler(
 				`kv bulk put binary-keys.json --namespace-id binary-namespace-id`
 			);
-			std.getAndClearOut();
 
 			await runWrangler(`kv key get binary --namespace-id binary-namespace-id`);
 			expect(proc.write).toEqual(binary);

--- a/packages/wrangler/src/__tests__/kv/local.test.ts
+++ b/packages/wrangler/src/__tests__/kv/local.test.ts
@@ -2,6 +2,7 @@ import { writeFileSync } from "node:fs";
 import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
 import { describe, it, vi } from "vitest";
 import { mockConsoleMethods } from "../helpers/mock-console";
+import { mockProcess } from "../helpers/mock-process";
 import { runWrangler } from "../helpers/run-wrangler";
 
 vi.unmock("undici");
@@ -9,6 +10,7 @@ vi.unmock("undici");
 describe("kv", () => {
 	runInTempDir();
 	const std = mockConsoleMethods();
+	const proc = mockProcess();
 
 	describe("local", () => {
 		it("should put local kv storage", async ({ expect }) => {
@@ -215,6 +217,31 @@ describe("kv", () => {
 				  }
 				]"
 			`);
+		});
+
+		it("should put binary values from base64 in local bulk kv storage", async ({
+			expect,
+		}) => {
+			// Bytes that are not valid UTF-8, so a UTF-8 round trip would replace
+			// them with U+FFFD. The first eight are the PNG signature.
+			const binary = Buffer.from([
+				0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x80, 0xff, 0xfe,
+			]);
+			const keyValues = [
+				{
+					key: "binary",
+					value: binary.toString("base64"),
+					base64: true,
+				},
+			];
+			writeFileSync("./binary-keys.json", JSON.stringify(keyValues));
+			await runWrangler(
+				`kv bulk put binary-keys.json --namespace-id binary-namespace-id`
+			);
+			std.getAndClearOut();
+
+			await runWrangler(`kv key get binary --namespace-id binary-namespace-id`);
+			expect(proc.write).toEqual(binary);
 		});
 
 		it("should delete local bulk kv storage", async ({ expect }) => {

--- a/packages/wrangler/src/kv/index.ts
+++ b/packages/wrangler/src/kv/index.ts
@@ -1064,9 +1064,8 @@ export const kvBulkPutCommand = createCommand({
 					for (const value of content) {
 						let data = value.value;
 						if (value.base64) {
-							// Decoding to a string here would re-read the bytes as UTF-8,
-							// so anything that is not valid UTF-8 (images, compressed
-							// blobs) would reach the store as U+FFFD.
+							// Put the raw bytes in, not a string. The value has to stay
+							// binary here so nothing decodes it on the way to the store.
 							data = Buffer.from(data, "base64");
 						}
 						await namespace.put(value.key, data, {

--- a/packages/wrangler/src/kv/index.ts
+++ b/packages/wrangler/src/kv/index.ts
@@ -1064,7 +1064,10 @@ export const kvBulkPutCommand = createCommand({
 					for (const value of content) {
 						let data = value.value;
 						if (value.base64) {
-							data = Buffer.from(data, "base64").toString();
+							// Decoding to a string here would re-read the bytes as UTF-8,
+							// so anything that is not valid UTF-8 (images, compressed
+							// blobs) would reach the store as U+FFFD.
+							data = Buffer.from(data, "base64");
 						}
 						await namespace.put(value.key, data, {
 							expiration: value.expiration,


### PR DESCRIPTION
No existing issue. I found this while comparing the local and remote KV write paths.

`kv bulk put` decodes `base64: true` entries and then calls `.toString()` on the result, which re-reads the bytes as UTF-8:

```ts
if (value.base64) {
	data = Buffer.from(data, "base64").toString();
}
```

Every byte that is not valid UTF-8 becomes `U+FFFD`, which is then stored as `ef bf bd`. So the value in the local store is not the value that was written, and `wrangler kv bulk put` writes locally by default, so the plain command is the affected one.

#8383 added this branch to make local `kv bulk put` honour `base64: true`, and its changeset says why: "For real (remote) kv, this is handled by the rest api. For local kv, it seems the base64 field was ignored, meaning encoded base64 content was stored locally rather than the raw values." The decode landed, the `.toString()` undoes it. Dropping `.toString()` finishes that fix.

The sibling path already does the right thing, so today the two local writers disagree about the same bytes. Writing the same 12 byte payload into one namespace, then reading both keys back through a Worker binding on `wrangler@4.123.0`:

```
kv key put --path : 89504e470d0a1a0a0080fffe
kv bulk put b64   : efbfbd504e470d0a1a0a00efbfbdefbfbdefbfbd
```

## Verification

Measured against `wrangler@4.123.0` from npm, in a project with one KV binding, reading back through `env.KV.get(key, "arrayBuffer")` in a Worker under `wrangler dev` rather than from CLI output, so this is the stored value and not a formatting artefact.

Input entry, 12 bytes, PNG signature followed by three bytes that are not valid UTF-8:

```json
[{ "key": "binary-png", "value": "iVBORw0KGgoAgP/+", "base64": true }]
```

- before: 20 bytes, `efbfbd504e470d0a1a0a00efbfbdefbfbdefbfbd`
- after: 12 bytes, `89504e470d0a1a0a0080fffe`, byte for byte what was encoded

An ASCII entry (`some raw data`) and an entry without `base64` are unchanged in both runs, which is what points at the UTF-8 round trip rather than at the store.

The new test fails on `main` with `expected Buffer[ 239, 191, 189, 80, 78, … ] to deeply equal Buffer[ 137, 80, 78, 71, 13, 10, … ]` and passes with the change. `src/__tests__/kv` is 118 passing, 0 failing. `oxfmt --check` and `oxlint` are clean on both changed files.

The existing bulk case only encodes `"some raw data"`, which is pure ASCII and survives a UTF-8 round trip, so CI could not see this. The new case uses bytes that cannot.

One thing I did not measure: that the remote path stores raw bytes. I have no account to test against, so that rests on the KV bulk API docs and on #8383's own description, not on something I ran. The change here is local only and does not touch `putKVBulkKeyValue`.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: this restores the behaviour the KV bulk API docs already describe for `base64`
