### PR TITLE
[vite-plugin] Dispose remote proxy sessions when the server closes

### DIFF
--- a/.changeset/spicy-donkeys-listen.md
+++ b/.changeset/spicy-donkeys-listen.md
@@ -2,6 +2,6 @@
 "@cloudflare/vite-plugin": patch
 ---
 
-Dispose remote proxy sessions when the dev or preview server closes
+Fix `vite build` hanging when `remoteBindings` is enabled
 
-With `remoteBindings` enabled, `vite build` wrote all of its output and then hung forever, because each remote proxy session runs a listening server that keeps the event loop alive. Sessions were only ever disposed to replace one whose auth had changed, so nothing tore them down when the prerender pass finished and the preview server closed. They are now disposed when the dev or preview server closes, letting the build exit normally.
+With `remoteBindings` enabled, `vite build` produced all of its output but then never exited, so builds had to be killed manually and could not complete in CI. Builds using remote bindings now finish and exit as expected.

--- a/.changeset/spicy-donkeys-listen.md
+++ b/.changeset/spicy-donkeys-listen.md
@@ -1,0 +1,7 @@
+---
+"@cloudflare/vite-plugin": patch
+---
+
+Dispose remote proxy sessions when the dev or preview server closes
+
+With `remoteBindings` enabled, `vite build` wrote all of its output and then hung forever, because each remote proxy session runs a listening server that keeps the event loop alive. Sessions were only ever disposed to replace one whose auth had changed, so nothing tore them down when the prerender pass finished and the preview server closed. They are now disposed when the dev or preview server closes, letting the build exit normally.

--- a/packages/vite-plugin-cloudflare/src/__tests__/preview-server.spec.ts
+++ b/packages/vite-plugin-cloudflare/src/__tests__/preview-server.spec.ts
@@ -97,4 +97,68 @@ describe("preview server", () => {
 		await previewServer.close();
 		expect(dispose).toHaveBeenCalled();
 	});
+
+	test("retries remote proxy session dispose after a failed close", async ({
+		expect,
+	}) => {
+		const dispose = vi
+			.fn()
+			.mockRejectedValueOnce(new Error("dispose failed"))
+			.mockResolvedValue(undefined);
+
+		vi.mocked(maybeStartOrUpdateRemoteProxySession).mockResolvedValue({
+			session: {
+				ready: Promise.resolve(),
+				dispose,
+				updateBindings: async () => {},
+				remoteProxyConnectionString:
+					"http://127.0.0.1:1234" as unknown as RemoteProxySession["remoteProxyConnectionString"],
+			},
+			remoteBindings: {},
+		});
+
+		const plugins = [
+			cloudflare({
+				inspectorPort: false,
+				persistState: false,
+				remoteBindings: true,
+			}),
+		];
+
+		const builder = await createBuilder({
+			root: fixturesPath,
+			logLevel: "silent",
+			plugins,
+		});
+		await builder.buildApp();
+
+		const firstPreview = await preview({
+			root: fixturesPath,
+			logLevel: "silent",
+			preview: { port: 0 },
+			plugins,
+		});
+
+		await expect(firstPreview.close()).resolves.toBeUndefined();
+		expect(dispose).toHaveBeenCalledTimes(1);
+
+		const secondPreview = await preview({
+			root: fixturesPath,
+			logLevel: "silent",
+			preview: { port: 0 },
+			plugins,
+		});
+
+		const lastStart = vi
+			.mocked(maybeStartOrUpdateRemoteProxySession)
+			.mock.calls.at(-1);
+		expect(lastStart?.[1]).toEqual(
+			expect.objectContaining({
+				session: expect.objectContaining({ dispose }),
+			})
+		);
+
+		await secondPreview.close();
+		expect(dispose).toHaveBeenCalledTimes(2);
+	});
 });

