### PR TITLE
Fix runtime types node compat any globals

### DIFF
--- a/.changeset/runtime-types-node-compat-any-globals.md
+++ b/.changeset/runtime-types-node-compat-any-globals.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/runtime-types": patch
+---
+
+Remove generated `Buffer` and `process` declarations typed as `any` from runtime types so they no longer shadow `@types/node` globals.

--- a/.changeset/runtime-types-node-compat-any-globals.md
+++ b/.changeset/runtime-types-node-compat-any-globals.md
@@ -1,5 +1,5 @@
 ---
-"@cloudflare/runtime-types": patch
+"wrangler": patch
 ---
 
 Remove generated `Buffer` and `process` declarations typed as `any` from runtime types so they no longer shadow `@types/node` globals.

--- a/packages/runtime-types/src/__tests__/runtime.test.ts
+++ b/packages/runtime-types/src/__tests__/runtime.test.ts
@@ -95,6 +95,49 @@ describe("generateRuntimeTypes", () => {
 		expect(MiniflareMock).not.toHaveBeenCalled();
 	});
 
+	it("removes node compat any globals from generated types", async ({
+		expect,
+	}) => {
+		dispatchFetchMock.mockResolvedValue({
+			ok: true,
+			text: async () =>
+				[
+					"declare const Buffer: any;",
+					"interface Env {}",
+					"declare const process: any;",
+					"declare const caches: CacheStorage;",
+				].join("\n"),
+		});
+
+		const result = await generateRuntimeTypes({
+			compatibilityDate: "2026-08-04",
+		});
+
+		expect(result.runtimeTypes).toBe(
+			["interface Env {}", "declare const caches: CacheStorage;"].join("\n")
+		);
+	});
+
+	it("removes node compat any globals from cached types", async ({
+		expect,
+	}) => {
+		const header = getRuntimeHeader(WORKERD_VERSION, "2026-08-04", []);
+
+		const result = await generateRuntimeTypes({
+			compatibilityDate: "2026-08-04",
+			existingContent: [
+				header,
+				RUNTIME_TYPES_MARKER,
+				"declare const Buffer: any;",
+				"interface Env {}",
+				"declare const process: any;",
+			].join("\n"),
+		});
+
+		expect(result.runtimeTypes).toBe("interface Env {}");
+		expect(MiniflareMock).not.toHaveBeenCalled();
+	});
+
 	it("regenerates when the cached header is stale", async ({ expect }) => {
 		const staleHeader = getRuntimeHeader(WORKERD_VERSION, "2020-01-01", []);
 

--- a/packages/runtime-types/src/runtime.ts
+++ b/packages/runtime-types/src/runtime.ts
@@ -68,7 +68,9 @@ export async function generateRuntimeTypes({
 		if (existingHeader === header && existingTypesStart !== -1) {
 			return {
 				runtimeHeader: header,
-				runtimeTypes: lines.slice(existingTypesStart + 1).join("\n"),
+				runtimeTypes: stripNodeJsCompatAnyDeclarations(
+					lines.slice(existingTypesStart + 1).join("\n")
+				),
 				isCached: true,
 			};
 		}
@@ -82,7 +84,18 @@ export async function generateRuntimeTypes({
 		),
 	});
 
-	return { runtimeHeader: header, runtimeTypes: types, isCached: false };
+	return {
+		runtimeHeader: header,
+		runtimeTypes: stripNodeJsCompatAnyDeclarations(types),
+		isCached: false,
+	};
+}
+
+function stripNodeJsCompatAnyDeclarations(runtimeTypes: string) {
+	return runtimeTypes
+		.split(/\r?\n/)
+		.filter((line) => !/^declare const (Buffer|process): any;$/.test(line))
+		.join("\n");
 }
 
 /**


### PR DESCRIPTION
Fixes #15215.

Removes the generated `declare const Buffer: any;` and `declare const process: any;` lines from runtime types before returning generated or cached content. This keeps Wrangler generated types from shadowing `@types/node` globals when a compatibility date enables Node.js compatibility.

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: this only changes generated type output.