### PR TITLE
[workers-auth] Recover from a partially installed keyring native binding

### DIFF
--- a/.changeset/keyring-partial-native-install.md
+++ b/.changeset/keyring-partial-native-install.md
@@ -2,10 +2,8 @@
 "@cloudflare/workers-auth": patch
 ---
 
-fix: recover from a partially installed `@napi-rs/keyring` native binding
+Recover from a partially installed keyring backend on Windows
 
-On Windows, opting into keyring-backed credential storage lazily installs `@napi-rs/keyring`. The check for whether that binding was already present only tested that its `index.js` existed.
+Choosing to keep your credentials in the OS keyring on Windows installs a native backend the first time you opt in. An install interrupted part-way through — by a dropped connection, a full disk, or an npm told to skip optional packages — could leave a broken backend behind that was nonetheless treated as working. Every login, token refresh, and credential read from then on failed with an internal error, and because the broken state was never re-examined, no amount of retrying would clear it.
 
-That is not evidence of a working install. `index.js` `require`s a platform-specific `.node` binary which arrives as a separate package, so an `npm install` that is interrupted, runs out of disk, or fails to fetch the platform package leaves `index.js` on disk with nothing loadable beside it. The result was a permanently broken keyring: the binding was reported as available, so the install was never retried, and every credential read and write instead failed with a raw module-resolution error. The verdict was also memoised per process, so it could not be shaken off.
-
-A candidate binding is now only accepted once it has actually been loaded, which is the same thing the credential path does with it moments later. A half-installed binding is reported as absent, so it gets reinstalled and then works, rather than failing indefinitely.
+A broken backend is now spotted and reinstalled automatically. If the reinstall still cannot produce a working one, you get a single explanation of how to install it by hand and fall back to the plaintext credentials file for the rest of the session, rather than sitting through a fresh install attempt on every credential access.

--- a/.changeset/keyring-partial-native-install.md
+++ b/.changeset/keyring-partial-native-install.md
@@ -1,0 +1,11 @@
+---
+"@cloudflare/workers-auth": patch
+---
+
+fix: recover from a partially installed `@napi-rs/keyring` native binding
+
+On Windows, opting into keyring-backed credential storage lazily installs `@napi-rs/keyring`. The check for whether that binding was already present only tested that its `index.js` existed.
+
+That is not evidence of a working install. `index.js` `require`s a platform-specific `.node` binary which arrives as a separate package, so an `npm install` that is interrupted, runs out of disk, or fails to fetch the platform package leaves `index.js` on disk with nothing loadable beside it. The result was a permanently broken keyring: the binding was reported as available, so the install was never retried, and every credential read and write instead failed with a raw module-resolution error. The verdict was also memoised per process, so it could not be shaken off.
+
+A candidate binding is now only accepted once it has actually been loaded, which is the same thing the credential path does with it moments later. A half-installed binding is reported as absent, so it gets reinstalled and then works, rather than failing indefinitely.

