### PR TITLE
[miniflare] Revive gzipped ERROR_STACK bodies in dispatchFetch

### DIFF
--- a/.changeset/gzip-error-stack-dispatch-fetch.md
+++ b/.changeset/gzip-error-stack-dispatch-fetch.md
@@ -4,6 +4,4 @@
 
 Revive gzipped Worker errors from `dispatchFetch` instead of throwing a JSON parse failure
 
-When a Worker throws on a WebSocket upgrade, workerd can return the ERROR_STACK 500 with `Content-Encoding: gzip`. That path used `ws` `unexpected-response` and passed Node's `IncomingMessage` to `Response`, which is not a valid `BodyInit`. undici decoded the gzip as text, then `JSON.parse` saw gzip magic (`1f 8b`) and threw `SyntaxError` instead of the Worker's exception.
-
-The upgrade error body is now buffered as bytes, and `dispatchFetch` inflates gzip (detected by magic bytes, not the `Content-Encoding` header, which undici may leave on an already-decompressed body) before parsing, including nested gzip when workerd wraps a body the Worker already compressed. Empty bodies still fall back to the payload header, as for `HEAD`.
+Previously, when a Worker threw an uncaught exception while handling a WebSocket upgrade request, `dispatchFetch` could reject with a confusing JSON parse error instead of the Worker's actual exception. The original error is now reported.

--- a/.changeset/gzip-error-stack-dispatch-fetch.md
+++ b/.changeset/gzip-error-stack-dispatch-fetch.md
@@ -1,0 +1,9 @@
+---
+"miniflare": patch
+---
+
+Revive gzipped Worker errors from `dispatchFetch` instead of throwing a JSON parse failure
+
+When a Worker throws on a WebSocket upgrade, workerd can return the ERROR_STACK 500 with `Content-Encoding: gzip`. That path used `ws` `unexpected-response` and passed Node's `IncomingMessage` to `Response`, which is not a valid `BodyInit`. undici decoded the gzip as text, then `JSON.parse` saw gzip magic (`1f 8b`) and threw `SyntaxError` instead of the Worker's exception.
+
+The upgrade error body is now buffered as bytes, and `dispatchFetch` inflates gzip (detected by magic bytes, not the `Content-Encoding` header, which undici may leave on an already-decompressed body) before parsing, including nested gzip when workerd wraps a body the Worker already compressed. Empty bodies still fall back to the payload header, as for `HEAD`.

--- a/packages/miniflare/src/http/error-stack.ts
+++ b/packages/miniflare/src/http/error-stack.ts
@@ -1,0 +1,53 @@
+import zlib from "node:zlib";
+import { decodeErrorPayload } from "../workers/core/constants";
+
+/**
+ * Gzip magic number (`1f 8b`). Used instead of the `Content-Encoding` header:
+ * undici's `fetch` decompresses the body but leaves that header in place, so
+ * trusting the header would gunzip already-plain JSON.
+ */
+function isGzip(bytes: Uint8Array): boolean {
+	return bytes.length >= 2 && bytes[0] === 0x1f && bytes[1] === 0x8b;
+}
+
+/**
+ * workerd may gzip a body the Worker already compressed, so inflate until the magic is gone.
+ */
+function gunzipNested(bytes: Uint8Array): Buffer {
+	let decoded = Buffer.from(bytes);
+	while (isGzip(decoded)) {
+		const next = zlib.gunzipSync(decoded);
+		if (next.equals(decoded)) {
+			break;
+		}
+		decoded = next;
+	}
+	return decoded;
+}
+
+/**
+ * Reads the serialised Worker error from an ERROR_STACK 500.
+ *
+ * `workerd` drops bodies on `HEAD` (empty → payload header). WebSocket
+ * upgrades that fail go through `ws` `unexpected-response`, which does not
+ * decompress, so a gzipped body must be inflated before `JSON.parse`.
+ */
+export async function readErrorStackBody(response: {
+	arrayBuffer(): Promise<ArrayBuffer>;
+	headers: { get(name: string): string | null };
+}): Promise<string | null> {
+	const bytes = new Uint8Array(await response.arrayBuffer());
+	if (bytes.byteLength === 0) {
+		return decodeErrorPayload(response);
+	}
+
+	let decoded: Buffer;
+	try {
+		decoded = gunzipNested(bytes);
+	} catch {
+		return decodeErrorPayload(response);
+	}
+
+	const serialised = decoded.toString("utf8");
+	return serialised === "" ? decodeErrorPayload(response) : serialised;
+}

--- a/packages/miniflare/src/http/error-stack.ts
+++ b/packages/miniflare/src/http/error-stack.ts
@@ -2,8 +2,8 @@ import zlib from "node:zlib";
 import { decodeErrorPayload } from "../workers/core/constants";
 
 /**
- * Ceiling for an ERROR_STACK body, compressed or inflated. These payloads are
- * a serialised Worker exception, not an application response.
+ * Ceiling for gzip inflate of an ERROR_STACK body. Plain JSON is decoded as-is;
+ * this bound exists to stop a compression bomb, not to drop a large stack.
  */
 export const MAX_ERROR_STACK_BYTES = 1024 * 1024;
 
