### PR TITLE
[wrangler] Use FedRAMP container registries

### DIFF
--- a/.changeset/tidy-falcons-comply.md
+++ b/.changeset/tidy-falcons-comply.md
@@ -1,0 +1,8 @@
+---
+"@cloudflare/vite-plugin": patch
+"wrangler": patch
+---
+
+Use the FedRAMP High managed container registry when Wrangler targets the FedRAMP High compliance region
+
+Container builds, pushes, deployments, image commands, and local development now select the corresponding production or staging FedRAMP registry and API from either `compliance_region` or `CLOUDFLARE_COMPLIANCE_REGION`.

--- a/packages/containers-shared/src/images.ts
+++ b/packages/containers-shared/src/images.ts
@@ -16,6 +16,7 @@ import type {
 	ViteLogger,
 	WranglerLogger,
 } from "./types";
+import type { ComplianceConfig } from "@cloudflare/workers-utils";
 
 export const DEFAULT_CONTAINER_EGRESS_INTERCEPTOR_IMAGE =
 	"cloudflare/proxy-everything:3cb1195@sha256:0ef6716c52430096900b150d84a3302057d6cd2319dae7987128c85d0733e3c8";
@@ -43,14 +44,25 @@ export async function pullEgressInterceptorImage(
 	await runDockerCmd(dockerPath, args);
 }
 
