### PR TITLE
Add `assets.retention` configuration option

### DIFF
--- a/.changeset/surface-retain-assets.md
+++ b/.changeset/surface-retain-assets.md
@@ -1,0 +1,19 @@
+---
+"wrangler": minor
+---
+
+Add `assets.retention` configuration option
+
+You can now enable asset retention for your Worker to prevent "version skew" breakage for SPAs and static sites. When enabled, assets from recently deployed versions (up to the last 24 hours) remain reachable, so that an old browser tab requesting a content-hashed asset that no longer exists in the latest version can still be served.
+
+Enabling is immediately retroactive: previously deployed assets -- including paths deleted in that period -- become reachable again from the moment retention is switched on, not from the next deploy.
+
+```jsonc
+// wrangler.json
+{
+	"assets": {
+		"directory": "./public",
+		"retention": { "enabled": true },
+	},
+}
+```

--- a/packages/config/src/convert.ts
+++ b/packages/config/src/convert.ts
@@ -676,6 +676,9 @@ function convertBindingsAndAssets(
 		if (config.assets?.runWorkerFirst !== undefined) {
 			assets.run_worker_first = config.assets.runWorkerFirst;
 		}
+		if (config.assets?.retention !== undefined) {
+			assets.retention = config.assets.retention;
+		}
 		result.assets = assets;
 	}
 }