--- a/packages/mock-npm-registry/src/index.ts
+++ b/packages/mock-npm-registry/src/index.ts
@@ -15,6 +15,12 @@ const debugLog = util.debuglog("mock-npm-registry");
 const repoRoot = path.resolve(__dirname, "../../..");
 
 /**
+ * How long to wait for Verdaccio to actually exit after it has been killed,
+ * before giving up and letting teardown continue regardless.
+ */
+const EXIT_TIMEOUT = 10_000;
+
+/**
  * Start a mock local npm registry (using verdaccio) to host local copies of packages under test.
  *
  * The `targetPackages` will be published to the local npm repository along with any of their local dependencies.
@@ -289,6 +295,13 @@ async function startVerdaccioServer(configPath: string) {
 			require.resolve("verdaccio/bin/verdaccio"),
 			["-c", configPath]
 		);
+
+		// Attached before anything can stop the server, so the event can never
+		// be missed by a listener registered too late to see it.
+		const exited = new Promise<void>((res) => {
+			server.once("exit", () => res());
+		});
+
 		server.on("error", reject);
 		server.on("disconnect", reject);
 
@@ -302,14 +315,46 @@ async function startVerdaccioServer(configPath: string) {
 			}
 		});
 
-		function stop() {
-			return new Promise<void>((res) => {
-				if (server?.pid) {
-					treeKill(server.pid, () => res());
-				} else {
-					res();
-				}
+		/**
+		 * Stop the server, resolving only once it has really exited.
+		 *
+		 * `treeKill`'s callback fires once the signals have been *delivered*,
+		 * not once the process tree has finished exiting. Callers remove the
+		 * registry's storage directory immediately afterwards and may restart
+		 * on the same port, both of which race a Verdaccio that is still
+		 * shutting down — producing `ENOTEMPTY`/`EBUSY` on directory removal
+		 * (particularly on Windows, where an open file blocks deletion) and
+		 * `EADDRINUSE` on restart. So wait for the real `exit` event.
+		 *
+		 * Bounded, because a process wedged in an uninterruptible state must
+		 * not hang test teardown forever: after `EXIT_TIMEOUT` we proceed and
+		 * let the caller's own error handling deal with the consequences,
+		 * which is still strictly better than not waiting at all.
+		 */
+		async function stop() {
+			const pid = server.pid;
+			if (pid === undefined) {
+				return;
+			}
+			await new Promise<void>((res) => {
+				// Errors are ignored: the usual one is "no such process",
+				// meaning it has already exited, which is what we want anyway.
+				treeKill(pid, () => res());
 			});
+			let timer: NodeJS.Timeout | undefined;
+			try {
+				await Promise.race([
+					exited,
+					new Promise<void>((res) => {
+						timer = setTimeout(res, EXIT_TIMEOUT);
+						// Don't hold the event loop open just to await a
+						// timeout we may never need.
+						timer.unref();
+					}),
+				]);
+			} finally {
+				clearTimeout(timer);
+			}
 		}
 	});
 }

