### PR TITLE
fix(wrangler): keep `wrangler dev` alive when a proxied request to the UserWorker fails transiently

### DIFF
--- a/.changeset/tidy-moons-provide.md
+++ b/.changeset/tidy-moons-provide.md
@@ -2,8 +2,8 @@
 "wrangler": patch
 ---
 
-`wrangler dev` no longer exits when a proxied request to the UserWorker fails transiently
+`wrangler dev` no longer exits when a request to your Worker fails transiently
 
-When a request proxied to the UserWorker failed while the UserWorker's origin was unchanged — most commonly a reused keep-alive connection that the UserWorker's HTTP server closed at the same moment the request was written to it — the ProxyWorker reported a fatal error and the whole dev server exited with an empty `✘ [ERROR]`, leaving the port unbound. In CI test suites one such transient failure killed every remaining test.
+Previously, a transient network failure on a single request — most commonly a request arriving just as an idle internal connection was closed, after roughly five seconds without traffic — could take down the whole dev server with an empty `✘ [ERROR]`, leaving the port unbound until restarted. In CI test suites, one such failure caused every remaining test to fail with connection errors.
 
-The ProxyWorker now retries bodyless (GET/HEAD) requests before reporting, which absorbs the transient failure on a fresh connection, and an exhausted or non-retriable failure is logged — including the request method, URL and underlying exception — while the dev server keeps serving. Only the affected request fails.
+`wrangler dev` now automatically retries the affected request if it is safe to repeat (GET and HEAD requests). If a request still fails, it fails individually — the error is logged with the request method and URL — and the dev server keeps serving.

--- a/.changeset/tidy-moons-provide.md
+++ b/.changeset/tidy-moons-provide.md
@@ -1,0 +1,9 @@
+---
+"wrangler": patch
+---
+
+`wrangler dev` no longer exits when a proxied request to the UserWorker fails transiently
+
+When a request proxied to the UserWorker failed while the UserWorker's origin was unchanged — most commonly a reused keep-alive connection that the UserWorker's HTTP server closed at the same moment the request was written to it — the ProxyWorker reported a fatal error and the whole dev server exited with an empty `✘ [ERROR]`, leaving the port unbound. In CI test suites one such transient failure killed every remaining test.
+
+The ProxyWorker now retries bodyless (GET/HEAD) requests before reporting, which absorbs the transient failure on a fresh connection, and an exhausted or non-retriable failure is logged — including the request method, URL and underlying exception — while the dev server keeps serving. Only the affected request fails.

--- a/packages/wrangler/src/__tests__/api/startDevWorker/DevEnv.test.ts
+++ b/packages/wrangler/src/__tests__/api/startDevWorker/DevEnv.test.ts
@@ -1,5 +1,6 @@
 import { describe, test } from "vitest";
 import { DevEnv } from "../../../api/startDevWorker/DevEnv";