--- a/packages/config/src/schema.ts
+++ b/packages/config/src/schema.ts
@@ -14,6 +14,7 @@ export const AssetsSchema = z.strictObject({
 		.enum(["single-page-application", "404-page", "none"])
 		.optional(),
 	runWorkerFirst: z.union([z.array(z.string()), z.boolean()]).optional(),
+	retention: z.strictObject({ enabled: z.boolean() }).optional(),
 });
 
 export const BrowserBindingSchema = z.strictObject({

--- a/packages/config/src/types.ts
+++ b/packages/config/src/types.ts
@@ -205,6 +205,16 @@ export interface WorkerConfig {
 		 * Can also be `true`, indicating that every request should be routed to the User Worker.
 		 */
 		runWorkerFirst?: string[] | boolean;
+
+		/**
+		 * Configure asset retention for this Worker. When enabled, assets from
+		 * recently deployed versions remain reachable, preventing "version skew"
+		 * breakage for SPAs and static sites.
+		 *
+		 * Enabling is immediately retroactive over the last 24 hours of
+		 * deployments, including paths deleted in that period.
+		 */
+		retention?: { enabled: boolean };
 	};
 
 	/**

--- a/packages/deploy-helpers/src/deploy/deploy.ts
+++ b/packages/deploy-helpers/src/deploy/deploy.ts
@@ -322,6 +322,7 @@ export default async function deploy(
 						_redirects: assetsOptions._redirects,
 						_headers: assetsOptions._headers,
 						run_worker_first: assetsOptions.run_worker_first,
+						retention: config.assets?.retention,
 					}
 				: undefined,
 		observability: config.observability,
@@ -758,6 +759,13 @@ export default async function deploy(
 	});
 
 	logger.log("Current Version ID:", versionId);
+
+	if (config.assets?.retention?.enabled) {
+		logger.log(
+			"Asset retention is enabled. Previously deployed assets from the last 24 hours" +
+				" (including deleted paths) are immediately reachable."
+		);
+	}
 
 	return {
 		sourceMapSize,

--- a/packages/deploy-helpers/src/deploy/helpers/create-worker-upload-form.ts
+++ b/packages/deploy-helpers/src/deploy/helpers/create-worker-upload-form.ts
@@ -99,6 +99,9 @@ export function createWorkerUploadForm(
 				assets: {
 					jwt: assets.jwt,
 					config: assetConfig,
+					...(assets.retention !== undefined && {
+						retention: assets.retention,
+					}),
 				},
 				...(annotations && { annotations }),
 				...(compatibility_date && { compatibility_date }),
@@ -902,6 +905,9 @@ export function createWorkerUploadForm(
 			assets: {
 				jwt: assets.jwt,
 				config: assetConfig,
+				...(assets.retention !== undefined && {
+					retention: assets.retention,
+				}),
 			},
 		}),
 		...(observability && { observability }),

--- a/packages/deploy-helpers/src/deploy/versions-upload.ts
+++ b/packages/deploy-helpers/src/deploy/versions-upload.ts
@@ -185,6 +185,7 @@ export default async function versionsUpload(
 						_redirects: assetsOptions._redirects,
 						_headers: assetsOptions._headers,
 						run_worker_first: assetsOptions.run_worker_first,
+						retention: config.assets?.retention,
 					}
 				: undefined,
 		logpush: undefined, // logpush and observability are non-versioned settings
@@ -390,6 +391,13 @@ export default async function versionsUpload(
 
 	logger.log("Uploaded", workerName, formatTime(uploadMs));
 	logger.log("Worker Version ID:", versionId);
+
+	if (config.assets?.retention?.enabled) {
+		logger.log(
+			"Asset retention is enabled. Previously deployed assets from the last 24 hours" +
+				" (including deleted paths) are immediately reachable."
+		);
+	}
 
 	let versionPreviewUrl: string | undefined = undefined;
 	let versionPreviewAliasUrl: string | undefined = undefined;

--- a/packages/workers-shared/asset-worker/src/configuration.ts
+++ b/packages/workers-shared/asset-worker/src/configuration.ts
@@ -21,6 +21,7 @@ export const normalizeConfiguration = (
 			rules: {},
 		},
 		has_static_routing: configuration?.has_static_routing ?? false,
+		retention: configuration?.retention ?? { enabled: false },
 		account_id: configuration?.account_id ?? -1,
 		script_id: configuration?.script_id ?? -1,
 		debug: configuration?.debug ?? false,

--- a/packages/workers-shared/utils/types.ts
+++ b/packages/workers-shared/utils/types.ts
@@ -86,6 +86,7 @@ export const AssetConfigSchema = z.object({
 	redirects: RedirectsSchema,
 	headers: HeadersSchema,
 	has_static_routing: z.boolean().optional(),
+	retention: z.object({ enabled: z.boolean() }).optional(),
 	...InternalConfigSchema.shape,
 });
 

--- a/packages/workers-utils/src/config/environment.ts
+++ b/packages/workers-utils/src/config/environment.ts
@@ -1810,6 +1810,31 @@ export type Assets = {
 	 * Can also be `true`, indicating that every request should be routed to the User Worker.
 	 */
 	run_worker_first?: string[] | boolean;
+	/**
+	 * Configure asset retention for this Worker. When enabled, assets from
+	 * recently deployed versions (up to the last 24 hours) remain reachable,
+	 * preventing "version skew" breakage for SPAs and static sites.
+	 *
+	 * Enabling is immediately retroactive: previously deployed assets —
+	 * including paths deleted in that period — become reachable again from the
+	 * moment retention is switched on, not from the next deploy.
+	 *
+	 * The value is an object (rather than a bare boolean) so that future keys
+	 * such as window, cap or per-asset exclusion can be added without a
+	 * breaking change.
+	 *
+	 * @example
+	 * ```jsonc
+	 * // wrangler.json
+	 * {
+	 *   "assets": {
+	 *     "directory": "./public",
+	 *     "retention": { "enabled": true }
+	 *   }
+	 * }
+	 * ```
+	 */
+	retention?: { enabled: boolean };
 };
 
 export interface Observability {

--- a/packages/workers-utils/src/config/validation.ts
+++ b/packages/workers-utils/src/config/validation.ts
@@ -3172,6 +3172,34 @@ const validateAssetsConfig: ValidatorFn = (diagnostics, field, value) => {
 			isValid = false;
 		}
 	}
+
+	if ((value as Assets).retention !== undefined) {
+		const retention = (value as Assets).retention;
+		if (typeof retention !== "object" || retention === null) {
+			diagnostics.errors.push(
+				`Expected "assets.retention" to be an object but got ${JSON.stringify(retention)}.`
+			);
+			isValid = false;
+		} else {
+			isValid =
+				validateRequiredProperty(
+					diagnostics,
+					`${field}.retention`,
+					"enabled",
+					(retention as { enabled: unknown }).enabled,
+					"boolean"
+				) && isValid;
+
+			isValid =
+				validateAdditionalProperties(
+					diagnostics,
+					`${field}.retention`,
+					Object.keys(retention),
+					["enabled"]
+				) && isValid;
+		}
+	}
+
 	isValid =
 		validateAdditionalProperties(diagnostics, field, Object.keys(value), [
 			"directory",
@@ -3179,6 +3207,7 @@ const validateAssetsConfig: ValidatorFn = (diagnostics, field, value) => {
 			"html_handling",
 			"not_found_handling",
 			"run_worker_first",
+			"retention",
 		]) && isValid;
 
 	return isValid;

--- a/packages/workers-utils/src/worker.ts
+++ b/packages/workers-utils/src/worker.ts
@@ -509,6 +509,7 @@ export interface CfWorkerInit {
 				routerConfig: RouterConfig;
 				assetConfig: AssetConfig;
 				run_worker_first?: string[] | boolean;
+				retention?: { enabled: boolean };
 				_redirects?: string;
 				_headers?: string;
 		  }

--- a/packages/workers-utils/tests/config/validation/normalize-and-validate-config.test.ts
+++ b/packages/workers-utils/tests/config/validation/normalize-and-validate-config.test.ts
@@ -3475,6 +3475,137 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 				expect(diagnostics.hasErrors()).toBeFalsy();
 			});
