### PR TITLE
[wrangler] Time out stalled asset uploads

### DIFF
--- a/.changeset/calm-assets-retry.md
+++ b/.changeset/calm-assets-retry.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Prevent Workers Assets uploads from hanging indefinitely
+
+Asset upload requests now time out after two minutes and enter Wrangler's existing retry flow. If all retries time out, Wrangler reports a resumable upload error instead of waiting for the surrounding build to terminate the deployment.

--- a/packages/deploy-helpers/src/deploy/helpers/assets.ts
+++ b/packages/deploy-helpers/src/deploy/helpers/assets.ts
@@ -66,6 +66,7 @@ const BULK_UPLOAD_CONCURRENCY = 3;
 const EDGE_KV_UPLOAD_CONCURRENCY = 50;
 const MAX_UPLOAD_ATTEMPTS = 5;
 const MAX_UPLOAD_GATEWAY_ERRORS = 5;
+const ASSET_UPLOAD_REQUEST_TIMEOUT_MS = 2 * 60 * 1000;
 
 const MAX_DIFF_LINES = 100;
 
@@ -195,6 +196,9 @@ export const syncAssets = async (
 
 			try {
 				let res: UploadResponse;
+				const abortSignal = AbortSignal.timeout(
+					ASSET_UPLOAD_REQUEST_TIMEOUT_MS
+				);
 				if (useSingleAssetUpload) {
 					const manifestEntry = bucket[0];
 					const absFilePath = path.join(assetDirectory, manifestEntry[0]);
@@ -210,7 +214,9 @@ export const syncAssets = async (
 							},
 							body: createReadStream(absFilePath),
 							duplex: "half",
-						}
+						},
+						undefined,
+						abortSignal
 					);
 				} else {
 					// Populate the payload only when actually uploading (this is limited to 3 concurrent uploads at 50 MiB per bucket meaning we'd only load in a max of ~150 MiB)
@@ -243,7 +249,9 @@ export const syncAssets = async (
 								Authorization: `Bearer ${initializeAssetsResponse.jwt}`,
 							},
 							body: payload,
-						}
+						},
+						undefined,
+						abortSignal
 					);
 				}
 				uploadedAssetsCount += bucket.length;
@@ -292,6 +300,14 @@ export const syncAssets = async (
 							}. Please try again.\n` +
 							`Assets already uploaded have been saved, so the next attempt will automatically resume from this point.`,
 						{ telemetryMessage: "Asset upload took too long" }
+					);
+				} else if (e instanceof DOMException && e.name === "TimeoutError") {
+					throw new FatalError(
+						`Asset upload timed out on bucket ${bucketIndex + 1}/${
+							uploadBuckets.length
+						} after ${MAX_UPLOAD_ATTEMPTS} retries.\n` +
+							`Assets already uploaded have been saved, so the next attempt will automatically resume from this point.`,
+						{ telemetryMessage: "asset upload request timed out" }
 					);
 				} else {
 					throw e;

--- a/packages/wrangler/src/__tests__/deploy/assets.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/assets.test.ts
@@ -1107,6 +1107,7 @@ describe("deploy", () => {
 		it("should upload each asset individually with raw bytes when wrangler_single_asset_uploads is true", async ({
 			expect,
 		}) => {
+			const timeoutSpy = vi.spyOn(AbortSignal, "timeout");
 			const sendMetricsEventSpy = vi
 				.spyOn(metrics, "sendMetricsEvent")
 				.mockImplementation(() => {});
@@ -1163,6 +1164,8 @@ describe("deploy", () => {
 			await runWrangler("deploy");
 
 			expect(uploadedRequests).toHaveLength(2);
+			expect(timeoutSpy).toHaveBeenCalledTimes(2);
+			expect(timeoutSpy).toHaveBeenCalledWith(2 * 60 * 1000);
 
 			// Verify per-hash URLs with no query string
 			const paths = uploadedRequests.map((r) => new URL(r.url).pathname).sort();


### PR DESCRIPTION
Addresses https://github.com/cloudflare/workers-sdk/issues/14964 and https://github.com/cloudflare/workers-sdk/issues/15060.

Workers Assets upload requests currently have no request-level timeout. If the upload API stops responding, the request never rejects, so Wrangler's existing retry handling is never reached and the deploy hangs until an external build timeout kills it.

This adds a two-minute timeout to each individual and legacy bulk asset upload attempt. Timed-out requests enter the existing retry flow with a fresh signal for each attempt. If the retries are exhausted, Wrangler reports that the upload can be resumed instead of hanging indefinitely.

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: This only changes timeout and retry behavior for stalled API requests.

*A picture of a cute animal (not mandatory, but encouraged)*

> [!NOTE]
> This is a contribution from an AI agent: Codex, GPT-5.
