### PR TITLE
[miniflare] Recover from a partially downloaded Chrome install

### DIFF
--- a/.changeset/browser-rendering-partial-chrome-install.md
+++ b/.changeset/browser-rendering-partial-chrome-install.md
@@ -1,0 +1,9 @@
+---
+"miniflare": patch
+---
+
+Recover automatically from a partially downloaded Chrome install for the Browser Run binding
+
+If the Chrome download for a `browser` binding was interrupted — a cancelled dev session, a killed test run, a machine going to sleep — the next launch could fail indefinitely with `Failed to launch the browser process!`, usually alongside a message about being unable to load `resources.pak`. `@puppeteer/browsers` treats an install as present as soon as the executable exists, and the Chrome archives extract alphabetically, so the executable is written long before the resources it needs. Every subsequent launch then reused the half-written directory, and the only way out was deleting the Chrome cache by hand.
+
+Miniflare now detects this: an install that Chrome has never successfully started from is cleared and re-downloaded on a failed launch, rather than reused forever. Overlapping launches also share a single download instead of racing to populate the same directory.

--- a/.github/workflows/test-and-check-other-node.yml
+++ b/.github/workflows/test-and-check-other-node.yml
@@ -82,9 +82,16 @@ jobs:
       # @puppeteer/browsers at runtime. Caching the binary avoids repeat
       # downloads and reduces the chance of tests hanging while waiting for
       # the download to finish within their timeout window.
+      #
+      # Restore only, deliberately. This shares its key with `test-and-check.yml`,
+      # which saves the cache only once a `.miniflare-install-complete` marker
+      # proves Chrome actually launched from the install. Cache keys are
+      # write-once, so saving here too would let this workflow publish an
+      # unvalidated — possibly half-extracted — Chrome that the validated save
+      # could then never replace.
       - name: Restore Chrome browser cache (Browser Run)
         if: steps.should_run.outputs.result == 'true'
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           key: chrome-${{ runner.os }}-${{ hashFiles('packages/miniflare/src/plugins/browser-rendering/browser-version.ts') }}
           path: |

--- a/.github/workflows/test-and-check.yml
+++ b/.github/workflows/test-and-check.yml
@@ -134,18 +134,24 @@ jobs:
       # Browser Run tests in `packages/miniflare/test/plugins/browser/index.spec.ts`
       # and the `fixtures/browser-run` fixture use `@puppeteer/browsers` to
       # download Chrome into the global Wrangler cache. Caching that binary
-      # across CI runs avoids ~150 MB of repeat downloads per run and reduces
-      # the surface area for the intermittent partial-extraction race that
-      # surfaces as `The browser folder (...) exists but the executable (...)
-      # is missing` (see #13971, #13980).
+      # across CI runs avoids ~150 MB of repeat downloads per run.
+      #
+      # Note this is `cache/restore` paired with an explicit `cache/save`
+      # below, not plain `cache`: `actions/cache` saves from a post step
+      # declaring `post-if: success()`, so a job that fails for *any* reason
+      # never saves. Combined with this workflow only running on
+      # `pull_request`/`merge_group` — so nothing is ever written to
+      # `refs/heads/main`, the one ref every PR can restore from — that left
+      # Windows re-downloading Chrome on every single run.
       #
       # The Browser Run fixture is skipped on Ubuntu (AppArmor), but the
       # miniflare browser spec runs everywhere, so the cache is needed on all
       # three OSes for `packages-and-tools` and on Windows + macOS for
       # `fixtures`.
       - name: Restore Chrome browser cache (Browser Run)
+        id: chrome-cache
         if: steps.changes.outputs.everything_but_markdown == 'true' && (matrix.suite == 'packages-and-tools' || (matrix.suite == 'fixtures' && matrix.os != 'ubuntu-latest'))
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           # The Chrome version lives in
           # `packages/miniflare/src/plugins/browser-rendering/browser-version.ts`.
@@ -193,6 +199,40 @@ jobs:
           WRANGLER_LOG_PATH: ${{ runner.temp }}/wrangler-debug-logs/
           TEST_REPORT_PATH: ${{ runner.temp }}/test-report/index.html
           CI_OS: ${{ matrix.description }}
+
+      # Only cache an install that Miniflare marked as complete. Without this
+      # check a job interrupted mid-download would publish a half-extracted
+      # Chrome under the cache key, which — because `@puppeteer/browsers`
+      # considers an install present as soon as the executable exists — every
+      # later run would restore and fail to launch.
+      - name: Check for a complete Chrome install
+        id: chrome-complete
+        if: always() && steps.chrome-cache.outcome == 'success' && steps.chrome-cache.outputs.cache-hit != 'true'
+        shell: bash
+        run: |
+          for dir in "$HOME/.cache/.wrangler/chrome" \
+                     "$HOME/Library/Caches/.wrangler/chrome" \
+                     "$HOME/AppData/Local/xdg.cache/.wrangler/chrome"; do
+            if [ -d "$dir" ] && [ -n "$(find "$dir" -name .miniflare-install-complete -print -quit)" ]; then
+              echo "Found a complete Chrome install under $dir"
+              echo "complete=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          done
+          echo "No complete Chrome install found; skipping cache save"
+          echo "complete=false" >> "$GITHUB_OUTPUT"
+
+      # Saved here rather than in a post step so that an unrelated test failure
+      # elsewhere in the job doesn't stop Chrome from being cached.
+      - name: Save Chrome browser cache (Browser Run)
+        if: always() && steps.chrome-complete.outputs.complete == 'true'
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          key: chrome-${{ runner.os }}-${{ hashFiles('packages/miniflare/src/plugins/browser-rendering/browser-version.ts') }}
+          path: |
+            ~/.cache/.wrangler/chrome
+            ~/Library/Caches/.wrangler/chrome
+            ~/AppData/Local/xdg.cache/.wrangler/chrome
 
       - name: Upload turbo logs
         if: always()

--- a/packages/miniflare/src/plugins/browser-rendering/index.ts
+++ b/packages/miniflare/src/plugins/browser-rendering/index.ts
@@ -15,12 +15,7 @@ import {
 	remoteProxyClientWorker,
 	WORKER_BINDING_SERVICE_LOOPBACK,
 } from "../shared";
-import {
-	discardIncompleteInstall,
-	ensureBrowserInstalled,
-	getInstallGeneration,
-	markInstallVerified,
-} from "./install";
+import { ensureBrowserInstalled } from "./install";
 import { BrowserStartupError, waitForExit } from "./process";
 import type { Service } from "../../runtime";
 import type { Log } from "../../shared";
@@ -162,8 +157,10 @@ export async function launchBrowser({
 		}
 	};
 