--- a/packages/workers-auth/src/credential-store/key-providers/lazy-installer.ts
+++ b/packages/workers-auth/src/credential-store/key-providers/lazy-installer.ts
@@ -112,6 +112,37 @@ function getInstalledBindingPath(installDir: string): string {
 }
 
 /**
+ * Whether `candidate` is a binding this process can actually load.
+ *
+ * The presence of `index.js` is *not* sufficient evidence of a working
+ * install. `@napi-rs/keyring`'s `index.js` `require`s a platform-specific
+ * `.node` binary, which is a separate optional dependency: an `npm install`
+ * that is interrupted, runs out of disk, or fails to fetch the platform
+ * package can leave `index.js` on disk with no loadable binary beside it.
+ *
+ * Probing with a real `require` is the only honest test, because that is
+ * exactly what {@link resolveKeyringEntryFactory} does moments later. Without
+ * it, a half-installed binding is reported as "available" forever: the
+ * resolver never re-runs the install, and every credential read and write
+ * throws a raw module-resolution error instead.
+ *
+ * `require` caches on success, so the load is not repeated when the factory
+ * subsequently resolves the same path. This only runs on the Windows keyring
+ * opt-in path, so it never `dlopen`s a native binary for users who have not
+ * opted in.
+ */
+function canLoadKeyringBinding(candidate: string): boolean {
+	try {
+		createRequire(candidate)(candidate);
+		return true;
+	} catch {
+		// Missing or unloadable native binary: treat the install as absent so
+		// the caller reinstalls rather than failing on every credential access.
+		return false;
+	}
+}
+
+/**
  * Locate an installed `@napi-rs/keyring` binding usable from this process.
  *
  * Search order:
@@ -119,6 +150,11 @@ function getInstalledBindingPath(installDir: string): string {
  *   2. The user's global npm root, so a manual `npm install -g
  *      @napi-rs/keyring` works in CI environments where the lazy install
  *      path is unavailable.
+ *
+ * A candidate only counts when it actually loads (see
+ * {@link canLoadKeyringBinding}) — a half-installed binding is reported as
+ * absent so the caller reinstalls it, rather than being trusted forever on the
+ * strength of an `index.js` that cannot be required.
  *
  * Returns `null` when no binding is available; callers handle the missing
  * binding case explicitly so they can surface remediation instructions.
@@ -135,7 +171,7 @@ export function findKeyringBinding(installDir: string): string | null {
 		return cached;
 	}
 	const lazy = getInstalledBindingPath(installDir);
-	if (existsSync(path.join(lazy, "index.js"))) {
+	if (existsSync(path.join(lazy, "index.js")) && canLoadKeyringBinding(lazy)) {
 		cachedBindingPathByDir.set(installDir, lazy);
 		return lazy;
 	}
@@ -143,7 +179,10 @@ export function findKeyringBinding(installDir: string): string | null {
 		const r = npmRunner(["root", "-g"]);
 		if (r.status === 0) {
 			const global = path.join(r.stdout.trim(), "@napi-rs", "keyring");
-			if (existsSync(path.join(global, "index.js"))) {
+			if (
+				existsSync(path.join(global, "index.js")) &&
+				canLoadKeyringBinding(global)
+			) {
 				cachedBindingPathByDir.set(installDir, global);
 				return global;
 			}

--- a/packages/workers-auth/src/credential-store/key-providers/lazy-installer.ts
+++ b/packages/workers-auth/src/credential-store/key-providers/lazy-installer.ts
@@ -199,9 +199,10 @@ export function findKeyringBinding(installDir: string): string | null {
  * Install `@napi-rs/keyring` into the private install dir using the user's
  * `npm`.
  *
- * Throws a {@link UserError} when `npm` cannot be spawned or returns a
- * non-zero exit code, so callers can surface actionable remediation hints
- * rather than a raw stack trace.
+ * Throws a {@link UserError} when `npm` cannot be spawned, returns a non-zero
+ * exit code, or exits cleanly without leaving a loadable binding behind, so
+ * callers can surface actionable remediation hints rather than a raw stack
+ * trace.
  */
 export function installKeyringBindingSync(installDir: string): void {
 	const dir = installDir;
@@ -252,10 +253,32 @@ export function installKeyringBindingSync(installDir: string): void {
 			{ telemetryMessage: "workers-auth keyring npm install failed" }
 		);
 	}
-	// Fresh install landed on disk — invalidate the cached "not found"
-	// result for this install dir so the next `findKeyringBinding()` call
-	// picks the new path up immediately instead of returning the stale `null`.
+	// Something landed on disk — invalidate the cached "not found" result for
+	// this install dir so the verification below, and every later
+	// `findKeyringBinding()` call, re-probes instead of returning the stale
+	// `null`.
 	cachedBindingPathByDir.delete(installDir);
