### PR TITLE
Pass access.dev through to Miniflare via `unstable_getMiniflareWorkerOptions()`

### DIFF
--- a/.changeset/access-dev-vite-plugin.md
+++ b/.changeset/access-dev-vite-plugin.md
@@ -1,0 +1,9 @@
+---
+"wrangler": patch
+---
+
+Simulate `ctx.access` under `@cloudflare/vite-plugin` when `access.dev` is configured
+
+The `access.dev` config (added in wrangler 4.123.0) simulates a Cloudflare Access identity locally, but it was only wired into the `wrangler dev` path. When the dev server ran through `@cloudflare/vite-plugin`, `ctx.access` resolved to `undefined` with no warning, even though the docs list the Vite plugin as supported.
+
+The shared config translation used by the Vite plugin (`unstable_getMiniflareWorkerOptions`) now passes `access.dev` through to the Miniflare worker options, the same way `wrangler dev` already does, so `ctx.access.getIdentity()` returns the configured identity in both dev paths.

--- a/.changeset/access-dev-vite-plugin.md
+++ b/.changeset/access-dev-vite-plugin.md
@@ -1,9 +1,0 @@
----
-"wrangler": patch
----
-
-Simulate `ctx.access` under `@cloudflare/vite-plugin` when `access.dev` is configured
-
-The `access.dev` config (added in wrangler 4.123.0) simulates a Cloudflare Access identity locally, but it was only wired into the `wrangler dev` path. When the dev server ran through `@cloudflare/vite-plugin`, `ctx.access` resolved to `undefined` with no warning, even though the docs list the Vite plugin as supported.
-
-The shared config translation used by the Vite plugin (`unstable_getMiniflareWorkerOptions`) now passes `access.dev` through to the Miniflare worker options, the same way `wrangler dev` already does, so `ctx.access.getIdentity()` returns the configured identity in both dev paths.

--- a/.changeset/access-dev-vitest-pool.md
+++ b/.changeset/access-dev-vitest-pool.md
@@ -1,0 +1,6 @@
+---
+"wrangler": patch
+"@cloudflare/vitest-pool-workers": patch
+---
+
+Honor `access.dev` when running Workers with `@cloudflare/vitest-pool-workers`, so `ctx.access.getIdentity()` returns the configured identity just as it does with `wrangler dev`.

--- a/packages/wrangler/src/__tests__/unstable-get-miniflare-worker-options.test.ts
+++ b/packages/wrangler/src/__tests__/unstable-get-miniflare-worker-options.test.ts
@@ -170,7 +170,7 @@ describe("unstable_getMiniflareWorkerOptions", () => {
 			const { workerOptions } =
 				unstable_getMiniflareWorkerOptions("./wrangler.json");
 			// Without this, `ctx.access` resolves to `undefined` under
-			// @cloudflare/vite-plugin even though `wrangler dev` honours it.
+			// @cloudflare/vitest-pool-workers even though `wrangler dev` honours it.
 			expect(workerOptions.access).toEqual({
 				aud: "my-app-aud-tag",
 				identity: {

--- a/packages/wrangler/src/__tests__/unstable-get-miniflare-worker-options.test.ts
+++ b/packages/wrangler/src/__tests__/unstable-get-miniflare-worker-options.test.ts
@@ -146,6 +146,57 @@ describe("unstable_getMiniflareWorkerOptions", () => {
 		});
 	});
 
+	describe("Cloudflare Access local dev simulation (`ctx.access`)", () => {
+		it("passes `access.dev` through to the Miniflare worker options", ({
+			expect,
+		}) => {
+			writeWranglerConfig(
+				{
+					name: "test-worker",
+					main: "./index.js",
+					compatibility_date: "2024-10-04",
+					access: {
+						dev: {
+							aud: "my-app-aud-tag",
+							identity: {
+								email: "user@example.com",
+								name: "Test User",
+							},
+						},
+					},
+				},
+				"./wrangler.json"
+			);
+			const { workerOptions } =
+				unstable_getMiniflareWorkerOptions("./wrangler.json");
+			// Without this, `ctx.access` resolves to `undefined` under
+			// @cloudflare/vite-plugin even though `wrangler dev` honours it.
+			expect(workerOptions.access).toEqual({
+				aud: "my-app-aud-tag",
+				identity: {
+					email: "user@example.com",
+					name: "Test User",
+				},
+			});
+		});
+
+		it("leaves `access` undefined when no `access` config is present", ({
+			expect,
+		}) => {
+			writeWranglerConfig(
+				{
+					name: "test-worker",
+					main: "./index.js",
+					compatibility_date: "2024-10-04",
+				},
+				"./wrangler.json"
+			);
+			const { workerOptions } =
+				unstable_getMiniflareWorkerOptions("./wrangler.json");
+			expect(workerOptions.access).toBeUndefined();
+		});
+	});
+
 	describe("typed services bindings with `dev.plugin`", () => {
 		it("routes a typed service binding with `dev.plugin` to miniflare's unsafe-binding plugin pathway", ({
 			expect,

--- a/packages/wrangler/src/api/integrations/platform/index.ts
+++ b/packages/wrangler/src/api/integrations/platform/index.ts
@@ -513,6 +513,7 @@ export function unstable_getMiniflareWorkerOptions(
 		compatibilityFlags: config.compatibility_flags,
 		modulesRules,
 		zone: getZoneFromConfig(config),
+		access: config.access?.dev,
 
 		...bindingOptions,
 		...sitesOptions,


### PR DESCRIPTION
Pass access.dev through to Miniflare via unstable_getMiniflareWorkerOptions()

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: bug fix