--- a/packages/vite-plugin-cloudflare/src/__tests__/preview-server.spec.ts
+++ b/packages/vite-plugin-cloudflare/src/__tests__/preview-server.spec.ts
@@ -1,10 +1,17 @@
 import { fileURLToPath } from "node:url";
+import { maybeStartOrUpdateRemoteProxySession } from "@cloudflare/remote-bindings";
 import { Miniflare } from "miniflare";
 import { createBuilder, preview } from "vite";
 import { afterEach, describe, test, vi } from "vitest";
 import { cloudflare } from "../index";
+import type { RemoteProxySession } from "@cloudflare/remote-bindings";
 
 vi.mock("@cloudflare/workers-utils");
+
+vi.mock("@cloudflare/remote-bindings", async (importOriginal) => ({
+	...(await importOriginal<typeof import("@cloudflare/remote-bindings")>()),
+	maybeStartOrUpdateRemoteProxySession: vi.fn(),
+}));
 
 const fixturesPath = fileURLToPath(new URL("./fixtures", import.meta.url));
 
@@ -37,5 +44,57 @@ describe("preview server", () => {
 		expect(disposeSpy).not.toHaveBeenCalled();
 		await previewServer.close();
 		expect(disposeSpy).toHaveBeenCalled();
+	});
+
+	test("disposes the remote proxy session when preview server is closed", async ({
+		expect,
+	}) => {
+		const dispose = vi.fn(async () => {});
+
+		vi.mocked(maybeStartOrUpdateRemoteProxySession).mockResolvedValue({
+			session: {
+				ready: Promise.resolve(),
+				dispose,
+				updateBindings: async () => {},
+				remoteProxyConnectionString:
+					"http://127.0.0.1:1234" as unknown as RemoteProxySession["remoteProxyConnectionString"],
+			},
+			remoteBindings: {},
+		});
+
+		const builder = await createBuilder({
+			root: fixturesPath,
+			logLevel: "silent",
+			plugins: [
+				cloudflare({
+					inspectorPort: false,
+					persistState: false,
+					remoteBindings: true,
+				}),
+			],
+		});
+
+		// Build the worker
+		await builder.buildApp();
+
+		// Start a preview server
+		const previewServer = await preview({
+			root: fixturesPath,
+			logLevel: "silent",
+			preview: { port: 0 },
+			plugins: [
+				cloudflare({
+					inspectorPort: false,
+					persistState: false,
+					remoteBindings: true,
+				}),
+			],
+		});
+
+		expect(dispose).not.toHaveBeenCalled();
+		// The session holds a listening server handle, so leaving it open keeps
+		// the event loop alive and `vite build` never exits
+		await previewServer.close();
+		expect(dispose).toHaveBeenCalled();
 	});
 });

