### PR TITLE
[miniflare] Terminate workerd when the parent receives SIGHUP

### DIFF
--- a/.changeset/miniflare-sighup-orphan-workerd.md
+++ b/.changeset/miniflare-sighup-orphan-workerd.md
@@ -1,0 +1,7 @@
+---
+"miniflare": patch
+---
+
+Terminate `workerd` when the Miniflare process receives `SIGHUP`
+
+Miniflare listened for `SIGINT` and `SIGTERM` but not `SIGHUP`, so on `SIGHUP` it exited without running any handler: `dispose()` never ran, the `SIGKILL` that stops `workerd` was never reached, and the child was left running with no parent. This mostly affected tools that embed Miniflare, such as `@cloudflare/vitest-pool-workers` and `@cloudflare/vite-plugin`, where nothing else cleans up the runtime. `SIGHUP` is now handled like the other termination signals, so `workerd` is stopped and the temporary directory is removed.

--- a/.changeset/miniflare-sighup-orphan-workerd.md
+++ b/.changeset/miniflare-sighup-orphan-workerd.md
@@ -2,6 +2,6 @@
 "miniflare": patch
 ---
 
-Terminate `workerd` when the Miniflare process receives `SIGHUP`
+Shut down `workerd` when Miniflare is terminated with `SIGHUP`
 
-Miniflare listened for `SIGINT` and `SIGTERM` but not `SIGHUP`, so on `SIGHUP` it exited without running any handler: `dispose()` never ran, the `SIGKILL` that stops `workerd` was never reached, and the child was left running with no parent. This mostly affected tools that embed Miniflare, such as `@cloudflare/vitest-pool-workers` and `@cloudflare/vite-plugin`, where nothing else cleans up the runtime. `SIGHUP` is now handled like the other termination signals, so `workerd` is stopped and the temporary directory is removed.
+On `SIGHUP`, Miniflare now stops `workerd` and removes its temporary directory instead of leaving them behind. Previously only `SIGINT` and `SIGTERM` were handled, so tools that embed Miniflare, such as `@cloudflare/vitest-pool-workers` and `@cloudflare/vite-plugin`, could leave a stray process and directory behind on each run.

--- a/packages/miniflare/src/exit-hook.ts
+++ b/packages/miniflare/src/exit-hook.ts
@@ -43,6 +43,12 @@ function onSignalTerm(): void {
 	process.exit(128 + 15);
 }
 