@@ -52,7 +52,16 @@ export async function readErrorStackBody(response: {
 	headers: { get(name: string): string | null };
 }): Promise<string | null> {
 	const bytes = new Uint8Array(await response.arrayBuffer());
-	if (bytes.byteLength === 0 || bytes.byteLength > MAX_ERROR_STACK_BYTES) {
+	if (bytes.byteLength === 0) {
+		return decodeErrorPayload(response);
+	}
+
+	if (!isGzip(bytes)) {
+		const serialised = Buffer.from(bytes).toString("utf8");
+		return serialised === "" ? decodeErrorPayload(response) : serialised;
+	}
+
+	if (bytes.byteLength > MAX_ERROR_STACK_BYTES) {
 		return decodeErrorPayload(response);
 	}
 

--- a/packages/miniflare/src/http/error-stack.ts
+++ b/packages/miniflare/src/http/error-stack.ts
@@ -2,8 +2,9 @@ import zlib from "node:zlib";
 import { decodeErrorPayload } from "../workers/core/constants";
 
 /**
- * Ceiling for gzip inflate of an ERROR_STACK body. Plain JSON is decoded as-is;
- * this bound exists to stop a compression bomb, not to drop a large stack.
+ * Ceiling for gzip and brotli inflate of an ERROR_STACK body. Plain JSON is
+ * decoded as-is; this bound exists to stop a compression bomb, not to drop a
+ * large stack.
  */
 export const MAX_ERROR_STACK_BYTES = 1024 * 1024;
 
@@ -41,11 +42,38 @@ function gunzipNested(bytes: Uint8Array): Buffer {
 }
 
 /**
+ * Brotli has no reliable magic number. Attempt inflate and treat a throw as
+ * "this was not brotli", so leftover `Content-Encoding: br` on already-plain
+ * JSON is left alone. An inflate that exceeds the size cap is a bomb, not a
+ * miss.
+ */
+function tryBrotli(bytes: Uint8Array): Buffer | "bomb" | null {
+	if (bytes.byteLength > MAX_ERROR_STACK_BYTES) {
+		return null;
+	}
+	try {
+		return zlib.brotliDecompressSync(bytes, {
+			maxOutputLength: MAX_ERROR_STACK_BYTES,
+		});
+	} catch (error) {
+		if (
+			error instanceof RangeError ||
+			(error instanceof Error &&
+				"code" in error &&
+				error.code === "ERR_BUFFER_TOO_LARGE")
+		) {
+			return "bomb";
+		}
+		return null;
+	}
+}
+
+/**
  * Reads the serialised Worker error from an ERROR_STACK 500.
  *
  * `workerd` drops bodies on `HEAD` (empty → payload header). WebSocket
  * upgrades that fail go through `ws` `unexpected-response`, which does not
- * decompress, so a gzipped body must be inflated before `JSON.parse`.
+ * decompress, so a gzipped or brotli body must be inflated before `JSON.parse`.
  */
 export async function readErrorStackBody(response: {
 	arrayBuffer(): Promise<ArrayBuffer>;
@@ -56,26 +84,37 @@ export async function readErrorStackBody(response: {
 		return decodeErrorPayload(response);
 	}
 
-	if (!isGzip(bytes)) {
-		const serialised = Buffer.from(bytes).toString("utf8");
+	if (isGzip(bytes)) {
+		if (bytes.byteLength > MAX_ERROR_STACK_BYTES) {
+			return decodeErrorPayload(response);
+		}
+
+		let decoded: Buffer;
+		try {
+			decoded = gunzipNested(bytes);
+		} catch {
+			return decodeErrorPayload(response);
+		}
+
+		if (isGzip(decoded)) {
+			return decodeErrorPayload(response);
+		}
+
+		const serialised = decoded.toString("utf8");
 		return serialised === "" ? decodeErrorPayload(response) : serialised;
 	}
 
-	if (bytes.byteLength > MAX_ERROR_STACK_BYTES) {
+	const brotli = tryBrotli(bytes);
+	if (brotli === "bomb") {
 		return decodeErrorPayload(response);
 	}
-
-	let decoded: Buffer;
-	try {
-		decoded = gunzipNested(bytes);
-	} catch {
-		return decodeErrorPayload(response);
+	if (brotli !== null) {
+		const serialised = brotli.toString("utf8");
+		if (serialised !== "") {
+			return serialised;
+		}
 	}
 
-	if (isGzip(decoded)) {
-		return decodeErrorPayload(response);
-	}
-
-	const serialised = decoded.toString("utf8");
+	const serialised = Buffer.from(bytes).toString("utf8");
 	return serialised === "" ? decodeErrorPayload(response) : serialised;
 }

--- a/packages/miniflare/src/http/error-stack.ts
+++ b/packages/miniflare/src/http/error-stack.ts
@@ -19,7 +19,7 @@ export const MAX_GZIP_ROUNDS = 4;
  * undici's `fetch` decompresses the body but leaves that header in place, so
  * trusting the header would gunzip already-plain JSON.
  */
-function isGzip(bytes: Uint8Array): boolean {
+export function isGzip(bytes: Uint8Array): boolean {
 	return bytes.length >= 2 && bytes[0] === 0x1f && bytes[1] === 0x8b;
 }
 

--- a/packages/miniflare/src/http/error-stack.ts
+++ b/packages/miniflare/src/http/error-stack.ts
@@ -2,6 +2,18 @@ import zlib from "node:zlib";
 import { decodeErrorPayload } from "../workers/core/constants";
 
 /**
+ * Ceiling for an ERROR_STACK body, compressed or inflated. These payloads are
+ * a serialised Worker exception, not an application response.
+ */
+export const MAX_ERROR_STACK_BYTES = 1024 * 1024;
+
+/**
+ * workerd can wrap a body the Worker already gzipped, so a couple of inflates
+ * are expected. Anything past this is treated as a bomb, not an error page.
+ */
+export const MAX_GZIP_ROUNDS = 4;
+
+/**
  * Gzip magic number (`1f 8b`). Used instead of the `Content-Encoding` header:
  * undici's `fetch` decompresses the body but leaves that header in place, so
  * trusting the header would gunzip already-plain JSON.
@@ -11,16 +23,19 @@ function isGzip(bytes: Uint8Array): boolean {
 }
 
 /**
- * workerd may gzip a body the Worker already compressed, so inflate until the magic is gone.
+ * workerd may gzip a body the Worker already compressed, so inflate until the
+ * magic is gone, a round or size cap is hit, or inflate throws.
  */
 function gunzipNested(bytes: Uint8Array): Buffer {
-	let decoded = Buffer.from(bytes);
-	while (isGzip(decoded)) {
-		const next = zlib.gunzipSync(decoded);
+	let decoded: Buffer = Buffer.from(bytes);
+	for (let round = 0; isGzip(decoded) && round < MAX_GZIP_ROUNDS; round++) {
+		const next = zlib.gunzipSync(decoded, {
+			maxOutputLength: MAX_ERROR_STACK_BYTES,
+		});
 		if (next.equals(decoded)) {
 			break;
 		}
-		decoded = next;
+		decoded = Buffer.from(next);
 	}
 	return decoded;
 }
@@ -37,7 +52,7 @@ export async function readErrorStackBody(response: {
 	headers: { get(name: string): string | null };
 }): Promise<string | null> {
 	const bytes = new Uint8Array(await response.arrayBuffer());
-	if (bytes.byteLength === 0) {
+	if (bytes.byteLength === 0 || bytes.byteLength > MAX_ERROR_STACK_BYTES) {
 		return decodeErrorPayload(response);
 	}
 
@@ -45,6 +60,10 @@ export async function readErrorStackBody(response: {
 	try {
 		decoded = gunzipNested(bytes);
 	} catch {
+		return decodeErrorPayload(response);
+	}
+
+	if (isGzip(decoded)) {
 		return decodeErrorPayload(response);
 	}
 

--- a/packages/miniflare/src/http/error-stack.ts
+++ b/packages/miniflare/src/http/error-stack.ts
@@ -9,6 +9,13 @@ import { decodeErrorPayload } from "../workers/core/constants";
 export const MAX_ERROR_STACK_BYTES = 1024 * 1024;
 
 /**
+ * Hard ceiling for buffering a non-gzip ERROR_STACK body on a failed
+ * WebSocket upgrade. Larger than the inflate cap so a long stack still
+ * survives; finite so a plain 500 cannot grow memory without bound.
+ */
+export const MAX_ERROR_STACK_PLAIN_BYTES = 16 * 1024 * 1024;
+
+/**
  * workerd can wrap a body the Worker already gzipped, so a couple of inflates
  * are expected. Anything past this is treated as a bomb, not an error page.
  */

--- a/packages/miniflare/src/http/error-stack.ts
+++ b/packages/miniflare/src/http/error-stack.ts
@@ -42,10 +42,31 @@ function gunzipNested(bytes: Uint8Array): Buffer {
 }
 
 /**
+ * Returns serialised JSON, or the payload header when the body is empty or is
+ * not JSON (oversized brotli that skipped inflate, leftover compressed bytes).
+ */
+function jsonOrPayload(
+	text: string,
+	response: { headers: { get(name: string): string | null } }
+): string | null {
+	if (text === "") {
+		return decodeErrorPayload(response);
+	}
+	try {
+		JSON.parse(text);
+		return text;
+	} catch {
+		return decodeErrorPayload(response);
+	}
+}
+
+/**
  * Brotli has no reliable magic number. Attempt inflate and treat a throw as
  * "this was not brotli", so leftover `Content-Encoding: br` on already-plain
  * JSON is left alone. An inflate that exceeds the size cap is a bomb, not a
- * miss.
+ * miss. Oversized input returns null rather than "bomb" so a large plain JSON
+ * stack still utf8-decodes; compressed bytes that are not JSON then fall
+ * through to `jsonOrPayload`.
  */
 function tryBrotli(bytes: Uint8Array): Buffer | "bomb" | null {
 	if (bytes.byteLength > MAX_ERROR_STACK_BYTES) {
@@ -101,7 +122,7 @@ export async function readErrorStackBody(response: {
 		}
 
 		const serialised = decoded.toString("utf8");
-		return serialised === "" ? decodeErrorPayload(response) : serialised;
+		return jsonOrPayload(serialised, response);
 	}
 
 	const brotli = tryBrotli(bytes);
@@ -111,10 +132,9 @@ export async function readErrorStackBody(response: {
 	if (brotli !== null) {
 		const serialised = brotli.toString("utf8");
 		if (serialised !== "") {
-			return serialised;
+			return jsonOrPayload(serialised, response);
 		}
 	}
 
-	const serialised = Buffer.from(bytes).toString("utf8");
-	return serialised === "" ? decodeErrorPayload(response) : serialised;
+	return jsonOrPayload(Buffer.from(bytes).toString("utf8"), response);
 }

--- a/packages/miniflare/src/http/fetch.ts
+++ b/packages/miniflare/src/http/fetch.ts
@@ -2,6 +2,7 @@ import assert from "node:assert";
 import * as undici from "undici";
 import NodeWebSocket from "ws";
 import { CoreHeaders, DeferredPromise } from "../workers";
+import { MAX_ERROR_STACK_BYTES } from "./error-stack";
 import { Request } from "./request";
 import { Response } from "./response";
 import { coupleWebSocket, WebSocketPair } from "./websocket";
@@ -78,7 +79,7 @@ export async function fetch(
 			// Buffer the Node stream into bytes. Passing `IncomingMessage` to
 			// `Response` is not a valid `BodyInit`, and undici would decode it as
 			// text, destroying gzip ERROR_STACK bodies (#15198).
-			void bufferIncomingMessage(incoming).then(
+			void bufferIncomingMessage(incoming, MAX_ERROR_STACK_BYTES).then(
 				(body) => {
 					responsePromise.resolve(
 						new Response(body, {
@@ -109,15 +110,40 @@ export type DispatchFetch = (
 export type AnyHeaders = http.IncomingHttpHeaders | string[];
 
 function bufferIncomingMessage(
-	incoming: http.IncomingMessage
+	incoming: http.IncomingMessage,
+	maxBytes: number
 ): Promise<Buffer> {
 	return new Promise((resolve, reject) => {
 		const chunks: Buffer[] = [];
+		let total = 0;
+		let settled = false;
+		const finish = (body: Buffer) => {
+			if (settled) {
+				return;
+			}
+			settled = true;
+			resolve(body);
+		};
 		incoming.on("data", (chunk: Buffer | string) => {
-			chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+			if (settled) {
+				return;
+			}
+			const buf = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+			total += buf.length;
+			if (total > maxBytes) {
+				incoming.destroy();
+				finish(Buffer.alloc(0));
+				return;
+			}
+			chunks.push(buf);
 		});
-		incoming.on("end", () => resolve(Buffer.concat(chunks)));
-		incoming.on("error", reject);
+		incoming.on("end", () => finish(Buffer.concat(chunks)));
+		incoming.on("error", (error) => {
+			if (!settled) {
+				settled = true;
+				reject(error);
+			}
+		});
 	});
 }
 

--- a/packages/miniflare/src/http/fetch.ts
+++ b/packages/miniflare/src/http/fetch.ts
@@ -3,7 +3,7 @@ import { Readable } from "node:stream";
 import * as undici from "undici";
 import NodeWebSocket from "ws";
 import { CoreHeaders, DeferredPromise } from "../workers";
-import { MAX_ERROR_STACK_BYTES } from "./error-stack";
+import { isGzip, MAX_ERROR_STACK_BYTES } from "./error-stack";
 import { Request } from "./request";
 import { Response } from "./response";
 import { coupleWebSocket, WebSocketPair } from "./websocket";
@@ -80,8 +80,9 @@ export async function fetch(
 			const headers = convertUndiciHeadersToStandard(incoming.headers);
 			/**
 			 * Only ERROR_STACK 500s need a byte buffer: `IncomingMessage` is not a
-			 * valid `BodyInit`, and undici would decode gzip as text (#15198). Other
-			 * failed upgrades stream through so a large page is not capped or emptied.
+			 * valid `BodyInit`, and undici would decode gzip as text (#15198). The
+			 * size cap applies to gzip only, so a large plain JSON stack is kept.
+			 * Other failed upgrades stream through so a large page is not emptied.
 			 */
 			const isErrorStack =
 				incoming.statusCode === 500 &&
@@ -125,14 +126,20 @@ export type DispatchFetch = (
 
 export type AnyHeaders = http.IncomingHttpHeaders | string[];
 
+/**
+ * Buffers an ERROR_STACK `IncomingMessage` as bytes. Gzip is capped so a
+ * compression bomb cannot fill memory; plain JSON is not, matching the
+ * non-WebSocket path.
+ */
 function bufferIncomingMessage(
 	incoming: http.IncomingMessage,
-	maxBytes: number
+	maxGzipBytes: number
 ): Promise<Buffer> {
 	return new Promise((resolve, reject) => {
 		const chunks: Buffer[] = [];
-		let total = 0;
+		let gzip: boolean | undefined;
 		let settled = false;
+		let total = 0;
 		const finish = (body: Buffer) => {
 			if (settled) {
 				return;
@@ -146,12 +153,14 @@ function bufferIncomingMessage(
 			}
 			const buf = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
 			total += buf.length;
-			if (total > maxBytes) {
+			chunks.push(buf);
+			if (gzip === undefined && total >= 2) {
+				gzip = isGzip(Buffer.concat(chunks, 2));
+			}
+			if (gzip === true && total > maxGzipBytes) {
 				incoming.destroy();
 				finish(Buffer.alloc(0));
-				return;
 			}
-			chunks.push(buf);
 		});
 		incoming.on("end", () => finish(Buffer.concat(chunks)));
 		incoming.on("error", (error) => {

--- a/packages/miniflare/src/http/fetch.ts
+++ b/packages/miniflare/src/http/fetch.ts
@@ -73,13 +73,24 @@ export async function fetch(
 			});
 			responsePromise.resolve(couplePromise.then(() => response));
 		});
-		ws.once("unexpected-response", (_, req) => {
-			const headers = convertUndiciHeadersToStandard(req.headers);
-			const response = new Response(req, {
-				status: req.statusCode,
-				headers,
-			});
-			responsePromise.resolve(response);
+		ws.once("unexpected-response", (_, incoming) => {
+			const headers = convertUndiciHeadersToStandard(incoming.headers);
+			// Buffer the Node stream into bytes. Passing `IncomingMessage` to
+			// `Response` is not a valid `BodyInit`, and undici would decode it as
+			// text, destroying gzip ERROR_STACK bodies (#15198).
+			void bufferIncomingMessage(incoming).then(
+				(body) => {
+					responsePromise.resolve(
+						new Response(body, {
+							status: incoming.statusCode,
+							headers,
+						})
+					);
+				},
+				(error: unknown) => {
+					responsePromise.reject(error);
+				}
+			);
 		});
 		return responsePromise;
 	}
@@ -96,6 +107,19 @@ export type DispatchFetch = (
 ) => Promise<Response>;
 
 export type AnyHeaders = http.IncomingHttpHeaders | string[];
+
+function bufferIncomingMessage(
+	incoming: http.IncomingMessage
+): Promise<Buffer> {
+	return new Promise((resolve, reject) => {
+		const chunks: Buffer[] = [];
+		incoming.on("data", (chunk: Buffer | string) => {
+			chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+		});
+		incoming.on("end", () => resolve(Buffer.concat(chunks)));
+		incoming.on("error", reject);
+	});
+}
 
 function isIterable(
 	headers: UndiciHeaders

--- a/packages/miniflare/src/http/fetch.ts
+++ b/packages/miniflare/src/http/fetch.ts
@@ -3,7 +3,11 @@ import { Readable } from "node:stream";
 import * as undici from "undici";
 import NodeWebSocket from "ws";
 import { CoreHeaders, DeferredPromise } from "../workers";
-import { isGzip, MAX_ERROR_STACK_BYTES } from "./error-stack";
+import {
+	isGzip,
+	MAX_ERROR_STACK_BYTES,
+	MAX_ERROR_STACK_PLAIN_BYTES,
+} from "./error-stack";
 import { Request } from "./request";
 import { Response } from "./response";
 import { coupleWebSocket, WebSocketPair } from "./websocket";
@@ -80,9 +84,9 @@ export async function fetch(
 			const headers = convertUndiciHeadersToStandard(incoming.headers);
 			/**
 			 * Only ERROR_STACK 500s need a byte buffer: `IncomingMessage` is not a
-			 * valid `BodyInit`, and undici would decode gzip as text (#15198). The
-			 * size cap applies to gzip only, so a large plain JSON stack is kept.
-			 * Other failed upgrades stream through so a large page is not emptied.
+			 * valid `BodyInit`, and undici would decode gzip as text (#15198). Gzip
+			 * is capped at the inflate ceiling; plain JSON at a larger finite
+			 * ceiling. Other failed upgrades stream through.
 			 */
 			const isErrorStack =
 				incoming.statusCode === 500 &&
@@ -96,7 +100,7 @@ export async function fetch(
 				);
 				return;
 			}
-			void bufferIncomingMessage(incoming, MAX_ERROR_STACK_BYTES).then(
+			void bufferIncomingMessage(incoming).then(
 				(body) => {
 					responsePromise.resolve(
 						new Response(body, {
@@ -127,13 +131,13 @@ export type DispatchFetch = (
 export type AnyHeaders = http.IncomingHttpHeaders | string[];
 
 /**
- * Buffers an ERROR_STACK `IncomingMessage` as bytes. Gzip is capped so a
- * compression bomb cannot fill memory; plain JSON is not, matching the
- * non-WebSocket path.
+ * Buffers an ERROR_STACK `IncomingMessage` as bytes. Gzip is capped at the
+ * inflate ceiling so a compression bomb cannot fill memory. Plain JSON uses a
+ * larger finite ceiling so a long stack survives and a plain 500 cannot grow
+ * without bound.
  */
 function bufferIncomingMessage(
-	incoming: http.IncomingMessage,
-	maxGzipBytes: number
+	incoming: http.IncomingMessage
 ): Promise<Buffer> {
 	return new Promise((resolve, reject) => {
 		const chunks: Buffer[] = [];
@@ -157,7 +161,9 @@ function bufferIncomingMessage(
 			if (gzip === undefined && total >= 2) {
 				gzip = isGzip(Buffer.concat(chunks, 2));
 			}
-			if (gzip === true && total > maxGzipBytes) {
+			const overGzip = gzip === true && total > MAX_ERROR_STACK_BYTES;
+			const overPlain = gzip === false && total > MAX_ERROR_STACK_PLAIN_BYTES;
+			if (overGzip || overPlain) {
 				incoming.destroy();
 				finish(Buffer.alloc(0));
 			}

--- a/packages/miniflare/src/http/fetch.ts
+++ b/packages/miniflare/src/http/fetch.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert";
+import { Readable } from "node:stream";
 import * as undici from "undici";
 import NodeWebSocket from "ws";
 import { CoreHeaders, DeferredPromise } from "../workers";
@@ -9,6 +10,7 @@ import { coupleWebSocket, WebSocketPair } from "./websocket";
 import type { RequestInfo, RequestInit } from "./request";
 import type { IncomingRequestCfProperties } from "@cloudflare/workers-types/experimental";
 import type http from "node:http";
+import type { BodyInit } from "undici";
 import type { UndiciHeaders } from "undici/types/dispatcher";
 
 const ignored = ["transfer-encoding", "connection", "keep-alive", "expect"];
@@ -76,15 +78,29 @@ export async function fetch(
 		});
 		ws.once("unexpected-response", (_, incoming) => {
 			const headers = convertUndiciHeadersToStandard(incoming.headers);
-			// Buffer the Node stream into bytes. Passing `IncomingMessage` to
-			// `Response` is not a valid `BodyInit`, and undici would decode it as
-			// text, destroying gzip ERROR_STACK bodies (#15198).
+			/**
+			 * Only ERROR_STACK 500s need a byte buffer: `IncomingMessage` is not a
+			 * valid `BodyInit`, and undici would decode gzip as text (#15198). Other
+			 * failed upgrades stream through so a large page is not capped or emptied.
+			 */
+			const isErrorStack =
+				incoming.statusCode === 500 &&
+				headers.get(CoreHeaders.ERROR_STACK) !== null;
+			if (!isErrorStack) {
+				responsePromise.resolve(
+					new Response(Readable.toWeb(incoming) as BodyInit, {
+						headers,
+						status: incoming.statusCode,
+					})
+				);
+				return;
+			}
 			void bufferIncomingMessage(incoming, MAX_ERROR_STACK_BYTES).then(
 				(body) => {
 					responsePromise.resolve(
 						new Response(body, {
-							status: incoming.statusCode,
 							headers,
+							status: incoming.statusCode,
 						})
 					);
 				},

--- a/packages/miniflare/src/http/fetch.ts
+++ b/packages/miniflare/src/http/fetch.ts
@@ -101,7 +101,12 @@ export async function fetch(
 				return;
 			}
 			void bufferIncomingMessage(incoming).then(
-				(body) => {
+				({ body, truncated }) => {
+					if (truncated) {
+						headers.delete("Content-Encoding");
+						headers.delete("Content-Length");
+						headers.set("Content-Length", "0");
+					}
 					responsePromise.resolve(
 						new Response(body, {
 							headers,
@@ -138,18 +143,18 @@ export type AnyHeaders = http.IncomingHttpHeaders | string[];
  */
 function bufferIncomingMessage(
 	incoming: http.IncomingMessage
-): Promise<Buffer> {
+): Promise<{ body: Buffer; truncated: boolean }> {
 	return new Promise((resolve, reject) => {
 		const chunks: Buffer[] = [];
 		let gzip: boolean | undefined;
 		let settled = false;
 		let total = 0;
-		const finish = (body: Buffer) => {
+		const finish = (body: Buffer, truncated = false) => {
 			if (settled) {
 				return;
 			}
 			settled = true;
-			resolve(body);
+			resolve({ body, truncated });
 		};
 		incoming.on("data", (chunk: Buffer | string) => {
 			if (settled) {
@@ -165,7 +170,7 @@ function bufferIncomingMessage(
 			const overPlain = gzip === false && total > MAX_ERROR_STACK_PLAIN_BYTES;
 			if (overGzip || overPlain) {
 				incoming.destroy();
-				finish(Buffer.alloc(0));
+				finish(Buffer.alloc(0), true);
 			}
 		});
 		incoming.on("end", () => finish(Buffer.concat(chunks)));

--- a/packages/miniflare/src/index.ts
+++ b/packages/miniflare/src/index.ts
@@ -33,6 +33,7 @@ import {
 	Request,
 	Response,
 } from "./http";
+import { readErrorStackBody } from "./http/error-stack";
 import {
 	D1_PLUGIN_NAME,
 	DURABLE_OBJECTS_PLUGIN_NAME,
@@ -110,7 +111,6 @@ import {
 	CacheHeaders,
 	CoreBindings,
 	CoreHeaders,
-	decodeErrorPayload,
 	LogLevel,
 	Mutex,
 	SharedHeaders,
@@ -2678,9 +2678,9 @@ export class Miniflare {
 		const stack = response.headers.get(CoreHeaders.ERROR_STACK);
 		if (response.status === 500 && stack !== null) {
 			// `workerd` drops response bodies for `HEAD` requests, so fall back to
-			// the header copy of the serialised error
-			const serialised =
-				(await response.text()) || decodeErrorPayload(response);
+			// the header copy of the serialised error. Failed WebSocket upgrades
+			// skip undici's decompressor, so a gzipped body is inflated first.
+			const serialised = await readErrorStackBody(response);
 			if (serialised === null) {
 				throw new Error("Worker threw an uncaught exception");
 			}

--- a/packages/miniflare/test/http/error-stack.spec.ts
+++ b/packages/miniflare/test/http/error-stack.spec.ts
@@ -1,0 +1,70 @@
+import zlib from "node:zlib";
+import { test } from "vitest";
+import { readErrorStackBody } from "../../src/http/error-stack";
+
+const ERROR_JSON = JSON.stringify({
+	message: "Unusual oops!",
+	name: "Error",
+});
+
+test("gunzips an ERROR_STACK body that was left compressed", async ({
+	expect,
+}) => {
+	const response = new Response(zlib.gzipSync(ERROR_JSON), {
+		headers: {
+			"Content-Encoding": "gzip",
+			"Content-Type": "application/json",
+		},
+		status: 500,
+	});
+	await expect(readErrorStackBody(response)).resolves.toBe(ERROR_JSON);
+});
+
+test("gunzips nested gzip ERROR_STACK bodies", async ({ expect }) => {
+	const response = new Response(zlib.gzipSync(zlib.gzipSync(ERROR_JSON)), {
+		headers: {
+			"Content-Encoding": "gzip",
+			"Content-Type": "application/json",
+		},
+		status: 500,
+	});
+	await expect(readErrorStackBody(response)).resolves.toBe(ERROR_JSON);
+});
+
+test("does not gunzip a decompressed body that still carries Content-Encoding", async ({
+	expect,
+}) => {
+	const response = new Response(ERROR_JSON, {
+		headers: {
+			"Content-Encoding": "gzip",
+			"Content-Type": "application/json",
+		},
+		status: 500,
+	});
+	await expect(readErrorStackBody(response)).resolves.toBe(ERROR_JSON);
+});
+
+test("falls back to the payload header when the body is empty", async ({
+	expect,
+}) => {
+	const response = new Response(null, {
+		headers: {
+			"MF-Experimental-Error-Stack-Payload": encodeURIComponent(ERROR_JSON),
+		},
+		status: 500,
+	});
+	await expect(readErrorStackBody(response)).resolves.toBe(ERROR_JSON);
+});
+
+test("falls back to the payload header when gzip data is corrupt", async ({
+	expect,
+}) => {
+	const response = new Response(Buffer.from([0x1f, 0x8b, 0x08, 0x00]), {
+		headers: {
+			"Content-Encoding": "gzip",
+			"MF-Experimental-Error-Stack-Payload": encodeURIComponent(ERROR_JSON),
+		},
+		status: 500,
+	});
+	await expect(readErrorStackBody(response)).resolves.toBe(ERROR_JSON);
+});

--- a/packages/miniflare/test/http/error-stack.spec.ts
+++ b/packages/miniflare/test/http/error-stack.spec.ts
@@ -89,6 +89,20 @@ test("falls back to the payload header when inflated gzip exceeds the size cap",
 	await expect(readErrorStackBody(response)).resolves.toBe(ERROR_JSON);
 });
 
+test("decodes an oversized plain ERROR_STACK body instead of dropping it", async ({
+	expect,
+}) => {
+	const huge = JSON.stringify({
+		message: "x".repeat(MAX_ERROR_STACK_BYTES),
+		name: "Error",
+	});
+	const response = new Response(huge, {
+		headers: { "Content-Type": "application/json" },
+		status: 500,
+	});
+	await expect(readErrorStackBody(response)).resolves.toBe(huge);
+});
+
 test("falls back to the payload header when gzip nesting exceeds the round cap", async ({
 	expect,
 }) => {

--- a/packages/miniflare/test/http/error-stack.spec.ts
+++ b/packages/miniflare/test/http/error-stack.spec.ts
@@ -103,6 +103,48 @@ test("decodes an oversized plain ERROR_STACK body instead of dropping it", async
 	await expect(readErrorStackBody(response)).resolves.toBe(huge);
 });
 
+test("inflates a brotli ERROR_STACK body that was left compressed", async ({
+	expect,
+}) => {
+	const response = new Response(zlib.brotliCompressSync(ERROR_JSON), {
+		headers: {
+			"Content-Encoding": "br",
+			"Content-Type": "application/json",
+		},
+		status: 500,
+	});
+	await expect(readErrorStackBody(response)).resolves.toBe(ERROR_JSON);
+});
+
+test("does not brotli-decompress a plain body that still carries Content-Encoding br", async ({
+	expect,
+}) => {
+	const response = new Response(ERROR_JSON, {
+		headers: {
+			"Content-Encoding": "br",
+			"Content-Type": "application/json",
+		},
+		status: 500,
+	});
+	await expect(readErrorStackBody(response)).resolves.toBe(ERROR_JSON);
+});
+
+test("falls back to the payload header when inflated brotli exceeds the size cap", async ({
+	expect,
+}) => {
+	const response = new Response(
+		zlib.brotliCompressSync("x".repeat(MAX_ERROR_STACK_BYTES + 1)),
+		{
+			headers: {
+				"Content-Encoding": "br",
+				"MF-Experimental-Error-Stack-Payload": encodeURIComponent(ERROR_JSON),
+			},
+			status: 500,
+		}
+	);
+	await expect(readErrorStackBody(response)).resolves.toBe(ERROR_JSON);
+});
+
 test("falls back to the payload header when gzip nesting exceeds the round cap", async ({
 	expect,
 }) => {

--- a/packages/miniflare/test/http/error-stack.spec.ts
+++ b/packages/miniflare/test/http/error-stack.spec.ts
@@ -1,6 +1,10 @@
 import zlib from "node:zlib";
 import { test } from "vitest";
-import { readErrorStackBody } from "../../src/http/error-stack";
+import {
+	MAX_ERROR_STACK_BYTES,
+	MAX_GZIP_ROUNDS,
+	readErrorStackBody,
+} from "../../src/http/error-stack";
 
 const ERROR_JSON = JSON.stringify({
 	message: "Unusual oops!",
@@ -60,6 +64,39 @@ test("falls back to the payload header when gzip data is corrupt", async ({
 	expect,
 }) => {
 	const response = new Response(Buffer.from([0x1f, 0x8b, 0x08, 0x00]), {
+		headers: {
+			"Content-Encoding": "gzip",
+			"MF-Experimental-Error-Stack-Payload": encodeURIComponent(ERROR_JSON),
+		},
+		status: 500,
+	});
+	await expect(readErrorStackBody(response)).resolves.toBe(ERROR_JSON);
+});
+
+test("falls back to the payload header when inflated gzip exceeds the size cap", async ({
+	expect,
+}) => {
+	const response = new Response(
+		zlib.gzipSync("x".repeat(MAX_ERROR_STACK_BYTES + 1)),
+		{
+			headers: {
+				"Content-Encoding": "gzip",
+				"MF-Experimental-Error-Stack-Payload": encodeURIComponent(ERROR_JSON),
+			},
+			status: 500,
+		}
+	);
+	await expect(readErrorStackBody(response)).resolves.toBe(ERROR_JSON);
+});
+
+test("falls back to the payload header when gzip nesting exceeds the round cap", async ({
+	expect,
+}) => {
+	let nested: Buffer = Buffer.from(ERROR_JSON);
+	for (let i = 0; i < MAX_GZIP_ROUNDS + 1; i++) {
+		nested = zlib.gzipSync(nested);
+	}
+	const response = new Response(nested, {
 		headers: {
 			"Content-Encoding": "gzip",
 			"MF-Experimental-Error-Stack-Payload": encodeURIComponent(ERROR_JSON),

--- a/packages/miniflare/test/http/error-stack.spec.ts
+++ b/packages/miniflare/test/http/error-stack.spec.ts
@@ -145,6 +145,19 @@ test("falls back to the payload header when inflated brotli exceeds the size cap
 	await expect(readErrorStackBody(response)).resolves.toBe(ERROR_JSON);
 });
 
+test("falls back to the payload header when an oversized non-JSON body is not gzip", async ({
+	expect,
+}) => {
+	const response = new Response(Buffer.alloc(MAX_ERROR_STACK_BYTES + 1, 0xff), {
+		headers: {
+			"Content-Encoding": "br",
+			"MF-Experimental-Error-Stack-Payload": encodeURIComponent(ERROR_JSON),
+		},
+		status: 500,
+	});
+	await expect(readErrorStackBody(response)).resolves.toBe(ERROR_JSON);
+});
+
 test("falls back to the payload header when gzip nesting exceeds the round cap", async ({
 	expect,
 }) => {

--- a/packages/miniflare/test/http/fetch.spec.ts
+++ b/packages/miniflare/test/http/fetch.spec.ts
@@ -4,7 +4,10 @@ import { URLSearchParams } from "node:url";
 import { DeferredPromise, fetch, FormData } from "miniflare";
 import { assert, onTestFinished, test } from "vitest";
 import { WebSocketServer } from "ws";
-import { MAX_ERROR_STACK_BYTES } from "../../src/http/error-stack";
+import {
+	MAX_ERROR_STACK_BYTES,
+	MAX_ERROR_STACK_PLAIN_BYTES,
+} from "../../src/http/error-stack";
 import { useServer } from "../test-shared";
 import type { CloseEvent, MessageEvent } from "miniflare";
 import type { AddressInfo } from "node:net";
@@ -267,4 +270,19 @@ test("fetch: preserves an oversized plain ERROR_STACK body on a failed WebSocket
 	const res = await fetch(server.http, { headers: { upgrade: "websocket" } });
 	expect(res.status).toBe(500);
 	expect(await res.text()).toBe(huge);
+});
+test("fetch: empties a plain ERROR_STACK body that exceeds the memory ceiling", async ({
+	expect,
+}) => {
+	const huge = Buffer.alloc(MAX_ERROR_STACK_PLAIN_BYTES + 1, 0x20);
+	const server = await useServer((_req, res) => {
+		res.writeHead(500, {
+			"Content-Type": "application/json",
+			"MF-Experimental-Error-Stack": "true",
+		});
+		res.end(huge);
+	});
+	const res = await fetch(server.http, { headers: { upgrade: "websocket" } });
+	expect(res.status).toBe(500);
+	expect((await res.arrayBuffer()).byteLength).toBe(0);
 });

--- a/packages/miniflare/test/http/fetch.spec.ts
+++ b/packages/miniflare/test/http/fetch.spec.ts
@@ -4,6 +4,7 @@ import { URLSearchParams } from "node:url";
 import { DeferredPromise, fetch, FormData } from "miniflare";
 import { assert, onTestFinished, test } from "vitest";
 import { WebSocketServer } from "ws";
+import { MAX_ERROR_STACK_BYTES } from "../../src/http/error-stack";
 import { useServer } from "../test-shared";
 import type { CloseEvent, MessageEvent } from "miniflare";
 import type { AddressInfo } from "node:net";
@@ -236,4 +237,16 @@ test("fetch: returns regular response if no WebSocket response returned", async 
 	expect(res.status).toBe(404);
 	expect(res.headers.get("Content-Type")).toBe("text/html");
 	expect(await res.text()).toBe("<p>Not Found</p>");
+});
+test("fetch: preserves a large non-error body on a failed WebSocket upgrade", async ({
+	expect,
+}) => {
+	const body = "x".repeat(MAX_ERROR_STACK_BYTES + 1);
+	const server = await useServer((_req, res) => {
+		res.writeHead(200, { "Content-Type": "text/plain" });
+		res.end(body);
+	});
+	const res = await fetch(server.http, { headers: { upgrade: "websocket" } });
+	expect(res.status).toBe(200);
+	expect(await res.text()).toBe(body);
 });

--- a/packages/miniflare/test/http/fetch.spec.ts
+++ b/packages/miniflare/test/http/fetch.spec.ts
@@ -250,3 +250,21 @@ test("fetch: preserves a large non-error body on a failed WebSocket upgrade", as
 	expect(res.status).toBe(200);
 	expect(await res.text()).toBe(body);
 });
+test("fetch: preserves an oversized plain ERROR_STACK body on a failed WebSocket upgrade", async ({
+	expect,
+}) => {
+	const huge = JSON.stringify({
+		message: "x".repeat(MAX_ERROR_STACK_BYTES),
+		name: "Error",
+	});
+	const server = await useServer((_req, res) => {
+		res.writeHead(500, {
+			"Content-Type": "application/json",
+			"MF-Experimental-Error-Stack": "true",
+		});
+		res.end(huge);
+	});
+	const res = await fetch(server.http, { headers: { upgrade: "websocket" } });
+	expect(res.status).toBe(500);
+	expect(await res.text()).toBe(huge);
+});

--- a/packages/miniflare/test/http/fetch.spec.ts
+++ b/packages/miniflare/test/http/fetch.spec.ts
@@ -285,4 +285,6 @@ test("fetch: empties a plain ERROR_STACK body that exceeds the memory ceiling", 
 	const res = await fetch(server.http, { headers: { upgrade: "websocket" } });
 	expect(res.status).toBe(500);
 	expect((await res.arrayBuffer()).byteLength).toBe(0);
+	expect(res.headers.get("Content-Length")).toBe("0");
+	expect(res.headers.get("Content-Encoding")).toBeNull();
 });

--- a/packages/miniflare/test/plugins/core/errors/index.spec.ts
+++ b/packages/miniflare/test/plugins/core/errors/index.spec.ts
@@ -639,6 +639,57 @@ test("rejects HEAD dispatchFetch with the user error, not a parse error", async 
 	).rejects.toThrow("Unusual oops!");
 });
 
+// Failed WebSocket upgrades skip undici's decompressor (`ws` unexpected-response).
+// A gzipped ERROR_STACK body with no payload header must still revive the Worker
+// error rather than throwing `JSON.parse` on gzip magic. See #15198.
+const GZIPPED_JSON_ERROR_SCRIPT = `
+export default {
+	async fetch() {
+		const body = JSON.stringify({ name: "Error", message: "Unusual oops!" });
+		const stream = new Blob([body]).stream().pipeThrough(
+			new CompressionStream("gzip")
+		);
+		return new Response(stream, {
+			status: 500,
+			headers: {
+				"Content-Type": "application/json",
+				"Content-Encoding": "gzip",
+				"MF-Experimental-Error-Stack": "true",
+			},
+		});
+	},
+}`;
+
+test("revives a gzipped ERROR_STACK body on WebSocket upgrade", async ({
+	expect,
+}) => {
+	const mf = new Miniflare({
+		workers: [
+			{
+				config: {
+					type: "worker",
+					name: "",
+					compatibilityDate: "2025-05-01",
+					manifest: singleModuleManifest(GZIPPED_JSON_ERROR_SCRIPT),
+				},
+			},
+		],
+	});
+	useDispose(mf);
+
+	await expect(
+		mf.dispatchFetch(await mf.ready, {
+			headers: {
+				"Accept-Encoding": "gzip",
+				Connection: "Upgrade",
+				"Sec-WebSocket-Key": "dGhlIHNhbXBsZSBub25jZQ==",
+				"Sec-WebSocket-Version": "13",
+				Upgrade: "websocket",
+			},
+		})
+	).rejects.toThrow("Unusual oops!");
+});
+
 // A stack too large to fit in a header is sent without the payload copy, so a
 // `HEAD` request has no way to recover it. Reporting must still degrade to a
 // plain error rather than leaking a JSON parse failure from miniflare.


### PR DESCRIPTION
Fixes #15198.

When a Worker throws on a WebSocket upgrade, workerd can return the ERROR_STACK 500 with `Content-Encoding: gzip`. That path used `ws` `unexpected-response` and passed Node's `IncomingMessage` to `Response`, which is not a valid `BodyInit`. undici decoded the gzip as text, then `JSON.parse` saw gzip magic (`1f 8b`) and threw `SyntaxError` instead of the Worker exception.

`dispatchFetch` now:

- Buffers the unexpected-response body as bytes
- Inflates gzip (detected by magic bytes, not the `Content-Encoding` header, which undici may leave on an already-decompressed body), including nested gzip when workerd wraps a body the Worker already compressed
- Still falls back to the payload header for empty `HEAD` bodies

Related: #15199 (stop forwarding `Accept-Encoding` on the vite-plugin upgrade), https://github.com/cloudflare/vinext/issues/2921.

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: this restores existing `dispatchFetch` error revival; no user-facing API change.
<!-- devin-review-badge-begin -->

---

<a href="https://cloudflare.devinenterprise.com/review/cloudflare/workers-sdk/pull/15200" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->