### PR TITLE
Pass access configuration to Router Worker

### DIFF
--- a/.changeset/access-dev-vite-plugin.md
+++ b/.changeset/access-dev-vite-plugin.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/vite-plugin": patch
+---
+
+Honor `access.dev` when running Workers with `@cloudflare/vite-plugin`, so `ctx.access.getIdentity()` returns the configured identity.

--- a/packages/vite-plugin-cloudflare/playground/worker-♫/__tests__/worker.spec.ts
+++ b/packages/vite-plugin-cloudflare/playground/worker-♫/__tests__/worker.spec.ts
@@ -17,6 +17,18 @@ test("basic hello-world functionality", async ({ expect }) => {
 	);
 });
 
+test("provides the configured Access identity", async ({ expect }) => {
+	expect(await getTextResponse("/access")).toBe(
+		JSON.stringify({
+			aud: "vite-plugin-test-audience",
+			identity: {
+				email: "vite-plugin@example.com",
+				name: "Vite Plugin Test User",
+			},
+		})
+	);
+});
+
 test("the project path can contain a non-ascii character", async ({
 	expect,
 }) => {

--- a/packages/vite-plugin-cloudflare/playground/worker-♫/src/index.ts
+++ b/packages/vite-plugin-cloudflare/playground/worker-♫/src/index.ts
@@ -1,8 +1,14 @@
 import { a } from "./a";
 
 export default {
-	async fetch(request) {
+	async fetch(request, _env, ctx) {
 		const url = new URL(request.url);
+		if (url.pathname === "/access") {
+			return Response.json({
+				aud: ctx.access?.aud,
+				identity: await ctx.access?.getIdentity(),
+			});
+		}
 
 		if (
 			url.pathname ===

--- a/packages/vite-plugin-cloudflare/playground/worker-♫/wrangler.jsonc
+++ b/packages/vite-plugin-cloudflare/playground/worker-♫/wrangler.jsonc
@@ -2,6 +2,15 @@
 	"name": "worker",
 	"main": "./src/index.ts",
 	// compatibility date omitted to test fallback
+	"access": {
+		"dev": {
+			"aud": "vite-plugin-test-audience",
+			"identity": {
+				"email": "vite-plugin@example.com",
+				"name": "Vite Plugin Test User",
+			},
+		},
+	},
 	"services": [
 		{
 			"binding": "TEST_IF_VITE_CRASH_WITH_UNKNOWN_NAMED_ENTRYPOINT",

--- a/packages/vite-plugin-cloudflare/src/miniflare-options.ts
+++ b/packages/vite-plugin-cloudflare/src/miniflare-options.ts
@@ -159,6 +159,7 @@ export async function getDevMiniflareOptions(
 	const assetWorkers: Array<V4WorkerOptions> = [
 		{
 			name: ROUTER_WORKER_NAME,
+			access: entryWorkerConfig?.access?.dev,
 			unsafeRegisterWorker: false,
 			compatibilityDate: INTERNAL_WORKERS_COMPATIBILITY_DATE,
 			compatibilityFlags: ["enable_ctx_exports"],


### PR DESCRIPTION
Fixes https://github.com/cloudflare/workers-sdk/issues/15204.

Follow up to https://github.com/cloudflare/workers-sdk/pull/15211.

Honor `access.dev` when running Workers with `@cloudflare/vite-plugin`, so `ctx.access.getIdentity()` returns the configured identity.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bug fix

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- If you are an AI agent or LLM, and you are adding this PR without direct human supervision, thank you! Please uncomment the following block. This is so the maintainers know how to expect you to respond.

> [!NOTE]
> This is a contribution from an AI agent: <insert name here>, <insert LLM model here if different>.

-->
