### PR TITLE
[vite-plugin] Drop Accept-Encoding on Worker WebSocket upgrades

### DIFF
--- a/.changeset/vite-plugin-ws-drop-accept-encoding.md
+++ b/.changeset/vite-plugin-ws-drop-accept-encoding.md
@@ -4,6 +4,4 @@
 
 Stop forwarding `Accept-Encoding` on Worker WebSocket upgrades in `vite dev`
 
-The upgrade handler copied every browser header onto the synthetic `dispatchFetch`, including `Accept-Encoding: gzip`. A Worker throw then came back as a gzipped ERROR_STACK 500, which miniflare parsed as JSON and rejected. On 1.43.0 that rejection was unhandled and killed the process; on current main it is caught and the socket is destroyed, so the Worker error is still lost.
-
-A 101 has no body, so the content-coding header is dropped before the upgrade is forwarded. Pair with the miniflare gzip ERROR_STACK fix.
+Previously, when a Worker threw an error while handling a WebSocket upgrade during `vite dev`, the underlying error was lost (and on older versions the dev server could exit). Worker errors on WebSocket upgrades are now surfaced correctly.

--- a/.changeset/vite-plugin-ws-drop-accept-encoding.md
+++ b/.changeset/vite-plugin-ws-drop-accept-encoding.md
@@ -1,0 +1,9 @@
+---
+"@cloudflare/vite-plugin": patch
+---
+
+Stop forwarding `Accept-Encoding` on Worker WebSocket upgrades in `vite dev`
+
+The upgrade handler copied every browser header onto the synthetic `dispatchFetch`, including `Accept-Encoding: gzip`. A Worker throw then came back as a gzipped ERROR_STACK 500, which miniflare parsed as JSON and rejected. On 1.43.0 that rejection was unhandled and killed the process; on current main it is caught and the socket is destroyed, so the Worker error is still lost.
+
+A 101 has no body, so the content-coding header is dropped before the upgrade is forwarded. Pair with the miniflare gzip ERROR_STACK fix.

--- a/packages/vite-plugin-cloudflare/src/__tests__/websockets.spec.ts
+++ b/packages/vite-plugin-cloudflare/src/__tests__/websockets.spec.ts
@@ -178,6 +178,41 @@ describe("handleWebSocket", () => {
 		expect(init.headers.get("sec-websocket-version")).toBe("13");
 	});
 
+	test("does not forward Accept-Encoding on the upgrade dispatchFetch", async ({
+		expect,
+	}) => {
+		const mf = await listen();
+
+		const deferred = new DeferredPromise<Response>();
+		const mockedDispatchFetch = vi
+			.spyOn(mf, "dispatchFetch")
+			.mockReturnValue(deferred);
+
+		const socket = await connect();
+		socket.write(
+			"GET / HTTP/1.1\r\n" +
+				`Host: 127.0.0.1:${port}\r\n` +
+				"Upgrade: websocket\r\n" +
+				"Connection: Upgrade\r\n" +
+				"Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n" +
+				"Sec-WebSocket-Version: 13\r\n" +
+				"Accept-Encoding: gzip, deflate, br, zstd\r\n\r\n"
+		);
+
+		await vi.waitFor(() => expect(mf.dispatchFetch).toHaveBeenCalled());
+		deferred.resolve(new Response(null));
+		socket.destroy();
+
+		assert(mockedDispatchFetch.mock.lastCall);
+		const init = mockedDispatchFetch.mock.lastCall[1];
+		assert(
+			init?.headers instanceof Headers,
+			"Test expects headers object passed to dispatchFetch to be Headers instance"
+		);
+		expect(init.headers.get("accept-encoding")).toBeNull();
+		expect(init.headers.get("upgrade")).toBe("websocket");
+	});
+
 	/**
 	 * Performs a websocket upgrade with the given headers and returns the URL
 	 * that was dispatched to miniflare.

--- a/packages/vite-plugin-cloudflare/src/websockets.ts
+++ b/packages/vite-plugin-cloudflare/src/websockets.ts
@@ -66,6 +66,10 @@ export function handleWebSocket(
 				}
 
 				const headers = createHeaders(request);
+				// A 101 has no body. Forwarding the browser's `Accept-Encoding`
+				// makes workerd gzip ERROR_STACK 500s; miniflare's WebSocket
+				// upgrade path then JSON.parses the compressed bytes (#15198, #15199).
+				headers.delete("Accept-Encoding");
 
 				if (entryWorkerName) {
 					headers.set(CoreHeaders.ROUTE_OVERRIDE, entryWorkerName);


### PR DESCRIPTION
Fixes #15199.

`handleWebSocket` copied every browser header onto the synthetic `dispatchFetch`, including `Accept-Encoding: gzip`. A Worker throw then came back as a gzipped ERROR_STACK 500. On vite-plugin 1.43.0 that rejection was unhandled and killed the process; on current main #14862 catches it and destroys the socket, so the process lives but the Worker error is still lost.

A 101 has no body, so `Accept-Encoding` is dropped before the upgrade is forwarded.

The parse itself is fixed in miniflare (#15198). Non-101 upgrade responses are still destroyed; that remains #15170.

Related: #15198, #15170, https://github.com/cloudflare/vinext/issues/2921.

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: this is a dev-server header handling fix with no user-facing API change.