### PR TITLE
[ci] Update Bonk to OpenCode 1.18.18

### DIFF
--- a/.github/workflows/bonk-pr-review.yml
+++ b/.github/workflows/bonk-pr-review.yml
@@ -60,11 +60,12 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_AI_GATEWAY_ACCOUNT_ID }}
           CLOUDFLARE_GATEWAY_ID: ${{ secrets.CF_AI_GATEWAY_NAME }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_AI_GATEWAY_TOKEN }}
+          OPENCODE_CONFIG_CONTENT: '{"provider":{"cloudflare-ai-gateway":{"models":{"anthropic/claude-opus-4-8":{}}}}}'
         with:
           oidc_base_url: https://ask-bonk.cloudflare-exponent.workers.dev/auth
           model: "cloudflare-ai-gateway/anthropic/claude-opus-4-8"
           variant: "high"
           forks: "false"
           permissions: write
-          opencode_version: 1.15.13 # pin to this version as certain ones cause ProviderInitError issues
+          opencode_version: 1.18.18
           prompt: ${{ steps.prompt.outputs.value }}

--- a/.github/workflows/bonk.yml
+++ b/.github/workflows/bonk.yml
@@ -70,6 +70,7 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_AI_GATEWAY_ACCOUNT_ID }}
           CLOUDFLARE_GATEWAY_ID: ${{ secrets.CF_AI_GATEWAY_NAME }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_AI_GATEWAY_TOKEN }}
+          OPENCODE_CONFIG_CONTENT: '{"provider":{"cloudflare-ai-gateway":{"models":{"anthropic/claude-opus-4-8":{}}}}}'
         with:
           oidc_base_url: https://ask-bonk.cloudflare-exponent.workers.dev/auth
           model: "cloudflare-ai-gateway/anthropic/claude-opus-4-8"
@@ -77,5 +78,5 @@ jobs:
           mentions: "/bonk,@ask-bonk"
           permissions: write
           agent: bonk
-          opencode_version: 1.15.13 # pin to this version as certain ones cause ProviderInitError issues
+          opencode_version: 1.18.18
           prompt: ${{ steps.prompt.outputs.value }}


### PR DESCRIPTION
Update both Bonk workflows from OpenCode `1.15.13` to the current `1.18.18` release.

The first validation run confirmed `1.18.18` installed successfully, then exposed the actual provider error: OpenCode did not recognize the configured `cloudflare-ai-gateway/anthropic/claude-opus-4-8` model. This also explicitly registers that model through `OPENCODE_CONFIG_CONTENT`, matching the repository's existing `.github/opencode.json` registration without applying its unrelated local permissions to Bonk.

A fresh Bonk run with this change passed model resolution and reached Anthropic; it now fails on the repository's provider credential with `Invalid Anthropic API Key`, which is separate from the OpenCode version/configuration change.

---

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: these are GitHub Actions configuration changes; both workflows pass YAML parsing, `actionlint`, and `git diff --check`. The explicit provider registration was also verified with OpenCode `1.18.18` model discovery.
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: this is an internal CI workflow dependency and provider configuration update.

*A picture of a cute animal (not mandatory, but encouraged)*
