### PR TITLE
[wrangler] Fix r2 object put and r2 bulk put storing a different key in local mode

### DIFF
--- a/.changeset/r2-local-object-key-encoding.md
+++ b/.changeset/r2-local-object-key-encoding.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Fix `r2 object put` and `r2 bulk put` storing a different key in local mode
+
+Keys that are not URL-safe were mangled on the way into local storage. A key with a space or a non-ASCII character was stored under its percent-encoded name, so a later `r2 object get` for that key reported that the key does not exist. Two keys that differ only after a `#` collapsed into a single object, and the second upload replaced the first. A key with a `%` that is not a valid escape failed outright with "Invalid URL string.", and one with a valid escape, such as `%41.txt`, was stored as `A.txt`. Spaces, non-ASCII characters, `#` and `%` now survive the trip into local storage. Remote writes were never affected, and objects already in local state are left where they are.

--- a/packages/wrangler/src/__tests__/r2/local.test.ts
+++ b/packages/wrangler/src/__tests__/r2/local.test.ts
@@ -68,6 +68,82 @@ describe("r2", () => {
 				`);
 			});
 
+			it("should round trip local objects whose keys are not URL safe", async ({
+				expect,
+			}) => {
+				const keys = [
+					"my report.pdf",
+					"report#1.pdf",
+					"sale?50.pdf",
+					"héllo.txt",
+					"invoices/2026/q1.pdf",
+					"50%off.pdf",
+					"my%20report.pdf",
+				];
+				fs.writeFileSync("payload", "quarterly numbers");
+
+				for (const key of keys) {
+					await runWrangler(
+						`r2 object put "bucket-object-test/${key}" --file ./payload`
+					);
+					await runWrangler(
+						`r2 object get "bucket-object-test/${key}" --file ./downloaded`
+					);
+
+					expect(`${key} holds ${fs.readFileSync("downloaded", "utf8")}`).toBe(
+						`${key} holds quarterly numbers`
+					);
+					fs.rmSync("downloaded");
+				}
+				std.getAndClearOut();
+			});
+
+			it("should keep two local objects whose keys differ after a hash", async ({
+				expect,
+			}) => {
+				fs.writeFileSync("first", "january");
+				fs.writeFileSync("second", "february");
+
+				await runWrangler(
+					`r2 object put "bucket-object-test/archive#2026-01.zip" --file ./first`
+				);
+				await runWrangler(
+					`r2 object put "bucket-object-test/archive#2026-02.zip" --file ./second`
+				);
+				std.getAndClearOut();
+
+				await runWrangler(
+					`r2 object get "bucket-object-test/archive#2026-01.zip" --file ./got-first`
+				);
+				await runWrangler(
+					`r2 object get "bucket-object-test/archive#2026-02.zip" --file ./got-second`
+				);
+				std.getAndClearOut();
+
+				expect(fs.readFileSync("got-first", "utf8")).toBe("january");
+				expect(fs.readFileSync("got-second", "utf8")).toBe("february");
+			});
+
+			it("should bulk put a local object whose key is not URL safe", async ({
+				expect,
+			}) => {
+				fs.writeFileSync("payload", "quarterly numbers");
+				fs.writeFileSync(
+					"list.json",
+					JSON.stringify([{ key: "my report #1.pdf", file: "payload" }])
+				);
+
+				await runWrangler(
+					`r2 bulk put bucket-object-test --filename ./list.json`
+				);
+				await runWrangler(
+					`r2 object get "bucket-object-test/my report #1.pdf" --file ./downloaded`
+				);
+				std.getAndClearOut();
+
+				expect(fs.readFileSync("downloaded", "utf8")).toBe("quarterly numbers");
+			});
+
 			it("should bulk put R2 objects to a local bucket", async ({ expect }) => {
 				await expect(() =>
 					runWrangler(

--- a/packages/wrangler/src/r2/helpers/object.ts
+++ b/packages/wrangler/src/r2/helpers/object.ts
@@ -176,7 +176,7 @@ export async function usingLocalBucket<T>(
         try {
           if (request.method !== "PUT") return new Response(null, { status: 405 });
           const url = new URL(request.url);
-          const key = url.pathname.substring(1);
+          const key = decodeURIComponent(url.pathname.substring(1));
           const optsHeader = request.headers.get("Wrangler-R2-Put-Options");
           const opts = JSON.parse(optsHeader);
           await env.BUCKET.put(key, request.body, opts);

--- a/packages/wrangler/src/r2/object.ts
+++ b/packages/wrangler/src/r2/object.ts
@@ -373,15 +373,18 @@ export const r2ObjectPutCommand = createCommand({
 					// currently doesn't support sending these. Instead,
 					// `usingLocalBucket()` provides a single `PUT` endpoint
 					// for writing to a local bucket.
-					await mf.dispatchFetch(`http://localhost/${key}`, {
-						method: "PUT",
-						body: objectStream,
-						duplex: "half",
-						headers: {
-							"Content-Length": String(sizeBytes),
-							"Wrangler-R2-Put-Options": JSON.stringify(putOptions),
-						},
-					});
+					await mf.dispatchFetch(
+						`http://localhost/${encodeURIComponent(key)}`,
+						{
+							method: "PUT",
+							body: objectStream,
+							duplex: "half",
+							headers: {
+								"Content-Length": String(sizeBytes),
+								"Wrangler-R2-Put-Options": JSON.stringify(putOptions),
+							},
+						}
+					);
 				}
 			);
 		} else {
@@ -654,15 +657,18 @@ export const r2BulkPutCommand = createCommand({
 							// currently doesn't support sending these. Instead,
 							// `usingLocalBucket()` provides a single `PUT` endpoint
 							// for writing to a local bucket.
-							await mf.dispatchFetch(`http://localhost/${entry.key}`, {
-								method: "PUT",
-								body: stream.Readable.toWeb(fs.createReadStream(entry.file)),
-								duplex: "half",
-								headers: {
-									"Content-Length": String(entry.size),
-									"Wrangler-R2-Put-Options": jsonPutOptions,
-								},
-							});
+							await mf.dispatchFetch(
+								`http://localhost/${encodeURIComponent(entry.key)}`,
+								{
+									method: "PUT",
+									body: stream.Readable.toWeb(fs.createReadStream(entry.file)),
+									duplex: "half",
+									headers: {
+										"Content-Length": String(entry.size),
+										"Wrangler-R2-Put-Options": jsonPutOptions,
+									},
+								}
+							);
 						})
 					);
 