+
+	// A zero exit code is not evidence of a usable binding. The
+	// platform-specific `.node` binary ships as an *optional* dependency of
+	// `@napi-rs/keyring`, and npm exits 0 when an optional dependency cannot
+	// be fetched — as it also does when configured to skip optional
+	// dependencies entirely. Reporting success here would leave the resolver
+	// on the `needs-install` branch, which only latches its session failure
+	// flag when the install *throws*: it would therefore respawn this whole
+	// install on every credential read and write, and still fail at the end
+	// of each one. Failing loudly instead bounds the retries to one per
+	// session and routes the user through the normal remediation/fallback
+	// path.
+	if (findKeyringBinding(installDir) === null) {
+		throw new UserError(
+			`\`npm\` reported success but the \`@napi-rs/keyring\` native binding still cannot be loaded.\n\n` +
+				`Its platform-specific binary ships as a separate optional package, so a download that was skipped or interrupted leaves the binding unusable.\n\n` +
+				`Retry once the underlying issue is fixed, or install the binding globally:\n` +
+				`  npm install -g @napi-rs/keyring@${PINNED_KEYRING_VERSION}`,
+			{ telemetryMessage: "workers-auth keyring install incomplete" }
+		);
+	}
 }
 
 /**
@@ -300,6 +323,13 @@ interface KeyringModule {
 /**
  * Resolve the active keyring entry factory, loading the lazy-installed
  * binding from `installDir` when no test override is registered.
+ *
+ * Callers are expected to have resolved the binding's availability first, so a
+ * missing binding here means it went away between resolution and use (an
+ * uninstall, or a directory cleaned up mid-session). That is rare enough to be
+ * close to an internal invariant violation, but it is still the user's machine
+ * that has to be fixed, so it carries the same remediation hint as the
+ * installer rather than a bare stack trace.
  */
 export function resolveKeyringEntryFactory(
 	installDir: string
@@ -309,8 +339,11 @@ export function resolveKeyringEntryFactory(
 	}
 	const bindingPath = findKeyringBinding(installDir);
 	if (bindingPath === null) {
-		throw new Error(
-			"`@napi-rs/keyring` binding not found. Call `installKeyringBindingSync()` first."
+		throw new UserError(
+			`The \`@napi-rs/keyring\` native binding is not available.\n\n` +
+				`Retry the command, or install the binding globally:\n` +
+				`  npm install -g @napi-rs/keyring@${PINNED_KEYRING_VERSION}`,
+			{ telemetryMessage: "workers-auth keyring binding not loadable" }
 		);
 	}
 	const mod = createRequire(bindingPath)(bindingPath) as KeyringModule;

--- a/packages/workers-auth/tests/credential-store/key-providers/lazy-installer.test.ts
+++ b/packages/workers-auth/tests/credential-store/key-providers/lazy-installer.test.ts
@@ -98,6 +98,78 @@ describe("lazy keyring installer", () => {
 			expect(findKeyringBinding(installDir())).toBeNull();
 		});
 
+		it("treats a binding whose native binary is missing as absent", ({
+			expect,
+		}) => {
+			// Regression: an interrupted `npm install` can leave `index.js` on
+			// disk without the platform-specific `.node` binary it requires.
+			// Trusting `index.js` alone reported that wreck as "available"
+			// forever — the install was never retried and every credential
+			// read threw a raw module-resolution error instead.
+			const dir = path.join(
+				installDir(),
+				"node_modules",
+				"@napi-rs",
+				"keyring"
+			);
+			mkdirSync(dir, { recursive: true });
+			writeFileSync(
+				path.join(dir, "index.js"),
+				// Exactly what the real binding does, minus the binary.
+				'require("./keyring.win32-x64-msvc.node");'
+			);
+			setNpmRunner((args) => {
+				lastInvocation = args;
+				return mockResult({ stdout: "/nonexistent/global/root\n" });
+			});
+
+			expect(findKeyringBinding(installDir())).toBeNull();
+			// Having rejected the local wreck, it still probes the global root.
+			expect(lastInvocation).toEqual(["root", "-g"]);
+		});
+
+		it("ignores a global binding that cannot be loaded", ({ expect }) => {
+			const globalRoot = path.join(getGlobalConfigPath(), "global-npm-root");
+			const bindingDir = path.join(globalRoot, "@napi-rs", "keyring");
+			mkdirSync(bindingDir, { recursive: true });
+			writeFileSync(
+				path.join(bindingDir, "index.js"),
+				'require("./keyring.win32-x64-msvc.node");'
+			);
+			setNpmRunner(() => mockResult({ stdout: globalRoot + "\n" }));
+			expect(findKeyringBinding(installDir())).toBeNull();
+		});
+
+		it("recovers when a reinstall repairs a half-installed binding", ({
+			expect,
+		}) => {
+			// The end-to-end recovery this is all for: a broken install must be
+			// reported absent (so the resolver reinstalls), and the repaired
+			// install must then be picked up.
+			const dir = path.join(
+				installDir(),
+				"node_modules",
+				"@napi-rs",
+				"keyring"
+			);
+			mkdirSync(dir, { recursive: true });
+			writeFileSync(
+				path.join(dir, "index.js"),
+				'require("./keyring.win32-x64-msvc.node");'
+			);
+			setNpmRunner((args) => {
+				if (args[0] === "root") {
+					return mockResult({ stdout: "/nonexistent/global/root\n" });
+				}
+				writeFileSync(path.join(dir, "index.js"), "module.exports = {};");
+				return mockResult({});
+			});
+
+			expect(findKeyringBinding(installDir())).toBeNull();
+			installKeyringBindingSync(installDir());
+			expect(findKeyringBinding(installDir())).toBe(dir);
+		});
+
 		it("memoizes the result so repeated calls do not re-spawn npm", ({
 			expect,
 		}) => {

--- a/packages/workers-auth/tests/credential-store/key-providers/lazy-installer.test.ts
+++ b/packages/workers-auth/tests/credential-store/key-providers/lazy-installer.test.ts
@@ -1,6 +1,6 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
-import { getGlobalConfigPath } from "@cloudflare/workers-utils";
+import { getGlobalConfigPath, UserError } from "@cloudflare/workers-utils";
 import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
 import { afterEach, beforeEach, describe, it } from "vitest";
 import {
@@ -8,6 +8,7 @@ import {
 	getKeyringInstallDir,
 	installKeyringBindingSync,
 	PINNED_KEYRING_VERSION,
+	resolveKeyringEntryFactory,
 	setNpmRunner,
 } from "../../../src/credential-store/key-providers/lazy-installer";
 import type { SpawnSyncReturns } from "node:child_process";
@@ -193,8 +194,21 @@ describe("lazy keyring installer", () => {
 		it("creates a private host package.json before invoking npm install", ({
 			expect,
 		}) => {
+			const bindingDir = path.join(
+				installDir(),
+				"node_modules",
+				"@napi-rs",
+				"keyring"
+			);
 			setNpmRunner((args) => {
 				lastInvocation = args;
+				// The install verifies its own work, so the runner has to
+				// actually land a loadable binding to count as a success.
+				mkdirSync(bindingDir, { recursive: true });
+				writeFileSync(
+					path.join(bindingDir, "index.js"),
+					"module.exports = {};"
+				);
 				return mockResult({});
 			});
 			installKeyringBindingSync(installDir());
@@ -233,13 +247,56 @@ describe("lazy keyring installer", () => {
 			);
 		});
 
+		it("throws a UserError when npm exits 0 without leaving a loadable binding", ({
+			expect,
+		}) => {
+			// npm exits 0 when an optional dependency cannot be fetched, and
+			// the platform-specific `.node` binary is exactly that. Reporting
+			// success here would leave the resolver on its `needs-install`
+			// branch — which only latches its session failure flag when the
+			// install throws — so the whole install would be respawned on
+			// every single credential read and write.
+			const bindingDir = path.join(
+				installDir(),
+				"node_modules",
+				"@napi-rs",
+				"keyring"
+			);
+			setNpmRunner((args) => {
+				if (args[0] === "root") {
+					return mockResult({ stdout: "/nonexistent/global/root\n" });
+				}
+				mkdirSync(bindingDir, { recursive: true });
+				writeFileSync(
+					path.join(bindingDir, "index.js"),
+					'require("./keyring.win32-x64-msvc.node");'
+				);
+				return mockResult({});
+			});
+
+			// A `UserError` specifically: the resolver reports it verbatim when
+			// keyring storage was forced via `CLOUDFLARE_AUTH_USE_KEYRING`.
+			expect(() => installKeyringBindingSync(installDir())).toThrow(UserError);
+			expect(() => installKeyringBindingSync(installDir())).toThrow(
+				/`npm` reported success but the `@napi-rs\/keyring` native binding still cannot be loaded[\s\S]*npm install -g @napi-rs\/keyring@\d+\.\d+\.\d+/
+			);
+		});
+
 		it("does not overwrite an existing host package.json", ({ expect }) => {
 			const dir = installDir();
 			mkdirSync(dir, { recursive: true });
 			const hostPkgJson = path.join(dir, "package.json");
 			writeFileSync(hostPkgJson, '{"customMarker":true}');
 
-			setNpmRunner(() => mockResult({}));
+			const bindingDir = path.join(dir, "node_modules", "@napi-rs", "keyring");
+			setNpmRunner(() => {
+				mkdirSync(bindingDir, { recursive: true });
+				writeFileSync(
+					path.join(bindingDir, "index.js"),
+					"module.exports = {};"
+				);
+				return mockResult({});
+			});
 			installKeyringBindingSync(installDir());
 			expect(readFileSync(hostPkgJson, "utf-8")).toContain("customMarker");
 		});
@@ -283,6 +340,22 @@ describe("lazy keyring installer", () => {
 			// Next lookup must re-check the filesystem and return the new
 			// binding path (not the cached `null`).
 			expect(findKeyringBinding(installDir())).toBe(bindingDir);
+		});
+	});
+
+	describe("resolveKeyringEntryFactory", () => {
+		it("throws a UserError with remediation when no binding is available", ({
+			expect,
+		}) => {
+			// Callers resolve availability before getting here, so this is
+			// close to an internal invariant violation — but it is still the
+			// user's machine that needs fixing, so it must not surface as a
+			// bare module-resolution stack trace.
+			setNpmRunner(() => mockResult({ stdout: "/nonexistent/global/root\n" }));
+			expect(() => resolveKeyringEntryFactory(installDir())).toThrow(UserError);
+			expect(() => resolveKeyringEntryFactory(installDir())).toThrow(
+				/native binding is not available[\s\S]*npm install -g @napi-rs\/keyring@\d+\.\d+\.\d+/
+			);
 		});
 	});
 });

--- a/packages/workers-auth/tests/credential-store/resolver.test.ts
+++ b/packages/workers-auth/tests/credential-store/resolver.test.ts
@@ -396,6 +396,86 @@ describe("createCredentialStorageContext — resolver", () => {
 				resolveStore({ isKeyringEnabled: true, isNonInteractiveOrCI: false })
 			).toThrow();
 		});
+
+		it("stops retrying when npm exits 0 but the binding is still unloadable", ({
+			expect,
+		}) => {
+			// npm exits 0 when the platform-specific optional package cannot be
+			// fetched, leaving an `index.js` that cannot be required. Unless
+			// that counts as an install failure the session latch never gets
+			// set, so the multi-second install is respawned on every single
+			// credential read and write — and still fails at the end of each.
+			stubPlatform("win32");
+
+			let installCalls = 0;
+			const bindingDir = path.join(
+				getKeyringInstallDir(getGlobalConfigPath()),
+				"node_modules",
+				"@napi-rs",
+				"keyring"
+			);
+			setNpmRunner((args) => {
+				if (args[0] === "install") {
+					installCalls += 1;
+					mkdirSync(bindingDir, { recursive: true });
+					writeFileSync(
+						path.join(bindingDir, "index.js"),
+						'require("./keyring.win32-x64-msvc.node");'
+					);
+					return mockResult({});
+				}
+				return mockResult({ status: 0, stdout: "/nowhere\n" });
+			});
+
+			const { getActiveStore } = createCredentialStorageContext({
+				serviceName: "wrangler",
+				getConfigPath: () => getGlobalConfigPath(),
+				isKeyringEnabled: () => true,
+				logger: silentLogger,
+				isNonInteractiveOrCI: () => false,
+				loginCommand: "wrangler login",
+			});
+			const kinds = [
+				getActiveStore().kind,
+				getActiveStore().kind,
+				getActiveStore().kind,
+			];
+			expect(installCalls).toBe(1);
+			expect(kinds).toEqual(["file", "file", "file"]);
+			expect(warn).toHaveBeenCalledWith(
+				expect.stringContaining("still cannot be loaded")
+			);
+		});
+
+		it("hard-errors when CLOUDFLARE_AUTH_USE_KEYRING=true and the install lands no loadable binding", ({
+			expect,
+		}) => {
+			stubPlatform("win32");
+			vi.stubEnv("CLOUDFLARE_AUTH_USE_KEYRING", "true");
+			const bindingDir = path.join(
+				getKeyringInstallDir(getGlobalConfigPath()),
+				"node_modules",
+				"@napi-rs",
+				"keyring"
+			);
+			setNpmRunner((args) => {
+				if (args[0] === "install") {
+					mkdirSync(bindingDir, { recursive: true });
+					writeFileSync(
+						path.join(bindingDir, "index.js"),
+						'require("./keyring.win32-x64-msvc.node");'
+					);
+					return mockResult({});
+				}
+				return mockResult({ status: 0, stdout: "/nowhere\n" });
+			});
+
+			// Reported verbatim rather than silently downgraded to the
+			// plaintext file, because the user demanded keyring storage.
+			expect(() =>
+				resolveStore({ isKeyringEnabled: true, isNonInteractiveOrCI: false })
+			).toThrow(/still cannot be loaded/);
+		});
 	});
 
 	describe("unsupported platform", () => {


### PR DESCRIPTION
Two instances of the same class of bug found while auditing the codebase after #15206, which fixed a partially-downloaded Chrome install in miniflare. The shared principle: **the presence of files is not evidence of a working install, and a delivered signal is not evidence of an exited process.**

### `workers-auth`: a half-installed keyring binding was trusted forever

On Windows, opting into keyring-backed credential storage lazily `npm install`s `@napi-rs/keyring`. `findKeyringBinding()` accepted any candidate whose `index.js` existed:

```ts
if (existsSync(path.join(lazy, "index.js"))) {
	cachedBindingPathByDir.set(installDir, lazy);
	return lazy;
}
```

That `index.js` `require`s a platform-specific `.node` binary which npm delivers as a *separate* package. An install that is interrupted, runs out of disk, or fails to fetch the platform package leaves `index.js` on disk with nothing loadable beside it.

The consequences compounded:

1. `resolveKeyProvider()` saw a non-`null` result and returned `kind: "available"`, so the `needs-install` branch was never taken and **the install was never retried**.
2. Every credential read and write then threw a raw module-resolution error from `createRequire(...)` in `resolveKeyringEntryFactory()` — no remediation hint, no fallback.
3. The verdict is memoised in `cachedBindingPathByDir`, which is only invalidated by a successful install or `setNpmRunner()`. Since step 1 means no install is ever attempted, **the breakage was permanent** for that config dir.

A candidate is now only accepted once it has actually been `require`d — precisely what the credential path does with it moments later, so this costs nothing extra (`require` caches on success) and only ever runs on the Windows opt-in path. A half-installed binding is reported absent, so the resolver reinstalls it and it then works.

#### Bounding the retry

Reporting the wreck as absent fixes the permanent breakage but, as [Devin spotted](https://github.com/cloudflare/workers-sdk/pull/15223#discussion_r3791528274), leaves the retry unbounded in one case. `npm` exits 0 when an optional dependency cannot be fetched, and the platform-specific `.node` binary is exactly that — so on a machine where it can never be fetched (no network route to the platform package, or an npm configured to skip optional dependencies), the install "succeeds" while producing nothing loadable.

`handleNeedsInstall()` only latches `installFailedThisSession` when the install *throws*, so nothing latched, and because the resolver re-resolves on every credential operation it took the `needs-install` branch again on the very next read or write. The user would sit through a fresh multi-second install before every single credential access, each one still ending in an internal error.

The install now verifies its own work: after npm exits 0 it checks the binding actually loads, and throws a `UserError` when it does not. That routes the failure through the existing remediation path — one attempt per session, a single explanation, then a fallback to the plaintext credentials file, or a hard error when `CLOUDFLARE_AUTH_USE_KEYRING=true` demanded the keyring. A transient failure is still retried on the next invocation, since the latch is per-process.

`resolveKeyringEntryFactory()` also no longer throws a bare `Error` when the binding is unavailable. With resolution now verifying loadability that is close to an internal invariant violation, but it is still the user's machine that has to be fixed, so it carries the same remediation hint.

### `mock-npm-registry`: `stop()` resolved before the process had exited

```ts
treeKill(server.pid, () => res());
```

`treeKill`'s callback fires when the signals have been *delivered*, not when the process tree has finished exiting. Callers `removeDir()` the registry's storage directory immediately afterwards and may restart on the same port, both of which race a Verdaccio that is still shutting down — `ENOTEMPTY`/`EBUSY` on directory removal (notably on Windows, where an open file blocks deletion) and `EADDRINUSE` on restart.

It now waits for the real `exit` event, bounded by a 10s timeout so a wedged process cannot hang test teardown. The listener is attached at `fork()` time rather than inside `stop()`, so the event cannot be missed. `packages/wrangler/e2e/helpers/command.ts` already used this pattern correctly; this brings the registry helper in line.

### Testing notes

The `workers-auth` change has six new tests, each mutation-verified — removing the corresponding guard fails exactly the intended test and nothing else:

| Test | Fails when |
| --- | --- |
| `treats a binding whose native binary is missing as absent` | the lazy-dir load check is removed |
| `ignores a global binding that cannot be loaded` | the global-root load check is removed |
| `recovers when a reinstall repairs a half-installed binding` | the lazy-dir load check is removed |
| `throws a UserError when npm exits 0 without leaving a loadable binding` | the post-install verification is removed |
| `stops retrying when npm exits 0 but the binding is still unloadable` | the post-install verification is removed (`expected 3 to be 1` — three credential operations, three installs) |
| `hard-errors when CLOUDFLARE_AUTH_USE_KEYRING=true and the install lands no loadable binding` | the post-install verification is removed |
| `throws a UserError with remediation when no binding is available` | `resolveKeyringEntryFactory()` reverts to a bare `Error` |

The fixtures reproduce the real failure exactly, with an `index.js` containing `require("./keyring.win32-x64-msvc.node")` and no such binary. Two pre-existing tests whose fake npm runner exited 0 without writing anything now have to land a loadable binding, since the install verifies itself.

I did **not** add a test for the `mock-npm-registry` change, and want to be upfront about why: I wrote one, and it passed against the unfixed code too. Verdaccio exits fast enough after being signalled on macOS that the port is already free by the time the assertion runs, so the test proved nothing. The race only bites where an exiting process still holds its files or the port is reclaimed before the listener is released, which I cannot reproduce on this platform. Rather than commit a test that would give false confidence, I've left it out. That code path is exercised (though not asserted on) by the `create-cloudflare`, `vitest-pool-workers`, and `vite-plugin-cloudflare` e2e global setups.

`pnpm check` passes: 0 lint errors, all typecheck tasks green, `workers-auth` 16 test files / 173 tests passing, plus `wrangler`'s 93 `user.test.ts` tests.

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: both changes fix internal failure-recovery behaviour with no change to any documented interface. The keyring install remains transparent to the user; it now repairs itself, and when it cannot, it degrades gracefully instead of failing permanently.

> [!NOTE]
> This is a contribution from an AI agent: OpenCode, claude-opus-5.