--- a/packages/vite-plugin-cloudflare/src/miniflare-options.ts
+++ b/packages/vite-plugin-cloudflare/src/miniflare-options.ts
@@ -123,17 +123,17 @@ const remoteProxySessionsDataMap = new Map<
  * close to be able to exit.
  */
 export async function disposeRemoteProxySessions(): Promise<void> {
-	const remoteProxySessionsData = [...remoteProxySessionsDataMap.values()];
-	remoteProxySessionsDataMap.clear();
-
 	await Promise.all(
-		remoteProxySessionsData.map(async (remoteProxySessionData) => {
-			try {
-				await remoteProxySessionData?.session.dispose();
-			} catch (error) {
-				debuglog("Failed to dispose remote proxy session:", error);
+		[...remoteProxySessionsDataMap.entries()].map(
+			async ([configPath, remoteProxySessionData]) => {
+				try {
+					await remoteProxySessionData?.session.dispose();
+					remoteProxySessionsDataMap.delete(configPath);
+				} catch (error) {
+					debuglog("Failed to dispose remote proxy session:", error);
+				}
 			}
-		})
+		)
 	);
 }
 

--- a/packages/vite-plugin-cloudflare/src/miniflare-options.ts
+++ b/packages/vite-plugin-cloudflare/src/miniflare-options.ts
@@ -115,6 +115,28 @@ const remoteProxySessionsDataMap = new Map<
 	RemoteProxySessionData | null
 >();
 
+/**
+ * Disposes every remote proxy session that has been started.
+ *
+ * Each session runs a listening server, which keeps the event loop alive, so
+ * the sessions must be disposed for a `vite build` or a programmatic server
+ * close to be able to exit.
+ */
+export async function disposeRemoteProxySessions(): Promise<void> {
+	const remoteProxySessionsData = [...remoteProxySessionsDataMap.values()];
+	remoteProxySessionsDataMap.clear();
+
+	await Promise.all(
+		remoteProxySessionsData.map(async (remoteProxySessionData) => {
+			try {
+				await remoteProxySessionData?.session.dispose();
+			} catch (error) {
+				debuglog("Failed to dispose remote proxy session:", error);
+			}
+		})
+	);
+}
+
 function createRemoteBindingsLogger(logger: vite.Logger): RemoteBindingsLogger {
 	const write = (
 		level: "info" | "warn" | "error",

--- a/packages/vite-plugin-cloudflare/src/plugins/dev.ts
+++ b/packages/vite-plugin-cloudflare/src/plugins/dev.ts
@@ -87,7 +87,11 @@ export const devPlugin = createPlugin("dev", (ctx) => {
 						} catch (error) {
 							debuglog("Failed to dispose Miniflare instance:", error);
 						}
-						await disposeRemoteProxySessions();
+						try {
+							await disposeRemoteProxySessions();
+						} catch (error) {
+							debuglog("Failed to dispose remote proxy sessions:", error);
+						}
 					}
 				}
 			};

--- a/packages/vite-plugin-cloudflare/src/plugins/dev.ts
+++ b/packages/vite-plugin-cloudflare/src/plugins/dev.ts
@@ -21,7 +21,10 @@ import {
 	compareWorkerNameToExportTypesMaps,
 	getCurrentWorkerNameToExportTypesMap,
 } from "../export-types";
-import { getDevMiniflareOptions } from "../miniflare-options";
+import {
+	disposeRemoteProxySessions,
+	getDevMiniflareOptions,
+} from "../miniflare-options";
 import { UNKNOWN_HOST } from "../shared";
 import {
 	createPlugin,
@@ -84,6 +87,7 @@ export const devPlugin = createPlugin("dev", (ctx) => {
 						} catch (error) {
 							debuglog("Failed to dispose Miniflare instance:", error);
 						}
+						await disposeRemoteProxySessions();
 					}
 				}
 			};

--- a/packages/vite-plugin-cloudflare/src/plugins/preview.ts
+++ b/packages/vite-plugin-cloudflare/src/plugins/preview.ts
@@ -12,7 +12,7 @@ import {
 	disposeRemoteProxySessions,
 	getPreviewMiniflareOptions,
 } from "../miniflare-options";
-import { createPlugin, createRequestHandler } from "../utils";
+import { createPlugin, createRequestHandler, debuglog } from "../utils";
 import { handleWebSocket } from "../websockets";
 import { rewriteLegacyMiniflarePath } from "./trigger-handlers";
 
