### PR TITLE
[config] Deregister config loader module hooks once the load has finished

### DIFF
--- a/.changeset/purple-lions-shave.md
+++ b/.changeset/purple-lions-shave.md
@@ -1,0 +1,11 @@
+---
+"@cloudflare/config": patch
+"@cloudflare/vite-plugin": patch
+"wrangler": patch
+---
+
+Deregister the `cloudflare.config.ts` Node module hooks once the config has loaded
+
+The config loader installs `module.registerHooks()` hooks to resolve `with { type: "cf-worker" }` import attributes and track config dependencies. Those hooks are process-wide and were never removed, so after the first config load they stayed in Node's hook chain for the rest of the process and interfered with unrelated module loads in downstream tooling — most visibly breaking Vite/rolldown builds where the loader's `load` hook ended up in the chain for CSS and route modules.
+
+Registrations are now reference counted and released as soon as the config's module graph has finished loading, so the hooks are only installed while a config is actually being imported. Nested and concurrent loads are safe, and watch mode re-registers on each reload.

--- a/packages/config/src/__tests__/load.test.ts
+++ b/packages/config/src/__tests__/load.test.ts
@@ -5,6 +5,56 @@ import { runInTempDir, seed } from "@cloudflare/workers-utils/test-helpers";
 import { describe, it } from "vitest";
 import { InputWorkerSchema } from "../schema";
 
+// Use a file:// URL rather than a raw filesystem path so the embedded
+// `import` specifier is valid on Windows (where absolute paths like
+// `C:\...` are not accepted as ESM specifiers).
+const SOURCE_ENTRY = pathToFileURL(path.resolve(__dirname, "../load.ts")).href;
+
+// Subprocess snippet that reports whether the config hooks are currently
+// installed in Node's hook chain. While they are, a `cf-worker` import is
+// short-circuited to a synthetic module whose default export is the entrypoint
+// path — tests pair this with an `src/index.ts` that has no default export of
+// its own, so a string default can only have come from the hooks.
+const CF_WORKER_PROBE = `
+	async function hooksInstalled() {
+		try {
+			const mod = await import(
+				"./src/index.ts?probe=" + Math.random(),
+				{ with: { type: "cf-worker" } }
+			);
+			return typeof mod.default === "string";
+		} catch {
+			return false;
+		}
+	}
+`;
+
+/**
+ * Run an ES module script in a Node subprocess and parse its stdout as JSON.
+ *
+ * @param script Module source to evaluate. It must write a JSON payload to
+ *   `process.stdout`.
+ * @param cwd Working directory for the subprocess. Defaults to the test's
+ *   temporary directory.
+ * @returns The parsed JSON payload written by the script.
+ */
+function runScriptInSubprocess<T>(script: string, cwd = process.cwd()): T {
+	const result = spawnSync(
+		process.execPath,
+		["--input-type=module", "-e", script],
+		{
+			cwd,
+			encoding: "utf8",
+		}
+	);
+	if (result.status !== 0) {
+		throw new Error(
+			`Subprocess failed (status ${result.status}):\n${result.stderr}`
+		);
+	}
+	return JSON.parse(result.stdout) as T;
+}
+
 // Vitest's module runner intercepts dynamic imports before Node's
 // `module.registerHooks` can see them, so we cannot exercise `loadConfig`
 // inside a test directly. Instead, we run a small Node program in a
