### PR TITLE
chore: bump `capnp-es` to 0.0.16.

### DIFF
--- a/.changeset/ripe-rice-hang.md
+++ b/.changeset/ripe-rice-hang.md
@@ -1,0 +1,6 @@
+---
+"miniflare": patch
+"@cloudflare/vitest-pool-workers": patch
+---
+
+Bump `capnp-es` to 0.0.16.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,8 +28,8 @@ catalogs:
       specifier: 4.1.0
       version: 4.1.0
     capnp-es:
-      specifier: 0.0.15
-      version: 0.0.15
+      specifier: 0.0.16
+      version: 0.0.16
     capnweb:
       specifier: 0.5.0
       version: 0.5.0
@@ -2436,7 +2436,7 @@ importers:
         version: 8.3.5
       capnp-es:
         specifier: catalog:default
-        version: 0.0.15(typescript@5.8.3)
+        version: 0.0.16(typescript@5.8.3)
       capnweb:
         specifier: catalog:default
         version: 0.5.0
@@ -4129,7 +4129,7 @@ importers:
         version: 0.2.14
       capnp-es:
         specifier: catalog:default
-        version: 0.0.15(typescript@5.8.3)
+        version: 0.0.16(typescript@5.8.3)
       devalue:
         specifier: ^5.6.3
         version: 5.6.3
@@ -11170,11 +11170,11 @@ packages:
   caniuse-lite@1.0.30001809:
     resolution: {integrity: sha512-xxWVywk6a6Arlk+hymeycyn/VgqEfLDxupvhH/xiY5SJ/18kmi9o6MiO320DCUzypORHLtvh0I4i04tUhCNHNQ==}
 
-  capnp-es@0.0.15:
-    resolution: {integrity: sha512-p3nLMXKmoMtO1pjdX3QrdtNep+gi9A3Q6k1GaVPyMsvdLLU6HH8wQxJJ7zs86ywti4BxSkaaksF7UZ3+NGI2JQ==}
+  capnp-es@0.0.16:
+    resolution: {integrity: sha512-pqhhnRqGfDdgHa+rz4JVO9j1jnkyqsHRYrD4RBtIwxCknYSRG7Mjs+x3IRfd20u+ZGS0IhW2L7cDv9ZcIkCYhQ==}
     hasBin: true
     peerDependencies:
-      typescript: ^5.7.3
+      typescript: ^5.7.3 || ^6.0.0
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -23834,7 +23834,7 @@ snapshots:
 
   caniuse-lite@1.0.30001809: {}
 
-  capnp-es@0.0.15(typescript@5.8.3):
+  capnp-es@0.0.16(typescript@5.8.3):
     optionalDependencies:
       typescript: 5.8.3
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -51,8 +51,6 @@ minimumReleaseAgeExclude:
   # wasm module it brings as soon as possible
   # TODO(dario): remove in a few days
   - "rosie-skills"
-  # capnp-es@0.0.15 was released by us on Aug 11, 2026.
-  - "capnp-es@0.0.15"
 
 # ──────────────────────────────────────────────────────────────────────────────
 # Build scripts
@@ -137,7 +135,7 @@ catalog:
   msw: "2.14.6"
   tinyglobby: "0.2.16"
   "tree-kill": "1.2.2"
-  "capnp-es": "0.0.15"
+  "capnp-es": "0.0.16"
   "capnweb": "0.5.0"
   zod: "4.4.3"
   "ci-info": "4.4.0"


### PR DESCRIPTION
Changes in capnp-es 0.0.16

- Extend the peer dep on Typescript to v6
- Bump dependencies

There is no behavior change in 0.0.16 - verified by re-generating the .ts files with 0.0.16 and making sure there is no diff.
This update is done to prepare for when workers-sdk switches to TS 6 and to keep it in sync with workerd.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: no behavior change
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: no user facing change (and no behavior change)

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- If you are an AI agent or LLM, and you are adding this PR without direct human supervision, thank you! Please uncomment the following block. This is so the maintainers know how to expect you to respond.

> [!NOTE]
> This is a contribution from an AI agent: <insert name here>, <insert LLM model here if different>.

-->