+import { castErrorCause } from "../../../api/startDevWorker/events";
 import { mockConsoleMethods } from "../../helpers/mock-console";
 
 describe("DevEnv", () => {
@@ -104,12 +105,24 @@ describe("DevEnv", () => {
 			const fatalEvents: unknown[] = [];
 			devEnv.on("error", (event) => fatalEvents.push(event));
 
+			// the ProxyWorker posts its error to the ProxyController as JSON, so
+			// what reaches handleErrorEvent is a plain object wrapped by
+			// castErrorCause — an Error with NO message, carrying the real detail
+			// on `.cause`. Build the cause the same way so this test cannot pass
+			// with a message the production path never has.
+			const reportedByProxyWorker = JSON.parse(
+				JSON.stringify({
+					name: "Error",
+					message:
+						"GET http://127.0.0.1:8787/ (failed after 3 attempts): Network connection lost.",
+					stack: "Error: Network connection lost.\n    at <anonymous>",
+				})
+			) as unknown;
+
 			devEnv.dispatch({
 				type: "error",
 				reason: "Error inside ProxyWorker",
-				cause: new Error(
-					"GET http://127.0.0.1:8787/ (failed after 3 attempts): Network connection lost."
-				),
+				cause: castErrorCause(reportedByProxyWorker),
 				source: "ProxyController",
 				data: {},
 			});

--- a/packages/wrangler/src/__tests__/api/startDevWorker/DevEnv.test.ts
+++ b/packages/wrangler/src/__tests__/api/startDevWorker/DevEnv.test.ts
@@ -108,10 +108,10 @@ describe("DevEnv", () => {
 				type: "error",
 				reason: "Error inside ProxyWorker",
 				cause: new Error(
-					"GET http://127.0.0.1:8787/ (attempt 3): Network connection lost."
+					"GET http://127.0.0.1:8787/ (failed after 3 attempts): Network connection lost."
 				),
 				source: "ProxyController",
-				data: undefined,
+				data: {},
 			});
 
 			expect(std.err).toContain("Error inside ProxyWorker");

--- a/packages/wrangler/src/__tests__/api/startDevWorker/DevEnv.test.ts
+++ b/packages/wrangler/src/__tests__/api/startDevWorker/DevEnv.test.ts
@@ -95,5 +95,31 @@ describe("DevEnv", () => {
 
 			void devEnv.teardown();
 		});
+
+		test("should log ProxyWorker request errors without tearing down the dev session", ({
+			expect,
+		}) => {
+			const devEnv = new DevEnv();
+
+			const fatalEvents: unknown[] = [];
+			devEnv.on("error", (event) => fatalEvents.push(event));
+
+			devEnv.dispatch({
+				type: "error",
+				reason: "Error inside ProxyWorker",
+				cause: new Error(
+					"GET http://127.0.0.1:8787/ (attempt 3): Network connection lost."
+				),
+				source: "ProxyController",
+				data: undefined,
+			});
+
+			expect(std.err).toContain("Error inside ProxyWorker");
+			expect(std.err).toContain("Network connection lost.");
+			// one failed proxied request must not become a fatal dev-session error
+			expect(fatalEvents).toHaveLength(0);
+
+			void devEnv.teardown();
+		});
 	});
 });

--- a/packages/wrangler/src/api/startDevWorker/DevEnv.ts
+++ b/packages/wrangler/src/api/startDevWorker/DevEnv.ts
@@ -187,6 +187,22 @@ export class DevEnv extends EventEmitter implements ControllerBus {
 			logger.debug(`Error in ${event.source}: ${event.reason}\n`, event.cause);
 			logger.debug("=> Error contextual data:", event.data);
 		}