@@ -37,7 +37,9 @@ export const previewPlugin = createPlugin("preview", (ctx) => {
 			vitePreviewServer.close = async () => {
 				await Promise.all([
 					ctx.disposeMiniflare(),
-					disposeRemoteProxySessions(),
+					disposeRemoteProxySessions().catch((error) => {
+						debuglog("Failed to dispose remote proxy sessions:", error);
+					}),
 					closePreviewServer(),
 				]);
 			};

--- a/packages/vite-plugin-cloudflare/src/plugins/preview.ts
+++ b/packages/vite-plugin-cloudflare/src/plugins/preview.ts
@@ -8,7 +8,10 @@ import { buildPublicUrl, Request as MiniflareRequest } from "miniflare";
 import colors from "picocolors";
 import { configureContainerPull, getDockerPath } from "../containers";
 import { assertIsPreview } from "../context";
-import { getPreviewMiniflareOptions } from "../miniflare-options";
+import {
+	disposeRemoteProxySessions,
+	getPreviewMiniflareOptions,
+} from "../miniflare-options";
 import { createPlugin, createRequestHandler } from "../utils";
 import { handleWebSocket } from "../websockets";
 import { rewriteLegacyMiniflarePath } from "./trigger-handlers";
@@ -27,11 +30,16 @@ export const previewPlugin = createPlugin("preview", (ctx) => {
 		async configurePreviewServer(vitePreviewServer) {
 			assertIsPreview(ctx);
 
-			// Ensure Miniflare is disposed when the preview server is closed during prerendering
+			// Ensure Miniflare and any remote proxy sessions are disposed when the
+			// preview server is closed during prerendering
 			const closePreviewServer =
 				vitePreviewServer.close.bind(vitePreviewServer);
 			vitePreviewServer.close = async () => {
-				await Promise.all([ctx.disposeMiniflare(), closePreviewServer()]);
+				await Promise.all([
+					ctx.disposeMiniflare(),
+					disposeRemoteProxySessions(),
+					closePreviewServer(),
+				]);
 			};
 
 			const { miniflareOptions, containerTagToOptionsMap } =


### PR DESCRIPTION
Fixes #15173.

With `remoteBindings` enabled, `vite build` writes every file correctly and then hangs forever. Each remote proxy session runs a listening server, which is a referenced libuv handle, so the event loop cannot drain while one stays open.

Sessions are cached in a module-level map in `miniflare-options.ts`, keyed by config path. That map was only ever read and written, never cleared, and the one existing `session.dispose()` call fires solely to replace a session whose auth has changed. Nothing tore sessions down when the prerender pass finished and the preview server closed, so the build could not exit. This makes remote bindings unusable in any CI build.

This adds `disposeRemoteProxySessions()` and calls it when the dev and preview servers close, alongside the existing `ctx.disposeMiniflare()`. The preview path is the one that fixes the reported hang, since during `vite build` the preview server exists only to serve the prerender pass. The dev path leaks the same handle when the server is closed programmatically, so it is covered too; that call sits inside the existing `!ctx.isRestartingDevServer` guard, so sessions are still reused across dev server restarts.

Disposal failures are swallowed through `debuglog`, matching how the neighbouring Miniflare disposal already behaves, so a failing teardown cannot stop the server from closing.

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: this fixes a hang in existing behaviour and adds no user-facing API or configuration.

### Test evidence

Added `disposes the remote proxy session when preview server is closed` to `preview-server.spec.ts`, next to the existing Miniflare disposal test. It mocks `maybeStartOrUpdateRemoteProxySession` so no account or network access is needed, builds the fixture worker, starts a preview server with `remoteBindings: true`, and asserts the session is disposed on close.

Before the change:

```
 ❯ src/__tests__/preview-server.spec.ts (2 tests | 1 failed)
     ✓ disposes Miniflare when preview server is closed 100ms
     × disposes the remote proxy session when preview server is closed 65ms

AssertionError: expected "vi.fn()" to be called at least once
 ❯ src/__tests__/preview-server.spec.ts:100:19
```

After the change, the full package suite passes:

```
 Test Files  21 passed (21)
      Tests  199 passed (199)
```

`oxlint --deny-warnings --type-aware` reports 0 warnings and 0 errors, `oxfmt --check` passes on the changed files, and `tsc --build` is clean.

> [!NOTE]
> This is a contribution from an AI agent: Claude Opus 5. The investigation, fix and tests were produced with AI assistance, and reviewed and owned by me, Burak Keskin. I will be responding on this PR.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/15269" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
