### PR TITLE
[wrangler] Skip container deploy e2e tests on non-Linux CI

### DIFF
--- a/packages/wrangler/e2e/durable-objects-exports.test.ts
+++ b/packages/wrangler/e2e/durable-objects-exports.test.ts
@@ -16,14 +16,7 @@ const CONTAINER_DEPLOY_TIMEOUT = 240_000;
 
 // The container deploy tests never *run* a container, but they do have to build
 // and push a `linux/amd64` image, which needs Docker. That rules out the hosted
-// non-Linux CI runners:
-//   - macOS runners ship no Docker CLI or daemon at all.
-//   - Windows runners ship the Docker CLI without the buildx plugin, so the
-//     classic builder rejects the `--load` flag that we always pass. Even with
-//     buildx installed the daemon serves Windows containers, so it could not
-//     build a Linux image anyway.
-// Gating on `ci.isCI` rather than the platform alone keeps these running locally
-// on macOS and Windows, where Docker Desktop is usually available.
+// non-Linux CI runners.
 const skipContainerDeployTests =
 	Boolean(process.env.LOCAL_TESTS_WITHOUT_DOCKER) ||
 	(ci.isCI && process.platform !== "linux");

--- a/packages/wrangler/e2e/durable-objects-exports.test.ts
+++ b/packages/wrangler/e2e/durable-objects-exports.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert";
 import { setTimeout } from "node:timers/promises";
 import { getCloudflareContainerRegistry } from "@cloudflare/containers-shared";
+import ci from "ci-info";
 import dedent from "ts-dedent";
 import { afterAll, beforeAll, describe, it } from "vitest";
 import { CLOUDFLARE_ACCOUNT_ID } from "./helpers/account-id";
@@ -12,6 +13,20 @@ const TIMEOUT = 60_000;
 // Deploys that build and push a container image are much slower than a plain
 // `wrangler deploy`.
 const CONTAINER_DEPLOY_TIMEOUT = 240_000;
+
+// The container deploy tests never *run* a container, but they do have to build
+// and push a `linux/amd64` image, which needs Docker. That rules out the hosted
+// non-Linux CI runners:
+//   - macOS runners ship no Docker CLI or daemon at all.
+//   - Windows runners ship the Docker CLI without the buildx plugin, so the
+//     classic builder rejects the `--load` flag that we always pass. Even with
+//     buildx installed the daemon serves Windows containers, so it could not
+//     build a Linux image anyway.
+// Gating on `ci.isCI` rather than the platform alone keeps these running locally
+// on macOS and Windows, where Docker Desktop is usually available.
+const skipContainerDeployTests =
+	Boolean(process.env.LOCAL_TESTS_WITHOUT_DOCKER) ||
+	(ci.isCI && process.platform !== "linux");
 
 describe.skipIf(!CLOUDFLARE_ACCOUNT_ID)(
 	"durable-objects-exports",
@@ -624,9 +639,7 @@ describe.skipIf(!CLOUDFLARE_ACCOUNT_ID)(
 			});
 		});
 
-		// Pushing the container image needs Docker. Unlike the local dev tests we
-		// never *run* the container, so this is not restricted to Linux.
-		describe.skipIf(process.env.LOCAL_TESTS_WITHOUT_DOCKER)(
+		describe.skipIf(skipContainerDeployTests)(
 			"containers attached via `exports`: deploy",
 			{ timeout: CONTAINER_DEPLOY_TIMEOUT },
 			() => {
@@ -682,7 +695,16 @@ describe.skipIf(!CLOUDFLARE_ACCOUNT_ID)(
 						`,
 					});
 
-					await helper.run(`wrangler containers build . -t ${imageTag} -p`);
+					const build = await helper.run(
+						`wrangler containers build . -t ${imageTag} -p`
+					);
+					// Assert here rather than letting the tests below fail on a missing
+					// image, so that a broken or missing Docker installation is reported
+					// as such instead of as an unrelated assertion in `getDeployedUrl()`.
+					assert(
+						build.status === 0,
+						`Failed to build and push ${imageTag} (exit code ${build.status}):\n${build.stderr}`
+					);
 					// Give the registry a moment to make the pushed image available.
 					await setTimeout(5_000);
 				}, CONTAINER_DEPLOY_TIMEOUT);


### PR DESCRIPTION
The `containers attached via `exports`: deploy` tests in `packages/wrangler/e2e/durable-objects-exports.test.ts` build and push a `linux/amd64` image via `wrangler containers build`, which needs Docker. That is not available on the hosted non-Linux runners, so these tests fail on every macOS and Windows E2E run:

- **macOS** runners ship no Docker CLI or daemon at all → `The Docker CLI is needed to build the image but could not be launched.`
- **Windows** runners ship the Docker CLI (29.x) *without* the buildx plugin, so the classic builder rejects the `--load` flag that `containers-shared` always passes → `unknown flag: --load`, exit code 125. Even with buildx installed, the daemon on those runners serves Windows containers, so it could not build a Linux image anyway.

The pre-existing `LOCAL_TESTS_WITHOUT_DOCKER` guard did not help here, because `e2e/validate-environment.ts` only sets that variable when `CI !== "true"` — so in CI this block was effectively ungated. This PR additionally gates it on `ci.isCI && process.platform !== "linux"`, matching the containers deploy tests already in `e2e/deployments.test.ts`. Using `ci.isCI` rather than the platform alone keeps the tests running locally on macOS and Windows, where Docker Desktop is usually available.

No coverage is lost: these tests assert that the API links a container to a Durable Object declared via `exports`, which is platform-independent and still covered on Linux. The sibling `containers attached via `exports`` block (dry-run only, no Docker) continues to run on all platforms.

Second, `beforeAll` now asserts that the `containers build` actually succeeded. `helper.run()` does not throw on a non-zero exit, so the failed build was silently swallowed and the failure only surfaced ~70 lines later as an unrelated `AssertionError: (match?.groups)` inside `getDeployedUrl()` — which is why the macOS cause was hard to identify from the logs.

Deliberately **not** included, to keep this focused:

- Wrangler assumes `buildx` is present. Any user on a classic-only Docker CLI gets the raw `unknown flag: --load` + exit 125 with no explanation. That is a real user-facing gap worth fixing separately in `containers-shared` (either invoke `docker buildx build` explicitly, or probe `docker buildx version` and raise a proper `UserError`).
- There are now three spellings of "skip container tests on non-Linux CI" (`containers.dev.test.ts`, `deployments.test.ts`, `durable-objects-exports.test.ts`) that could be unified into one shared helper.

Verified by collecting the suite with `vitest list`:

| Environment | `skipContainerDeployTests` | Tests collected |
| --- | --- | --- |
| `CI=true`, darwin (reproduces CI) | `true` | 17 of 19 — the 2 container build tests excluded |
| local, darwin, Docker running | `false` | 19 of 19 |

Failing jobs this fixes:

- [Wrangler E2E (macOS, shard 3/4)](https://github.com/cloudflare/workers-sdk/actions/runs/31971314902/job/95224098510)
- [Wrangler E2E (Windows, shard 3/4)](https://github.com/cloudflare/workers-sdk/actions/runs/31971314902/job/95224098626)

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: this only changes which platforms an existing E2E test runs on. There is no change to Wrangler's behaviour, CLI surface or output.

> [!NOTE]
> This is a contribution from an AI agent: opencode, claude-opus-5.
