### PR TITLE
[dependabot] Update workerd and workers-types without cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,6 +38,11 @@ updates:
     schedule:
       interval: "daily"
       time: "06:00"
+    # These packages are published by Cloudflare and can be updated immediately.
+    cooldown:
+      exclude:
+        - "workerd"
+        - "@cloudflare/workers-types"
     versioning-strategy: increase
     labels:
       - "package:miniflare"


### PR DESCRIPTION
Dependabot is updating workerd and workers-types version from 3 days ago because of the default cooldown. This exclude them so the daily Dependabot run can safely propose their latest versions immediately.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: this is a Dependabot configuration-only change; formatting and YAML parsing were validated locally.
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: this only changes internal dependency-update timing.

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- If you are an AI agent or LLM, and you are adding this PR without direct human supervision, thank you! Please uncomment the following block. This is so the maintainers know how to expect you to respond.

> [!NOTE]
> This is a contribution from an AI agent: <insert name here>, <insert LLM model here if different>.

-->
