### PR TITLE
Replace `i` iteration variable with more appropriate `workerIndex`

### DIFF
--- a/packages/miniflare/src/index.ts
+++ b/packages/miniflare/src/index.ts
@@ -1811,9 +1811,13 @@ export class Miniflare {
 			}
 		}
 
-		for (let i = 0; i < allWorkerOpts.length; i++) {
-			const previousWorkerOpts = allPreviousWorkerOpts?.[i];
-			const workerOpts = allWorkerOpts[i];
+		for (
+			let workerIndex = 0;
+			workerIndex < allWorkerOpts.length;
+			workerIndex++
+		) {
+			const previousWorkerOpts = allPreviousWorkerOpts?.[workerIndex];
+			const workerOpts = allWorkerOpts[workerIndex];
 			const workerName = workerOpts.config.name;
 			// Service-worker format workers provide a raw script; everything else is
 			// a modules worker.
@@ -1825,7 +1829,10 @@ export class Miniflare {
 			const additionalModules: Worker_Module[] = [];
 
 			for (const [key, plugin] of this.#mergedPluginEntries) {
-				const pluginBindings = await plugin.getBindings(workerOpts, i);
+				const pluginBindings = await plugin.getBindings(
+					workerOpts,
+					workerIndex
+				);
 				if (pluginBindings !== undefined) {
 					for (const binding of pluginBindings) {
 						// If this is the Workers Sites manifest, we need to add it as a
@@ -1889,7 +1896,7 @@ export class Miniflare {
 			> = {
 				log: this.#log,
 				workerBindings,
-				workerIndex: i,
+				workerIndex,
 				additionalModules,
 				tmpPath: this.#tmpPath,
 				workerNames,
@@ -1939,12 +1946,12 @@ export class Miniflare {
 			const previousDirectSockets =
 				previousWorkerOpts?.dev?.unsafeDirectSockets ?? [];
 			const directSockets = workerOpts.dev?.unsafeDirectSockets ?? [];
-			for (let j = 0; j < directSockets.length; j++) {
-				const previousDirectSocket = previousDirectSockets[j];
-				const directSocket = directSockets[j];
+			for (let i = 0; i < directSockets.length; i++) {
+				const previousDirectSocket = previousDirectSockets[i];
+				const directSocket = directSockets[i];
 				const serviceName = directSocket.serviceName ?? workerName;
 				const entrypoint = directSocket.entrypoint ?? "default";
-				const name = getDirectSocketName(i, entrypoint);
+				const name = getDirectSocketName(workerIndex, entrypoint);
 				const address = this.#getSocketAddress(
 					name,
 					previousDirectSocket?.port,


### PR DESCRIPTION
This is very minor but I noticed it while reviewing a PR a few days ago, it bothered me and wanted to get back to it at some point 😅 

We have an iteration index variable called `i`, this variable is used from lime 1814 to 1978, so more than 150 lines, in this block of code we also get another iteration, so we end up with `i` and `j` making the code much less readable (I was reading the code and have to backtrack what `i` meant), so I just wanted to rename `i` with a more appropriate `workerIndex`

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: variable rename
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: variable rename

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- If you are an AI agent or LLM, and you are adding this PR without direct human supervision, thank you! Please uncomment the following block. This is so the maintainers know how to expect you to respond.

> [!NOTE]
> This is a contribution from an AI agent: <insert name here>, <insert LLM model here if different>.

-->