+function onSignalHup(): void {
+	runCallbacks();
+	// eslint-disable-next-line unicorn/no-process-exit -- intentional: replicate default SIGHUP behavior
+	process.exit(128 + 1);
+}
+
 function onMessage(message: unknown): void {
 	if (message === "shutdown") {
 		runCallbacks();
@@ -57,6 +63,13 @@ function addListeners(): void {
 	process.on("exit", onExit);
 	process.on("SIGINT", onSignalInt);
 	process.on("SIGTERM", onSignalTerm);
+	// Without this, `SIGHUP` exits without running any handler, so `dispose()`
+	// never reaches the `SIGKILL` that stops `workerd` and it is left reparented
+	// to init. Matters most when Miniflare is embedded rather than run under
+	// `wrangler dev`, which leaves `workerd` in the caller's process group where
+	// the signal reaches it anyway.
+	// See https://github.com/cloudflare/workers-sdk/issues/9193.
+	process.on("SIGHUP", onSignalHup);
 	// Only listen for IPC "shutdown" messages (PM2 support) when the process
 	// actually has an IPC channel.  Even without this guard the listener is
 	// harmless when there is no channel, but being explicit avoids any
@@ -71,6 +84,7 @@ function removeListeners(): void {
 	process.removeListener("exit", onExit);
 	process.removeListener("SIGINT", onSignalInt);
 	process.removeListener("SIGTERM", onSignalTerm);
+	process.removeListener("SIGHUP", onSignalHup);
 	process.removeListener("message", onMessage);
 }
 

--- a/packages/miniflare/test/exit-hook.spec.ts
+++ b/packages/miniflare/test/exit-hook.spec.ts
@@ -1,9 +1,11 @@
-import { afterEach, test } from "vitest";
+import { afterEach, test, vi } from "vitest";
 import { exitHook } from "../src/exit-hook";
 
-// The handlers call `process.exit()`, so these tests assert on listener
-// registration rather than invoking the handlers directly.
-const SIGNALS = ["SIGINT", "SIGTERM", "SIGHUP"] as const;
+const SIGNALS = [
+	["SIGINT", 128 + 2],
+	["SIGTERM", 128 + 15],
+	["SIGHUP", 128 + 1],
+] as const;
 
 const unregisters: (() => void)[] = [];
 
@@ -19,24 +21,43 @@ afterEach(() => {
 	}
 });
 
-test("exitHook: listens for SIGHUP so the runtime is disposed on hangup", ({
-	expect,
-}) => {
-	const before = process.listenerCount("SIGHUP");
-	register();
-	expect(process.listenerCount("SIGHUP")).toBe(before + 1);
-});
+test.for(SIGNALS)(
+	"exitHook: runs callbacks and exits on %s",
+	([signal, exitCode], { expect }) => {
+		const listenersBefore = new Set(process.listeners(signal));
+		const callback = vi.fn();
+		register(callback);
+
+		const signalHandler = process
+			.listeners(signal)
+			.find((listener) => !listenersBefore.has(listener));
+		if (signalHandler === undefined) {
+			throw new Error(`Expected exitHook() to register a ${signal} listener`);
+		}
+
+		const exit = vi.spyOn(process, "exit").mockImplementation((code) => {
+			throw new Error(`process.exit(${String(code)})`);
+		});
+		try {
+			expect(() => signalHandler(signal)).toThrow(`process.exit(${exitCode})`);
+			expect(callback).toHaveBeenCalledOnce();
+			expect(exit).toHaveBeenCalledWith(exitCode);
+		} finally {
+			exit.mockRestore();
+		}
+	}
+);
 
 test("exitHook: registers a listener for every termination signal", ({
 	expect,
 }) => {
 	const before = Object.fromEntries(
-		SIGNALS.map((signal) => [signal, process.listenerCount(signal)])
+		SIGNALS.map(([signal]) => [signal, process.listenerCount(signal)])
 	);
 
 	register();
 
-	for (const signal of SIGNALS) {
+	for (const [signal] of SIGNALS) {
 		expect(process.listenerCount(signal)).toBe(before[signal] + 1);
 	}
 });
@@ -45,7 +66,7 @@ test("exitHook: removes every signal listener once the last callback unregisters
 	expect,
 }) => {
 	const before = Object.fromEntries(
-		SIGNALS.map((signal) => [signal, process.listenerCount(signal)])
+		SIGNALS.map(([signal]) => [signal, process.listenerCount(signal)])
 	);
 
 	const unregisterFirst = register();
@@ -53,12 +74,12 @@ test("exitHook: removes every signal listener once the last callback unregisters
 
 	unregisterFirst();
 	// Listeners stay while another callback is still registered.
-	for (const signal of SIGNALS) {
+	for (const [signal] of SIGNALS) {
 		expect(process.listenerCount(signal)).toBe(before[signal] + 1);
 	}
 
 	unregisterSecond();
-	for (const signal of SIGNALS) {
+	for (const [signal] of SIGNALS) {
 		expect(process.listenerCount(signal)).toBe(before[signal]);
 	}
 });

--- a/packages/miniflare/test/exit-hook.spec.ts
+++ b/packages/miniflare/test/exit-hook.spec.ts
@@ -1,0 +1,64 @@
+import { afterEach, test } from "vitest";
+import { exitHook } from "../src/exit-hook";
+
+// The handlers call `process.exit()`, so these tests assert on listener
+// registration rather than invoking the handlers directly.
+const SIGNALS = ["SIGINT", "SIGTERM", "SIGHUP"] as const;
+
+const unregisters: (() => void)[] = [];
+
+function register(callback: () => void = () => {}) {
+	const unregister = exitHook(callback);
+	unregisters.push(unregister);
+	return unregister;
+}
+
+afterEach(() => {
+	while (unregisters.length > 0) {
+		unregisters.pop()?.();
+	}
+});
+
+test("exitHook: listens for SIGHUP so the runtime is disposed on hangup", ({
+	expect,
+}) => {
+	const before = process.listenerCount("SIGHUP");
+	register();
+	expect(process.listenerCount("SIGHUP")).toBe(before + 1);
+});
+
+test("exitHook: registers a listener for every termination signal", ({
+	expect,
+}) => {
+	const before = Object.fromEntries(
+		SIGNALS.map((signal) => [signal, process.listenerCount(signal)])
+	);
+
+	register();
+
+	for (const signal of SIGNALS) {
+		expect(process.listenerCount(signal)).toBe(before[signal] + 1);
+	}
+});
+
+test("exitHook: removes every signal listener once the last callback unregisters", ({
+	expect,
+}) => {
+	const before = Object.fromEntries(
+		SIGNALS.map((signal) => [signal, process.listenerCount(signal)])
+	);
+
+	const unregisterFirst = register();
+	const unregisterSecond = register();
+
+	unregisterFirst();
+	// Listeners stay while another callback is still registered.
+	for (const signal of SIGNALS) {
+		expect(process.listenerCount(signal)).toBe(before[signal] + 1);
+	}
+
+	unregisterSecond();
+	for (const signal of SIGNALS) {
+		expect(process.listenerCount(signal)).toBe(before[signal]);
+	}
+});


### PR DESCRIPTION
Related to #9193. This closes one path to an orphaned `workerd`, not all of them.

`packages/miniflare/src/exit-hook.ts` listens for `exit`, `SIGINT`, `SIGTERM` and an IPC `message`, but not `SIGHUP`. So on `SIGHUP` Node exits without running any handler: the dispose callback never runs, execution never reaches `runtimeProcess.kill("SIGKILL")` in `src/runtime/index.ts`, and `workerd` is left running with no parent.

That set of signals looks inherited rather than chosen. It's the same set the `exit-hook` npm package listens for, which this file replaced in #13515. For a plain CLI that's harmless, since nothing is left behind when the process dies. Miniflare owns a child process, so it isn't. (`signal-exit`, also in this tree, does include `SIGHUP`.)

This is the circumstance @kentonv was pointing at: "miniflare must be failing to send the SIGKILL in some circumstances". The `SIGKILL` is correct and already there; it just isn't reached.

### When it actually leaks

Running `wrangler dev` from a shell puts `workerd` in the terminal's process group. A `SIGHUP` on that group reaches `workerd` directly, so it exits on its own and Miniflare's cleanup never has to work. **Closing a terminal window does not reproduce this.** I checked on iTerm2, Zed's terminal and `tmux kill-session`, and all three were clean.

The leak shows up when Miniflare is embedded instead, which is how `vitest-pool-workers`, `@cloudflare/vite-plugin` and `remote-bindings` use it. There the signal only reaches the host process, and `vitest-pool-workers` never calls `dispose()` itself, so this hook is the only thing left that can stop `workerd`. That matches @koistya's zombie `workerd` under the VSCode Vitest extension, and the "could have been the Vitest runner code" case @petebacondarwin raised.

Minimal repro. Embed Miniflare, keep the process alive the way a watch-mode runner would, then send it `SIGHUP`:

```js
const mf = new Miniflare({ script: "...", modules: true, port: 0 });
await mf.ready;
setInterval(() => {}, 1000);
```

### Measurements

Signalling the host process only. If `workerd` receives the signal directly it exits by itself and the trial measures nothing. Three trials per cell on GitHub-hosted runners, miniflare 4.20260701.0:

| OS | before | after |
| --- | --- | --- |
| Linux | **orphaned 3/3** | **clean 3/3** |
| macOS | **orphaned 3/3** | **clean 3/3** |

`SIGHUP` also leaked the temp directory, since `removeDirSync` sits in the same callback. That goes away too.

I ran the same trials through `wrangler dev` as well, signalling only the process that owns `workerd` so the process group couldn't shield it. Same split on both platforms, and `SIGTERM` and `SIGINT` stayed clean before and after, so the paths that already worked are unchanged. An earlier 30-trial run on macOS agreed.

### Scope

`SIGKILL` on the parent can't be handled at all, so crashes and `kill -9` still leak. The orphans that first sent me looking at this turned out to be a different route, and one I couldn't pin down. Each sat in its own process group whose leader had already exited, so no signal ever reached them and no handler would have helped. Reports in #9193 about idle servers or editor integrations are probably on routes like that and will likely survive this change. Covering them means killing the process tree rather than one child, which is a much larger change.

Windows is untested. `exit-hook.ts` has no platform branching and Node raises `SIGHUP` there when a console window closes, so I'd expect the same gap. But `process.kill()` can't deliver `SIGHUP` on Windows, and `GenerateConsoleCtrlEvent` accepts only `CTRL_C_EVENT` and `CTRL_BREAK_EVENT`, so measuring it needs an interactive session rather than CI. I'd rather leave it unclaimed than report a number I can't stand behind.

The process-group and `tree-kill` approaches @danawoodman and @petebacondarwin raised in the thread would cover more ground than this does, and nothing here gets in their way. It's twelve lines, and it doesn't change how any process is spawned.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: internal cleanup behaviour, with no change to any public API, CLI flag or configuration option.

> [!NOTE]
> This is a contribution from an AI agent: Claude Code, Opus 5. The agent did the
> diagnosis and wrote the harness; verifying it across operating systems on CI was
> my call, and I reviewed the finding, the scope and the wording here.