-	let { executablePath, installDir } = await install();
-	log.debug(`Chrome ${browserVersion} available at ${executablePath}`);
+	let installed = await install();
+	log.debug(
+		`Chrome ${browserVersion} available at ${installed.executablePath}`
+	);
 
 	// https://github.com/puppeteer/puppeteer/blob/44516936ad4a878f9a89e835a9fa7b04360d6fb9/packages/puppeteer-core/src/node/ChromeLauncher.ts#L156
 	const disabledFeatures = [
@@ -230,7 +227,7 @@ export async function launchBrowser({
 
 		const launchArgs = [...args, `--user-data-dir=${tempUserData}`];
 		const browserProcess = launch({
-			executablePath,
+			executablePath: installed.executablePath,
 			args: process.env.CI ? [...launchArgs, "--no-sandbox"] : launchArgs,
 			handleSIGTERM: false,
 			dumpio: false,
@@ -278,10 +275,6 @@ export async function launchBrowser({
 		}
 	};
 
-	// Taken before launching, so that if a concurrent launch discards and
-	// replaces this installation while we are failing, we can tell.
-	const generation = getInstallGeneration(installDir);
-
 	let launched: Awaited<ReturnType<typeof launchOnce>>;
 	try {
 		launched = await launchOnce();
@@ -300,30 +293,28 @@ export async function launchBrowser({
 		if (!(e instanceof BrowserStartupError)) {
 			throw e;
 		}
-		const discarded = await discardIncompleteInstall(
-			installDir,
-			generation,
-			log
-		);
-		if (!discarded.cleared && discarded.reason !== "superseded") {
+		const discarded = await installed.discard();
+		if (discarded.outcome === "cleanup-failed") {
 			// Miniflare logs to a no-op by default, so anything worth knowing
 			// has to travel on the error itself.
-			if (discarded.reason === "cleanup-failed") {
-				throw new Error(
-					`Chrome failed to launch from ${installDir}, and the directory could not be removed to re-download it. Delete it manually and try again.`,
-					{ cause: discarded.cause }
-				);
-			}
+			throw new Error(
+				`Chrome failed to launch from ${installed.installDir}, and the directory could not be removed to re-download it. Delete it manually and try again.`,
+				{ cause: discarded.cause }
+			);
+		}
+		if (discarded.outcome === "verified") {
 			throw e;
 		}
+		// Either we cleared the install or a concurrent launch replaced it;
+		// either way there is a fresh one to try.
 		log.debug(`Retrying Chrome launch after re-installing: ${e}`);
-		({ executablePath, installDir } = await install());
+		installed = await install();
 		launched = await launchOnce();
 	}
 
 	// Chrome started, so this install is known-good. Recording that is what
 	// lets a *future* launch failure be attributed to a bad download.
-	await markInstallVerified(installDir, log);
+	await installed.markVerified();
 
 	const startTime = Date.now();
 	return {

--- a/packages/miniflare/src/plugins/browser-rendering/index.ts
+++ b/packages/miniflare/src/plugins/browser-rendering/index.ts
@@ -2,18 +2,8 @@ import fs from "node:fs";
 import path from "node:path";
 import { brandColor, dim, red } from "@cloudflare/cli-shared-helpers/colors";
 import { spinner } from "@cloudflare/cli-shared-helpers/interactive";
-import {
-	getGlobalWranglerCachePath,
-	removeDir,
-} from "@cloudflare/workers-utils";
-import {
-	Browser,
-	CDP_WEBSOCKET_ENDPOINT_REGEX,
-	detectBrowserPlatform,
-	install,
-	launch,
-	resolveBuildId,
-} from "@puppeteer/browsers";
+import { removeDir } from "@cloudflare/workers-utils";
+import { CDP_WEBSOCKET_ENDPOINT_REGEX, launch } from "@puppeteer/browsers";
 import BROWSER_RENDERING_WORKER from "worker:browser-rendering/binding";
 import { kVoid } from "../../runtime";
 import {
@@ -25,10 +15,16 @@ import {
 	remoteProxyClientWorker,
 	WORKER_BINDING_SERVICE_LOOPBACK,
 } from "../shared";
+import {
+	discardIncompleteInstall,
+	ensureBrowserInstalled,
+	getInstallGeneration,
+	markInstallVerified,
+} from "./install";
+import { BrowserStartupError, waitForExit } from "./process";
 import type { Service } from "../../runtime";
 import type { Log } from "../../shared";
 import type { Plugin } from "../shared";
-import type { InstalledBrowser, InstallOptions } from "@puppeteer/browsers";
 
 export const BROWSER_RENDERING_PLUGIN_NAME = "browser-rendering";
 const BROWSER_RENDERING_REMOTE_SERVICE_NAME = `${BROWSER_RENDERING_PLUGIN_NAME}:remote`;
@@ -133,55 +129,41 @@ export async function launchBrowser({
 	log: Log;
 	tmpPath: string;
 }) {
-	const platform = detectBrowserPlatform();
-	if (!platform) {
-		throw new Error("The current platform is not supported.");
-	}
-	const browser = Browser.CHROME;
 	const sessionId = crypto.randomUUID();
 
 	const s = spinner();
 	let startedDownloading = false;
 
-	const installOptions = {
-		browser,
-		platform,
-		cacheDir: getGlobalWranglerCachePath(),
-		buildId: await resolveBuildId(browser, platform, browserVersion),
-		downloadProgressCallback: (downloadedBytes: number, totalBytes: number) => {
-			if (!startedDownloading) {
-				s.start(`Downloading browser...`);
-				startedDownloading = true;
+	const install = async () => {
+		try {
+			return await ensureBrowserInstalled({
+				browserVersion,
+				log,
+				onProgress: (downloadedBytes, totalBytes) => {
+					if (!startedDownloading) {
+						s.start(`Downloading browser...`);
+						startedDownloading = true;
+					}
+					const progress = Math.round((downloadedBytes / totalBytes) * 100);
+					s.update(`Downloading browser... ${progress}%`);
+				},
+			});
+		} catch (e) {
+			if (startedDownloading) {
+				s.stop(`${red("failed")} ${dim(`browser download`)}`);
+				startedDownloading = false;
 			}
-			const progress = Math.round((downloadedBytes / totalBytes) * 100);
-			s.update(`Downloading browser... ${progress}%`);
-		},
+			throw e;
+		} finally {
+			if (startedDownloading) {
+				s.stop(`${brandColor("downloaded")} ${dim(`browser`)}`);
+				startedDownloading = false;
+			}
+		}
 	};
 
-	let executablePath: string;
-	try {
-		({ executablePath } = await installWithCorruptedCacheRecovery(
-			installOptions,
-			log
-		));
-	} catch (e) {
-		if (startedDownloading) {
-			s.stop(`${red("failed")} ${dim(`browser download`)}`);
-		}
-		throw e;
-	}
-
-	if (startedDownloading) {
-		s.stop(`${brandColor("downloaded")} ${dim(`browser`)}`);
-		log.debug(`${browser} ${browserVersion} available at ${executablePath}`);
-	}
-
-	const tempUserData = path.join(
-		tmpPath,
-		"browser-rendering",
-		`profile-${sessionId}`
-	);
-	await fs.promises.mkdir(tempUserData, { recursive: true });
+	let { executablePath, installDir } = await install();
+	log.debug(`Chrome ${browserVersion} available at ${executablePath}`);
 
 	// https://github.com/puppeteer/puppeteer/blob/44516936ad4a878f9a89e835a9fa7b04360d6fb9/packages/puppeteer-core/src/node/ChromeLauncher.ts#L156
 	const disabledFeatures = [
@@ -225,98 +207,131 @@ export async function launchBrowser({
 		"--disable-extensions",
 		"about:blank",
 		"--remote-debugging-port=0",
-		`--user-data-dir=${tempUserData}`,
 	];
 
-	const browserProcess = launch({
-		executablePath,
-		args: process.env.CI ? [...args, "--no-sandbox"] : args,
-		handleSIGTERM: false,
-		dumpio: false,
-		pipe: false,
-		onExit: async () => {
+	// Each attempt gets its own profile directory. `@puppeteer/browsers` fires
+	// `onExit` without awaiting it, and `waitForExit` only waits for the process
+	// to go, not for that cleanup — so a retry sharing the path could have its
+	// freshly written profile deleted by the previous attempt's `removeDir`.
+	let attempt = 0;
+
+	const launchOnce = async () => {
+		const tempUserData = path.join(
+			tmpPath,
+			"browser-rendering",
+			`profile-${sessionId}-${attempt++}`
+		);
+		await fs.promises.mkdir(tempUserData, { recursive: true });
+
+		// Whether Chrome got far enough to announce its DevTools endpoint, which
+		// is the line between "this install might be broken" and "something else
+		// went wrong". See `BrowserStartupError`.
+		let started = false;
+
+		const launchArgs = [...args, `--user-data-dir=${tempUserData}`];
+		const browserProcess = launch({
+			executablePath,
+			args: process.env.CI ? [...launchArgs, "--no-sandbox"] : launchArgs,
+			handleSIGTERM: false,
+			dumpio: false,
+			pipe: false,
+			onExit: async () => {
+				try {
+					await removeDir(tempUserData);
+				} catch (e) {
+					log.debug(`Unable to remove Chrome user data directory: ${e}`);
+				}
+			},
+		});
+		try {
+			const wsEndpoint = await browserProcess.waitForLineOutput(
+				CDP_WEBSOCKET_ENDPOINT_REGEX,
+				// Note: we pass an explicit timeout so the promise rejects instead of hanging forever
+				//       when Chrome fails to start or crashes before printing the DevTools URL.
+				//       Five minutes is generous enough to cover on-demand browser downloads on slow
+				//       connections while still failing within a reasonable window.
+				5 * 60 * 1_000
+			);
+			// Chrome announced itself, so it is running and its resources loaded.
+			started = true;
+			// On Windows in particular, Chrome may print the DevTools URL slightly
+			// before its listening socket is fully ready to accept connections.
+			// Probe the HTTP /json/version endpoint (served on the same port as the
+			// WS endpoint) with retry/backoff before declaring the browser ready, so
+			// that subsequent fetches from workerd don't race the OS and surface as
+			// `ConnectEx (#1225) connection refused` errors.
+			await waitForBrowserReady(wsEndpoint, log);
+			return { browserProcess, wsEndpoint };
+		} catch (e) {
+			// Leave nothing behind for the retry (or the caller) to trip over.
 			try {
-				await removeDir(tempUserData);
-			} catch (e) {
-				log.debug(`Unable to remove Chrome user data directory: ${e}`);
+				browserProcess.kill();
+			} catch {
+				// Already gone — which is the common case here, since Chrome
+				// exiting early is what makes `waitForLineOutput` reject.
 			}
-		},
-	});
-	const wsEndpoint = await browserProcess.waitForLineOutput(
-		CDP_WEBSOCKET_ENDPOINT_REGEX,
-		// Note: we pass an explicit timeout so the promise rejects instead of hanging forever
-		//       when Chrome fails to start or crashes before printing the DevTools URL.
-		//       Five minutes is generous enough to cover on-demand browser downloads on slow
-		//       connections while still failing within a reasonable window.
-		5 * 60 * 1_000
-	);
-	// On Windows in particular, Chrome may print the DevTools URL slightly
-	// before its listening socket is fully ready to accept connections.
-	// Probe the HTTP /json/version endpoint (served on the same port as the
-	// WS endpoint) with retry/backoff before declaring the browser ready, so
-	// that subsequent fetches from workerd don't race the OS and surface as
-	// `ConnectEx (#1225) connection refused` errors.
-	await waitForBrowserReady(wsEndpoint, log);
-	const startTime = Date.now();
-	return { sessionId, browserProcess, startTime, wsEndpoint };
-}
+			// Wait for it to actually go. On Windows a dying Chrome keeps
+			// handles open on files inside the install directory, which makes
+			// clearing a bad install fail.
+			await waitForExit(browserProcess);
+			throw started ? e : new BrowserStartupError(e);
+		}
+	};
 
-/**
- * Regex matching the `@puppeteer/browsers` error thrown when its cache
- * directory exists but the executable inside it is missing — typically
- * because a previous `install()` was interrupted mid-extraction (test
- * timeout, process kill) or because an external agent (Windows Defender,
- * antivirus, disk cleanup) removed the executable from a previously-good
- * install.
- *
- * @puppeteer/browsers source:
- * https://github.com/puppeteer/puppeteer/blob/main/packages/browsers/src/install.ts
- */
-const CORRUPTED_CACHE_ERROR_PATTERN =
-	/The browser folder \((.+?)\) exists but the executable .+? is missing/;
+	// Taken before launching, so that if a concurrent launch discards and
+	// replaces this installation while we are failing, we can tell.
+	const generation = getInstallGeneration(installDir);
 
-/**
- * Run `@puppeteer/browsers` `install()`, but if it fails with the
- * "folder exists but executable is missing" error, clear the corrupted
- * cache directory and retry once.
- *
- * Recovers from a known intermittent failure on CI runners (especially
- * Windows) where the cache state can become partially populated and stay
- * that way for the rest of the run, breaking every subsequent test until
- * the runner is recycled.
- */
-async function installWithCorruptedCacheRecovery(
-	installOptions: InstallOptions & { unpack?: true },
-	log: Log
-): Promise<InstalledBrowser> {
+	let launched: Awaited<ReturnType<typeof launchOnce>>;
 	try {
-		return await install(installOptions);
+		launched = await launchOnce();
 	} catch (e) {
-		const match = (e as Error)?.message?.match(CORRUPTED_CACHE_ERROR_PATTERN);
-		if (!match) {
+		// A Chrome that never starts may be a Chrome that was never fully
+		// downloaded: `@puppeteer/browsers` considers an install present once
+		// the directory and executable exist, but the Chrome-for-Testing
+		// archives extract alphabetically, so an interrupted install leaves
+		// `chrome.exe` in place while `resources.pak` and friends are still
+		// missing. Clear such an install and try once more, rather than
+		// failing every launch until the cache is manually deleted.
+		//
+		// Anything that fails once Chrome is up is out of scope: it has already
+		// loaded the resources a partial download would lack, so deleting it
+		// would cost a needless re-download without fixing anything.
+		if (!(e instanceof BrowserStartupError)) {
 			throw e;
 		}
-		const corruptedPath = match[1];
-		log.warn(
-			`Detected corrupted Chrome cache at ${corruptedPath}; clearing and retrying install.`
+		const discarded = await discardIncompleteInstall(
+			installDir,
+			generation,
+			log
 		);
-		try {
-			await removeDir(corruptedPath);
-		} catch (cleanupError) {
-			throw new Error(
-				`Failed to clear corrupted Chrome cache at ${corruptedPath} after detecting "${(e as Error).message}". Manual cleanup may be required.`,
-				{ cause: cleanupError }
-			);
+		if (!discarded.cleared && discarded.reason !== "superseded") {
+			// Miniflare logs to a no-op by default, so anything worth knowing
+			// has to travel on the error itself.
+			if (discarded.reason === "cleanup-failed") {
+				throw new Error(
+					`Chrome failed to launch from ${installDir}, and the directory could not be removed to re-download it. Delete it manually and try again.`,
+					{ cause: discarded.cause }
+				);
+			}
+			throw e;
 		}
-		try {
-			return await install(installOptions);
-		} catch (retryError) {
-			throw new Error(
-				`Chrome install failed after clearing corrupted cache at ${corruptedPath}: ${(retryError as Error).message}`,
-				{ cause: retryError }
-			);
-		}
+		log.debug(`Retrying Chrome launch after re-installing: ${e}`);
+		({ executablePath, installDir } = await install());
+		launched = await launchOnce();
 	}
+
+	// Chrome started, so this install is known-good. Recording that is what
+	// lets a *future* launch failure be attributed to a bad download.
+	await markInstallVerified(installDir, log);
+
+	const startTime = Date.now();
+	return {
+		sessionId,
+		browserProcess: launched.browserProcess,
+		startTime,
+		wsEndpoint: launched.wsEndpoint,
+	};
 }
 
 /**

--- a/packages/miniflare/src/plugins/browser-rendering/index.ts
+++ b/packages/miniflare/src/plugins/browser-rendering/index.ts
@@ -295,10 +295,12 @@ export async function launchBrowser({
 		}
 		const discarded = await installed.discard();
 		if (discarded.outcome === "cleanup-failed") {
-			// Miniflare logs to a no-op by default, so anything worth knowing
-			// has to travel on the error itself.
+			// Miniflare logs to a no-op by default and the loopback sends only
+			// an error's `stack`, so both halves of the story have to be in the
+			// message: what stopped Chrome starting, and what stopped us
+			// clearing the install it failed from.
 			throw new Error(
-				`Chrome failed to launch from ${installed.installDir}, and the directory could not be removed to re-download it. Delete it manually and try again.`,
+				`Chrome failed to launch from ${installed.installDir}, and the directory could not be removed to re-download it (${discarded.cause}). Delete it manually and try again. Chrome failed with: ${e.message}`,
 				{ cause: discarded.cause }
 			);
 		}

--- a/packages/miniflare/src/plugins/browser-rendering/install.ts
+++ b/packages/miniflare/src/plugins/browser-rendering/install.ts
@@ -10,19 +10,10 @@ import {
 	install,
 	resolveBuildId,
 } from "@puppeteer/browsers";
+import type { Log } from "../../shared";
 import type { InstalledBrowser, InstallOptions } from "@puppeteer/browsers";
 
-/**
- * The subset of Miniflare's `Log` used while installing Chrome.
- *
- * Kept structural rather than importing `Log` so that this module can be
- * loaded standalone (e.g. by `scripts/install-browser.ts` under
- * `esbuild-register`) without pulling in the rest of Miniflare.
- */
-export interface InstallLog {
-	warn(message: string): void;
-	debug(message: string): void;
-}
+type InstallLog = Pick<Log, "warn" | "debug">;
 
 /**
  * Marker written into a Chrome installation directory once Chrome has
@@ -67,16 +58,16 @@ const installs = {
 	inFlight: new Map<string, Promise<InstalledBrowser>>(),
 
 	/**
-	 * Installations Chrome has launched from during this process.
+	 * Installation directories Chrome has launched from during this process.
 	 *
-	 * Recorded synchronously on a successful launch, ahead of the on-disk
-	 * marker, which is written asynchronously and best-effort. Launches run
-	 * concurrently — one per session acquire — so without this there is a window
-	 * in which one session has a working Chrome running while another, having
-	 * just failed, still sees no marker and would delete the directory out from
-	 * under it.
+	 * A directory is added synchronously on a successful launch, ahead of the
+	 * on-disk marker, which is written asynchronously and best-effort. Launches
+	 * run concurrently — one per session acquire — so without this there is a
+	 * window in which one session has a working Chrome running while another,
+	 * having just failed, still sees no marker and would delete the directory
+	 * out from under it.
 	 */
-	verified: new Set<string>(),
+	verifiedDirs: new Set<string>(),
 
 	/**
 	 * Bumped whenever an installation is discarded, so that concurrent launches
@@ -105,26 +96,40 @@ function withInstallLock<T>(
 }
 
 /**
- * Token identifying the state of an installation at the point a launch began.
- *
- * Pass to {@link discardIncompleteInstall} so it can refuse to delete an
+ * Token identifying the state of an installation at the point a launch began,
+ * so that {@link discardIncompleteInstall} can refuse to delete an
  * installation that has already been replaced since.
  */
-export function getInstallGeneration(installDir: string): number {
+function getInstallGeneration(installDir: string): number {
 	return installs.generations.get(installDir) ?? 0;
 }
 
-export interface EnsureBrowserInstalledOptions {
-	browserVersion: string;
-	log: InstallLog;
-	/** Invoked as the archive downloads. Not called when already installed. */
-	onProgress?: (downloadedBytes: number, totalBytes: number) => void;
-}
-
-export interface EnsuredBrowser {
+/**
+ * A resolved Chrome installation, and the two things a caller can report back
+ * about it once it has tried to launch.
+ *
+ * Both are methods on the installation rather than free functions because
+ * they need the generation of the directory *this* caller was handed, which
+ * has to be captured before the launch it is reporting on. See
+ * {@link discardIncompleteInstall}.
+ */
+interface BrowserInstall {
 	executablePath: string;
 	/** Absolute path of the versioned installation directory. */
 	installDir: string;
+	/**
+	 * Record that Chrome launched successfully from this installation, so that
+	 * a later launch failure can be told apart from a broken download.
+	 *
+	 * Best-effort: losing the marker only costs a re-download in the unlikely
+	 * event that Chrome stops starting.
+	 */
+	markVerified(): Promise<void>;
+	/**
+	 * Clear this installation because Chrome failed to start from it, unless
+	 * there is positive evidence that it is fine.
+	 */
+	discard(): Promise<DiscardResult>;
 }
 
 /**
@@ -137,7 +142,12 @@ export async function ensureBrowserInstalled({
 	browserVersion,
 	log,
 	onProgress,
-}: EnsureBrowserInstalledOptions): Promise<EnsuredBrowser> {
+}: {
+	browserVersion: string;
+	log: InstallLog;
+	/** Invoked as the archive downloads. Not called when already installed. */
+	onProgress?: (downloadedBytes: number, totalBytes: number) => void;
+}): Promise<BrowserInstall> {
 	const platform = detectBrowserPlatform();
 	if (!platform) {
 		throw new Error("The current platform is not supported.");
@@ -160,8 +170,7 @@ export async function ensureBrowserInstalled({
 	const existing = installs.inFlight.get(installDir);
 	if (existing) {
 		log.debug(`Waiting for an in-progress Chrome install at ${installDir}`);
-		const installed = await existing;
-		return { executablePath: installed.executablePath, installDir };
+		return toBrowserInstall(await existing, installDir, log);
 	}
 
 	const pending = installWithCorruptedCacheRecovery(
@@ -172,8 +181,24 @@ export async function ensureBrowserInstalled({
 	});
 	installs.inFlight.set(installDir, pending);
 
-	const installed = await pending;
-	return { executablePath: installed.executablePath, installDir };
+	return toBrowserInstall(await pending, installDir, log);
+}
+
+function toBrowserInstall(
+	installed: InstalledBrowser,
+	installDir: string,
+	log: InstallLog
+): BrowserInstall {
+	// Captured here, before the caller has had a chance to launch, so that if a
+	// concurrent launch discards and replaces this installation while this
+	// caller is failing, `discard()` can tell.
+	const generation = getInstallGeneration(installDir);
+	return {
+		executablePath: installed.executablePath,
+		installDir,
+		markVerified: () => markInstallVerified(installDir, log),
+		discard: () => discardIncompleteInstall(installDir, generation, log),
+	};
 }
 
 /**
@@ -192,26 +217,20 @@ export function isInstallMarkedComplete(installDir: string): boolean {
  * Whether Chrome is known to have launched from this installation, either
  * earlier in this process or in a previous one.
  */
-export function isInstallVerified(installDir: string): boolean {
+function isInstallVerified(installDir: string): boolean {
 	return (
-		installs.verified.has(installDir) || isInstallMarkedComplete(installDir)
+		installs.verifiedDirs.has(installDir) || isInstallMarkedComplete(installDir)
 	);
 }
 
-/**
- * Record that Chrome launched successfully from this installation, so that a
- * later launch failure can be told apart from a broken download.
- *
- * Best-effort: losing the marker only costs a re-download in the unlikely
- * event that Chrome stops starting.
- */
-export async function markInstallVerified(
+/** Backs {@link BrowserInstall.markVerified}. */
+async function markInstallVerified(
 	installDir: string,
 	log: InstallLog
 ): Promise<void> {
 	// Before any `await`, so a concurrent launch that fails in the meantime
 	// cannot conclude this installation is unproven.
-	installs.verified.add(installDir);
+	installs.verifiedDirs.add(installDir);
 	if (isInstallMarkedComplete(installDir)) {
 		return;
 	}
@@ -235,22 +254,22 @@ export async function markInstallVerified(
 const DISCARD_TIMEOUT = 10_000;
 const DISCARD_RETRY_DELAY = 500;
 
-export type DiscardResult =
+type DiscardResult =
 	/** Cleared; the caller may re-install and retry. */
-	| { cleared: true }
-	/** Left alone because Chrome is known to have launched from it before. */
-	| { cleared: false; reason: "verified" }
+	| { outcome: "cleared" }
 	/**
 	 * Left alone because a concurrent launch already replaced it. The caller
 	 * should retry against the new installation rather than delete it.
 	 */
-	| { cleared: false; reason: "superseded" }
+	| { outcome: "superseded" }
+	/** Left alone because Chrome is known to have launched from it before. */
+	| { outcome: "verified" }
 	/** Could not be cleared. */
-	| { cleared: false; reason: "cleanup-failed"; cause: unknown };
+	| { outcome: "cleanup-failed"; cause: unknown };
 
 /**
- * Clear an installation that Chrome failed to start from, unless we have
- * positive evidence that it is fine.
+ * Backs {@link BrowserInstall.discard}: clear an installation that Chrome
+ * failed to start from, unless we have positive evidence that it is fine.
  *
  * Refuses in two cases, both of which would otherwise throw away a working
  * ~150 MB download:
@@ -264,7 +283,7 @@ export type DiscardResult =
  * @param generation from {@link getInstallGeneration}, taken *before* the
  * launch attempt that failed.
  */
-export async function discardIncompleteInstall(
+async function discardIncompleteInstall(
 	installDir: string,
 	generation: number,
 	log: InstallLog
@@ -280,10 +299,10 @@ export async function discardIncompleteInstall(
 			log.debug(
 				`Not clearing ${installDir}: a concurrent launch already replaced it.`
 			);
-			return { cleared: false, reason: "superseded" };
+			return { outcome: "superseded" };
 		}
 		if (isInstallVerified(installDir)) {
-			return { cleared: false, reason: "verified" };
+			return { outcome: "verified" };
 		}
 		log.warn(
 			`Chrome failed to start from ${installDir}, which it has never successfully started from; clearing it so it can be downloaded again.`
@@ -295,7 +314,7 @@ export async function discardIncompleteInstall(
 			try {
 				await removeDir(installDir);
 				installs.generations.set(installDir, generation + 1);
-				return { cleared: true };
+				return { outcome: "cleared" };
 			} catch (e) {
 				lastError = e;
 				log.debug(`Could not clear ${installDir} yet, retrying: ${e}`);
@@ -305,7 +324,7 @@ export async function discardIncompleteInstall(
 			}
 		} while (Date.now() < deadline);
 
-		return { cleared: false, reason: "cleanup-failed", cause: lastError };
+		return { outcome: "cleanup-failed", cause: lastError };
 	});
 }
 

--- a/packages/miniflare/src/plugins/browser-rendering/install.ts
+++ b/packages/miniflare/src/plugins/browser-rendering/install.ts
@@ -1,0 +1,382 @@
+import fs from "node:fs";
+import path from "node:path";
+import {
+	getGlobalWranglerCachePath,
+	removeDir,
+} from "@cloudflare/workers-utils";
+import {
+	Browser,
+	detectBrowserPlatform,
+	install,
+	resolveBuildId,
+} from "@puppeteer/browsers";
+import type { InstalledBrowser, InstallOptions } from "@puppeteer/browsers";
+
+/**
+ * The subset of Miniflare's `Log` used while installing Chrome.
+ *
+ * Kept structural rather than importing `Log` so that this module can be
+ * loaded standalone (e.g. by `scripts/install-browser.ts` under
+ * `esbuild-register`) without pulling in the rest of Miniflare.
+ */
+export interface InstallLog {
+	warn(message: string): void;
+	debug(message: string): void;
+}
+
+/**
+ * Marker written into a Chrome installation directory once Chrome has
+ * actually launched from it.
+ *
+ * Deliberately *not* written when `install()` resolves. `install()` treats an
+ * installation as present if the directory exists and contains the
+ * executable, which is not enough: the Chrome-for-Testing archives extract
+ * alphabetically, so `chrome.exe` lands well before `resources.pak`. An
+ * install interrupted part-way therefore satisfies `install()` while
+ * producing a Chrome that exits with
+ * `ERROR:resource_bundle.cc] Failed to load ...\resources.pak` on launch.
+ *
+ * Keying the marker on a successful launch instead means it answers the only
+ * question worth asking — "is this install known to work?" — and cannot be
+ * fooled by a directory that merely looks plausible.
+ */
+const INSTALL_COMPLETE_MARKER = ".miniflare-install-complete";
+
+/**
+ * Coordination for the Chrome installation shared by everything in this
+ * process, keyed by installation directory.
+ *
+ * Deliberately module scope. What is being coordinated is a single directory
+ * under the global Wrangler cache, which is shared by every `Miniflare`
+ * instance here — and indeed by every process on the machine. Narrowing this
+ * to one instance would reintroduce exactly the races it exists to prevent:
+ * two instances racing to populate the same directory, or one deleting an
+ * install another is running Chrome from.
+ *
+ * Bounded by the number of distinct Chrome versions used, which is one.
+ */
+const installs = {
+	/**
+	 * In-flight installs. Without this, two overlapping
+	 * `ensureBrowserInstalled()` calls both reach `install()`; the second sees
+	 * the first's partially-extracted directory, short-circuits, and hands back
+	 * a path to a Chrome that cannot launch. That is the common shape in tests,
+	 * where a timed-out test abandons its install but the download keeps running
+	 * in the background and the next test starts immediately.
+	 */
+	inFlight: new Map<string, Promise<InstalledBrowser>>(),
+
+	/**
+	 * Installations Chrome has launched from during this process.
+	 *
+	 * Recorded synchronously on a successful launch, ahead of the on-disk
+	 * marker, which is written asynchronously and best-effort. Launches run
+	 * concurrently — one per session acquire — so without this there is a window
+	 * in which one session has a working Chrome running while another, having
+	 * just failed, still sees no marker and would delete the directory out from
+	 * under it.
+	 */
+	verified: new Set<string>(),
+
+	/**
+	 * Bumped whenever an installation is discarded, so that concurrent launches
+	 * can tell "nobody has dealt with this yet" from "a peer already replaced it
+	 * while I was failing".
+	 */
+	generations: new Map<string, number>(),
+
+	/** Serialises recovery per installation directory. */
+	locks: new Map<string, Promise<unknown>>(),
+};
+
+function withInstallLock<T>(
+	installDir: string,
+	fn: () => Promise<T>
+): Promise<T> {
+	const previous = installs.locks.get(installDir) ?? Promise.resolve();
+	// Swallow the predecessor's rejection: we only need its completion, and it
+	// is reported to whoever is awaiting it.
+	const result = previous.catch(() => {}).then(fn);
+	installs.locks.set(
+		installDir,
+		result.catch(() => {})
+	);
+	return result;
+}
+
+/**
+ * Token identifying the state of an installation at the point a launch began.
+ *
+ * Pass to {@link discardIncompleteInstall} so it can refuse to delete an
+ * installation that has already been replaced since.
+ */
+export function getInstallGeneration(installDir: string): number {
+	return installs.generations.get(installDir) ?? 0;
+}
+
+export interface EnsureBrowserInstalledOptions {
+	browserVersion: string;
+	log: InstallLog;
+	/** Invoked as the archive downloads. Not called when already installed. */
+	onProgress?: (downloadedBytes: number, totalBytes: number) => void;
+}
+
+export interface EnsuredBrowser {
+	executablePath: string;
+	/** Absolute path of the versioned installation directory. */
+	installDir: string;
+}
+
+/**
+ * Resolve a fully-installed Chrome for the Browser Run binding, downloading
+ * it into the global Wrangler cache if necessary.
+ *
+ * Concurrent calls for the same version share a single install.
+ */
+export async function ensureBrowserInstalled({
+	browserVersion,
+	log,
+	onProgress,
+}: EnsureBrowserInstalledOptions): Promise<EnsuredBrowser> {
+	const platform = detectBrowserPlatform();
+	if (!platform) {
+		throw new Error("The current platform is not supported.");
+	}
+	const browser = Browser.CHROME;
+	const cacheDir = getGlobalWranglerCachePath();
+	const buildId = await resolveBuildId(browser, platform, browserVersion);
+	const installDir = getInstallDir(cacheDir, browser, platform, buildId);
+
+	// Deliberately not annotated `InstallOptions`: `install()` is overloaded on
+	// `unpack`, and only the `unpack?: true` form returns an `InstalledBrowser`.
+	const installOptions = {
+		browser,
+		platform,
+		cacheDir,
+		buildId,
+		downloadProgressCallback: onProgress,
+	};
+
+	const existing = installs.inFlight.get(installDir);
+	if (existing) {
+		log.debug(`Waiting for an in-progress Chrome install at ${installDir}`);
+		const installed = await existing;
+		return { executablePath: installed.executablePath, installDir };
+	}
+
+	const pending = installWithCorruptedCacheRecovery(
+		installOptions,
+		log
+	).finally(() => {
+		installs.inFlight.delete(installDir);
+	});
+	installs.inFlight.set(installDir, pending);
+
+	const installed = await pending;
+	return { executablePath: installed.executablePath, installDir };
+}
+
+/**
+ * Whether Chrome is known to have launched from this installation before.
+ *
+ * A `false` result does not mean the install is broken — one predating the
+ * marker, or simply never used, is usually fine — but it does mean we cannot
+ * vouch for it, which is enough to justify re-installing if Chrome then fails
+ * to launch. See {@link discardIncompleteInstall}.
+ */
+export function isInstallMarkedComplete(installDir: string): boolean {
+	return fs.existsSync(path.join(installDir, INSTALL_COMPLETE_MARKER));
+}
+
+/**
+ * Whether Chrome is known to have launched from this installation, either
+ * earlier in this process or in a previous one.
+ */
+export function isInstallVerified(installDir: string): boolean {
+	return (
+		installs.verified.has(installDir) || isInstallMarkedComplete(installDir)
+	);
+}
+
+/**
+ * Record that Chrome launched successfully from this installation, so that a
+ * later launch failure can be told apart from a broken download.
+ *
+ * Best-effort: losing the marker only costs a re-download in the unlikely
+ * event that Chrome stops starting.
+ */
+export async function markInstallVerified(
+	installDir: string,
+	log: InstallLog
+): Promise<void> {
+	// Before any `await`, so a concurrent launch that fails in the meantime
+	// cannot conclude this installation is unproven.
+	installs.verified.add(installDir);
+	if (isInstallMarkedComplete(installDir)) {
+		return;
+	}
+	try {
+		await fs.promises.writeFile(
+			path.join(installDir, INSTALL_COMPLETE_MARKER),
+			""
+		);
+	} catch (e) {
+		log.debug(`Unable to mark the Chrome install as verified: ${e}`);
+	}
+}
+
+/**
+ * How long to keep retrying removal of a bad install.
+ *
+ * `removeDir` already retries briefly, but Windows can hold handles on a
+ * just-crashed Chrome for longer than that — and giving up means the install
+ * stays broken for every subsequent launch, so it is worth being patient.
+ */
+const DISCARD_TIMEOUT = 10_000;
+const DISCARD_RETRY_DELAY = 500;
+
+export type DiscardResult =
+	/** Cleared; the caller may re-install and retry. */
+	| { cleared: true }
+	/** Left alone because Chrome is known to have launched from it before. */
+	| { cleared: false; reason: "verified" }
+	/**
+	 * Left alone because a concurrent launch already replaced it. The caller
+	 * should retry against the new installation rather than delete it.
+	 */
+	| { cleared: false; reason: "superseded" }
+	/** Could not be cleared. */
+	| { cleared: false; reason: "cleanup-failed"; cause: unknown };
+
+/**
+ * Clear an installation that Chrome failed to start from, unless we have
+ * positive evidence that it is fine.
+ *
+ * Refuses in two cases, both of which would otherwise throw away a working
+ * ~150 MB download:
+ *
+ * - Chrome has launched from it before, so a failure now is a real bug worth
+ *   surfacing rather than a corrupt download to paper over.
+ * - A concurrent launch has already discarded and replaced it since
+ *   `generation` was taken, so the directory on disk is no longer the one that
+ *   failed — and may well be in use.
+ *
+ * @param generation from {@link getInstallGeneration}, taken *before* the
+ * launch attempt that failed.
+ */
+export async function discardIncompleteInstall(
+	installDir: string,
+	generation: number,
+	log: InstallLog
+): Promise<DiscardResult> {
+	return withInstallLock(installDir, async () => {
+		// Staleness first: if the directory has been replaced since `generation`
+		// was taken, the install that failed is already gone, so the caller
+		// should retry against its replacement. Checking `isInstallVerified`
+		// ahead of this would report a *replaced and since proven* install as
+		// "verified" and make the caller give up, even though a working Chrome
+		// is sitting right there.
+		if (getInstallGeneration(installDir) !== generation) {
+			log.debug(
+				`Not clearing ${installDir}: a concurrent launch already replaced it.`
+			);
+			return { cleared: false, reason: "superseded" };
+		}
+		if (isInstallVerified(installDir)) {
+			return { cleared: false, reason: "verified" };
+		}
+		log.warn(
+			`Chrome failed to start from ${installDir}, which it has never successfully started from; clearing it so it can be downloaded again.`
+		);
+
+		const deadline = Date.now() + DISCARD_TIMEOUT;
+		let lastError: unknown;
+		do {
+			try {
+				await removeDir(installDir);
+				installs.generations.set(installDir, generation + 1);
+				return { cleared: true };
+			} catch (e) {
+				lastError = e;
+				log.debug(`Could not clear ${installDir} yet, retrying: ${e}`);
+				await new Promise((resolve) =>
+					setTimeout(resolve, DISCARD_RETRY_DELAY)
+				);
+			}
+		} while (Date.now() < deadline);
+
+		return { cleared: false, reason: "cleanup-failed", cause: lastError };
+	});
+}
+
+/**
+ * Mirror of `@puppeteer/browsers`' `Cache#installationDir`.
+ *
+ * https://github.com/puppeteer/puppeteer/blob/main/packages/browsers/src/Cache.ts
+ */
+function getInstallDir(
+	cacheDir: string,
+	browser: Browser,
+	platform: string,
+	buildId: string
+): string {
+	return path.join(cacheDir, browser, `${platform}-${buildId}`);
+}
+
+/**
+ * Regex matching the `@puppeteer/browsers` error thrown when its cache
+ * directory exists but the executable inside it is missing — typically
+ * because a previous `install()` was interrupted mid-extraction (test
+ * timeout, process kill) or because an external agent (Windows Defender,
+ * antivirus, disk cleanup) removed the executable from a previously-good
+ * install.
+ *
+ * @puppeteer/browsers source:
+ * https://github.com/puppeteer/puppeteer/blob/main/packages/browsers/src/install.ts
+ */
+const CORRUPTED_CACHE_ERROR_PATTERN =
+	/The browser folder \((.+?)\) exists but the executable .+? is missing/;
+
+/**
+ * Run `@puppeteer/browsers` `install()`, but if it fails with the
+ * "folder exists but executable is missing" error, clear the corrupted
+ * cache directory and retry once.
+ *
+ * Recovers from a known intermittent failure on CI runners (especially
+ * Windows) where the cache state can become partially populated and stay
+ * that way for the rest of the run, breaking every subsequent test until
+ * the runner is recycled.
+ */
+async function installWithCorruptedCacheRecovery(
+	installOptions: InstallOptions & { unpack?: true },
+	log: InstallLog
+): Promise<InstalledBrowser> {
+	try {
+		return await install(installOptions);
+	} catch (e) {
+		const match = (e as Error)?.message?.match(CORRUPTED_CACHE_ERROR_PATTERN);
+		if (!match) {
+			throw e;
+		}
+		const corruptedPath = match[1];
+		log.warn(
+			`Detected corrupted Chrome cache at ${corruptedPath}; clearing and retrying install.`
+		);
+		try {
+			await removeDir(corruptedPath);
+		} catch (cleanupError) {
+			throw new Error(
+				`Failed to clear corrupted Chrome cache at ${corruptedPath} after detecting "${(e as Error).message}". Manual cleanup may be required.`,
+				{ cause: cleanupError }
+			);
+		}
+		try {
+			return await install(installOptions);
+		} catch (retryError) {
+			throw new Error(
+				`Chrome install failed after clearing corrupted cache at ${corruptedPath}: ${(retryError as Error).message}`,
+				{ cause: retryError }
+			);
+		}
+	}
+}

--- a/packages/miniflare/src/plugins/browser-rendering/process.ts
+++ b/packages/miniflare/src/plugins/browser-rendering/process.ts
@@ -5,6 +5,27 @@ const BROWSER_CLOSE_TIMEOUT = 5_000;
 
 type BrowserProcess = Pick<Process, "hasClosed" | "kill">;
 
+/**
+ * Chrome exited before announcing its DevTools endpoint — i.e. it never got
+ * as far as running.
+ *
+ * Distinguished from every other launch failure because it is the only one
+ * that can implicate the installation itself. Once Chrome has printed its
+ * banner it has already loaded the resources a partial download would be
+ * missing, so a failure after that point (a readiness probe timing out, a
+ * profile directory that cannot be created) says nothing about the install
+ * and must not be "recovered" by deleting it.
+ *
+ * The underlying message is preserved so callers and logs are unaffected.
+ */
+export class BrowserStartupError extends Error {
+	override readonly name = "BrowserStartupError";
+
+	constructor(cause: unknown) {
+		super(cause instanceof Error ? cause.message : String(cause), { cause });
+	}
+}
+
 function waitForGracefulClose(
 	browserProcess: BrowserProcess,
 	wsEndpoint: string,
@@ -39,9 +60,9 @@ function waitForGracefulClose(
 	});
 }
 
-async function waitForExit(
+export async function waitForExit(
 	browserProcess: BrowserProcess,
-	timeoutMs: number
+	timeoutMs = BROWSER_CLOSE_TIMEOUT
 ): Promise<void> {
 	let timeout: NodeJS.Timeout | undefined;
 	await Promise.race([

--- a/packages/miniflare/test/plugins/browser/index.spec.ts
+++ b/packages/miniflare/test/plugins/browser/index.spec.ts
@@ -1,6 +1,7 @@
-import { Miniflare } from "miniflare";
+import { Log, LogLevel, Miniflare } from "miniflare";
 import {
 	afterEach,
+	beforeAll,
 	beforeEach,
 	describe,
 	test,
@@ -64,11 +65,20 @@ async function waitForClosedConnection(ws: WebSocket): Promise<void> {
 
 const BROWSER_RENDERING_RETRY = {
 	retry: {
-		condition: /Chrome readiness probe .* timed out|Test timed out/i,
+		condition:
+			/Chrome readiness probe .* timed out|Test timed out|Failed to launch (the browser process|local browser)/i,
 		count: 3,
 		delay: 1_000,
 	},
 } satisfies TestOptions;
+
+/**
+ * Budget for the one-off Chrome download in {@link warmChromeInstall}.
+ *
+ * Generous on purpose: a cold CI runner fetches ~150 MB before the first
+ * browser can start.
+ */
+const CHROME_INSTALL_TIMEOUT = 10 * 60 * 1_000;
 
 const BROWSER_WORKER_SCRIPT = () => `
 export default {
@@ -81,9 +91,55 @@ export default {
 };
 `;
 
+/**
+ * Download and launch Chrome once, before any of the timed tests run.
+ *
+ * The tests below allow 20s each, which is nowhere near enough to fetch
+ * ~150 MB of Chrome on a cold runner. Left to the first test, the download
+ * loses that race and the test is abandoned while `@puppeteer/browsers` is
+ * still extracting — but the archive extracts alphabetically, so the
+ * executable is already on disk and every later `install()` short-circuits
+ * onto a half-written directory. Chrome then dies on startup with
+ * `Failed to load ...resources.pak`, failing tests that have nothing wrong
+ * with them.
+ *
+ * Doing the install here, under a timeout that can actually accommodate it,
+ * means the tests only ever see a complete install.
+ */
+async function warmChromeInstall(): Promise<void> {
+	const mf = new Miniflare({
+		// Miniflare logs to a no-op by default, which makes a failure here
+		// (a bad cached install, a download that will not complete) impossible
+		// to diagnose from CI output alone.
+		log: new Log(LogLevel.WARN),
+		workers: [
+			{
+				config: {
+					type: "worker",
+					name: "warmup",
+					compatibilityDate: "2024-11-20",
+					manifest: singleModuleManifest(BROWSER_WORKER_SCRIPT()),
+					env: { MYBROWSER: { type: "browser" } },
+				},
+			},
+		],
+	});
+	try {
+		const res = await mf.dispatchFetch("https://localhost/session");
+		const text = await res.text();
+		if (!text.includes("sessionId")) {
+			throw new Error(`Failed to warm up the Chrome install: ${text}`);
+		}
+	} finally {
+		// Disposal closes the browser process, so the tests start from scratch.
+		await mf.dispose();
+	}
+}
+
 // We need to run browser rendering tests in a serial manner to avoid a race condition installing the browser.
-// We set the timeout quite high here as one of these tests will need to download the Chrome headless browser.
 describe.sequential("browser rendering", { timeout: 20_000 }, () => {
+	beforeAll(warmChromeInstall, CHROME_INSTALL_TIMEOUT);
+
 	// The CLI spinner outputs to stdout, so we mute it during tests
 	beforeEach(() => {
 		vi.spyOn(process.stdout, "write").mockImplementation(() => true);

--- a/packages/miniflare/test/plugins/browser/install.spec.ts
+++ b/packages/miniflare/test/plugins/browser/install.spec.ts
@@ -1,0 +1,274 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { removeDirSync } from "@cloudflare/workers-utils";
+import { afterEach, beforeEach, describe, test, vi } from "vitest";
+import {
+	discardIncompleteInstall,
+	ensureBrowserInstalled,
+	getInstallGeneration,
+	isInstallMarkedComplete,
+	markInstallVerified,
+} from "../../../src/plugins/browser-rendering/install";
+
+const BUILD_ID = "126.0.6478.182";
+const PLATFORM = "linux64";
+
+let cacheDir: string;
+
+vi.mock("@cloudflare/workers-utils", async (importOriginal) => ({
+	...(await importOriginal<typeof import("@cloudflare/workers-utils")>()),
+	// Keep the real `removeDir`; only the cache location is faked.
+	getGlobalWranglerCachePath: () => cacheDir,
+}));
+
+const install = vi.hoisted(() => vi.fn());
+
+vi.mock("@puppeteer/browsers", () => ({
+	Browser: { CHROME: "chrome" },
+	detectBrowserPlatform: () => PLATFORM,
+	resolveBuildId: (_browser: string, _platform: string, version: string) =>
+		Promise.resolve(version),
+	install,
+}));
+
+const log = {
+	warn: vi.fn(),
+	debug: vi.fn(),
+};
+
+/** The directory `ensureBrowserInstalled` should resolve to. */
+function installDirFor(): string {
+	return path.join(cacheDir, "chrome", `${PLATFORM}-${BUILD_ID}`);
+}
+
+/** Make `install()` behave like a real extraction into the cache. */
+function stubSuccessfulInstall(): void {
+	install.mockImplementation(async () => {
+		const installDir = installDirFor();
+		await fs.promises.mkdir(installDir, { recursive: true });
+		await fs.promises.writeFile(path.join(installDir, "chrome"), "");
+		return { executablePath: path.join(installDir, "chrome") };
+	});
+}
+
+beforeEach(() => {
+	cacheDir = fs.mkdtempSync(path.join(os.tmpdir(), "miniflare-chrome-"));
+	install.mockReset();
+	log.warn.mockReset();
+	log.debug.mockReset();
+});
+
+afterEach(() => {
+	removeDirSync(cacheDir);
+});
+
+describe("ensureBrowserInstalled", () => {
+	test("resolves the versioned install directory", async ({ expect }) => {
+		stubSuccessfulInstall();
+
+		const { installDir, executablePath } = await ensureBrowserInstalled({
+			browserVersion: BUILD_ID,
+			log,
+		});
+
+		expect(installDir).toBe(installDirFor());
+		expect(executablePath).toBe(path.join(installDirFor(), "chrome"));
+	});
+
+	test("shares a single install between concurrent callers", async ({
+		expect,
+	}) => {
+		// Without the in-flight map, the second caller reaches `install()` while
+		// the first is still extracting. `@puppeteer/browsers` then short-circuits
+		// on the partially-written directory and hands back a Chrome that cannot
+		// launch — the failure this map exists to prevent.
+		install.mockImplementation(async () => {
+			// Long enough to still be extracting when the second call arrives.
+			await new Promise((resolve) => setTimeout(resolve, 50));
+			const installDir = installDirFor();
+			await fs.promises.mkdir(installDir, { recursive: true });
+			return { executablePath: path.join(installDir, "chrome") };
+		});
+
+		const [first, second] = await Promise.all([
+			ensureBrowserInstalled({ browserVersion: BUILD_ID, log }),
+			ensureBrowserInstalled({ browserVersion: BUILD_ID, log }),
+		]);
+
+		expect(first.executablePath).toBe(second.executablePath);
+		expect(install).toHaveBeenCalledTimes(1);
+	});
+
+	test("allows a fresh install once the previous one has settled", async ({
+		expect,
+	}) => {
+		stubSuccessfulInstall();
+
+		await ensureBrowserInstalled({ browserVersion: BUILD_ID, log });
+		await ensureBrowserInstalled({ browserVersion: BUILD_ID, log });
+
+		expect(install).toHaveBeenCalledTimes(2);
+	});
+
+	test("does not mark the install as verified", async ({ expect }) => {
+		// `install()` resolving proves nothing: it short-circuits whenever the
+		// directory and executable exist, which a half-extracted archive
+		// satisfies. Marking here would suppress the recovery in
+		// `discardIncompleteInstall`.
+		stubSuccessfulInstall();
+
+		const { installDir } = await ensureBrowserInstalled({
+			browserVersion: BUILD_ID,
+			log,
+		});
+
+		expect(isInstallMarkedComplete(installDir)).toBe(false);
+	});
+});
+
+describe("markInstallVerified", () => {
+	test("marks the install, idempotently", async ({ expect }) => {
+		const installDir = installDirFor();
+		fs.mkdirSync(installDir, { recursive: true });
+
+		expect(isInstallMarkedComplete(installDir)).toBe(false);
+		await markInstallVerified(installDir, log);
+		expect(isInstallMarkedComplete(installDir)).toBe(true);
+		await markInstallVerified(installDir, log);
+		expect(isInstallMarkedComplete(installDir)).toBe(true);
+	});
+
+	test("does not throw when the install directory is gone", async ({
+		expect,
+	}) => {
+		await markInstallVerified(installDirFor(), log);
+
+		expect(isInstallMarkedComplete(installDirFor())).toBe(false);
+		expect(log.debug).toHaveBeenCalled();
+	});
+});
+
+describe("discardIncompleteInstall", () => {
+	test("clears an unverified install", async ({ expect }) => {
+		const installDir = installDirFor();
+		fs.mkdirSync(installDir, { recursive: true });
+		fs.writeFileSync(path.join(installDir, "chrome"), "");
+
+		const generation = getInstallGeneration(installDir);
+
+		expect(await discardIncompleteInstall(installDir, generation, log)).toEqual(
+			{ cleared: true }
+		);
+		expect(fs.existsSync(installDir)).toBe(false);
+		expect(log.warn).toHaveBeenCalled();
+	});
+
+	test("keeps an install that Chrome has already launched from", async ({
+		expect,
+	}) => {
+		// A launch failure here is a real bug, not a bad download, so deleting
+		// 150 MB and trying again would only hide it.
+		const installDir = installDirFor();
+		fs.mkdirSync(installDir, { recursive: true });
+		await markInstallVerified(installDir, log);
+
+		expect(
+			await discardIncompleteInstall(
+				installDir,
+				getInstallGeneration(installDir),
+				log
+			)
+		).toEqual({ cleared: false, reason: "verified" });
+		expect(fs.existsSync(installDir)).toBe(true);
+		expect(log.warn).not.toHaveBeenCalled();
+	});
+
+	test("keeps an install a concurrent launch is still confirming", async ({
+		expect,
+	}) => {
+		// Launches run concurrently, one per session acquire. If one succeeds
+		// while another is failing, the failing one must not delete the
+		// directory the working Chrome is running from — even though the on-disk
+		// marker has not been written yet.
+		const installDir = installDirFor();
+		fs.mkdirSync(installDir, { recursive: true });
+		const generation = getInstallGeneration(installDir);
+
+		// Deliberately not awaited: the marker write is still in flight.
+		const marking = markInstallVerified(installDir, log);
+
+		expect(await discardIncompleteInstall(installDir, generation, log)).toEqual(
+			{ cleared: false, reason: "verified" }
+		);
+		expect(fs.existsSync(installDir)).toBe(true);
+
+		await marking;
+	});
+
+	test("keeps an install a concurrent launch has already replaced", async ({
+		expect,
+	}) => {
+		// Two launches failing against the same bad install: the first clears
+		// and re-downloads it, and the second must retry against that fresh
+		// copy rather than delete it too.
+		const installDir = installDirFor();
+		fs.mkdirSync(installDir, { recursive: true });
+		const staleGeneration = getInstallGeneration(installDir);
+
+		expect(
+			await discardIncompleteInstall(installDir, staleGeneration, log)
+		).toEqual({ cleared: true });
+
+		// Stand in for the peer's re-download.
+		fs.mkdirSync(installDir, { recursive: true });
+		fs.writeFileSync(path.join(installDir, "chrome"), "");
+
+		expect(
+			await discardIncompleteInstall(installDir, staleGeneration, log)
+		).toEqual({ cleared: false, reason: "superseded" });
+		expect(fs.existsSync(path.join(installDir, "chrome"))).toBe(true);
+	});
+
+	test("retries against a replacement the peer has already proven", async ({
+		expect,
+	}) => {
+		// The peer got all the way through: cleared, re-downloaded, launched and
+		// marked verified. The launch still holding the old generation must be
+		// told to retry, not that the install is fine — otherwise it fails while
+		// a working Chrome is available.
+		const installDir = installDirFor();
+		fs.mkdirSync(installDir, { recursive: true });
+		const staleGeneration = getInstallGeneration(installDir);
+
+		await discardIncompleteInstall(installDir, staleGeneration, log);
+		fs.mkdirSync(installDir, { recursive: true });
+		await markInstallVerified(installDir, log);
+
+		expect(
+			await discardIncompleteInstall(installDir, staleGeneration, log)
+		).toEqual({ cleared: false, reason: "superseded" });
+	});
+
+	test("reports why an install could not be cleared", async ({ expect }) => {
+		// Windows keeps handles on a just-crashed Chrome, so removal can fail.
+		// The caller turns this into an actionable error, which matters because
+		// Miniflare logs to a no-op by default.
+		const installDir = installDirFor();
+		fs.mkdirSync(installDir, { recursive: true });
+		const locked = new Error("EBUSY: resource busy or locked");
+		vi.spyOn(fs.promises, "rm").mockRejectedValue(locked);
+
+		const result = await discardIncompleteInstall(
+			installDir,
+			getInstallGeneration(installDir),
+			log
+		);
+
+		expect(result).toEqual({
+			cleared: false,
+			reason: "cleanup-failed",
+			cause: locked,
+		});
+	}, 20_000);
+});

--- a/packages/miniflare/test/plugins/browser/install.spec.ts
+++ b/packages/miniflare/test/plugins/browser/install.spec.ts
@@ -4,11 +4,8 @@ import path from "node:path";
 import { removeDirSync } from "@cloudflare/workers-utils";
 import { afterEach, beforeEach, describe, test, vi } from "vitest";
 import {
-	discardIncompleteInstall,
 	ensureBrowserInstalled,
-	getInstallGeneration,
 	isInstallMarkedComplete,
-	markInstallVerified,
 } from "../../../src/plugins/browser-rendering/install";
 
 const BUILD_ID = "126.0.6478.182";
@@ -42,6 +39,11 @@ function installDirFor(): string {
 	return path.join(cacheDir, "chrome", `${PLATFORM}-${BUILD_ID}`);
 }
 
+/** Take a handle on the install, as a session about to launch Chrome would. */
+function acquireInstall() {
+	return ensureBrowserInstalled({ browserVersion: BUILD_ID, log });
+}
+
 /** Make `install()` behave like a real extraction into the cache. */
 function stubSuccessfulInstall(): void {
 	install.mockImplementation(async () => {
@@ -67,10 +69,7 @@ describe("ensureBrowserInstalled", () => {
 	test("resolves the versioned install directory", async ({ expect }) => {
 		stubSuccessfulInstall();
 
-		const { installDir, executablePath } = await ensureBrowserInstalled({
-			browserVersion: BUILD_ID,
-			log,
-		});
+		const { installDir, executablePath } = await acquireInstall();
 
 		expect(installDir).toBe(installDirFor());
 		expect(executablePath).toBe(path.join(installDirFor(), "chrome"));
@@ -92,8 +91,8 @@ describe("ensureBrowserInstalled", () => {
 		});
 
 		const [first, second] = await Promise.all([
-			ensureBrowserInstalled({ browserVersion: BUILD_ID, log }),
-			ensureBrowserInstalled({ browserVersion: BUILD_ID, log }),
+			acquireInstall(),
+			acquireInstall(),
 		]);
 
 		expect(first.executablePath).toBe(second.executablePath);
@@ -105,8 +104,8 @@ describe("ensureBrowserInstalled", () => {
 	}) => {
 		stubSuccessfulInstall();
 
-		await ensureBrowserInstalled({ browserVersion: BUILD_ID, log });
-		await ensureBrowserInstalled({ browserVersion: BUILD_ID, log });
+		await acquireInstall();
+		await acquireInstall();
 
 		expect(install).toHaveBeenCalledTimes(2);
 	});
@@ -114,53 +113,51 @@ describe("ensureBrowserInstalled", () => {
 	test("does not mark the install as verified", async ({ expect }) => {
 		// `install()` resolving proves nothing: it short-circuits whenever the
 		// directory and executable exist, which a half-extracted archive
-		// satisfies. Marking here would suppress the recovery in
-		// `discardIncompleteInstall`.
+		// satisfies. Marking here would suppress the recovery in `discard()`.
 		stubSuccessfulInstall();
 
-		const { installDir } = await ensureBrowserInstalled({
-			browserVersion: BUILD_ID,
-			log,
-		});
+		const { installDir } = await acquireInstall();
 
 		expect(isInstallMarkedComplete(installDir)).toBe(false);
 	});
 });
 
-describe("markInstallVerified", () => {
+describe("markVerified", () => {
 	test("marks the install, idempotently", async ({ expect }) => {
-		const installDir = installDirFor();
-		fs.mkdirSync(installDir, { recursive: true });
+		stubSuccessfulInstall();
+		const installed = await acquireInstall();
 
-		expect(isInstallMarkedComplete(installDir)).toBe(false);
-		await markInstallVerified(installDir, log);
-		expect(isInstallMarkedComplete(installDir)).toBe(true);
-		await markInstallVerified(installDir, log);
-		expect(isInstallMarkedComplete(installDir)).toBe(true);
+		expect(isInstallMarkedComplete(installed.installDir)).toBe(false);
+		await installed.markVerified();
+		expect(isInstallMarkedComplete(installed.installDir)).toBe(true);
+		await installed.markVerified();
+		expect(isInstallMarkedComplete(installed.installDir)).toBe(true);
 	});
 
 	test("does not throw when the install directory is gone", async ({
 		expect,
 	}) => {
-		await markInstallVerified(installDirFor(), log);
+		// Resolve an install without creating anything on disk, as if the
+		// directory had been swept up between installing and launching.
+		install.mockResolvedValue({
+			executablePath: path.join(installDirFor(), "chrome"),
+		});
+		const installed = await acquireInstall();
 
-		expect(isInstallMarkedComplete(installDirFor())).toBe(false);
+		await installed.markVerified();
+
+		expect(isInstallMarkedComplete(installed.installDir)).toBe(false);
 		expect(log.debug).toHaveBeenCalled();
 	});
 });
 
-describe("discardIncompleteInstall", () => {
+describe("discard", () => {
 	test("clears an unverified install", async ({ expect }) => {
-		const installDir = installDirFor();
-		fs.mkdirSync(installDir, { recursive: true });
-		fs.writeFileSync(path.join(installDir, "chrome"), "");
+		stubSuccessfulInstall();
+		const installed = await acquireInstall();
 
-		const generation = getInstallGeneration(installDir);
-
-		expect(await discardIncompleteInstall(installDir, generation, log)).toEqual(
-			{ cleared: true }
-		);
-		expect(fs.existsSync(installDir)).toBe(false);
+		expect(await installed.discard()).toEqual({ outcome: "cleared" });
+		expect(fs.existsSync(installed.installDir)).toBe(false);
 		expect(log.warn).toHaveBeenCalled();
 	});
 
@@ -169,18 +166,12 @@ describe("discardIncompleteInstall", () => {
 	}) => {
 		// A launch failure here is a real bug, not a bad download, so deleting
 		// 150 MB and trying again would only hide it.
-		const installDir = installDirFor();
-		fs.mkdirSync(installDir, { recursive: true });
-		await markInstallVerified(installDir, log);
+		stubSuccessfulInstall();
+		const installed = await acquireInstall();
+		await installed.markVerified();
 
-		expect(
-			await discardIncompleteInstall(
-				installDir,
-				getInstallGeneration(installDir),
-				log
-			)
-		).toEqual({ cleared: false, reason: "verified" });
-		expect(fs.existsSync(installDir)).toBe(true);
+		expect(await installed.discard()).toEqual({ outcome: "verified" });
+		expect(fs.existsSync(installed.installDir)).toBe(true);
 		expect(log.warn).not.toHaveBeenCalled();
 	});
 
@@ -191,17 +182,15 @@ describe("discardIncompleteInstall", () => {
 		// while another is failing, the failing one must not delete the
 		// directory the working Chrome is running from — even though the on-disk
 		// marker has not been written yet.
-		const installDir = installDirFor();
-		fs.mkdirSync(installDir, { recursive: true });
-		const generation = getInstallGeneration(installDir);
+		stubSuccessfulInstall();
+		const succeeding = await acquireInstall();
+		const failing = await acquireInstall();
 
 		// Deliberately not awaited: the marker write is still in flight.
-		const marking = markInstallVerified(installDir, log);
+		const marking = succeeding.markVerified();
 
-		expect(await discardIncompleteInstall(installDir, generation, log)).toEqual(
-			{ cleared: false, reason: "verified" }
-		);
-		expect(fs.existsSync(installDir)).toBe(true);
+		expect(await failing.discard()).toEqual({ outcome: "verified" });
+		expect(fs.existsSync(failing.installDir)).toBe(true);
 
 		await marking;
 	});
@@ -212,22 +201,17 @@ describe("discardIncompleteInstall", () => {
 		// Two launches failing against the same bad install: the first clears
 		// and re-downloads it, and the second must retry against that fresh
 		// copy rather than delete it too.
-		const installDir = installDirFor();
-		fs.mkdirSync(installDir, { recursive: true });
-		const staleGeneration = getInstallGeneration(installDir);
+		stubSuccessfulInstall();
+		const first = await acquireInstall();
+		const second = await acquireInstall();
 
-		expect(
-			await discardIncompleteInstall(installDir, staleGeneration, log)
-		).toEqual({ cleared: true });
+		expect(await first.discard()).toEqual({ outcome: "cleared" });
 
 		// Stand in for the peer's re-download.
-		fs.mkdirSync(installDir, { recursive: true });
-		fs.writeFileSync(path.join(installDir, "chrome"), "");
+		await acquireInstall();
 
-		expect(
-			await discardIncompleteInstall(installDir, staleGeneration, log)
-		).toEqual({ cleared: false, reason: "superseded" });
-		expect(fs.existsSync(path.join(installDir, "chrome"))).toBe(true);
+		expect(await second.discard()).toEqual({ outcome: "superseded" });
+		expect(fs.existsSync(path.join(second.installDir, "chrome"))).toBe(true);
 	});
 
 	test("retries against a replacement the peer has already proven", async ({
@@ -237,37 +221,27 @@ describe("discardIncompleteInstall", () => {
 		// marked verified. The launch still holding the old generation must be
 		// told to retry, not that the install is fine — otherwise it fails while
 		// a working Chrome is available.
-		const installDir = installDirFor();
-		fs.mkdirSync(installDir, { recursive: true });
-		const staleGeneration = getInstallGeneration(installDir);
+		stubSuccessfulInstall();
+		const peer = await acquireInstall();
+		const stale = await acquireInstall();
 
-		await discardIncompleteInstall(installDir, staleGeneration, log);
-		fs.mkdirSync(installDir, { recursive: true });
-		await markInstallVerified(installDir, log);
+		await peer.discard();
+		await (await acquireInstall()).markVerified();
 
-		expect(
-			await discardIncompleteInstall(installDir, staleGeneration, log)
-		).toEqual({ cleared: false, reason: "superseded" });
+		expect(await stale.discard()).toEqual({ outcome: "superseded" });
 	});
 
 	test("reports why an install could not be cleared", async ({ expect }) => {
 		// Windows keeps handles on a just-crashed Chrome, so removal can fail.
 		// The caller turns this into an actionable error, which matters because
 		// Miniflare logs to a no-op by default.
-		const installDir = installDirFor();
-		fs.mkdirSync(installDir, { recursive: true });
+		stubSuccessfulInstall();
+		const installed = await acquireInstall();
 		const locked = new Error("EBUSY: resource busy or locked");
 		vi.spyOn(fs.promises, "rm").mockRejectedValue(locked);
 
-		const result = await discardIncompleteInstall(
-			installDir,
-			getInstallGeneration(installDir),
-			log
-		);
-
-		expect(result).toEqual({
-			cleared: false,
-			reason: "cleanup-failed",
+		expect(await installed.discard()).toEqual({
+			outcome: "cleanup-failed",
 			cause: locked,
 		});
 	}, 20_000);

--- a/packages/miniflare/test/plugins/browser/process.spec.ts
+++ b/packages/miniflare/test/plugins/browser/process.spec.ts
@@ -1,7 +1,10 @@
 import { once } from "node:events";
 import { onTestFinished, test, vi } from "vitest";
 import { WebSocketServer } from "ws";
-import { closeBrowserProcess } from "../../../src/plugins/browser-rendering/process";
+import {
+	BrowserStartupError,
+	closeBrowserProcess,
+} from "../../../src/plugins/browser-rendering/process";
 
 test("gracefully closes Chrome over CDP", async ({ expect }) => {
 	const closed = Promise.withResolvers<void>();
@@ -60,4 +63,17 @@ test("force kills Chrome when graceful close times out", async ({ expect }) => {
 	);
 
 	expect(browserProcess.kill).toHaveBeenCalledOnce();
+});
+
+test("BrowserStartupError preserves the underlying message", ({ expect }) => {
+	// The install-recovery path keys off this error type, and both the CI retry
+	// condition and the loopback response match on the message text, so
+	// wrapping must not obscure it.
+	const cause = new Error("Failed to launch the browser process! undefined");
+
+	const wrapped = new BrowserStartupError(cause);
+
+	expect(wrapped.message).toBe(cause.message);
+	expect(wrapped.cause).toBe(cause);
+	expect(wrapped.name).toBe("BrowserStartupError");
 });


### PR DESCRIPTION
Fixes the Windows CI failure in `packages/miniflare/test/plugins/browser/index.spec.ts` (`Failed to launch the browser process!` / `Failed to load ...\resources.pak`).

This reproduces on `main` and is unrelated to any single PR — see runs [94802577128](https://github.com/cloudflare/workers-sdk/actions/runs/94802577128), [94729853512](https://github.com/cloudflare/workers-sdk/actions/runs/94729853512), [94741594483](https://github.com/cloudflare/workers-sdk/actions/runs/94741594483).

### Root cause

`@puppeteer/browsers` considers an install present as soon as the directory and executable exist. Chrome-for-Testing archives extract alphabetically, so an interrupted install leaves `chrome.exe` in place while `resources.pak` is still missing — satisfying `install()` while producing a Chrome that dies on startup. Every later launch reused that directory, so a single interrupted download poisoned the cache permanently.

Two things made this near-certain on Windows CI:

1. The spec allows 20s per test, nowhere near enough for a cold ~150 MB download. The first test lost that race and was abandoned mid-extraction, leaving the rest of the file launching a half-written Chrome.
2. The Chrome cache was never populated. `actions/cache` saves from a post step declaring `post-if: success()`, so any job failure skipped the save — and since `test-and-check.yml` only runs on `pull_request`/`merge_group`, nothing is ever written to `refs/heads/main`, the one ref every PR can restore from. So every PR got a cold cache, every time, and each cold run could re-poison it.

Existing mitigations missed it: `CORRUPTED_CACHE_ERROR_PATTERN` only matched "executable is missing", and the retry condition only matched the timeout — so it stopped retrying once the failure became an assertion.

### Changes

- Extract `browser-rendering/install.ts`; overlapping installs now share one download instead of racing to populate the same directory.
- Mark an install only once Chrome has actually launched from it; on a launch failure, clear and re-download an unmarked install once. Known-good installs are left alone so real launch bugs still surface rather than being papered over with a 150 MB re-download.
- Wait for the browser process to exit before clearing. A crashed Chrome keeps handles open on files inside its install directory on Windows, so removal failed and the corrupt install survived. An unclearable install is now reported on the error itself, because Miniflare logs to a no-op by default.
- Download Chrome in a `beforeAll` with a 10 minute budget, so no test races the download.
- Broaden the retry condition to cover the launch failure, not just the timeout.
- Pair `cache/restore` with an explicit `cache/save`, gated on the completion marker so a partial install is never cached.
- Make `test-and-check-other-node.yml` restore-only. It shares this cache key, and keys are write-once, so leaving it on the combined `actions/cache` would let it publish an unvalidated Chrome that the marker-gated save could then never replace.

### Evidence

Measured with a temporary soak workflow (14 Windows jobs per run, since removed), comparing this branch against the same commit with the runtime fix reverted.

**Corrupt install** — delete `resources.pak`, keep `chrome.exe`, exactly reproducing the poisoned cache:

| variant | result | final install size |
| --- | --- | --- |
| baseline | 0/4 passed | 322M (still corrupt) |
| fixed | 2/2 passed | 331M (re-downloaded) |

The fixed runs log `...which it has never successfully started from; clearing it`, then re-download. Baseline fails with the exact CI error. An earlier iteration of the fix scored 1/2 here, which is what surfaced the Windows file-handle bug fixed above.

**Cold cache** — first test in the file, against its 20s timeout:

| | baseline | fixed |
| --- | --- | --- |
| first test (ms) | 11607, 15822, 13124, 11713, 11999 | 1727, 4008, 1754, 3083, 1806 |
| share of 20s budget | 58–79% | 9–20% |

Both variants passed 10/10 in the soak: on an idle runner the download beats the timeout. The baseline still leaves as little as 4.2s of headroom on the *good* case, while real CI runs this suite alongside two other packages.

**Cold cache, on real CI.** The soak could never make the cold case actually fail. Real CI just did, and it produced a clean controlled comparison. The Windows cache entry has since expired, so both of the following jobs logged `Cache not found for input keys: chrome-Windows-f12b2a29…` and downloaded Chrome cold, on the same OS, at the same time, from the same base:

| branch | has this fix | `test/plugins/browser/index.spec.ts` |
| --- | --- | --- |
| this PR ([job](https://github.com/cloudflare/workers-sdk/actions/runs/31940910463/job/95149852525)) | yes | 21 tests pass, 116560ms |
| #15209 ([job](https://github.com/cloudflare/workers-sdk/actions/runs/31941341281/job/95150881842)) | no | **9 failed**, `Test timed out in 20000ms` |

\#15209 is an unrelated test-output-noise PR that touches none of this code, so it shows what `main` does today on a cold cache: the first test blows its 20s budget mid-download, and the remaining tests then fail `expect(text.includes("sessionId")).toBe(true)` against a Chrome that never started — the exact cascade this PR fixes. It is the soak's 58–79%-of-budget figure tipping past 100% on a runner that is not idle.

This also means the failure is no longer merely latent: it is reproducing on `main` now that the cache has lapsed.

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: internal reliability fix with no user-facing interface change.