@@ -19,15 +69,11 @@ function runLoadConfigInSubprocess(args: {
 	exports: Record<string, unknown>;
 	dependencies: string[];
 } {
-	// Use a file:// URL rather than a raw filesystem path so the embedded
-	// `import` specifier is valid on Windows (where absolute paths like
-	// `C:\...` are not accepted as ESM specifiers).
-	const sourceEntry = pathToFileURL(path.resolve(__dirname, "../load.ts")).href;
 	const options = args.include
 		? `, { include: ${JSON.stringify(args.include)} }`
 		: "";
 	const script = `
-		import { loadConfig } from ${JSON.stringify(sourceEntry)};
+		import { loadConfig } from ${JSON.stringify(SOURCE_ENTRY)};
 		const result = await loadConfig(${JSON.stringify(args.configPath)}${options});
 		const serialisable = {
 			config: result.exports.default,
@@ -43,17 +89,7 @@ function runLoadConfigInSubprocess(args: {
 			return v;
 		}));
 	`;
-	const result = spawnSync(
-		process.execPath,
-		["--input-type=module", "-e", script],
-		{ cwd: args.cwd, encoding: "utf8" }
-	);
-	if (result.status !== 0) {
-		throw new Error(
-			`Subprocess failed (status ${result.status}):\n${result.stderr}`
-		);
-	}
-	return JSON.parse(result.stdout);
+	return runScriptInSubprocess(script, args.cwd);
 }
 
 describe("loadConfig", () => {
@@ -218,12 +254,12 @@ describe("loadConfig", () => {
 			"cloudflare.config.ts": `export default { name: "first" };`,
 		});
 
-		const sourceEntry = pathToFileURL(
-			path.resolve(__dirname, "../load.ts")
-		).href;
-		const script = `
+		const parsed = runScriptInSubprocess<{
+			first: { name: string };
+			second: { name: string };
+		}>(`
 			import { writeFileSync } from "node:fs";
-			import { loadConfig } from ${JSON.stringify(sourceEntry)};
+			import { loadConfig } from ${JSON.stringify(SOURCE_ENTRY)};
 			const first = await loadConfig("./cloudflare.config.ts");
 			writeFileSync("./cloudflare.config.ts", 'export default { name: "second" };');
 			const second = await loadConfig("./cloudflare.config.ts");
@@ -231,19 +267,7 @@ describe("loadConfig", () => {
 				first: first.exports.default,
 				second: second.exports.default,
 			}));
-		`;
-		const sub = spawnSync(
-			process.execPath,
-			["--input-type=module", "-e", script],
-			{ cwd: process.cwd(), encoding: "utf8" }
-		);
-		if (sub.status !== 0) {
-			throw new Error(`Subprocess failed: ${sub.stderr}`);
-		}
-		const parsed = JSON.parse(sub.stdout) as {
-			first: { name: string };
-			second: { name: string };
-		};
+		`);
 		expect(parsed.first.name).toBe("first");
 		expect(parsed.second.name).toBe("second");
 	});
@@ -295,5 +319,134 @@ describe("loadConfig", () => {
 		expect(result.dependencies).not.toContain(pkgPath);
 		// Sanity: the config file itself is still tracked.
 		expect(result.dependencies).toContain(path.resolve("cloudflare.config.ts"));
+	});
+
+	it("releases the module hooks once the load has finished", async ({
+		expect,
+	}) => {
+		await seed({
+			"src/index.ts": `// not executed`,
+			"cloudflare.config.ts": `
+				import * as entrypoint from "./src/index.ts" with { type: "cf-worker" };
+				export default { name: "w", entrypoint };
+			`,
+			"plain.ts": `export const value = "plain";`,
+		});
+
+		// While the hooks are installed, a `cf-worker` import is short-circuited
+		// to a synthetic module whose default export is the entrypoint path.
+		// `src/index.ts` has no default export of its own, so a string default
+		// is a reliable signal that the hooks are still in Node's hook chain.
+		const result = runScriptInSubprocess<{
+			config: { name: string };
+			hooksInstalledAfterLoad: boolean;
+			hooksInstalledAfterReRegister: boolean;
+			hooksInstalledAfterRelease: boolean;
+			plainImportWorks: boolean;
+		}>(`
+			import { loadConfig, registerConfigHooks } from ${JSON.stringify(SOURCE_ENTRY)};
+			${CF_WORKER_PROBE}
+
+			const { exports } = await loadConfig("./cloudflare.config.ts");
+			const hooksInstalledAfterLoad = await hooksInstalled();
+
+			// A fresh registration must install the hooks again rather than
+			// hand back a stale, already-deregistered handle.
+			const release = registerConfigHooks();
+			const hooksInstalledAfterReRegister = await hooksInstalled();
+			release();
+			// Releasing twice must not double-decrement the reference count.
+			release();
+			const hooksInstalledAfterRelease = await hooksInstalled();
+
+			const { value } = await import("./plain.ts");
+
+			process.stdout.write(JSON.stringify({
+				config: exports.default,
+				hooksInstalledAfterLoad,
+				hooksInstalledAfterReRegister,
+				hooksInstalledAfterRelease,
+				plainImportWorks: value === "plain",
+			}));
+		`);
+
+		expect(result.config.name).toBe("w");
+		expect(result.hooksInstalledAfterLoad).toBe(false);
+		expect(result.hooksInstalledAfterReRegister).toBe(true);
+		expect(result.hooksInstalledAfterRelease).toBe(false);
+		expect(result.plainImportWorks).toBe(true);
+	});
+
+	it("keeps the hooks installed for overlapping loads and releases them exactly once", async ({
+		expect,
+	}) => {
+		await seed({
+			"src/index.ts": `// not executed`,
+			// The dynamic `cf-worker` import runs after a tick, so it resolves
+			// while the other (faster) `loadConfig` call has already finished.
+			// If the hooks were released per-call rather than reference
+			// counted, this resolution would fail.
+			"slow.config.ts": `
+				await new Promise((resolve) => setTimeout(resolve, 100));
+				const entrypoint = await import("./src/index.ts", { with: { type: "cf-worker" } });
+				export default { name: "slow", entrypoint: entrypoint.default };
+			`,
+			"fast.config.ts": `export default { name: "fast" };`,
+		});
+
+		const result = runScriptInSubprocess<{
+			slow: { name: string; entrypoint: string };
+			fast: { name: string };
+			hooksInstalledAfterBoth: boolean;
+		}>(`
+			import { loadConfig } from ${JSON.stringify(SOURCE_ENTRY)};
+			${CF_WORKER_PROBE}
+
+			const [slow, fast] = await Promise.all([
+				loadConfig("./slow.config.ts"),
+				loadConfig("./fast.config.ts"),
+			]);
+
+			process.stdout.write(JSON.stringify({
+				slow: slow.exports.default,
+				fast: fast.exports.default,
+				hooksInstalledAfterBoth: await hooksInstalled(),
+			}));
+		`);
+
+		expect(result.fast.name).toBe("fast");
+		expect(result.slow.name).toBe("slow");
+		expect(result.slow.entrypoint).toBe(path.resolve("src/index.ts"));
+		expect(result.hooksInstalledAfterBoth).toBe(false);
+	});
+
+	it("releases the hooks when the config throws", async ({ expect }) => {
+		await seed({
+			"cloudflare.config.ts": `throw new Error("boom");`,
+			"src/index.ts": `// not executed`,
+		});
+
+		const result = runScriptInSubprocess<{
+			loadFailed: boolean;
+			hooksInstalledAfterFailure: boolean;
+		}>(`
+			import { loadConfig } from ${JSON.stringify(SOURCE_ENTRY)};
+			${CF_WORKER_PROBE}
+
+			let loadFailed = false;
+			try {
+				await loadConfig("./cloudflare.config.ts");
+			} catch {
+				loadFailed = true;
+			}
+
+			process.stdout.write(JSON.stringify({
+				loadFailed,
+				hooksInstalledAfterFailure: await hooksInstalled(),
+			}));
+		`);
+
+		expect(result.loadFailed).toBe(true);
+		expect(result.hooksInstalledAfterFailure).toBe(false);
 	});
 });