+		// A proxied request to the UserWorker failed while the UserWorker was NOT
+		// being reloaded — e.g. the UserWorker's HTTP server closed a reused
+		// keep-alive connection at the same moment the ProxyWorker wrote a
+		// request into it. The affected request has already failed (and the
+		// ProxyWorker retries GET/HEAD before reporting), but the dev session
+		// itself is healthy: tearing it down would turn one failed request into
+		// a dead dev server (see #14926). Log it and keep serving.
+		else if (
+			event.source === "ProxyController" &&
+			event.reason.startsWith("Error inside ProxyWorker")
+		) {
+			logger.error(
+				`${event.reason} (the affected request failed; the dev server continues): ${event.cause.message}`
+			);
+			logger.debug("=> Error contextual data:", event.data);
+		}
 		// Parse errors are recoverable by changing your Wrangler configuration file and saving
 		// All other errors from the ConfigController are non-recoverable
 		else if (

--- a/packages/wrangler/src/api/startDevWorker/DevEnv.ts
+++ b/packages/wrangler/src/api/startDevWorker/DevEnv.ts
@@ -26,7 +26,7 @@ import type {
 	ControllerEvent,
 	RuntimeController,
 } from "./BaseController";
-import type { ErrorEvent } from "./events";
+import type { ErrorEvent, SerializedError } from "./events";
 import type { Worker, WranglerStartDevWorkerInput } from "./types";
 
 type ControllerFactory<C extends Controller> = (devEnv: DevEnv) => C;
@@ -198,8 +198,14 @@ export class DevEnv extends EventEmitter implements ControllerBus {
 			event.source === "ProxyController" &&
 			event.reason.startsWith("Error inside ProxyWorker")
 		) {
+			// the ProxyWorker's report reaches us as JSON, so `castErrorCause` has
+			// wrapped it in a message-less Error carrying the detail on `.cause`
+			const detail =
+				event.cause.message ||
+				(event.cause.cause as SerializedError | undefined)?.message ||
+				"unknown error";
 			logger.error(
-				`${event.reason} (the affected request failed; the dev server continues): ${event.cause.message}`
+				`${event.reason} (the affected request failed; the dev server continues): ${detail}`
 			);
 			logger.debug("=> Error contextual data:", event.data);
 		}

--- a/packages/wrangler/src/api/startDevWorker/DevEnv.ts
+++ b/packages/wrangler/src/api/startDevWorker/DevEnv.ts
@@ -193,7 +193,7 @@ export class DevEnv extends EventEmitter implements ControllerBus {
 		// request into it. The affected request has already failed (and the
 		// ProxyWorker retries GET/HEAD before reporting), but the dev session
 		// itself is healthy: tearing it down would turn one failed request into
-		// a dead dev server (see #14926). Log it and keep serving.
+		// a dead dev server (see https://github.com/cloudflare/workers-sdk/issues/14926). Log it and keep serving.
 		else if (
 			event.source === "ProxyController" &&
 			event.reason.startsWith("Error inside ProxyWorker")

--- a/packages/wrangler/templates/startDevWorker/ProxyWorker.ts
+++ b/packages/wrangler/templates/startDevWorker/ProxyWorker.ts
@@ -164,80 +164,111 @@ export class ProxyWorker implements DurableObject {
 			}
 
 			// explicitly NOT await-ing this promise, we are in a loop and want to process the whole queue quickly + synchronously
-			void fetch(userWorkerUrl, new Request(request, { headers }))
-				.then(async (res) => {
-					res = new Response(res.body, res);
-					rewriteUrlRelatedHeaders(res.headers, innerUrl, outerUrl);
+			const attemptUserWorkerFetch = (attempt: number) =>
+				void fetch(userWorkerUrl, new Request(request, { headers }))
+					.then(async (res) => {
+						if (attempt > 1) {
+							console.warn(
+								`ProxyWorker: ${request.method} ${request.url} recovered on attempt ${attempt} after a dropped connection to the UserWorker`
+							);
+						}
 
-					await checkForPreviewTokenError(res, this.env, proxyData);
+						res = new Response(res.body, res);
+						rewriteUrlRelatedHeaders(res.headers, innerUrl, outerUrl);
 
-					if (isHtmlResponse(res)) {
-						res = insertLiveReloadScript(request, res, this.env, proxyData);
-					}
+						await checkForPreviewTokenError(res, this.env, proxyData);
 
-					if (isSseResponse(res)) {
-						void sendMessageToProxyController(this.env, {
-							type: "sseResponseDetected",
-						});
-					}
+						if (isHtmlResponse(res)) {
+							res = insertLiveReloadScript(request, res, this.env, proxyData);
+						}
 
-					deferredResponse.resolve(res);
-				})
-				.catch((error: Error) => {
-					// errors here are network errors or from response post-processing
-					// to catch only network errors, use the 2nd param of the fetch.then()
+						if (isSseResponse(res)) {
+							void sendMessageToProxyController(this.env, {
+								type: "sseResponseDetected",
+							});
+						}
 
-					// we have crossed an async boundary, so proxyData may have changed
-					// if proxyData.userWorkerUrl has changed, it means there is a new downstream UserWorker
-					// and that this error is stale since it was for a request to the old UserWorker
-					// only report the error if the request still targets the current
-					// UserWorker. isSameUserWorkerOrigin compares origin (not href) so a
-					// genuine error on a non-root path isn't misread as a reload — see
-					// its docs.
-					if (
-						isSameUserWorkerOrigin(userWorkerUrl, this.proxyData?.userWorkerUrl)
-					) {
-						void sendMessageToProxyController(this.env, {
-							type: "error",
-							error: {
-								name: error.name,
-								message: error.message,
-								stack: error.stack,
-								cause: error.cause,
-							},
-						});
+						deferredResponse.resolve(res);
+					})
+					.catch((error: Error) => {
+						// errors here are network errors or from response post-processing
+						// to catch only network errors, use the 2nd param of the fetch.then()
 
-						deferredResponse.reject(error);
-					}
-
-					// if the request can be retried (subset of idempotent requests which have no body), requeue it
-					else if (request.method === "GET" || request.method === "HEAD") {
-						this.requestRetryQueue.set(request, deferredResponse);
-						// we would only end up here if the downstream UserWorker is chang*ing*
-						// i.e. we are in a `pause`d state and expecting a `play` message soon
-						// this request will be processed (retried) when the `play` message arrives
-						// for that reason, we do not need to call `this.processQueue` here
-						// (but, also, it can't hurt to call it since it bails when
-						// in a `pause`d state i.e. `this.proxyData` is undefined)
-					}
-
-					// if the request cannot be retried, respond with 503 Service Unavailable
-					// important to note, this is not an (unexpected) error -- it is an acceptable flow of local development
-					// it would be incorrect to retry non-idempotent requests
-					// and would require cloning all body streams to avoid stream reuse (which is inefficient but not out of the question in the future)
-					// this is a good enough UX for now since it solves the most common GET use-case
-					else {
-						deferredResponse.resolve(
-							new Response(
-								"Your worker restarted mid-request. Please try sending the request again. Only GET or HEAD requests are retried automatically.",
-								{
-									status: 503,
-									headers: { "Retry-After": "0" },
-								}
+						// we have crossed an async boundary, so proxyData may have changed
+						// if proxyData.userWorkerUrl has changed, it means there is a new downstream UserWorker
+						// and that this error is stale since it was for a request to the old UserWorker
+						// only report the error if the request still targets the current
+						// UserWorker. isSameUserWorkerOrigin compares origin (not href) so a
+						// genuine error on a non-root path isn't misread as a reload — see
+						// its docs.
+						if (
+							isSameUserWorkerOrigin(
+								userWorkerUrl,
+								this.proxyData?.userWorkerUrl
 							)
-						);
-					}
-				});
+						) {
+							// the UserWorker origin is unchanged, so this is a transient
+							// network failure rather than a reload — most commonly the
+							// UserWorker's HTTP server closing a reused keep-alive
+							// connection at the same moment this request was written to it
+							// (kj's client pool idleTimeout and server pipelineTimeout both
+							// default to 5s, so a connection idling ~5s races the close).
+							// Retrying bodyless requests draws a fresh connection and
+							// absorbs the race, mirroring the requeue below for reloads.
+							if (
+								(request.method === "GET" || request.method === "HEAD") &&
+								attempt < 3
+							) {
+								setTimeout(
+									() => attemptUserWorkerFetch(attempt + 1),
+									attempt === 1 ? 0 : 250
+								);
+								return;
+							}
+
+							void sendMessageToProxyController(this.env, {
+								type: "error",
+								error: {
+									name: error.name,
+									message: `${request.method} ${request.url} (attempt ${attempt}): ${error.message}`,
+									stack: error.stack,
+									cause: error.cause,
+								},
+							});
+
+							deferredResponse.reject(error);
+						}
+
+						// if the request can be retried (subset of idempotent requests which have no body), requeue it
+						else if (request.method === "GET" || request.method === "HEAD") {
+							this.requestRetryQueue.set(request, deferredResponse);
+							// we would only end up here if the downstream UserWorker is chang*ing*
+							// i.e. we are in a `pause`d state and expecting a `play` message soon
+							// this request will be processed (retried) when the `play` message arrives
+							// for that reason, we do not need to call `this.processQueue` here
+							// (but, also, it can't hurt to call it since it bails when
+							// in a `pause`d state i.e. `this.proxyData` is undefined)
+						}
+
+						// if the request cannot be retried, respond with 503 Service Unavailable
+						// important to note, this is not an (unexpected) error -- it is an acceptable flow of local development
+						// it would be incorrect to retry non-idempotent requests
+						// and would require cloning all body streams to avoid stream reuse (which is inefficient but not out of the question in the future)
+						// this is a good enough UX for now since it solves the most common GET use-case
+						else {
+							deferredResponse.resolve(
+								new Response(
+									"Your worker restarted mid-request. Please try sending the request again. Only GET or HEAD requests are retried automatically.",
+									{
+										status: 503,
+										headers: { "Retry-After": "0" },
+									}
+								)
+							);
+						}
+					});
+
+			attemptUserWorkerFetch(1);
 		}
 	}
 }

--- a/packages/wrangler/templates/startDevWorker/ProxyWorker.ts
+++ b/packages/wrangler/templates/startDevWorker/ProxyWorker.ts
@@ -234,7 +234,21 @@ export class ProxyWorker implements DurableObject {
 								attempt < 2
 							) {
 								setTimeout(
-									() => attemptUserWorkerFetch(attempt + 1),
+									() => {
+										// the UserWorker may have started reloading while this
+										// retry was queued (even at 0ms — setTimeout defers to a
+										// later task). `proxyData` carries the destination AND the
+										// headers, so retrying with the captured one could reach
+										// the pre-reload Worker or send a stale preview token.
+										// Requeue instead and let the current proxyData rebuild it.
+										if (this.proxyData !== proxyData) {
+											this.requestRetryQueue.set(request, deferredResponse);
+											this.processQueue();
+											return;
+										}
+
+										attemptUserWorkerFetch(attempt + 1);
+									},
 									attempt === 0 ? 0 : 250
 								);
 								return;

--- a/packages/wrangler/templates/startDevWorker/ProxyWorker.ts
+++ b/packages/wrangler/templates/startDevWorker/ProxyWorker.ts
@@ -261,8 +261,9 @@ export class ProxyWorker implements DurableObject {
 								this.proxyData?.userWorkerUrl
 							)
 						) {
-							const attemptsNote =
-								attempt > 0 ? ` (failed after ${attempt + 1} attempts)` : "";
+							const attemptsNote = ` (failed after ${attempt + 1} ${
+								attempt === 0 ? "attempt" : "attempts"
+							})`;
 							void sendMessageToProxyController(this.env, {
 								type: "error",
 								error: {

--- a/packages/wrangler/templates/startDevWorker/ProxyWorker.ts
+++ b/packages/wrangler/templates/startDevWorker/ProxyWorker.ts
@@ -163,36 +163,90 @@ export class ProxyWorker implements DurableObject {
 				}
 			}
 
-			// explicitly NOT await-ing this promise, we are in a loop and want to process the whole queue quickly + synchronously
-			const attemptUserWorkerFetch = (attempt: number) =>
+			/**
+			 * Sends the request to the UserWorker and settles `deferredResponse`
+			 * with the outcome — or requeues the request if the UserWorker is
+			 * mid-reload. The promise chain is deliberately not awaited (`void`):
+			 * we are in a loop and want to process the whole queue quickly +
+			 * synchronously.
+			 *
+			 * A connection-level failure (the `fetch` itself rejects, so no
+			 * response was received) on a same-origin GET/HEAD request is retried
+			 * before being reported — see the rejection handler.
+			 *
+			 * Kept as a `const` arrow function: the handlers re-read
+			 * `this.proxyData` across async boundaries to detect UserWorker
+			 * reloads, so they need the ProxyWorker's lexical `this`.
+			 *
+			 * @param attempt the number of attempts that have already failed
+			 * (`0` on the first try)
+			 */
+			const attemptUserWorkerFetch = (attempt = 0) =>
 				void fetch(userWorkerUrl, new Request(request, { headers }))
-					.then(async (res) => {
-						if (attempt > 1) {
-							console.warn(
-								`ProxyWorker: ${request.method} ${request.url} recovered on attempt ${attempt} after a dropped connection to the UserWorker`
-							);
+					.then(
+						async (res) => {
+							if (attempt > 0) {
+								console.warn(
+									`ProxyWorker: ${request.method} ${request.url} recovered on attempt ${attempt + 1} after a dropped connection to the UserWorker`
+								);
+							}
+
+							res = new Response(res.body, res);
+							rewriteUrlRelatedHeaders(res.headers, innerUrl, outerUrl);
+
+							await checkForPreviewTokenError(res, this.env, proxyData);
+
+							if (isHtmlResponse(res)) {
+								res = insertLiveReloadScript(request, res, this.env, proxyData);
+							}
+
+							if (isSseResponse(res)) {
+								void sendMessageToProxyController(this.env, {
+									type: "sseResponseDetected",
+								});
+							}
+
+							deferredResponse.resolve(res);
+						},
+						(error: Error) => {
+							// the fetch itself rejected: a connection-level failure, and no
+							// response was received. Errors thrown while post-processing a
+							// received response skip this handler and land in the .catch
+							// below, so they are reported rather than retried and can never
+							// re-run the UserWorker's handler.
+							//
+							// When the UserWorker origin is unchanged (i.e. this is not a
+							// reload — see the same check in the .catch below), the failure
+							// is most commonly the UserWorker's HTTP server closing a reused
+							// keep-alive connection at the same moment this request was
+							// written to it (kj's client pool idleTimeout and server
+							// pipelineTimeout both default to 5s, so a connection idling ~5s
+							// races the close). Retrying bodyless requests draws a fresh
+							// connection and absorbs the race, mirroring the requeue in the
+							// .catch for reloads: retry immediately, then once more after
+							// 250ms (3 attempts in total).
+							if (
+								isSameUserWorkerOrigin(
+									userWorkerUrl,
+									this.proxyData?.userWorkerUrl
+								) &&
+								(request.method === "GET" || request.method === "HEAD") &&
+								attempt < 2
+							) {
+								setTimeout(
+									() => attemptUserWorkerFetch(attempt + 1),
+									attempt === 0 ? 0 : 250
+								);
+								return;
+							}
+
+							throw error;
 						}
-
-						res = new Response(res.body, res);
-						rewriteUrlRelatedHeaders(res.headers, innerUrl, outerUrl);
-
-						await checkForPreviewTokenError(res, this.env, proxyData);
-
-						if (isHtmlResponse(res)) {
-							res = insertLiveReloadScript(request, res, this.env, proxyData);
-						}
-
-						if (isSseResponse(res)) {
-							void sendMessageToProxyController(this.env, {
-								type: "sseResponseDetected",
-							});
-						}
-
-						deferredResponse.resolve(res);
-					})
+					)
 					.catch((error: Error) => {
-						// errors here are network errors or from response post-processing
-						// to catch only network errors, use the 2nd param of the fetch.then()
+						// errors here are from response post-processing, or connection-
+						// level failures rethrown by the rejection handler above (a
+						// non-retriable method, or the retry budget was exhausted)
 
 						// we have crossed an async boundary, so proxyData may have changed
 						// if proxyData.userWorkerUrl has changed, it means there is a new downstream UserWorker
@@ -207,30 +261,13 @@ export class ProxyWorker implements DurableObject {
 								this.proxyData?.userWorkerUrl
 							)
 						) {
-							// the UserWorker origin is unchanged, so this is a transient
-							// network failure rather than a reload — most commonly the
-							// UserWorker's HTTP server closing a reused keep-alive
-							// connection at the same moment this request was written to it
-							// (kj's client pool idleTimeout and server pipelineTimeout both
-							// default to 5s, so a connection idling ~5s races the close).
-							// Retrying bodyless requests draws a fresh connection and
-							// absorbs the race, mirroring the requeue below for reloads.
-							if (
-								(request.method === "GET" || request.method === "HEAD") &&
-								attempt < 3
-							) {
-								setTimeout(
-									() => attemptUserWorkerFetch(attempt + 1),
-									attempt === 1 ? 0 : 250
-								);
-								return;
-							}
-
+							const attemptsNote =
+								attempt > 0 ? ` (failed after ${attempt + 1} attempts)` : "";
 							void sendMessageToProxyController(this.env, {
 								type: "error",
 								error: {
 									name: error.name,
-									message: `${request.method} ${request.url} (attempt ${attempt}): ${error.message}`,
+									message: `${request.method} ${request.url}${attemptsNote}: ${error.message}`,
 									stack: error.stack,
 									cause: error.cause,
 								},
@@ -268,7 +305,7 @@ export class ProxyWorker implements DurableObject {
 						}
 					});
 
-			attemptUserWorkerFetch(1);
+			attemptUserWorkerFetch();
 		}
 	}
 }


### PR DESCRIPTION
Fixes #14926. Also mitigates the empty-message symptom of #14906 for this path by including the request method, URL, attempt count and underlying exception in the logged error.

## The bug

`wrangler dev` runs the ProxyWorker (binding the public port) and the UserWorker runtime as separate workerd processes. When a proxied request to the UserWorker fails while the UserWorker's origin is **unchanged**, the ProxyWorker reports `{type: "error"}`, `ProxyController.onProxyWorkerMessage` escalates it via `emitErrorEvent`, `DevEnv.handleErrorEvent` falls through to the fatal re-emit, and the entire dev server exits with an empty `✘ [ERROR]` (the error crosses a JSON boundary, so `castErrorCause` produces a message-less `Error`), leaving the port unbound. In CI test suites, one transient failure kills every remaining test with `ERR_CONNECTION_REFUSED` — several independent reports on #14926 describe exactly this.

## Root cause of the transient failure itself

kj HTTP defaults collide: the client pool closes idle connections after 5s (`HttpClientSettings.idleTimeout`) and the server closes idle keep-alive connections after 5s (`HttpServerSettings.pipelineTimeout`). For a pooled ProxyWorker→UserWorker connection idling ≈5s, both timers fire ~simultaneously; a request written into the connection as the server's close is in flight gets an RST, surfaced as `Error: Network connection lost.`.

Reproduced organically (no fault injection): bursts of ~48 concurrent GETs separated by idle gaps swept 3.0→7.9s in 0.1s steps against `wrangler dev` hit the fatal within one sweep, at a 4.2s outer gap (per-connection idle 4.2–5.2s given the ~1s burst spread) — failed requests interleaved with same-millisecond 200s (stale pool checkouts die, fresh connections succeed), while the UserWorker runtime never exited and its isolate was never re-created. Deterministic variant: SIGKILL the UserWorker runtime under request load (miniflare restarts it reusing the port, so the in-flight failures are same-origin).

## The fix (two small pieces)

1. **`ProxyWorker.ts`**: same-origin fetch failures now retry bodyless (GET/HEAD) requests — immediately, then once more after 250ms — before reporting. The retry draws a fresh connection, absorbing the race. This mirrors the existing requeue-on-reload behaviour and its rationale comment ("it would be incorrect to retry non-idempotent requests"); non-GET/HEAD behaviour is unchanged. Recovered requests log a `console.warn` so absorbed events remain visible. The reported error now includes method, URL and attempt count.
2. **`DevEnv.ts`**: `handleErrorEvent` classifies `"Error inside ProxyWorker"` reports as recoverable — logged via `logger.error` with the underlying exception — instead of falling through to the fatal top-level re-emit. This sits alongside the existing recoverable carve-out for other ProxyController reasons. One failed proxied request should never take down the dev session.

With both pieces, the kill-the-runtime repro goes from "dev server exits, port unbound" to: in-flight GETs retry across the restart (5 of 11 recovered in my run), the rest fail individually with the error logged, and the server keeps serving.

---

- Tests
  - [x] Tests included/updated — `DevEnv.test.ts` gains a test asserting a ProxyWorker error report is logged and does **not** re-emit a fatal top-level `error` event.
  - [x] Automated tests not possible - manual testing has been completed as follows: the retry path was validated against a real `wrangler dev` session two ways — (a) the organic idle-gap sweep described above (7,200 requests: zero server-side failures with the fix; the fatal within one sweep without it), and (b) SIGKILL-ing the UserWorker runtime under load (server survives; GETs recover across the restart). Note: I could not run the wrangler vitest suite locally because `@cloudflare/remote-bindings#build` fails in my environment on a pristine `main` checkout (its tsdown `embed-workers` plugin resolves template paths incorrectly there), so I'm relying on CI for the full suite; `turbo check:type --filter=wrangler` and `oxfmt` pass locally.
- Public documentation
  - [x] Documentation not necessary because: behavioural bug fix in `wrangler dev` internals; a changeset is included.

> [!NOTE]
> This is a contribution from an AI agent: Claude Code (Claude Fable 5), working under the direction and review of Gregory Collett.
<!-- devin-review-badge-begin -->

---

<a href="https://cloudflare.devinenterprise.com/review/cloudflare/workers-sdk/pull/15252" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->