### PR DESCRIPTION
After #15192 I went looking for the same shape of bug elsewhere in the local-mode commands, and `r2 object put` has one.

The key travels to the local bucket worker inside a URL, ``dispatchFetch(`http://localhost/${key}`)`` in `src/r2/object.ts`, and the worker pulls it back out with `url.pathname.substring(1)`. Nothing decodes it, so storage ends up holding whatever URL parsing made of the key. `get` and `delete` never take that hop. They hand the key straight to the binding, so put writes one name and get looks for another.

Six uploads on wrangler 4.124.0, then the keys sitting in `.wrangler/state`:

```
my report.pdf          →  my%20report.pdf
héllo.txt              →  h%C3%A9llo.txt
archive#2026-01.zip    →  archive
archive#2026-02.zip    →  archive
invoices/2026/q1.pdf   →  invoices/2026/q1.pdf
plain.txt              →  plain.txt
```

Six uploads and five objects. Each one printed "Upload complete.", and the two archives quietly became one. Getting `my report.pdf` back afterwards fails with "The specified key does not exist." A `%` goes one of two ways. `50%off.pdf` stops on "Invalid URL string.", while `%41.txt` reports success and lands as `A.txt`. `kv key put "my report.pdf"` on the same CLI keeps the space, because the local KV path calls `namespace.put(key, ...)` with no URL in the middle.

The fix encodes the key going in and decodes it coming out. Keys that work today keep working, `invoices/2026/q1.pdf` and `my%20report.pdf` both still round trip. Objects already in local state are left where they are, since nothing gets renamed, so an object an older wrangler stored as `my%20report.pdf` is still reachable only under that name. Two keys don't survive either way, `.` and `..`, because URL normalisation eats dot segments before any encoding can help. That's the same before and after, and I've left it alone. Bulk put builds the same URL, so it gets the same treatment.

Tests in `src/__tests__/r2/local.test.ts` cover a round trip over seven awkward keys, two keys that differ only after a `#`, and one bulk put. Without the fix those three fail on "The specified key does not exist." With it, `src/__tests__/r2` runs 209 of 209. `oxfmt --check`, `oxlint --deny-warnings --type-aware`, `tsc -p ./tsconfig.json` and `tsc -p ./src/__tests__/tsconfig.json` are all clean.

I've left the remote path alone. It builds the same URL shape in `src/r2/helpers/object.ts`, and `fetch()` drops the fragment before the request goes out. Pointing wrangler at a local server with `CLOUDFLARE_API_BASE_URL` shows what it sends:

```
put "bucket/archive#2026-01.zip"     PUT /accounts/.../objects/archive
put "bucket/sale?50.pdf"             PUT /accounts/.../objects/sale?50.pdf
delete "bucket/archive#2026-01.zip"  DELETE /accounts/.../objects/archive
```

Encoding there would send `invoices%2F2026%2Fq1.pdf` where today it sends `invoices/2026/q1.pdf`, and I have no account to check whether the API reads those the same way. Say which shape you want and I'll add it here.

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: this is a bug fix to local `r2 object put` and `r2 bulk put`, no command or option changes

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/15261" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->