--- a/packages/config/src/load.ts
+++ b/packages/config/src/load.ts
@@ -40,13 +40,22 @@ export async function loadConfig(
 	configPath: string,
 	options?: { include?: string[] }
 ): Promise<LoadConfigResult> {
-	registerConfigHooks();
+	const release = registerConfigHooks();
 	const url = pathToFileURL(configPath).href;
 	const dependencies = new Set<string>();
-	const mod = await depsStore.run(
-		dependencies,
-		() => import(url, { with: { [CF_ATTR]: CF_NO_CACHE_VALUE } })
-	);
+	let mod: unknown;
+	try {
+		// The hooks are only needed while the config's module graph is being
+		// resolved and loaded. Releasing them afterwards keeps them out of
+		// Node's global hook chain, where they would otherwise interfere with
+		// unrelated module loads for the rest of the process's lifetime.
+		mod = await depsStore.run(
+			dependencies,
+			() => import(url, { with: { [CF_ATTR]: CF_NO_CACHE_VALUE } })
+		);
+	} finally {
+		release();
+	}
 
 	const exports: Record<string, unknown> = {};
 	for (const [name, value] of Object.entries(mod as Record<string, unknown>)) {
@@ -74,11 +83,22 @@ export interface LoadConfigResult {
 	dependencies: Set<string>;
 }
 
-let deregister: (() => void) | undefined;
+let activeHooks: { deregister: () => void } | undefined;
+let registrationCount = 0;
 
 /**
- * Register Node module hooks for loading Worker configs. Idempotent —
- * repeated calls return the same deregister function.
+ * Register Node module hooks for loading Worker configs.
+ *
+ * Registrations are reference counted — each call increments the count and
+ * returns a release function that decrements it. The hooks are installed on
+ * the first registration and deregistered once the count drops back to zero,
+ * so nested or concurrent registrations cannot tear the hooks down while
+ * another load is still in flight. Each returned release function is
+ * idempotent; calling it more than once has no further effect.
+ *
+ * The hooks are global to the process while installed, so callers must
+ * release them as soon as the module graph they care about has finished
+ * loading.
  *
  *  - Handles `with { type: "cf-worker" }` import attributes by synthesising an
  *    ES module whose default export is the entrypoint specifier. Relative
@@ -93,11 +113,10 @@ let deregister: (() => void) | undefined;
  *    propagated to all transitive imports via the parent URL, ensuring the
  *    entire subgraph is re-evaluated. Imports inside `node_modules` are
  *    skipped (treated as immutable for config purposes).
+ *
+ * @returns A function that releases this registration.
  */
 export function registerConfigHooks(): () => void {
-	if (deregister) {
-		return deregister;
-	}
 	if (typeof process !== "undefined" && process.versions.bun) {
 		throw new Error(
 			"cloudflare.config.ts loading is not supported on Bun. " +
@@ -113,7 +132,11 @@ export function registerConfigHooks(): () => void {
 		);
 	}
 
-	const hooks = registerHooks({
+	if (activeHooks) {
+		return acquireRegistration();
+	}
+
+	activeHooks = registerHooks({
 		resolve(specifier, context, nextResolve) {
 			// `importAttributes` may be absent for some resolution paths (e.g.
 			// CJS `require()` going through the hook chain after the hook has
@@ -197,12 +220,31 @@ export function registerConfigHooks(): () => void {
 		},
 	});
 
-	deregister = () => {
-		hooks.deregister();
-		deregister = undefined;
-	};
+	return acquireRegistration();
+}
 
-	return deregister;
+/**
+ * Take out a reference on the currently installed hooks.
+ *
+ * @returns An idempotent function that drops this reference, deregistering the
+ *   hooks once the last reference is released.
+ */
+function acquireRegistration(): () => void {
+	registrationCount++;
+
+	let released = false;
+
+	return () => {
+		if (released) {
+			return;
+		}
+		released = true;
+		registrationCount--;
+		if (registrationCount === 0) {
+			activeHooks?.deregister();
+			activeHooks = undefined;
+		}
+	};
 }
 
 function getParentUUID(parentURL: string | undefined): string | undefined {


### PR DESCRIPTION
Scope the `cloudflare.config.ts` loader's Node module hooks to the duration of a single load, instead of leaving them installed for the lifetime of the process.

`registerConfigHooks()` installs `module.registerHooks()` hooks that resolve `with { type: "cf-worker" }` import attributes and populate the dependency set for a config's module graph. Those hooks are process-wide, `loadConfig` registered them on every call, and the returned deregister function had no callers anywhere in the repo — so the first config load left the hooks in Node's hook chain permanently.

## The failure

- Node's hook chain is global — once installed, the loader's `resolve`/`load` hooks run for **every** subsequent module load in the process, not just config loads.
- `@cloudflare/vite-plugin` with `experimental.newConfig` enabled loads a config early in the Vite lifecycle, so the hooks are installed by the time the bundler starts pulling modules through Node's loader.
- A downstream report has TanStack Start (Vite 8 / rolldown) builds dying in CSS loading — `[plugin vite:css] … TypeError: [postcss] Expected a string, an ArrayBuffer, or a TypedArray to be returned for the "source" from the "load" hook but got null`, with the offending frame inside `@cloudflare/vite-plugin/dist/index.mjs` — the config loader's own `load` hook. TanStack Start's build planning imports route modules through Node's loader, and the cf hook is still sitting in the chain.
- Every build fails this way, so affected apps can't produce build output at all.

I have **not** reproduced the TanStack failure locally — the repro is from the downstream report. What is directly verifiable is the mechanism: the hooks were never deregistered, and they are global.

## The change

- `registerConfigHooks()` is now **reference counted** — each call takes out a reference and returns a release function; the hooks are installed on the first reference and deregistered when the count drops back to zero. Nested or concurrent loads can't tear the hooks down from under each other, and each release function is idempotent.
- `loadConfig` wraps the `import()` in `try`/`finally` and releases its registration in the `finally`, so the hooks are gone as soon as the config's module graph has been resolved — including when the config itself throws.
- The hooks are only needed *during* the import (the `cf-worker` attribute resolution and `depsStore` population both happen synchronously within the load), so nothing else needs them to stay installed. Watch mode re-loads the config, which re-registers.
- `registerConfigHooks` stays exported and still returns a release function, so external callers are unaffected. Bun / Node-version error behaviour is unchanged — both checks still run on every call.

## Tests

Extended `packages/config/src/__tests__/load.test.ts` (these run `loadConfig` in a Node subprocess, since Vitest's module runner intercepts dynamic imports before `registerHooks` can see them):

- The hooks are released once a load finishes, a fresh `registerConfigHooks()` installs them again rather than handing back a stale handle, releasing twice doesn't double-decrement, and an unrelated plain `import()` afterwards is unaffected.
- Two overlapping `loadConfig` calls both succeed — the faster one finishing must not deregister the hooks while the slower one is still resolving — and the hooks are released exactly once at the end. Verified this test fails against a naive non-reference-counted release.
- The hooks are released when the config throws.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: this is an internal fix to the config loader's module-hook lifetime. There is no user-facing API change — `registerConfigHooks` keeps its signature and `loadConfig` behaves identically from the caller's point of view.

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- If you are an AI agent or LLM, and you are adding this PR without direct human supervision, thank you! Please uncomment the following block. This is so the maintainers know how to expect you to respond.

> [!NOTE]
> This is a contribution from an AI agent: <insert name here>, <insert LLM model here if different>.

-->
