### PR TITLE
[autoconfig] Expose development commands in project detection

### DIFF
--- a/.changeset/calm-pandas-analyze.md
+++ b/.changeset/calm-pandas-analyze.md
@@ -1,0 +1,7 @@
+---
+"@cloudflare/autoconfig": minor
+---
+
+Expose development commands in project detection
+
+`getDetailsForAutoConfig()` now returns the detected development command. It no longer accepts Wrangler configuration or reports whether a project is configured. Callers must determine configuration status separately. `outputDir` may be undefined when no output directory is detected.

--- a/packages/autoconfig/src/details/framework-detection.ts
+++ b/packages/autoconfig/src/details/framework-detection.ts
@@ -17,7 +17,7 @@ import { isKnownFramework } from "../frameworks";
 import { staticFramework } from "../frameworks/all-frameworks";
 import type { AutoConfigContext } from "../context";
 import type { PackageManager } from "@cloudflare/workers-utils";
-import type { Config, TelemetryMessage } from "@cloudflare/workers-utils";
+import type { TelemetryMessage } from "@cloudflare/workers-utils";
 import type { Settings } from "@netlify/build-info";
 
 /**
@@ -30,10 +30,12 @@ import type { Settings } from "@netlify/build-info";
  * returns early with a synthetic "Cloudflare Pages" framework entry.
  *
  * @param projectPath Path to the project root
- * @param wranglerConfig Optional parsed wrangler config for the project
+ * @param context The autoconfig context
+ * @param options Optional framework detection settings
+ * @param options.pagesBuildOutputDir Output directory from a legacy Pages project
  * @returns An object containing:
- *   - `detectedFramework`: The matched framework together with its build
- *     command and output directory.
+ *   - `detectedFramework`: The matched framework together with its build and
+ *     development commands and output directory.
  *   - `packageManager`: The package manager detected in the project.
  *   - `isWorkspaceRoot`: `true` when the project path is the root of a
  *     monorepo workspace (only present when relevant).
@@ -46,7 +48,9 @@ import type { Settings } from "@netlify/build-info";
 export async function detectFramework(
 	projectPath: string,
 	context: AutoConfigContext,
-	wranglerConfig?: Config
+	options?: {
+		pagesBuildOutputDir?: string;
+	}
 ): Promise<{
 	detectedFramework: DetectedFramework;
 	packageManager: PackageManager;
@@ -101,7 +105,7 @@ export async function detectFramework(
 		await isPagesProject(
 			projectPath,
 			context,
-			wranglerConfig,
+			options?.pagesBuildOutputDir,
 			maybeDetectedFramework
 		)
 	) {
@@ -111,7 +115,7 @@ export async function detectFramework(
 					name: "Cloudflare Pages",
 					id: "cloudflare-pages",
 				},
-				dist: wranglerConfig?.pages_build_output_dir,
+				dist: options?.pagesBuildOutputDir,
 			},
 			packageManager,
 		};
@@ -220,6 +224,7 @@ type DetectedFramework = {
 		name: string;
 		id: string;
 	};
+	devCommand?: string | undefined;
 	buildCommand?: string | undefined;
 	dist?: string;
 };
@@ -227,10 +232,10 @@ type DetectedFramework = {
 async function isPagesProject(
 	projectPath: string,
 	context: AutoConfigContext,
-	wranglerConfig: Config | undefined,
+	pagesBuildOutputDir: string | undefined,
 	detectedFramework?: DetectedFramework | undefined
 ): Promise<boolean> {
-	if (wranglerConfig?.pages_build_output_dir) {
+	if (pagesBuildOutputDir) {
 		// The `pages_build_output_dir` is set only for Pages projects
 		return true;
 	}

--- a/packages/autoconfig/src/details/index.ts
+++ b/packages/autoconfig/src/details/index.ts
@@ -1,4 +1,3 @@
-import assert from "node:assert";
 import { statSync } from "node:fs";
 import { readdir, stat } from "node:fs/promises";
 import { join, relative, resolve } from "node:path";
@@ -6,11 +5,9 @@ import { brandColor } from "@cloudflare/cli-shared-helpers/colors";
 import {
 	checkWorkerNameValidity,
 	getWorkerName,
-	NpmPackageManager,
 	parsePackageJSON,
 	readFileSync,
 } from "@cloudflare/workers-utils";
-import { AutoConfigDetectionError } from "../errors";
 import { getFrameworkClassInstance } from "../frameworks";
 import {
 	allFrameworksInfos,
@@ -18,26 +15,9 @@ import {
 } from "../frameworks/all-frameworks";
 import { detectFramework } from "./framework-detection";
 import type { AutoConfigContext } from "../context";
-import type {
-	AutoConfigDetails,
-	AutoConfigDetailsForNonConfiguredProject,
-} from "../types";
+import type { AutoConfigDetails } from "../types";
 import type { PackageManager } from "@cloudflare/workers-utils";
-import type { Config, PackageJSON } from "@cloudflare/workers-utils";
-
-/**
- * Asserts that the current project being targeted for autoconfig is not already configured.
- *
- * @param details The details detected for the project.
- */
-export function assertNonConfigured(
-	details: AutoConfigDetails
-): asserts details is AutoConfigDetailsForNonConfiguredProject {
-	assert(
-		details.configured === false,
-		"Error: expected the current project not to be already configured"
-	);
-}
+import type { PackageJSON } from "@cloudflare/workers-utils";
 
 async function hasIndexHtml(dir: string): Promise<boolean> {
 	const children = await readdir(dir);
@@ -70,31 +50,22 @@ async function findAssetsDir(from: string): Promise<string | undefined> {
 	return undefined;
 }
 
-type DetectedFramework = {
-	framework: {
-		name: string;
-		id: string;
-	};
-	buildCommand?: string | undefined;
-	dist?: string;
-};
-
 /**
  * Detects project details needed for autoconfig: framework, package manager,
- * output directory, worker name, and whether the project is already configured.
+ * output directory, worker name, and build and development commands.
  *
- * @param options - Detection options including project path, wrangler config, and context.
+ * @param options - Detection options including project path, Pages build output directory, and context.
  * @returns The detected project details.
  */
 export async function getDetailsForAutoConfig({
 	projectPath = process.cwd(),
-	wranglerConfig,
+	pagesBuildOutputDir,
 	context,
 }: {
 	/** The path to the project, defaults to cwd. */
 	projectPath?: string;
-	/** The parsed wrangler configuration for the project (if any). */
-	wranglerConfig?: Config;
+	/** The output directory from a legacy Pages project, when known. */
+	pagesBuildOutputDir?: string;
 	/** The autoconfig context providing logger, dialogs, and other dependencies. */
 	context: AutoConfigContext;
 }): Promise<AutoConfigDetails> {
@@ -102,23 +73,8 @@ export async function getDetailsForAutoConfig({
 
 	logger.debug(`Running autoconfig detection in ${projectPath}...`);
 
-	if (
-		// If a real Wrangler config has been found the project is already configured for Workers
-		wranglerConfig?.configPath &&
-		// Unless `pages_build_output_dir` is set, since that indicates that the project is a Pages one instead
-		!wranglerConfig.pages_build_output_dir
-	) {
-		return {
-			configured: true,
-			projectPath,
-			workerName: getWorkerName(wranglerConfig.name, projectPath),
-			// Fall back to npm when already configured since we don't need to run package manager commands
-			packageManager: NpmPackageManager,
-		};
-	}
-
 	const { detectedFramework, packageManager, isWorkspaceRoot } =
-		await detectFramework(projectPath, context, wranglerConfig);
+		await detectFramework(projectPath, context, { pagesBuildOutputDir });
 
 	const framework = getFrameworkClassInstance(detectedFramework.framework.id);
 	const packageJsonPath = resolve(projectPath, "package.json");
@@ -134,85 +90,53 @@ export async function getDetailsForAutoConfig({
 		logger.debug("No package.json found when running autoconfig");
 	}
 
-	const configured = framework.isConfigured(projectPath) ?? false;
-
 	const outputDir =
 		detectedFramework?.dist ?? (await findAssetsDir(projectPath));
 
-	const baseDetails = {
+	return {
 		projectPath,
 		framework,
 		packageJson,
 		packageManager,
-		...(detectedFramework
-			? {
-					buildCommand: getProjectBuildCommand(
-						detectedFramework,
-						packageManager
-					),
-				}
-			: {}),
 		workerName: getWorkerName(packageJson?.name, projectPath),
-	};
-
-	if (configured) {
-		return {
-			...baseDetails,
-			configured: true,
-			isWorkspaceRoot,
-		};
-	}
-
-	if (!outputDir) {
-		const errorMessage =
-			framework.id === "static" || framework.id === "cloudflare-pages"
-				? "Could not detect a directory containing static files (e.g. html, css and js) for the project"
-				: "Failed to detect an output directory for the project";
-
-		throw new AutoConfigDetectionError(errorMessage, {
-			telemetryMessage: "autoconfig details output directory missing",
-			frameworkId: framework.id,
-			configured,
-		});
-	}
-
-	return {
-		...baseDetails,
+		devCommand: getProjectCommand(detectedFramework.devCommand, packageManager),
+		buildCommand: getProjectCommand(
+			detectedFramework.buildCommand,
+			packageManager
+		),
 		outputDir,
-		configured: false,
 		isWorkspaceRoot,
 	};
 }
 
 /**
- * Given a detected framework this function gets a `build` command for the target project that can be run in the terminal
- * (such as `npm run build` or `npx astro build`). If no build command is detected `undefined` is returned instead.
+ * Converts a detected project command into one that can be run in the terminal
+ * (such as `npm run build` or `npx astro dev`). If no command is detected
+ * `undefined` is returned instead.
  *
- * @param detectedFramework The detected framework (or settings) for the project
+ * @param command The detected project command
  * @param packageManager The package manager to use for command prefixes
- * @returns A runnable command for the build process if detected, undefined otherwise
+ * @returns A runnable project command if detected, undefined otherwise
  */
-function getProjectBuildCommand(
-	detectedFramework: DetectedFramework,
+function getProjectCommand(
+	command: string | undefined,
 	packageManager: PackageManager
 ): string | undefined {
-	if (!detectedFramework.buildCommand) {
+	if (!command) {
 		return undefined;
 	}
 
 	const { type, dlx, npx } = packageManager;
 
 	for (const packageManagerCommandPrefix of [type, dlx.join(" "), npx]) {
-		if (
-			detectedFramework.buildCommand.startsWith(packageManagerCommandPrefix)
-		) {
-			// The build command already is something like `npm run build` or similar
-			return detectedFramework.buildCommand;
+		if (command.startsWith(packageManagerCommandPrefix)) {
+			// The command already includes a package-manager prefix.
+			return command;
 		}
 	}
 
-	// The command is something like `astro build` so we need to prefix it with `npx` and equivalents
-	return `${npx} ${detectedFramework.buildCommand}`;
+	// Framework executables such as `astro build` need the appropriate package-manager prefix.
+	return `${npx} ${command}`;
 }
 
 /**

--- a/packages/autoconfig/src/index.ts
+++ b/packages/autoconfig/src/index.ts
@@ -25,8 +25,6 @@ export { displayAutoConfigDetails, confirmAutoConfigDetails } from "./details";
 
 export type {
 	AutoConfigDetails,
-	AutoConfigDetailsForConfiguredProject,
-	AutoConfigDetailsForNonConfiguredProject,
 	AutoConfigOptions,
 	AutoConfigSummary,
 } from "./types";

--- a/packages/autoconfig/src/run.ts
+++ b/packages/autoconfig/src/run.ts
@@ -12,11 +12,7 @@ import {
 	getTodaysCompatDate,
 	parseJSONC,
 } from "@cloudflare/workers-utils";
-import {
-	assertNonConfigured,
-	confirmAutoConfigDetails,
-	displayAutoConfigDetails,
-} from "./details";
+import { confirmAutoConfigDetails, displayAutoConfigDetails } from "./details";
 import {
 	isFrameworkSupported,
 	isKnownFramework,
@@ -28,7 +24,6 @@ import { usesTypescript } from "./uses-typescript";
 import type { AutoConfigContext } from "./context";
 import type {
 	AutoConfigDetails,
-	AutoConfigDetailsForNonConfiguredProject,
 	AutoConfigOptions,
 	AutoConfigSummary,
 } from "./types";
@@ -56,8 +51,6 @@ export async function runAutoConfig(
 	const enableWranglerInstallation =
 		autoConfigOptions.enableWranglerInstallation ?? true;
 
-	assertNonConfigured(autoConfigDetails);
-
 	displayAutoConfigDetails(autoConfigDetails, context);
 
 	const updatedAutoConfigDetails = skipConfirmations
@@ -71,7 +64,6 @@ export async function runAutoConfig(
 	}
 
 	autoConfigDetails = updatedAutoConfigDetails;
-	assertNonConfigured(autoConfigDetails);
 
 	if (isKnownFramework(autoConfigDetails.framework.id)) {
 		const frameworkIsSupported = isFrameworkSupported(
@@ -323,9 +315,7 @@ async function saveWranglerJsonc(
  * @returns A summary object describing all planned operations.
  */
 export async function buildOperationsSummary(
-	autoConfigDetails: AutoConfigDetailsForNonConfiguredProject & {
-		outputDir: NonNullable<AutoConfigDetails["outputDir"]>;
-	},
+	autoConfigDetails: AutoConfigDetails,
 	wranglerConfigToWrite: RawConfig | null,
 	projectCommands: {
 		build?: string;
@@ -335,6 +325,11 @@ export async function buildOperationsSummary(
 	context: AutoConfigContext,
 	packageJsonScriptsOverrides?: PackageJsonScriptsOverrides
 ): Promise<AutoConfigSummary> {
+	assert(
+		autoConfigDetails.outputDir,
+		"The Output Directory is unexpectedly missing"
+	);
+
 	const { logger } = context;
 	logger.log("");
 

--- a/packages/autoconfig/src/types.ts
+++ b/packages/autoconfig/src/types.ts
@@ -3,46 +3,26 @@ import type { Framework } from "./frameworks/framework-class";
 import type { PackageManager } from "@cloudflare/workers-utils";
 import type { PackageJSON, RawConfig } from "@cloudflare/workers-utils";
 
-/** Makes the specified keys of T optional. */
-type Optional<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;
-
-type AutoConfigDetailsBase = {
+export type AutoConfigDetails = {
 	/** The name of the worker */
 	workerName: string;
 	/** The path to the project (defaults to cwd) */
 	projectPath: string;
 	/** The content of the project's package.json file (if any) */
 	packageJson?: PackageJSON;
-	/** Whether the project is already configured (no autoconfig required) */
-	configured: boolean;
 	/** Details about the detected framework. It can be a JS framework or 'Static' if no actual JS framework is used. */
 	framework: Framework;
+	/** The dev command used to run the project locally (if any) */
+	devCommand?: string;
 	/** The build command used to build the project (if any) */
 	buildCommand?: string;
 	/** The output directory (if no framework is used, points to the raw asset files) */
-	outputDir: string;
+	outputDir?: string;
 	/** The detected package manager for the project */
 	packageManager: PackageManager;
 	/** Whether the current path is at the root of a workspace */
 	isWorkspaceRoot?: boolean;
 };
-
-export type AutoConfigDetailsForConfiguredProject = Optional<
-	AutoConfigDetailsBase,
-	// If AutoConfig detects that the project is already configured it's unnecessary to check
-	// what framework is being used nor the output directory, so in this case thee fields are optional
-	"framework" | "outputDir"
-> & {
-	configured: true;
-};
-
-export type AutoConfigDetailsForNonConfiguredProject = AutoConfigDetailsBase & {
-	configured: false;
-};
-
-export type AutoConfigDetails =
-	| AutoConfigDetailsForConfiguredProject
-	| AutoConfigDetailsForNonConfiguredProject;
 
 export type AutoConfigOptions = {
 	/** The autoconfig context providing logger, dialogs, and other dependencies. */

--- a/packages/autoconfig/tests/details/framework-detection/basic-framework-detection.test.ts
+++ b/packages/autoconfig/tests/details/framework-detection/basic-framework-detection.test.ts
@@ -46,4 +46,17 @@ describe("detectFramework() / basic framework detection", () => {
 		expect(result.detectedFramework?.buildCommand).toBeDefined();
 		expect(result.detectedFramework?.buildCommand).toContain("astro build");
 	});
+
+	it("includes devCommand in detectedFramework when available", async ({
+		expect,
+	}) => {
+		await seed({
+			"package.json": JSON.stringify({ dependencies: { astro: "5" } }),
+			"package-lock.json": JSON.stringify({ lockfileVersion: 3 }),
+		});
+
+		const result = await detectFramework(process.cwd(), context);
+
+		expect(result.detectedFramework.devCommand).toBe("astro dev");
+	});
 });

--- a/packages/autoconfig/tests/details/framework-detection/pages-project-detection.test.ts
+++ b/packages/autoconfig/tests/details/framework-detection/pages-project-detection.test.ts
@@ -3,13 +3,12 @@ import { runInTempDir, seed } from "@cloudflare/workers-utils/test-helpers";
 import { describe, it, vi } from "vitest";
 import { detectFramework } from "../../../src/details/framework-detection";
 import { createMockContext } from "../../helpers/mock-context";
-import type { Config } from "@cloudflare/workers-utils";
 
 describe("detectFramework() / Pages project detection", () => {
 	runInTempDir();
 	const context = createMockContext();
 
-	it("returns Cloudflare Pages framework when pages_build_output_dir is set in wrangler config", async ({
+	it("returns Cloudflare Pages framework when a Pages build output directory is provided", async ({
 		expect,
 	}) => {
 		await seed({
@@ -18,8 +17,8 @@ describe("detectFramework() / Pages project detection", () => {
 		});
 
 		const result = await detectFramework(process.cwd(), context, {
-			pages_build_output_dir: "./dist",
-		} as Config);
+			pagesBuildOutputDir: "./dist",
+		});
 
 		expect(result.detectedFramework?.framework.id).toBe("cloudflare-pages");
 		expect(result.detectedFramework?.framework.name).toBe("Cloudflare Pages");

--- a/packages/autoconfig/tests/details/get-details-for-auto-config.test.ts
+++ b/packages/autoconfig/tests/details/get-details-for-auto-config.test.ts
@@ -9,7 +9,6 @@ import {
 import { afterEach, describe, it, vi } from "vitest";
 import * as details from "../../src/details";
 import { createMockContext } from "../helpers/mock-context";
-import type { Config } from "@cloudflare/workers-utils";
 
 describe("autoconfig details - getDetailsForAutoConfig()", () => {
 	runInTempDir();
@@ -18,17 +17,6 @@ describe("autoconfig details - getDetailsForAutoConfig()", () => {
 
 	afterEach(() => {
 		vi.unstubAllGlobals();
-	});
-
-	it("should set configured: true if a configPath exists", async ({
-		expect,
-	}) => {
-		await expect(
-			details.getDetailsForAutoConfig({
-				wranglerConfig: { configPath: "/tmp" } as Config,
-				context,
-			})
-		).resolves.toMatchObject({ configured: true });
 	});
 
 	// Check that Astro is detected. We don't want to duplicate the tests of @netlify/build-info
@@ -58,8 +46,8 @@ describe("autoconfig details - getDetailsForAutoConfig()", () => {
 			await expect(
 				details.getDetailsForAutoConfig({ context })
 			).resolves.toMatchObject({
+				devCommand: pm === "pnpm" ? "pnpm astro dev" : "npx astro dev",
 				buildCommand: pm === "pnpm" ? "pnpm astro build" : "npx astro build",
-				configured: false,
 				outputDir: "dist",
 				packageJson: {
 					dependencies: {
@@ -188,16 +176,6 @@ describe("autoconfig details - getDetailsForAutoConfig()", () => {
 		});
 	});
 
-	it("an error should be thrown if no output dir can be detected", async ({
-		expect,
-	}) => {
-		await expect(
-			details.getDetailsForAutoConfig({ context })
-		).rejects.toThrowErrorMatchingInlineSnapshot(
-			`[Error: Could not detect a directory containing static files (e.g. html, css and js) for the project]`
-		);
-	});
-
 	it("outputDir should be set to cwd if an index.html file exists", async ({
 		expect,
 	}) => {
@@ -313,7 +291,7 @@ describe("autoconfig details - getDetailsForAutoConfig()", () => {
 	});
 
 	describe("Pages project detection", () => {
-		it("should detect Pages project when pages_build_output_dir is set in wrangler config", async ({
+		it("should detect a Pages project from its build output directory", async ({
 			expect,
 		}) => {
 			await seed({
@@ -321,14 +299,10 @@ describe("autoconfig details - getDetailsForAutoConfig()", () => {
 			});
 
 			const result = await details.getDetailsForAutoConfig({
-				wranglerConfig: {
-					configPath: "/tmp/wrangler.toml",
-					pages_build_output_dir: "./dist",
-				} as Config,
+				pagesBuildOutputDir: "./dist",
 				context,
 			});
 
-			expect(result.configured).toBe(false);
 			expect(result.framework?.id).toBe("cloudflare-pages");
 			expect(result.framework?.name).toBe("Cloudflare Pages");
 		});

--- a/packages/wrangler/src/__tests__/autoconfig/index.test.ts
+++ b/packages/wrangler/src/__tests__/autoconfig/index.test.ts
@@ -33,15 +33,19 @@ vi.mock("../../metrics/send-event", async (importOriginal) => {
 });
 
 /** Minimal mock satisfying {@link AutoConfigContext} for pass-through testing. */
-const mockContext = {} as AutoConfigContext;
+const mockContext = {
+	logger: { debug: vi.fn() },
+} as unknown as AutoConfigContext;
 
 /** Minimal mock satisfying {@link Config} for pass-through testing. */
-const mockConfig = {} as Config;
+const mockConfig = {
+	configPath: undefined,
+} as Config;
 
 /** Minimal mock satisfying {@link AutoConfigDetails} with a detected framework. */
 const mockDetails = {
-	configured: false,
-	framework: { id: "static" },
+	framework: { id: "static", isConfigured: () => false },
+	outputDir: "dist",
 } as unknown as AutoConfigDetails;
 
 /** Minimal mock satisfying {@link AutoConfigSummary}. */
@@ -70,7 +74,23 @@ describe("autoconfig wrappers", () => {
 	});
 
 	describe("runAutoConfigDetection", () => {
-		it("calls getDetailsForAutoConfig with the provided config and context, and returns the result", async ({
+		it("does not analyze a project with a Wrangler config", async ({
+			expect,
+		}) => {
+			const result = await runAutoConfigDetection({
+				command: "wrangler deploy",
+				wranglerConfig: {
+					...mockConfig,
+					configPath: "wrangler.json",
+				},
+				context: mockContext,
+			});
+
+			expect(getDetailsForAutoConfig).not.toHaveBeenCalled();
+			expect(result).toEqual({ configured: true });
+		});
+
+		it("gets project details and returns the validated result", async ({
 			expect,
 		}) => {
 			vi.mocked(getDetailsForAutoConfig).mockResolvedValue(mockDetails);
@@ -83,10 +103,31 @@ describe("autoconfig wrappers", () => {
 
 			expect(getDetailsForAutoConfig).toHaveBeenCalledOnce();
 			expect(getDetailsForAutoConfig).toHaveBeenCalledWith({
-				wranglerConfig: mockConfig,
+				projectPath: process.cwd(),
+				pagesBuildOutputDir: mockConfig.pages_build_output_dir,
 				context: mockContext,
 			});
-			expect(result).toBe(mockDetails);
+			expect(result).toEqual({
+				configured: false,
+				details: mockDetails,
+			});
+		});
+
+		it("requires an output directory for an unconfigured project", async ({
+			expect,
+		}) => {
+			vi.mocked(getDetailsForAutoConfig).mockResolvedValue({
+				...mockDetails,
+				outputDir: undefined,
+			});
+
+			await expect(
+				runAutoConfigDetection({
+					command: "wrangler deploy",
+					wranglerConfig: mockConfig,
+					context: mockContext,
+				})
+			).rejects.toThrow("Could not detect a directory containing static files");
 		});
 
 		it("sends detection_started then detection_completed on success", async ({

--- a/packages/wrangler/src/__tests__/autoconfig/run.test.ts
+++ b/packages/wrangler/src/__tests__/autoconfig/run.test.ts
@@ -166,7 +166,6 @@ describe("autoconfig (deploy)", () => {
 			.spyOn(autoconfig, "getDetailsForAutoConfig")
 			.mockImplementationOnce(() =>
 				Promise.resolve({
-					configured: false,
 					projectPath: process.cwd(),
 					workerName: "my-worker",
 					framework: new MockStaticFramework({ id: "static", name: "Static" }),
@@ -185,13 +184,19 @@ describe("autoconfig (deploy)", () => {
 	it("should not run autoconfig if project is already configured", async ({
 		expect,
 	}) => {
+		const framework = new MockStaticFramework({
+			id: "static",
+			name: "Static",
+		});
+		vi.spyOn(framework, "isConfigured").mockReturnValue(true);
 		const getDetailsSpy = vi
 			.spyOn(autoconfig, "getDetailsForAutoConfig")
 			.mockImplementationOnce(() =>
 				Promise.resolve({
-					configured: true,
 					projectPath: process.cwd(),
 					workerName: "my-worker",
+					framework,
+					outputDir: "./public",
 					packageManager: NpmPackageManager,
 				})
 			);
@@ -208,7 +213,6 @@ describe("autoconfig (deploy)", () => {
 	}) => {
 		vi.spyOn(autoconfig, "getDetailsForAutoConfig").mockImplementationOnce(() =>
 			Promise.resolve({
-				configured: false,
 				projectPath: process.cwd(),
 				workerName: "my-worker",
 				framework: {
@@ -279,7 +283,6 @@ describe("autoconfig (deploy)", () => {
 				{
 					projectPath: process.cwd(),
 					buildCommand: "echo 'built' > build.txt",
-					configured: false,
 					workerName: "my-worker",
 					framework: {
 						// "static" is used here because this test exercises the overall runAutoConfig
@@ -408,7 +411,6 @@ describe("autoconfig (deploy)", () => {
 				{
 					projectPath: process.cwd(),
 					workerName: "my-worker",
-					configured: false,
 					outputDir: "dist",
 					framework: new MockStaticFramework({ id: "static", name: "Static" }),
 					packageManager: NpmPackageManager,
@@ -445,7 +447,6 @@ describe("autoconfig (deploy)", () => {
 				{
 					projectPath: process.cwd(),
 					workerName: "my-worker",
-					configured: false,
 					outputDir: "dist",
 					framework: new MockStaticFramework({ id: "static", name: "Static" }),
 					packageManager: NpmPackageManager,
@@ -493,7 +494,6 @@ describe("autoconfig (deploy)", () => {
 			await autoconfig.runAutoConfig(
 				{
 					projectPath: process.cwd(),
-					configured: false,
 					framework: new MockStaticFramework({ id: "static", name: "Static" }),
 					workerName: "my-worker",
 					outputDir: "dist",
@@ -575,7 +575,6 @@ describe("autoconfig (deploy)", () => {
 				{
 					projectPath: process.cwd(),
 					workerName: "my-worker",
-					configured: false,
 					outputDir: process.cwd(),
 					framework: new MockStaticFramework({ id: "static", name: "Static" }),
 					packageManager: NpmPackageManager,
@@ -611,7 +610,6 @@ describe("autoconfig (deploy)", () => {
 				{
 					projectPath: process.cwd(),
 					workerName: "my-worker",
-					configured: false,
 					outputDir: process.cwd(),
 					framework: new MockStaticFramework({ id: "static", name: "Static" }),
 					packageManager: NpmPackageManager,
@@ -644,7 +642,6 @@ describe("autoconfig (deploy)", () => {
 				autoconfig.runAutoConfig(
 					{
 						projectPath: process.cwd(),
-						configured: false,
 						framework: new MockStaticFramework({
 							id: "static",
 							name: "Static",
@@ -672,7 +669,6 @@ describe("autoconfig (deploy)", () => {
 				autoconfig.runAutoConfig(
 					{
 						projectPath: process.cwd(),
-						configured: false,
 						framework: {
 							id: "cloudflare-pages",
 							name: "Cloudflare Pages",
@@ -702,7 +698,6 @@ describe("autoconfig (deploy)", () => {
 				autoconfig.runAutoConfig(
 					{
 						projectPath: process.cwd(),
-						configured: false,
 						framework: {
 							id: "hono",
 							name: "Hono",
@@ -737,7 +732,6 @@ describe("autoconfig (deploy)", () => {
 					{
 						projectPath: process.cwd(),
 						workerName: "my-worker",
-						configured: false,
 						outputDir: "dist",
 						framework: {
 							// "static" is used here because this test only exercises compatibility flag
@@ -778,7 +772,6 @@ describe("autoconfig (deploy)", () => {
 					{
 						projectPath: process.cwd(),
 						workerName: "my-worker",
-						configured: false,
 						outputDir: "dist",
 						framework: {
 							// "static" is used here because this test only exercises compatibility flag
@@ -822,7 +815,6 @@ describe("autoconfig (deploy)", () => {
 					{
 						projectPath: process.cwd(),
 						workerName: "my-worker",
-						configured: false,
 						outputDir: "dist",
 						framework: {
 							// "static" is used here because this test only exercises compatibility flag
@@ -861,7 +853,6 @@ describe("autoconfig (deploy)", () => {
 					{
 						projectPath: process.cwd(),
 						workerName: "my-worker",
-						configured: false,
 						outputDir: "dist",
 						framework: {
 							id: "static",
@@ -920,7 +911,6 @@ describe("autoconfig (deploy)", () => {
 				{
 					projectPath: process.cwd(),
 					workerName: "my-worker",
-					configured: false,
 					outputDir: "dist",
 					framework,
 					packageManager: NpmPackageManager,

--- a/packages/wrangler/src/__tests__/deploy/core.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/core.test.ts
@@ -616,7 +616,6 @@ describe("deploy", () => {
 		const getDetailsForAutoConfigSpy = vi
 			.spyOn(await import("@cloudflare/autoconfig"), "getDetailsForAutoConfig")
 			.mockResolvedValueOnce({
-				configured: false,
 				projectPath: process.cwd(),
 				workerName: "test-name",
 				framework: {
@@ -656,7 +655,6 @@ describe("deploy", () => {
 		const getDetailsForAutoConfigSpy = vi
 			.spyOn(await import("@cloudflare/autoconfig"), "getDetailsForAutoConfig")
 			.mockResolvedValueOnce({
-				configured: false,
 				projectPath: process.cwd(),
 				workerName: "test-name",
 				framework: {
@@ -1917,8 +1915,11 @@ describe("deploy", () => {
 			await import("@cloudflare/autoconfig"),
 			"getDetailsForAutoConfig"
 		).mockResolvedValueOnce({
-			configured: false,
-			framework: { id: "static", name: "Static" } as Framework,
+			framework: {
+				id: "static",
+				name: "Static",
+				isConfigured: () => false,
+			} as Framework,
 			workerName: "my-site",
 			projectPath: ".",
 			outputDir: "./public",

--- a/packages/wrangler/src/__tests__/deploy/open-next.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/open-next.test.ts
@@ -1,8 +1,10 @@
 import * as fs from "node:fs";
 import {
+	Framework,
 	getDetailsForAutoConfig,
 	getInstalledPackageVersion,
 } from "@cloudflare/autoconfig";
+import { NpmPackageManager } from "@cloudflare/workers-utils";
 import {
 	runInTempDir,
 	writeWranglerConfig,
@@ -37,6 +39,10 @@ import {
 	mockLastDeploymentRequest,
 	mockPatchScriptSettings,
 } from "./helpers";
+import type {
+	ConfigurationOptions,
+	ConfigurationResults,
+} from "@cloudflare/autoconfig";
 import type { ServiceMetadataRes } from "@cloudflare/workers-utils";
 import type { MockInstance } from "vitest";
 
@@ -69,6 +75,22 @@ vi.mock("@cloudflare/autoconfig", async (importOriginal) => ({
 }));
 vi.mock("@cloudflare/cli-shared-helpers/command");
 
+class MockStaticFramework extends Framework {
+	constructor() {
+		super({ id: "static", name: "Static" });
+	}
+	isConfigured(): boolean {
+		return true;
+	}
+	configure({ outputDir }: ConfigurationOptions): ConfigurationResults {
+		return {
+			wranglerConfig: {
+				assets: { directory: outputDir },
+			},
+		};
+	}
+}
+
 describe("deploy", () => {
 	mockAccountId();
 	mockApiToken();
@@ -100,10 +122,10 @@ describe("deploy", () => {
 		);
 		vi.mocked(getInstalledPackageVersion).mockReturnValue(undefined);
 		vi.mocked(getDetailsForAutoConfig).mockResolvedValue({
-			configured: true,
+			framework: new MockStaticFramework(),
 			workerName: "test-name",
 			projectPath: process.cwd(),
-			packageManager: { type: "npm" as const, npx: "npx" },
+			packageManager: NpmPackageManager,
 		} as Awaited<ReturnType<typeof getDetailsForAutoConfig>>);
 	});
 

--- a/packages/wrangler/src/autoconfig/index.ts
+++ b/packages/wrangler/src/autoconfig/index.ts
@@ -21,6 +21,16 @@ export {
 	sendAutoConfigProcessStartedMetricsEvent,
 } from "./telemetry-utils";
 
+type WranglerAutoConfigAnalysis =
+	| {
+			configured: true;
+			details?: AutoConfigDetails;
+	  }
+	| {
+			configured: false;
+			details: AutoConfigDetails;
+	  };
+
 /**
  * Detects project details for autoconfig, wrapped with telemetry instrumentation.
  *
@@ -31,7 +41,7 @@ export {
  * @param options.command - The Wrangler command that initiated autoconfig
  * @param options.wranglerConfig - The parsed wrangler configuration (if any)
  * @param options.context - The autoconfig context providing logger, dialogs, etc.
- * @returns The detected project details from {@link getDetailsForAutoConfig}
+ * @returns The detected project details and whether autoconfiguration is needed
  * @throws Re-throws any error from {@link getDetailsForAutoConfig} after recording telemetry
  */
 export async function runAutoConfigDetection({
@@ -42,7 +52,7 @@ export async function runAutoConfigDetection({
 	command: NonNullable<AutoConfigWranglerTriggerCommand>;
 	wranglerConfig: Config;
 	context: AutoConfigContext;
-}): Promise<AutoConfigDetails> {
+}): Promise<WranglerAutoConfigAnalysis> {
 	sendMetricsEvent(
 		"autoconfig_detection_started",
 		{ autoConfigId: getAutoConfigId(), command },
@@ -50,23 +60,63 @@ export async function runAutoConfigDetection({
 	);
 
 	try {
-		const details = await getDetailsForAutoConfig({
-			wranglerConfig,
-			context,
-		});
+		const projectPath = process.cwd();
+		let result: WranglerAutoConfigAnalysis;
+
+		if (
+			// If a real Wrangler config has been found the project is already configured for Workers
+			wranglerConfig.configPath &&
+			// Unless `pages_build_output_dir` is set, since that indicates that the project is a Pages one instead
+			!wranglerConfig.pages_build_output_dir
+		) {
+			context.logger.debug(`Running autoconfig detection in ${projectPath}...`);
+			result = {
+				configured: true,
+			};
+		} else {
+			const details = await getDetailsForAutoConfig({
+				projectPath,
+				pagesBuildOutputDir: wranglerConfig.pages_build_output_dir,
+				context,
+			});
+
+			if (details.framework?.isConfigured(projectPath)) {
+				result = {
+					configured: true,
+					details,
+				};
+			} else if (!details.outputDir) {
+				const errorMessage =
+					details.framework?.id === "static" ||
+					details.framework?.id === "cloudflare-pages"
+						? "Could not detect a directory containing static files (e.g. html, css and js) for the project"
+						: "Failed to detect an output directory for the project";
+
+				throw new AutoConfigDetectionError(errorMessage, {
+					telemetryMessage: "autoconfig details output directory missing",
+					frameworkId: details.framework?.id,
+					configured: false,
+				});
+			} else {
+				result = {
+					configured: false,
+					details,
+				};
+			}
+		}
 
 		sendMetricsEvent(
 			"autoconfig_detection_completed",
 			{
 				autoConfigId: getAutoConfigId(),
-				framework: details.framework?.id,
-				configured: details.configured,
+				framework: result.details?.framework?.id,
+				configured: result.configured,
 				success: true,
 			},
 			{}
 		);
 
-		return details;
+		return result;
 	} catch (error) {
 		sendMetricsEvent(
 			"autoconfig_detection_completed",

--- a/packages/wrangler/src/deploy/autoconfig.ts
+++ b/packages/wrangler/src/deploy/autoconfig.ts
@@ -107,13 +107,13 @@ export async function maybeRunAutoConfig<Args extends AutoConfigArgs>(
 		const autoConfigContext = createWranglerAutoConfigContext();
 
 		try {
-			const details = await runAutoConfigDetection({
+			const result = await runAutoConfigDetection({
 				command: "wrangler deploy",
 				wranglerConfig: config,
 				context: autoConfigContext,
 			});
 
-			if (details.framework?.id === "cloudflare-pages") {
+			if (result.details?.framework?.id === "cloudflare-pages") {
 				// If the project is a Pages project then warn the user but allow them to proceed if they wish so
 				logger.warn(
 					"It seems that you have run `wrangler deploy` on a Pages project, `wrangler pages deploy` should be used instead. Proceeding will likely produce unwanted results."
@@ -134,8 +134,8 @@ export async function maybeRunAutoConfig<Args extends AutoConfigArgs>(
 					});
 					return { config, aborted: true };
 				}
-			} else if (!details.configured) {
-				const autoConfigSummary = await runAutoConfigLogic(details, {
+			} else if (!result.configured) {
+				const autoConfigSummary = await runAutoConfigLogic(result.details, {
 					context: autoConfigContext,
 					dryRun: !!args.dryRun,
 					skipConfirmations: options.skipConfirmations === true,

--- a/packages/wrangler/src/setup.ts
+++ b/packages/wrangler/src/setup.ts
@@ -61,9 +61,9 @@ export const setupCommand = createCommand({
 
 		const context = createWranglerAutoConfigContext();
 
-		let details;
+		let result;
 		try {
-			details = await runAutoConfigDetection({
+			result = await runAutoConfigDetection({
 				command: "wrangler setup",
 				wranglerConfig: config,
 				context,
@@ -84,11 +84,10 @@ export const setupCommand = createCommand({
 			}
 		}
 
-		// Only run auto config if the project is not already configured
-		if (!details.configured) {
+		if (!result.configured) {
 			let autoConfigSummary;
 			try {
-				autoConfigSummary = await runAutoConfigLogic(details, {
+				autoConfigSummary = await runAutoConfigLogic(result.details, {
 					context,
 					runBuild: args.build,
 					skipConfirmations: args.yes,
@@ -132,7 +131,7 @@ export const setupCommand = createCommand({
 			const { type } = await getPackageManager();
 			logCompletionMessage(
 				`You can now deploy with ${brandColor(
-					details.packageJson ? `${type} run deploy` : "wrangler deploy"
+					result.details?.packageJson ? `${type} run deploy` : "wrangler deploy"
 				)}`
 			);
 		}


### PR DESCRIPTION
Expose detected development commands from `getDetailsForAutoConfig()` while moving Wrangler-specific configured-project handling into Wrangler. This lets other Cloudflare tooling reuse framework detection without supplying a Wrangler configuration.

The project-analysis result now represents detected project details only. Wrangler remains responsible for deciding whether autoconfiguration is required and for validating that an output directory is available before setup.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: this programmatic API change is documented by its package changeset and does not alter a documented Wrangler command workflow.

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- If you are an AI agent or LLM, and you are adding this PR without direct human supervision, thank you! Please uncomment the following block. This is so the maintainers know how to expect you to respond.

> [!NOTE]
> This is a contribution from an AI agent: <insert name here>, <insert LLM model here if different>.

-->