+/**
+ * Pulls a prebuilt image for local container development.
+ *
+ * @param dockerPath - Path to the Docker CLI executable.
+ * @param options - Container image and local development tag configuration.
+ * @param logger - Logger used for recoverable registry credential warnings.
+ * @param complianceConfig - Compliance configuration used to identify the managed registry.
+ * @returns An object with an `abort` function and a `ready` promise.
+ */
 export async function pullImage(
 	dockerPath: string,
 	options: Exclude<ContainerDevOptions, DockerfileConfig>,
-	logger: WranglerLogger | ViteLogger
+	logger: WranglerLogger | ViteLogger,
+	complianceConfig?: ComplianceConfig
 ): Promise<{ abort: () => void; ready: Promise<void> }> {
 	const domain = new URL(`http://${options.image_uri}`).hostname;
 
-	const isExternalRegistry = domain !== getCloudflareContainerRegistry();
+	const isExternalRegistry =
+		domain !== getCloudflareContainerRegistry(complianceConfig);
 	try {
 		await dockerLoginImageRegistry(dockerPath, domain);
 	} catch (e) {
@@ -99,6 +111,9 @@ export async function pullImage(
  * Because this runs when local dev starts, we also do some validation here,
  * such as checking if the Docker CLI is installed, and if the container images
  * expose any ports.
+ *
+ * @param args - Image preparation callbacks, Docker settings, and compliance configuration.
+ * @returns A promise that resolves when all configured images are ready.
  */
 export async function prepareContainerImagesForDev(args: {
 	dockerPath: string;
@@ -111,6 +126,7 @@ export async function prepareContainerImagesForDev(args: {
 		containerOptions: ContainerDevOptions;
 	}) => void;
 	logger: WranglerLogger | ViteLogger;
+	complianceConfig?: ComplianceConfig;
 }): Promise<void> {
 	const {
 		dockerPath,
@@ -150,7 +166,12 @@ export async function prepareContainerImagesForDev(args: {
 				containerOptions: options,
 			});
 		} else {
-			const pull = await pullImage(dockerPath, options, args.logger);
+			const pull = await pullImage(
+				dockerPath,
+				options,
+				args.logger,
+				args.complianceConfig
+			);
 			onContainerImagePreparationStart({
 				containerOptions: options,
 				abort: () => {
@@ -182,11 +203,20 @@ export async function prepareContainerImagesForDev(args: {
  * Resolve an image name to the full unambiguous name.
  *
  * image:tag -> prepend registry.cloudflare.com/accountid/
- * registry.cloudflare.com/image:tag -> registry.cloudlfare.com/accountid/image:tag
+ * registry.cloudflare.com/image:tag -> registry.cloudflare.com/accountid/image:tag
  * registry.cloudflare.com/accountid/image:tag -> no change
  * anyother-registry.com/anything -> no change
+ *
+ * @param accountId - Cloudflare account ID that owns managed-registry images.
+ * @param image - Image reference to normalize.
+ * @param complianceConfig - Compliance configuration used to select the managed registry.
+ * @returns The normalized image reference.
  */
-export function resolveImageName(accountId: string, image: string): string {
+export function resolveImageName(
+	accountId: string,
+	image: string,
+	complianceConfig?: ComplianceConfig
+): string {
 	let url: URL | undefined;
 	try {
 		url = new URL(`http://${image}`);
@@ -199,10 +229,14 @@ export function resolveImageName(accountId: string, image: string): string {
 		(!url.host.match(/[:.]/) && url.hostname !== "localhost")
 	) {
 		// Not a valid URL so assume it is in the format image:tag and prepend the registry
-		return getCloudflareRegistryWithAccountNamespace(accountId, image);
+		return getCloudflareRegistryWithAccountNamespace(
+			accountId,
+			image,
+			complianceConfig
+		);
 	}
 
-	if (url.hostname !== getCloudflareContainerRegistry()) {
+	if (url.hostname !== getCloudflareContainerRegistry(complianceConfig)) {
 		// hostname not the managed registry, passthrough
 		return image;
 	}
@@ -231,11 +265,17 @@ export function resolveImageName(accountId: string, image: string): string {
 
 /**
  * Get type of container registry, and validate.
- * We support Cloudflare managed registries plus the external registries listed in
+ * We support the configured Cloudflare managed registry plus the external registries listed in
  * `acceptedRegistries` below (currently AWS ECR, DockerHub, and Google Artifact Registry).
- * When using Cloudflare managed registries we expect CLOUDFLARE_CONTAINER_REGISTRY to be set
+ *
+ * @param domain - Registry hostname to validate.
+ * @param complianceConfig - Compliance configuration used to select the managed registry.
+ * @returns The matching registry type and credential metadata.
  */
-export const getAndValidateRegistryType = (domain: string): RegistryPattern => {
+export const getAndValidateRegistryType = (
+	domain: string,
+	complianceConfig?: ComplianceConfig
+): RegistryPattern => {
 	// TODO: use parseImageName when that gets moved to this package
 	if (domain.includes("://")) {
 		throw new Error(
@@ -273,9 +313,8 @@ export const getAndValidateRegistryType = (domain: string): RegistryPattern => {
 		},
 		{
 			type: "cloudflare",
-			// Make a regex based on the env var CLOUDFLARE_CONTAINER_REGISTRY
 			pattern: new RegExp(
-				`^${getCloudflareContainerRegistry().replace(/[\\.]/g, "\\$&")}$`
+				`^${getCloudflareContainerRegistry(complianceConfig).replace(/[\\.]/g, "\\$&")}$`
 			),
 			name: "Cloudflare Containers Managed Registry",
 		},

--- a/packages/containers-shared/src/knobs.ts
+++ b/packages/containers-shared/src/knobs.ts
@@ -1,16 +1,30 @@
+import {
+	COMPLIANCE_REGION_CONFIG_UNKNOWN,
+	getComplianceRegionSubdomain,
+} from "@cloudflare/workers-utils";
 import { MF_DEV_CONTAINER_PREFIX } from "./registry";
+import type { ComplianceConfig } from "@cloudflare/workers-utils";
 
-// Will return the default cloudflare managed registry for either a staging or production environment
-// based on the env var WRANGLER_API_ENVIRONMENT. The default registry can be overridden with the env
-// var CLOUDFLARE_CONTAINER_REGISTRY.
-export const getCloudflareContainerRegistry = () => {
+/**
+ * Returns the managed container registry for the configured API environment and compliance region.
+ *
+ * @param complianceConfig - Compliance configuration used to select the public or FedRAMP registry.
+ * @returns The managed registry hostname, respecting `CLOUDFLARE_CONTAINER_REGISTRY` and `WRANGLER_API_ENVIRONMENT`.
+ */
+export const getCloudflareContainerRegistry = (
+	complianceConfig: ComplianceConfig = COMPLIANCE_REGION_CONFIG_UNKNOWN
+): string => {
 	// previously defaulted to registry.cloudchamber.cfdata.org
-	return (
-		process.env.CLOUDFLARE_CONTAINER_REGISTRY ??
-		(process.env.WRANGLER_API_ENVIRONMENT === "staging"
-			? "staging.registry.cloudflare.com"
-			: "registry.cloudflare.com")
-	);
+	if (process.env.CLOUDFLARE_CONTAINER_REGISTRY) {
+		return process.env.CLOUDFLARE_CONTAINER_REGISTRY;
+	}
+
+	const environmentPrefix =
+		process.env.WRANGLER_API_ENVIRONMENT === "staging" ? "staging." : "";
+	const complianceRegionSubdomain =
+		getComplianceRegionSubdomain(complianceConfig);
+
+	return `${environmentPrefix}registry${complianceRegionSubdomain}.cloudflare.com`;
 };
 
 /** Prefixes with the cloudflare-dev namespace. The name should be the container's DO classname, and the tag a build uuid. */

--- a/packages/containers-shared/src/registry.ts
+++ b/packages/containers-shared/src/registry.ts
@@ -1,13 +1,20 @@
 import { getCloudflareContainerRegistry } from "./knobs";
+import type { ComplianceConfig } from "@cloudflare/workers-utils";
 
-// The Cloudflare managed registry is special in that the namesapces for repos should always
-// start with the Cloudflare Account tag
-// This is a helper to generate the image tag with correct namespace attached to the Cloudflare Registry host
+/**
+ * Adds the Cloudflare account namespace to an image tag in the managed registry.
+ *
+ * @param accountID - Cloudflare account ID that owns the image.
+ * @param tag - Image name and tag to namespace.
+ * @param complianceConfig - Compliance configuration used to select the managed registry.
+ * @returns The fully qualified managed-registry image reference.
+ */
 export const getCloudflareRegistryWithAccountNamespace = (
 	accountID: string,
-	tag: string
+	tag: string,
+	complianceConfig?: ComplianceConfig
 ): string => {
-	return `${getCloudflareContainerRegistry()}/${accountID}/${tag}`;
+	return `${getCloudflareContainerRegistry(complianceConfig)}/${accountID}/${tag}`;
 };
 
 export const MF_DEV_CONTAINER_PREFIX = "cloudflare-dev";

--- a/packages/containers-shared/tests/images.test.ts
+++ b/packages/containers-shared/tests/images.test.ts
@@ -133,6 +133,18 @@ describe("getAndValidateRegistryType - GAR", () => {
 	});
 });
 
+describe("getAndValidateRegistryType - Cloudflare managed registry", () => {
+	it("recognizes the FedRAMP High managed registry from Wrangler config", ({
+		expect,
+	}) => {
+		expect(
+			getAndValidateRegistryType("registry.fed.cloudflare.com", {
+				compliance_region: "fedramp_high",
+			}).type
+		).toBe("cloudflare");
+	});
+});
+
 describe("validateAndEncodeGarKey", () => {
 	it("base64-encodes a raw JSON key when the email matches", ({ expect }) => {
 		expect(validateAndEncodeGarKey(serviceAccountKey, clientEmail)).toBe(

--- a/packages/containers-shared/tests/knobs.test.ts
+++ b/packages/containers-shared/tests/knobs.test.ts
@@ -1,7 +1,11 @@
-import { describe, it, vi } from "vitest";
+import { afterEach, describe, it, vi } from "vitest";
 import { getCloudflareContainerRegistry } from "./../src/knobs";
 
 describe("getCloudflareContainerRegistry", () => {
+	afterEach(() => {
+		vi.unstubAllEnvs();
+	});
+
 	it("should return the managed registry", ({ expect }) => {
 		expect(getCloudflareContainerRegistry()).toBe("registry.cloudflare.com");
 		vi.stubEnv("WRANGLER_API_ENVIRONMENT", "production");
@@ -13,5 +17,38 @@ describe("getCloudflareContainerRegistry", () => {
 		expect(getCloudflareContainerRegistry()).toBe(
 			"staging.registry.cloudflare.com"
 		);
+	});
+
+	it("should return the FedRAMP High registry from the environment", ({
+		expect,
+	}) => {
+		vi.stubEnv("CLOUDFLARE_COMPLIANCE_REGION", "fedramp_high");
+		expect(getCloudflareContainerRegistry()).toBe(
+			"registry.fed.cloudflare.com"
+		);
+	});
+
+	it("should return the FedRAMP High registry from Wrangler config", ({
+		expect,
+	}) => {
+		expect(
+			getCloudflareContainerRegistry({ compliance_region: "fedramp_high" })
+		).toBe("registry.fed.cloudflare.com");
+	});
+
+	it("should return the staging FedRAMP High registry", ({ expect }) => {
+		vi.stubEnv("WRANGLER_API_ENVIRONMENT", "staging");
+		expect(
+			getCloudflareContainerRegistry({ compliance_region: "fedramp_high" })
+		).toBe("staging.registry.fed.cloudflare.com");
+	});
+
+	it("should allow an explicit registry override", ({ expect }) => {
+		vi.stubEnv("CLOUDFLARE_CONTAINER_REGISTRY", "registry.example.com");
+		vi.stubEnv("WRANGLER_API_ENVIRONMENT", "staging");
+		vi.stubEnv("CLOUDFLARE_COMPLIANCE_REGION", "fedramp_high");
+		expect(
+			getCloudflareContainerRegistry({ compliance_region: "public" })
+		).toBe("registry.example.com");
 	});
 });

--- a/packages/vite-plugin-cloudflare/src/__tests__/containers.spec.ts
+++ b/packages/vite-plugin-cloudflare/src/__tests__/containers.spec.ts
@@ -1,5 +1,6 @@
-import { describe, test } from "vitest";
-import { getContainerOptions } from "../containers";
+import { OpenAPI } from "@cloudflare/containers-shared";
+import { afterEach, beforeEach, describe, test, vi } from "vitest";
+import { configureContainerPull, getContainerOptions } from "../containers";
 import type { ResolvedWorkerConfig } from "../plugin-config";
 
 type Containers = ResolvedWorkerConfig["containers"];
@@ -116,5 +117,59 @@ describe("getContainerOptions", () => {
 				containerBuildId: "build-id",
 			})
 		).toEqual([]);
+	});
+});
+
+describe("configureContainerPull", () => {
+	beforeEach(() => {
+		vi.stubEnv("CLOUDFLARE_API_BASE_URL", undefined);
+		vi.stubEnv("CF_API_BASE_URL", undefined);
+		vi.stubEnv("CLOUDFLARE_COMPLIANCE_REGION", undefined);
+		vi.stubEnv("WRANGLER_API_ENVIRONMENT", undefined);
+	});
+
+	afterEach(() => {
+		vi.unstubAllEnvs();
+		OpenAPI.BASE = "";
+		OpenAPI.HEADERS = undefined;
+		OpenAPI.CREDENTIALS = "include";
+	});
+
+	test("uses the FedRAMP High API for managed registry credentials", ({
+		expect,
+	}) => {
+		configureContainerPull("abc123", "my-token", {
+			compliance_region: "fedramp_high",
+		});
+
+		expect(OpenAPI.BASE).toBe(
+			"https://api.fed.cloudflare.com/client/v4/accounts/abc123/containers"
+		);
+	});
+
+	test("uses the staging FedRAMP High API for managed registry credentials", ({
+		expect,
+	}) => {
+		vi.stubEnv("WRANGLER_API_ENVIRONMENT", "staging");
+
+		configureContainerPull("abc123", "my-token", {
+			compliance_region: "fedramp_high",
+		});
+
+		expect(OpenAPI.BASE).toBe(
+			"https://api.fed.staging.cloudflare.com/client/v4/accounts/abc123/containers"
+		);
+	});
+
+	test("preserves the explicit API base override", ({ expect }) => {
+		vi.stubEnv("CLOUDFLARE_API_BASE_URL", "https://api.example.com/client/v4");
+
+		configureContainerPull("abc123", "my-token", {
+			compliance_region: "fedramp_high",
+		});
+
+		expect(OpenAPI.BASE).toBe(
+			"https://api.example.com/client/v4/accounts/abc123/containers"
+		);
 	});
 });

--- a/packages/vite-plugin-cloudflare/src/containers.ts
+++ b/packages/vite-plugin-cloudflare/src/containers.ts
@@ -1,10 +1,38 @@
 import path from "node:path";
-import { getDevContainerImageName } from "@cloudflare/containers-shared/src/knobs";
 import {
+	configureOpenAPIForContainerPull,
+	getDevContainerImageName,
+} from "@cloudflare/containers-shared";
+import {
+	COMPLIANCE_REGION_CONFIG_UNKNOWN,
+	getCloudflareApiBaseUrl,
 	isDockerfile,
 	resolveContainerClassName,
 } from "@cloudflare/workers-utils";
 import type { ResolvedWorkerConfig } from "./plugin-config";
+import type { ComplianceConfig } from "@cloudflare/workers-utils";
+
+/**
+ * Configures the Containers API client used to retrieve image pull credentials.
+ *
+ * @param accountId - Cloudflare account ID that owns the managed registry.
+ * @param apiToken - API token used to request registry credentials.
+ * @param complianceConfig - Compliance configuration used to select the API endpoint.
+ * @returns No value.
+ */
+export function configureContainerPull(
+	accountId: string,
+	apiToken: string,
+	complianceConfig?: ComplianceConfig
+): void {
+	configureOpenAPIForContainerPull(
+		accountId,
+		apiToken,
+		getCloudflareApiBaseUrl(
+			complianceConfig ?? COMPLIANCE_REGION_CONFIG_UNKNOWN
+		)
+	);
+}
 
 /**
  * Returns the path to the Docker executable as defined by the

--- a/packages/vite-plugin-cloudflare/src/plugins/dev.ts
+++ b/packages/vite-plugin-cloudflare/src/plugins/dev.ts
@@ -1,6 +1,5 @@
 import assert from "node:assert";
 import {
-	configureOpenAPIForContainerPull,
 	getCloudflareContainerRegistry,
 	prepareContainerImagesForDev,
 } from "@cloudflare/containers-shared";
@@ -15,7 +14,7 @@ import {
 	kRequestType,
 	ROUTER_WORKER_NAME,
 } from "../constants";
-import { getDockerPath } from "../containers";
+import { configureContainerPull, getDockerPath } from "../containers";
 import { assertIsNotPreview } from "../context";
 import {
 	compareExportTypes,
@@ -250,7 +249,7 @@ export const devPlugin = createPlugin("dev", (ctx) => {
 						(opts) =>
 							"image_uri" in opts &&
 							new URL(`http://${opts.image_uri}`).hostname ===
-								getCloudflareContainerRegistry()
+								getCloudflareContainerRegistry(ctx.entryWorkerConfig)
 					);
 
 					if (hasCFRegistryImages) {
@@ -269,7 +268,7 @@ export const devPlugin = createPlugin("dev", (ctx) => {
 							);
 						}
 
-						configureOpenAPIForContainerPull(accountId, apiToken);
+						configureContainerPull(accountId, apiToken, ctx.entryWorkerConfig);
 					}
 
 					await prepareContainerImagesForDev({
@@ -278,6 +277,7 @@ export const devPlugin = createPlugin("dev", (ctx) => {
 						onContainerImagePreparationStart: () => {},
 						onContainerImagePreparationEnd: () => {},
 						logger: viteDevServer.config.logger,
+						complianceConfig: ctx.entryWorkerConfig,
 					});
 
 					containerImageTags = new Set(containerTagToOptionsMap.keys());

--- a/packages/vite-plugin-cloudflare/src/plugins/preview.ts
+++ b/packages/vite-plugin-cloudflare/src/plugins/preview.ts
@@ -1,5 +1,4 @@
 import {
-	configureOpenAPIForContainerPull,
 	getCloudflareContainerRegistry,
 	prepareContainerImagesForDev,
 } from "@cloudflare/containers-shared";
@@ -7,7 +6,7 @@ import { cleanupContainers } from "@cloudflare/containers-shared/src/utils";
 import { UserError } from "@cloudflare/workers-utils";
 import { buildPublicUrl, Request as MiniflareRequest } from "miniflare";
 import colors from "picocolors";
-import { getDockerPath } from "../containers";
+import { configureContainerPull, getDockerPath } from "../containers";
 import { assertIsPreview } from "../context";
 import { getPreviewMiniflareOptions } from "../miniflare-options";
 import { createPlugin, createRequestHandler } from "../utils";
@@ -73,7 +72,7 @@ export const previewPlugin = createPlugin("preview", (ctx) => {
 					(opts) =>
 						"image_uri" in opts &&
 						new URL(`http://${opts.image_uri}`).hostname ===
-							getCloudflareContainerRegistry()
+							getCloudflareContainerRegistry(ctx.allWorkerConfigs[0])
 				);
 
 				if (hasCFRegistryImages) {
@@ -94,7 +93,7 @@ export const previewPlugin = createPlugin("preview", (ctx) => {
 						);
 					}
 
-					configureOpenAPIForContainerPull(accountId, apiToken);
+					configureContainerPull(accountId, apiToken, ctx.allWorkerConfigs[0]);
 				}
 
 				await prepareContainerImagesForDev({
@@ -103,6 +102,7 @@ export const previewPlugin = createPlugin("preview", (ctx) => {
 					onContainerImagePreparationStart: () => {},
 					onContainerImagePreparationEnd: () => {},
 					logger: vitePreviewServer.config.logger,
+					complianceConfig: ctx.allWorkerConfigs[0],
 				});
 
 				const containerImageTags = new Set(containerTagToOptionsMap.keys());

--- a/packages/wrangler/src/__tests__/containers/config.test.ts
+++ b/packages/wrangler/src/__tests__/containers/config.test.ts
@@ -277,6 +277,40 @@ describe("getNormalizedContainerOptions", () => {
 		});
 	});
 
+	it("should use the FedRAMP High registry from Wrangler config", async ({
+		expect,
+	}) => {
+		const config: Config = {
+			name: "test-worker",
+			configPath: "/test/wrangler.jsonc",
+			topLevelName: "test-worker",
+			compliance_region: "fedramp_high",
+			containers: [
+				{
+					class_name: "TestContainer",
+					image: "test-image/test:latest",
+					name: "test-container",
+				},
+			],
+			durable_objects: {
+				bindings: [
+					{
+						name: "TEST_DO",
+						class_name: "TestContainer",
+					},
+				],
+			},
+			migrations: [{ tag: "v1", new_sqlite_classes: ["TestContainer"] }],
+		} as Partial<Config> as Config;
+
+		const result = await getNormalizedContainerOptions(config, {});
+
+		expect(result[0]).toMatchObject({
+			image_uri:
+				"registry.fed.cloudflare.com/some-account-id/test-image/test:latest",
+		});
+	});
+
 	it("should default max_instances and rollout_step_percentage accordingly", async ({
 		expect,
 	}) => {

--- a/packages/wrangler/src/api/startDevWorker/LocalRuntimeController.ts
+++ b/packages/wrangler/src/api/startDevWorker/LocalRuntimeController.ts
@@ -381,6 +381,9 @@ export class LocalRuntimeController extends RuntimeController {
 						this.containerBeingBuilt = undefined;
 					},
 					logger: logger,
+					complianceConfig: {
+						compliance_region: data.config.complianceRegion,
+					},
 				});
 				if (this.containerBeingBuilt) {
 					this.containerBeingBuilt.abortRequested = false;

--- a/packages/wrangler/src/api/startDevWorker/MultiworkerRuntimeController.ts
+++ b/packages/wrangler/src/api/startDevWorker/MultiworkerRuntimeController.ts
@@ -204,6 +204,9 @@ export class MultiworkerRuntimeController extends LocalRuntimeController {
 						this.containerBeingBuilt = undefined;
 					},
 					logger: logger,
+					complianceConfig: {
+						compliance_region: data.config.complianceRegion,
+					},
 				});
 				if (this.containerBeingBuilt) {
 					this.containerBeingBuilt.abortRequested = false;

--- a/packages/wrangler/src/cloudchamber/apply.ts
+++ b/packages/wrangler/src/cloudchamber/apply.ts
@@ -123,12 +123,17 @@ function createApplicationToModifyApplication(
 
 function applicationToCreateApplication(
 	accountId: string,
-	application: Application
+	application: Application,
+	config: Config
 ): CreateApplicationRequest {
 	const app: CreateApplicationRequest = {
 		configuration: {
 			...application.configuration,
-			image: resolveImageName(accountId, application.configuration.image),
+			image: resolveImageName(
+				accountId,
+				application.configuration.image,
+				config
+			),
 		},
 		constraints: application.constraints,
 		max_instances: application.max_instances,
@@ -252,6 +257,7 @@ function containerAppToCreateApplication(
 	containerApp: ContainerApp,
 	observability: Observability | undefined,
 	existingApp: Application | undefined,
+	config: Config,
 	skipDefaults = false
 ): CreateApplicationRequest {
 	const observabilityConfiguration = observabilityToConfiguration(
@@ -280,7 +286,7 @@ function containerAppToCreateApplication(
 		configuration: {
 			...configuration,
 			// De-sugar image name
-			image: resolveImageName(accountId, configuration.image),
+			image: resolveImageName(accountId, configuration.image, config),
 		},
 		// eslint-disable-next-line @typescript-eslint/no-deprecated -- kept for backward compatibility, `instances` is deprecated in favor of `max_instances`
 		instances: containerApp.instances ?? 0,
@@ -392,6 +398,7 @@ export async function apply(
 			appConfigNoDefaults,
 			config.observability,
 			application,
+			config,
 			args.skipDefaults
 		);
 
@@ -399,7 +406,9 @@ export async function apply(
 			// we need to sort the objects (by key) because the diff algorithm works with
 			// lines
 			const prevApp = sortObjectRecursive<CreateApplicationRequest>(
-				stripUndefined(applicationToCreateApplication(accountId, application))
+				stripUndefined(
+					applicationToCreateApplication(accountId, application, config)
+				)
 			);
 
 			// fill up fields that their defaults were changed over-time,

--- a/packages/wrangler/src/cloudchamber/build.ts
+++ b/packages/wrangler/src/cloudchamber/build.ts
@@ -31,7 +31,7 @@ import type {
 	ContainerNormalizedConfig,
 	ImageURIConfig,
 } from "@cloudflare/containers-shared";
-import type { Config } from "@cloudflare/workers-utils";
+import type { ComplianceConfig, Config } from "@cloudflare/workers-utils";
 
 export function buildYargs(yargs: CommonYargsArgv) {
 	return yargs
@@ -99,9 +99,10 @@ const TAG_SUFFIX_REGEXP = /:[\w][\w.-]{0,127}$/;
 
 function getRepositoryOnly(
 	externalAccountId: string,
-	imageTag: string
+	imageTag: string,
+	complianceConfig?: ComplianceConfig
 ): string {
-	return resolveImageName(externalAccountId, imageTag)
+	return resolveImageName(externalAccountId, imageTag, complianceConfig)
 		.replace(DIGEST_SUFFIX_REGEXP, "")
 		.replace(TAG_SUFFIX_REGEXP, "");
 }
@@ -109,14 +110,15 @@ function getRepositoryOnly(
 function imageRefWithDigest(
 	externalAccountId: string,
 	imageTag: string,
-	digest: string
+	digest: string,
+	complianceConfig?: ComplianceConfig
 ): string {
 	if (!DIGEST_VALUE_REGEXP.test(digest)) {
 		throw new Error(
 			`Expected image digest to match algorithm:hex format, got ${digest}`
 		);
 	}
-	return `${getRepositoryOnly(externalAccountId, imageTag)}@${digest}`;
+	return `${getRepositoryOnly(externalAccountId, imageTag, complianceConfig)}@${digest}`;
 }
 
 function findManifestDigest(manifestOutput: string): string {
@@ -133,7 +135,8 @@ function findManifestDigest(manifestOutput: string): string {
 function findRemoteDigest(
 	repoDigestsJson: string,
 	externalAccountId: string,
-	imageTag: string
+	imageTag: string,
+	complianceConfig?: ComplianceConfig
 ): string {
 	const parsedDigests = JSON.parse(repoDigestsJson);
 	if (!Array.isArray(parsedDigests)) {
@@ -142,7 +145,11 @@ function findRemoteDigest(
 		);
 	}
 
-	const repositoryOnly = getRepositoryOnly(externalAccountId, imageTag);
+	const repositoryOnly = getRepositoryOnly(
+		externalAccountId,
+		imageTag,
+		complianceConfig
+	);
 	logger.debug("respositoryOnly:", repositoryOnly);
 
 	// make sure the repository + name provided in wrangler config
@@ -151,7 +158,7 @@ function findRemoteDigest(
 		if (typeof d !== "string" || !d.includes("@")) {
 			return false;
 		}
-		const resolved = resolveImageName(externalAccountId, d);
+		const resolved = resolveImageName(externalAccountId, d, complianceConfig);
 		logger.debug(`Comparing ${resolved.split("@")[0]} to ${repositoryOnly}`);
 		return typeof d === "string" && resolved.split("@")[0] === repositoryOnly;
 	});
@@ -162,7 +169,12 @@ function findRemoteDigest(
 	}
 
 	const [, hash] = digest.split("@");
-	return imageRefWithDigest(externalAccountId, imageTag, hash);
+	return imageRefWithDigest(
+		externalAccountId,
+		imageTag,
+		hash,
+		complianceConfig
+	);
 }
 
 /**
@@ -174,6 +186,7 @@ function findRemoteDigest(
  * @param containerConfig - Optional container configuration for limit validation.
  * @param verifyDockerIsRunning - When `true` (the default), verifies Docker is installed and the
  *   daemon is running before building. Set to `false` when the caller has already performed this check.
+ * @param complianceConfig - Compliance configuration used to select the managed registry.
  *
  * @returns An {@link ImageRef} describing the built/pushed image.
  */
@@ -182,7 +195,8 @@ export async function buildAndMaybePush(
 	pathToDocker: string,
 	push: boolean,
 	containerConfig?: Exclude<ContainerNormalizedConfig, ImageURIConfig>,
-	verifyDockerIsRunning?: boolean
+	verifyDockerIsRunning?: boolean,
+	complianceConfig?: ComplianceConfig
 ): Promise<ImageRef> {
 	try {
 		const imageTag = args.tag;
@@ -235,7 +249,7 @@ export async function buildAndMaybePush(
 				pathToDocker,
 				// Won't be an external registry since this is building from a Dockerfile
 				// rather than specifying an image uri.
-				getCloudflareContainerRegistry()
+				getCloudflareContainerRegistry(complianceConfig)
 			);
 			try {
 				// We don't try to parse until this point because we don't want to fail on
@@ -243,7 +257,8 @@ export async function buildAndMaybePush(
 				const remoteDigest = findRemoteDigest(
 					imageInfo,
 					account.external_account_id,
-					imageTag
+					imageTag,
+					complianceConfig
 				);
 				const [, hash] = remoteDigest.split("@");
 
@@ -255,13 +270,17 @@ export async function buildAndMaybePush(
 				// If this errors, it probably doesn't exist and we should push,
 				// which we will do in the catch block.
 				logger.debug(
-					`'docker manifest inspect -v ${resolveImageName(account.external_account_id, remoteDigest)}:`
+					`'docker manifest inspect -v ${resolveImageName(account.external_account_id, remoteDigest, complianceConfig)}:`
 				);
 				const remoteManifest = runDockerCmdWithOutput(pathToDocker, [
 					"manifest",
 					"inspect",
 					"-v",
-					resolveImageName(account.external_account_id, remoteDigest),
+					resolveImageName(
+						account.external_account_id,
+						remoteDigest,
+						complianceConfig
+					),
 				]);
 				const parsedRemoteManifest = JSON.parse(remoteManifest);
 
@@ -285,7 +304,8 @@ export async function buildAndMaybePush(
 			// Re-tag the image to include the account ID
 			const namespacedImageTag = resolveImageName(
 				account.external_account_id,
-				args.tag
+				args.tag,
+				complianceConfig
 			);
 			logger.log(
 				`Image does not exist remotely, pushing: ${namespacedImageTag}`
@@ -302,7 +322,8 @@ export async function buildAndMaybePush(
 				remoteDigest = findRemoteDigest(
 					pushedImageInfo,
 					account.external_account_id,
-					namespacedImageTag
+					namespacedImageTag,
+					complianceConfig
 				);
 			} catch (error) {
 				if (error instanceof Error) {
@@ -319,7 +340,8 @@ export async function buildAndMaybePush(
 				remoteDigest = imageRefWithDigest(
 					account.external_account_id,
 					namespacedImageTag,
-					findManifestDigest(remoteManifest)
+					findManifestDigest(remoteManifest),
+					complianceConfig
 				);
 			}
 
@@ -340,8 +362,16 @@ export async function buildAndMaybePush(
 	}
 }
 
+/**
+ * Builds an image from the Cloudchamber command arguments and optionally pushes it.
+ *
+ * @param args - Parsed Cloudchamber build command arguments.
+ * @param complianceConfig - Compliance configuration used to select the managed registry.
+ * @returns A promise that resolves when the build and optional push complete.
+ */
 export async function buildCommand(
-	args: StrictYargsOptionsToInterface<typeof buildYargs>
+	args: StrictYargsOptionsToInterface<typeof buildYargs>,
+	complianceConfig?: ComplianceConfig
 ) {
 	// TODO: merge args with Wrangler config if available
 	if (existsSync(args.PATH) && !isDirectory(args.PATH)) {
@@ -371,7 +401,9 @@ export async function buildCommand(
 		args.push,
 		// this means we aren't validating defined limits for a container when building an image
 		// we will, however, still validate the image size against account level disk limits
-		undefined
+		undefined,
+		undefined,
+		complianceConfig
 	);
 }
 
@@ -382,11 +414,11 @@ export async function pushCommand(
 	try {
 		await dockerLoginImageRegistry(
 			args.pathToDocker,
-			getCloudflareContainerRegistry()
+			getCloudflareContainerRegistry(config)
 		);
 
 		const accountId = await getOrSelectAccountId(config);
-		const newTag = resolveImageName(accountId, args.TAG);
+		const newTag = resolveImageName(accountId, args.TAG, config);
 		const dockerPath = args.pathToDocker ?? getDockerPath();
 		await checkImagePlatform(dockerPath, args.TAG);
 		await runDockerCmd(dockerPath, ["tag", args.TAG, newTag]);
@@ -468,7 +500,7 @@ export const cloudchamberBuildCommand = createCommand({
 	positionalArgs: ["PATH"],
 	async handler(args, { config }) {
 		await fillOpenAPIConfiguration(config, cloudchamberScope);
-		await buildCommand(args);
+		await buildCommand(args, config);
 	},
 });
 

--- a/packages/wrangler/src/cloudchamber/images/images.ts
+++ b/packages/wrangler/src/cloudchamber/images/images.ts
@@ -20,7 +20,7 @@ import type {
 	StrictYargsOptionsToInterface,
 } from "../../yargs-types";
 import type { ImageRegistryPermissions } from "@cloudflare/containers-shared";
-import type { Config } from "@cloudflare/workers-utils";
+import type { ComplianceConfig, Config } from "@cloudflare/workers-utils";
 
 interface CatalogWithTagsResponse {
 	repositories: Record<string, string[]>;
@@ -95,9 +95,9 @@ async function handleDeleteImageCommand(
 	}
 
 	const digest = await promiseSpinner(
-		getCreds().then(async (creds) => {
+		getCreds(config).then(async (creds) => {
 			const accountId = await getOrSelectAccountId(config);
-			const url = new URL(`https://${getCloudflareContainerRegistry()}`);
+			const url = new URL(`https://${getCloudflareContainerRegistry(config)}`);
 			const baseUrl = `${url.protocol}//${url.host}`;
 			const [image, tag] = args.image.split(":");
 			const digest_ = await deleteTag(baseUrl, accountId, image, tag, creds);
@@ -130,8 +130,8 @@ async function handleListImagesCommand(
 	config: Config
 ) {
 	const responses = await promiseSpinner(
-		getCreds().then(async (creds) => {
-			const repos = await listReposWithTags(creds);
+		getCreds(config).then(async (creds) => {
+			const repos = await listReposWithTags(creds, config);
 			const processed: Repository[] = [];
 			const accountId = await getOrSelectAccountId(config);
 			const accountIdPrefix = new RegExp(`^${accountId}/`);
@@ -191,9 +191,12 @@ async function listImages(
 }
 
 async function listReposWithTags(
-	creds: string
+	creds: string,
+	complianceConfig?: ComplianceConfig
 ): Promise<Record<string, string[]>> {
-	const url = new URL(`https://${getCloudflareContainerRegistry()}`);
+	const url = new URL(
+		`https://${getCloudflareContainerRegistry(complianceConfig)}`
+	);
 	const catalogUrl = `${url.protocol}//${url.host}/v2/_catalog?tags=true`;
 
 	const response = await fetch(catalogUrl, {
@@ -261,10 +264,10 @@ async function deleteTag(
 	return digest;
 }
 
-async function getCreds(): Promise<string> {
+async function getCreds(complianceConfig?: ComplianceConfig): Promise<string> {
 	const credentials =
 		await ImageRegistriesService.generateImageRegistryCredentials(
-			getCloudflareContainerRegistry(),
+			getCloudflareContainerRegistry(complianceConfig),
 			{
 				expiration_minutes: 5,
 				permissions: ["pull", "push"] as ImageRegistryPermissions[],

--- a/packages/wrangler/src/containers/build.ts
+++ b/packages/wrangler/src/containers/build.ts
@@ -12,6 +12,7 @@ import type {
 	ContainerNormalizedConfig,
 	ImageURIConfig,
 } from "@cloudflare/containers-shared";
+import type { ComplianceConfig } from "@cloudflare/workers-utils";
 
 // --- Command definitions ---
 
@@ -58,7 +59,7 @@ export const containersBuildCommand = createCommand({
 	positionalArgs: ["PATH"],
 	async handler(args, { config }) {
 		await fillOpenAPIConfiguration(config, containersScope);
-		await buildCommand(args);
+		await buildCommand(args, config);
 	},
 });
 
@@ -90,13 +91,24 @@ export const containersPushCommand = createCommand({
 
 // --- Helper functions ---
 
+/**
+ * Builds a configured container image and optionally pushes it to the managed registry.
+ *
+ * @param containerConfig - Normalized Dockerfile-based container configuration.
+ * @param imageTag - Tag component that will be prefixed with the container name.
+ * @param dryRun - Whether to build without pushing the image.
+ * @param pathToDocker - Path to the Docker CLI executable.
+ * @param verifyDockerIsRunning - Whether to verify Docker before building.
+ * @param complianceConfig - Compliance configuration used to select the managed registry.
+ * @returns An {@link ImageRef} describing the built or pushed image.
+ */
 export async function buildContainer(
 	containerConfig: Exclude<ContainerNormalizedConfig, ImageURIConfig>,
-	/** just the tag component. will be prefixed with the container name */
 	imageTag: string,
 	dryRun: boolean,
 	pathToDocker: string,
-	verifyDockerIsRunning?: boolean
+	verifyDockerIsRunning?: boolean,
+	complianceConfig?: ComplianceConfig
 ): Promise<ImageRef> {
 	const imageFullName = containerConfig.name + ":" + imageTag.split("-")[0];
 	logger.log("Building image", imageFullName);
@@ -111,6 +123,7 @@ export async function buildContainer(
 		pathToDocker,
 		!dryRun,
 		containerConfig,
-		verifyDockerIsRunning
+		verifyDockerIsRunning,
+		complianceConfig
 	);
 }

--- a/packages/wrangler/src/containers/config.ts
+++ b/packages/wrangler/src/containers/config.ts
@@ -229,7 +229,8 @@ export const getNormalizedContainerOptions = async (
 					? container.image
 					: resolveImageName(
 							await getOrSelectAccountId(config),
-							container.image
+							container.image,
+							config
 						), // if it is not a dockerfile, it must be an image uri or have thrown an error
 			});
 		}

--- a/packages/wrangler/src/containers/deploy.ts
+++ b/packages/wrangler/src/containers/deploy.ts
@@ -96,7 +96,8 @@ export async function deployContainers(
 				versionId,
 				false, // dry runs will have already exited by this point
 				pathToDocker,
-				false
+				false,
+				config
 			);
 		} else {
 			imageRef = { newTag: container.image_uri };
@@ -314,6 +315,7 @@ function containerConfigToCreateRequest(
 	containerApp: ContainerNormalizedConfig,
 	imageRef: string,
 	durableObjectNamespaceId: string,
+	complianceConfig: ComplianceConfig,
 	prevApp?: Application
 ): CreateApplicationRequest {
 	return {
@@ -321,7 +323,7 @@ function containerConfigToCreateRequest(
 		scheduling_policy: containerApp.scheduling_policy,
 		configuration: {
 			// De-sugar image name
-			image: resolveImageName(accountId, imageRef),
+			image: resolveImageName(accountId, imageRef, complianceConfig),
 			// if disk/memory/vcpu is not defined in config, AND instance_type is also not defined, this will already have been defaulted to 'dev'
 			...("instance_type" in containerApp
 				? { instance_type: containerApp.instance_type }
@@ -424,6 +426,7 @@ export async function apply(
 			containerConfig,
 			imageRef,
 			args.durable_object_namespace_id,
+			config,
 			prevApp
 		),
 		containerConfig.name
@@ -453,7 +456,7 @@ export async function apply(
 		// we need to sort the objects (by key) because the diff algorithm works with lines
 		const normalisedPrevApp = sortObjectRecursive<ModifyApplicationRequestBody>(
 			stripUndefined(
-				cleanApplicationFromAPI(prevApp, containerConfig, accountId)
+				cleanApplicationFromAPI(prevApp, containerConfig, accountId, config)
 			)
 		);
 
@@ -713,17 +716,28 @@ const doAction = async (
 
 /**
  * clean up application object received from API so that we get a nicer diff when comparing it to the current config.
+ *
+ * @param prev - Previously deployed application returned by the API.
+ * @param currentConfig - Current normalized container configuration.
+ * @param accountId - Cloudflare account ID that owns managed-registry images.
+ * @param complianceConfig - Compliance configuration used to normalize managed-registry image references.
+ * @returns The cleaned application fields used to generate the deployment diff.
  */
 export function cleanApplicationFromAPI(
 	prev: Application,
 	currentConfig: ContainerNormalizedConfig,
-	accountId: string
+	accountId: string,
+	complianceConfig?: ComplianceConfig
 ): Partial<ModifyApplicationRequestBody> & Pick<Application, "configuration"> {
 	const cleanedPreviousApp: Partial<ModifyApplicationRequestBody> &
 		Pick<Application, "configuration"> = {
 		configuration: {
 			...prev.configuration,
-			image: resolveImageName(accountId, prev.configuration.image),
+			image: resolveImageName(
+				accountId,
+				prev.configuration.image,
+				complianceConfig
+			),
 		},
 		constraints: prev.constraints,
 		max_instances: prev.max_instances,

--- a/packages/wrangler/src/containers/images.ts
+++ b/packages/wrangler/src/containers/images.ts
@@ -15,7 +15,7 @@ import { logger } from "../logger";
 import { getOrSelectAccountId } from "../user";
 import { containersScope } from ".";
 import type { ImageRegistryPermissions } from "@cloudflare/containers-shared";
-import type { Config } from "@cloudflare/workers-utils";
+import type { ComplianceConfig, Config } from "@cloudflare/workers-utils";
 
 interface Repository {
 	name: string;
@@ -110,9 +110,9 @@ async function handleDeleteImageCommand(
 	}
 
 	const digest = await promiseSpinner(
-		getCreds().then(async (creds) => {
+		getCreds(config).then(async (creds) => {
 			const accountId = await getOrSelectAccountId(config);
-			const url = new URL(`https://${getCloudflareContainerRegistry()}`);
+			const url = new URL(`https://${getCloudflareContainerRegistry(config)}`);
 			const baseUrl = `${url.protocol}//${url.host}`;
 			const [image, tag] = args.image.split(":");
 			const digest_ = await deleteTag(baseUrl, accountId, image, tag, creds);
@@ -145,8 +145,8 @@ async function handleListImagesCommand(
 	config: Config
 ) {
 	const responses = await promiseSpinner(
-		getCreds().then(async (creds) => {
-			const repos = await listReposWithTags(creds);
+		getCreds(config).then(async (creds) => {
+			const repos = await listReposWithTags(creds, config);
 			const processed: Repository[] = [];
 			const accountId = await getOrSelectAccountId(config);
 			const accountIdPrefix = new RegExp(`^${accountId}/`);
@@ -211,9 +211,12 @@ interface CatalogWithTagsResponse {
 }
 
 async function listReposWithTags(
-	creds: string
+	creds: string,
+	complianceConfig?: ComplianceConfig
 ): Promise<Record<string, string[]>> {
-	const url = new URL(`https://${getCloudflareContainerRegistry()}`);
+	const url = new URL(
+		`https://${getCloudflareContainerRegistry(complianceConfig)}`
+	);
 	const catalogUrl = `${url.protocol}//${url.host}/v2/_catalog?tags=true`;
 
 	const response = await fetch(catalogUrl, {
@@ -281,10 +284,10 @@ async function deleteTag(
 	return digest;
 }
 
-async function getCreds(): Promise<string> {
+async function getCreds(complianceConfig?: ComplianceConfig): Promise<string> {
 	const credentials =
 		await ImageRegistriesService.generateImageRegistryCredentials(
-			getCloudflareContainerRegistry(),
+			getCloudflareContainerRegistry(complianceConfig),
 			{
 				expiration_minutes: 5,
 				permissions: ["pull", "push"] as ImageRegistryPermissions[],

--- a/packages/wrangler/src/containers/registries.ts
+++ b/packages/wrangler/src/containers/registries.ts
@@ -154,7 +154,7 @@ async function registryConfigureCommand(
 ) {
 	startSection("Configure a container registry");
 
-	const registryType = getAndValidateRegistryType(configureArgs.DOMAIN);
+	const registryType = getAndValidateRegistryType(configureArgs.DOMAIN, config);
 
 	if (registryType.type === "cloudflare") {
 		log(
@@ -675,15 +675,18 @@ async function registryDeleteCommand(
 	}
 }
 
-async function registryCredentialsCommand(credentialsArgs: {
-	DOMAIN?: string;
-	expirationMinutes: number;
-	push?: boolean;
-	pull?: boolean;
-	libraryPush?: boolean;
-	json?: boolean;
-}) {
-	const cloudflareRegistry = getCloudflareContainerRegistry();
+async function registryCredentialsCommand(
+	credentialsArgs: {
+		DOMAIN?: string;
+		expirationMinutes: number;
+		push?: boolean;
+		pull?: boolean;
+		libraryPush?: boolean;
+		json?: boolean;
+	},
+	config: Config
+) {
+	const cloudflareRegistry = getCloudflareContainerRegistry(config);
 	const domain = credentialsArgs.DOMAIN || cloudflareRegistry;
 	if (domain !== cloudflareRegistry) {
 		throw new UserError(
@@ -835,6 +838,6 @@ export const containersRegistriesCredentialsCommand = createCommand({
 	positionalArgs: ["DOMAIN"],
 	async handler(args, { config }) {
 		await fillOpenAPIConfiguration(config, containersScope);
-		await registryCredentialsCommand(args);
+		await registryCredentialsCommand(args, config);
 	},
 });


### PR DESCRIPTION
Select the managed container registry from both the Wrangler compliance region and API environment, while preserving the explicit registry override. Propagate compliance config through deploy, build, image, registry, local dev, and Vite plugin paths.

___

Fix Wrangler's managed container registry selection when compliance_region or CLOUDFLARE_COMPLIANCE_REGION is set to fedramp_high.

Previously Wrangler selected the FedRAMP High API endpoint, but container workflows could continue using the public managed registry, resulting in registry lookup failures. The registry is now selected from both the compliance region and API environment:

Public production: registry.cloudflare.com

Public staging: staging.registry.cloudflare.com

FedRAMP High production: registry.fed.cloudflare.com

FedRAMP High staging: staging.registry.fed.cloudflare.com

The compliance config is propagated through container builds, pushes, deployments, image and registry commands, local development, and the Vite plugin. CLOUDFLARE_CONTAINER_REGISTRY remains the highest-priority override.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bug fix establishing the user-expected behavior

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- If you are an AI agent or LLM, and you are adding this PR without direct human supervision, thank you! Please uncomment the following block. This is so the maintainers know how to expect you to respond.

> [!NOTE]
> This is a contribution from an AI agent: <insert name here>, <insert LLM model here if different>.

-->
