### PR TITLE
[edge-preview-authenticated-proxy] Release WShim metrics migration

### DIFF
--- a/.changeset/edge-preview-proxy-wshim-metrics.md
+++ b/.changeset/edge-preview-proxy-wshim-metrics.md
@@ -1,0 +1,7 @@
+---
+"@cloudflare/edge-preview-authenticated-proxy": patch
+---
+
+Release the Prometheus metrics migration to the internal `wshim` service binding
+
+Metrics were previously pushed with a plain `fetch()` to `workers-logging.cfdata.org`, which stopped working. The push was moved to the `WSHIM_SOCKET` binding in #14704, but that change was never released, so it never reached production and the Worker has been reporting no request/error counters since.

--- a/.changeset/edge-preview-proxy-wshim-metrics.md
+++ b/.changeset/edge-preview-proxy-wshim-metrics.md
@@ -2,6 +2,6 @@
 "@cloudflare/edge-preview-authenticated-proxy": patch
 ---
 
-Release the Prometheus metrics migration to the internal `wshim` service binding
+Fix missing request and error metrics for the edge preview proxy
 
-Metrics were previously pushed with a plain `fetch()` to `workers-logging.cfdata.org`, which stopped working. The push was moved to the `WSHIM_SOCKET` binding in #14704, but that change was never released, so it never reached production and the Worker has been reporting no request/error counters since.
+The proxy stopped reporting its request and error counters, so dashboards and alerts based on them had no data. Metrics reporting now works again.


### PR DESCRIPTION
Adds the changeset that [#14704](https://github.com/cloudflare/workers-sdk/pull/14704) omitted, so that `edge-preview-authenticated-proxy` actually gets deployed and starts reporting Prometheus metrics again.

### What's broken

The `Prometheus_Rule_Failed_Checks` pint alert has been firing against `chat-workers-devprod`. `pint_problem{owner="chat-workers-devprod"}` currently returns 12 series, all for this Worker and none for the other two DevProd Workers:

```
reporter: promql/series
kind:     recording
filename: /etc/prometheus/recording.d/global_edge_devprod.rules.yaml
name:     global:devprod_edge_preview_authenticated_proxy_error:ratio15m   (and :ratio3h)
problem:  query on nonexistent series: `edge` Prometheus server at
          https://edge.prometheus-access.cfdata.org didn't have any series for the
          `colo:devprod_edge_preview_authenticated_proxy_request:increase15m`
          metric in the last 1w.
```

The denominator of the SLI doesn't exist because the Worker isn't pushing any counters.

### Why

- **2026-06-13** — all three DevProd Workers stop reporting; the plain `fetch()` to `workers-logging.cfdata.org` no longer works.
- **2026-07-16** — #14704 migrates `edge-preview-authenticated-proxy`, `format-errors` and `playground-preview-worker` to the `WSHIM_SOCKET` internal service binding. That PR carried **no changeset**.
- **2026-07-17** — #14707 (zod v4) bumps `format-errors@0.0.9` and `playground-preview-worker@0.3.3`, which incidentally deploys them with the WShim change.
- **2026-07-18** — those two start reporting again and their pint problems clear.
- `edge-preview-authenticated-proxy` is still on **0.3.2**, released by #14157 which predates the WShim change.

`tools/deployments/deploy-non-npm-packages.ts` only deploys packages present in `PUBLISHED_PACKAGES`, i.e. packages that changesets actually version-bumped. All three Workers have `wrangler`/`@cloudflare/workers-utils` as *dev*Dependencies, so changesets never bumps them automatically. No changeset means no version bump, which means no deploy — the WShim fix was merged over a month ago but has never reached production.

### The change

A changeset only, no code changes. `changeset status` confirms `@cloudflare/edge-preview-authenticated-proxy` is now queued for a patch bump, which will put it into `PUBLISHED_PACKAGES` and trigger `wrangler deploy` on the next release.

### Verifying after release

`count(edge_preview_authenticated_proxy_devprod_edge_preview_authenticated_proxy_request_total)` should become non-empty and `pint_problem{owner="chat-workers-devprod"}` should go empty. `format-errors` took ~2 days to reappear after its deploy. The alert has `for: 4h`, so expect it to resolve a few hours after the series returns.

One thing to watch: #14704 also added `secrets.required` to this Worker's `wrangler.jsonc`. Those become `inherit` bindings and the API hard-fails the deploy if any of `PROMETHEUS_TOKEN`, `SENTRY_ACCESS_CLIENT_SECRET` or `SENTRY_ACCESS_CLIENT_ID` is unset. All three were used by the pre-#14704 code so they should already exist, but that's the first thing to check if the deploy step fails.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: this PR contains no code changes. It only adds the changeset that #14704 omitted, so the already-merged and tested code finally gets released.
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: this is an internal Cloudflare Worker with no public API surface.

*A picture of a cute animal (not mandatory, but encouraged)*

![a very serious looking owl](https://em-content.zobj.net/source/microsoft-teams/363/owl_1f989.png)

> [!NOTE]
> This is a contribution from an AI agent: OpenCode, claude-opus-5.