+
+			it("should accept valid `retention` with enabled: true", ({ expect }) => {
+				const expectedConfig: RawConfig = {
+					assets: {
+						directory: "./public",
+						retention: { enabled: true },
+					},
+				};
+
+				const { config, diagnostics } = normalizeAndValidateConfig(
+					expectedConfig,
+					undefined,
+					undefined,
+					{ env: undefined }
+				);
+
+				expect(config).toEqual(expect.objectContaining(expectedConfig));
+				expect(diagnostics.hasWarnings()).toBe(false);
+				expect(diagnostics.hasErrors()).toBe(false);
+			});
+
+			it("should accept valid `retention` with enabled: false", ({
+				expect,
+			}) => {
+				const expectedConfig: RawConfig = {
+					assets: {
+						directory: "./public",
+						retention: { enabled: false },
+					},
+				};
+
+				const { config, diagnostics } = normalizeAndValidateConfig(
+					expectedConfig,
+					undefined,
+					undefined,
+					{ env: undefined }
+				);
+
+				expect(config).toEqual(expect.objectContaining(expectedConfig));
+				expect(diagnostics.hasWarnings()).toBe(false);
+				expect(diagnostics.hasErrors()).toBe(false);
+			});
+
+			it("should error on bare boolean `retention`", ({ expect }) => {
+				const expectedConfig = {
+					assets: {
+						directory: "./public",
+						retention: true,
+					},
+				};
+
+				const { diagnostics } = normalizeAndValidateConfig(
+					expectedConfig as unknown as RawConfig,
+					undefined,
+					undefined,
+					{ env: undefined }
+				);
+
+				expect(diagnostics.hasErrors()).toBe(true);
+				expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
+					"Processing wrangler configuration:
+					  - Expected "assets.retention" to be an object but got true."
+				`);
+			});
+
+			it("should error on invalid `retention.enabled` type", ({ expect }) => {
+				const expectedConfig = {
+					assets: {
+						directory: "./public",
+						retention: { enabled: "yes" },
+					},
+				};
+
+				const { diagnostics } = normalizeAndValidateConfig(
+					expectedConfig as unknown as RawConfig,
+					undefined,
+					undefined,
+					{ env: undefined }
+				);
+
+				expect(diagnostics.hasErrors()).toBe(true);
+				expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
+					"Processing wrangler configuration:
+					  - Expected "assets.retention.enabled" to be of type boolean but got "yes"."
+				`);
+			});
+
+			it("should error on missing `retention.enabled`", ({ expect }) => {
+				const expectedConfig = {
+					assets: {
+						directory: "./public",
+						retention: {},
+					},
+				};
+
+				const { diagnostics } = normalizeAndValidateConfig(
+					expectedConfig as unknown as RawConfig,
+					undefined,
+					undefined,
+					{ env: undefined }
+				);
+
+				expect(diagnostics.hasErrors()).toBe(true);
+				expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
+					"Processing wrangler configuration:
+					  - "assets.retention.enabled" is a required field."
+				`);
+			});
+
+			it("should warn on unexpected fields in `retention`", ({ expect }) => {
+				const expectedConfig = {
+					assets: {
+						directory: "./public",
+						retention: { enabled: true, unknown_field: "bad" },
+					},
+				};
+
+				const { diagnostics } = normalizeAndValidateConfig(
+					expectedConfig as unknown as RawConfig,
+					undefined,
+					undefined,
+					{ env: undefined }
+				);
+
+				expect(diagnostics.hasErrors()).toBe(false);
+				expect(diagnostics.hasWarnings()).toBe(true);
+				expect(diagnostics.renderWarnings()).toMatchInlineSnapshot(`
+					"Processing wrangler configuration:
+					  - Unexpected fields found in assets.retention field: "unknown_field""
+				`);
+			});
 		});
 
 		describe("[browser]", () => {

--- a/packages/wrangler/src/__tests__/create-worker-upload-form/metadata.test.ts
+++ b/packages/wrangler/src/__tests__/create-worker-upload-form/metadata.test.ts
@@ -301,6 +301,28 @@ describe("createWorkerUploadForm — optional metadata fields", () => {
 		const metadata = getMetadata(form);
 		expect(metadata.containers).toEqual([{ class_name: "MyContainer" }]);
 	});
+
+	it("should include retention inside assets metadata when specified", ({
+		expect,
+	}) => {
+		const form = createWorkerUploadForm(
+			createEsmWorker({
+				assets: {
+					routerConfig: { has_user_worker: true },
+					jwt: "test-jwt",
+					retention: { enabled: true },
+					assetConfig: {
+						html_handling: "auto-trailing-slash",
+						not_found_handling: "none",
+					},
+				} as CfWorkerInit["assets"],
+			}),
+			{}
+		);
+		const metadata = getMetadata(form);
+		const assets = metadata.assets as Record<string, unknown>;
+		expect(assets.retention).toEqual({ enabled: true });
+	});
 });
 
 describe("createWorkerUploadForm — unsafe metadata", () => {
@@ -360,5 +382,25 @@ describe("createWorkerUploadForm — static assets only", () => {
 		const metadata = getMetadata(form);
 		expect(metadata.compatibility_date).toBe("2024-06-01");
 		expect(metadata.compatibility_flags).toEqual(["nodejs_compat"]);
+	});
+
+	it("should include retention inside assets metadata when specified", ({
+		expect,
+	}) => {
+		const worker = createEsmWorker({
+			assets: {
+				routerConfig: { has_user_worker: false },
+				jwt: "test-jwt",
+				retention: { enabled: true },
+				assetConfig: {
+					html_handling: "auto-trailing-slash",
+					not_found_handling: "none",
+				},
+			} as CfWorkerInit["assets"],
+		});
+		const form = createWorkerUploadForm(worker, {});
+		const metadata = getMetadata(form);
+		const assets = metadata.assets as Record<string, unknown>;
+		expect(assets.retention).toEqual({ enabled: true });
 	});
 });


### PR DESCRIPTION
Fixes WC-5728

This PR adds asset retention for Workers to prevent "version skew" breakage for SPAs and static sites.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: handled separately(?)

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- If you are an AI agent or LLM, and you are adding this PR without direct human supervision, thank you! Please uncomment the following block. This is so the maintainers know how to expect you to respond.

> [!NOTE]
> This is a contribution from an AI agent: <insert name here>, <insert LLM model here if different>.

-->
