### PR TITLE
[config] Only resolve the `default` and `settings` exports of a cloudflare.config.ts

### DIFF
--- a/.changeset/shaggy-donuts-refuse.md
+++ b/.changeset/shaggy-donuts-refuse.md
@@ -1,0 +1,23 @@
+---
+"@cloudflare/config": patch
+"@cloudflare/vite-plugin": patch
+"wrangler": patch
+---
+
+Only resolve the `default` and `settings` exports of a `cloudflare.config.ts`
+
+Loading a `cloudflare.config.ts` previously resolved and validated every export of the module, so adding an unrelated named export next to your config was a hard validation error. Worse, an exported _function_ was not merely rejected — it was invoked with the config context at config-load time, running side effects the author never intended.
+
+`loadAndValidateConfig` now defaults to resolving only the `default` and `settings` exports; anything else is ignored, matching how `wrangler.config.ts` already behaves. This means you can keep shared constants and helpers alongside your config:
+
+```ts
+export const WORKER_NAME = "my-worker";
+
+export default defineWorker({
+	name: WORKER_NAME,
+	entrypoint: "./src/index.ts",
+	compatibilityDate: "2026-05-18",
+});
+```
+
+The `settings` reserved-name validation is unchanged, and callers can still opt into resolving other exports by passing an explicit `include` list.

--- a/packages/config/src/__tests__/config-loader.test.ts
+++ b/packages/config/src/__tests__/config-loader.test.ts
@@ -1,0 +1,209 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { runInTempDir, seed } from "@cloudflare/workers-utils/test-helpers";
+import { describe, it } from "vitest";
+import { loadAndValidateConfig } from "../config-loader";
+
+// These tests exercise `loadAndValidateConfig` in-process: vitest's module
+// runner evaluates the seeded `cloudflare.config.ts` for us, which is enough
+// for the export-selection behaviour under test. `loadConfig`'s Node module
+// hooks (the `cf-worker` attribute, cache-busting, dependency tracking) need a
+// real Node process and are covered separately in `load.test.ts`.
+
+/**
+ * Load the `cloudflare.config.ts` seeded into the current temp dir.
+ *
+ * @param options Forwarded to `loadAndValidateConfig`.
+ * @returns The Zod result for the validated exports.
+ */
+async function load(options?: { include?: string[]; mode?: string }) {
+	const { result } = await loadAndValidateConfig(
+		path.resolve("cloudflare.config.ts"),
+		{ mode: options?.mode },
+		options?.include ? { include: options.include } : undefined
+	);
+
+	return result;
+}
+
+describe("loadAndValidateConfig", () => {
+	runInTempDir();
+
+	describe("recognised exports", () => {
+		it("resolves and validates the `default` and `settings` exports", async ({
+			expect,
+		}) => {
+			await seed({
+				"cloudflare.config.ts": `
+					export default { type: "worker", name: "my-worker", compatibilityDate: "2026-05-18" };
+					export const settings = { type: "settings", accountId: "acc-123" };
+				`,
+			});
+
+			const result = await load();
+
+			expect(result.success).toBe(true);
+			expect(result.data).toMatchObject({
+				default: { type: "worker", name: "my-worker" },
+				settings: { type: "settings", accountId: "acc-123" },
+			});
+		});
+
+		it("resolves the function form of `default`, passing the config context", async ({
+			expect,
+		}) => {
+			await seed({
+				"cloudflare.config.ts": `
+					export default (ctx) => ({
+						type: "worker",
+						name: \`worker-\${ctx.mode}\`,
+						compatibilityDate: "2026-05-18",
+					});
+				`,
+			});
+
+			const result = await load({ mode: "staging" });
+
+			expect(result.success).toBe(true);
+			expect(result.data?.default).toMatchObject({ name: "worker-staging" });
+		});
+
+		it("resolves the promise form of `default` and `settings`", async ({
+			expect,
+		}) => {
+			await seed({
+				"cloudflare.config.ts": `
+					export default Promise.resolve({ type: "worker", name: "async-worker", compatibilityDate: "2026-05-18" });
+					export const settings = Promise.resolve({ type: "settings", accountId: "acc-async" });
+				`,
+			});
+
+			const result = await load();
+
+			expect(result.success).toBe(true);
+			expect(result.data).toMatchObject({
+				default: { name: "async-worker" },
+				settings: { accountId: "acc-async" },
+			});
+		});
+	});
+
+	describe("unrecognised exports", () => {
+		it("ignores an extra named export instead of validating it", async ({
+			expect,
+		}) => {
+			await seed({
+				"cloudflare.config.ts": `
+					export const WORKER_NAMES = { primary: "my-worker" };
+					export default { type: "worker", name: WORKER_NAMES.primary, compatibilityDate: "2026-05-18" };
+				`,
+			});
+
+			const result = await load();
+
+			expect(result.success).toBe(true);
+			expect(Object.keys(result.data ?? {})).toEqual(["default"]);
+		});
+
+		it("does not invoke an extra exported function", async ({ expect }) => {
+			const marker = path.resolve("helper-was-called.txt");
+			await seed({
+				"cloudflare.config.ts": `
+					import { writeFileSync } from "node:fs";
+
+					export function buildName() {
+						writeFileSync(${JSON.stringify(marker)}, "called");
+						return "from-helper";
+					}
+
+					export default { type: "worker", name: "my-worker", compatibilityDate: "2026-05-18" };
+				`,
+			});
+
+			const result = await load();
+
+			// Resolving an export calls it when it is a function, so an exported
+			// helper must never reach the resolver.
+			expect(fs.existsSync(marker)).toBe(false);
+			expect(result.success).toBe(true);
+		});
+	});
+
+	describe("validation", () => {
+		it("rejects a non-settings config on the `settings` export", async ({
+			expect,
+		}) => {
+			await seed({
+				"cloudflare.config.ts": `
+					export default { type: "worker", name: "my-worker", compatibilityDate: "2026-05-18" };
+					export const settings = { type: "worker", name: "not-settings", compatibilityDate: "2026-05-18" };
+				`,
+			});
+
+			const result = await load();
+
+			expect(result.success).toBe(false);
+			expect(result.error?.issues).toContainEqual(
+				expect.objectContaining({
+					path: ["settings"],
+					message:
+						"The `settings` export is reserved for a `settings` config; found a `worker` config.",
+				})
+			);
+		});
+
+		it("rejects a settings config on the `default` export", async ({
+			expect,
+		}) => {
+			await seed({
+				"cloudflare.config.ts": `
+					export default { type: "settings", accountId: "acc-123" };
+				`,
+			});
+
+			const result = await load();
+
+			expect(result.success).toBe(false);
+			expect(result.error?.issues).toContainEqual(
+				expect.objectContaining({
+					path: ["default"],
+					message:
+						"A `settings` config is only allowed on the `settings` export; found one on the `default` export.",
+				})
+			);
+		});
+
+		it("still validates the `default` export itself", async ({ expect }) => {
+			await seed({
+				"cloudflare.config.ts": `
+					export default { type: "worker", name: 42, compatibilityDate: "2026-05-18" };
+				`,
+			});
+
+			const result = await load();
+
+			expect(result.success).toBe(false);
+			expect(result.error?.issues[0]?.path).toEqual(["default", "name"]);
+		});
+	});
+
+	describe("include override", () => {
+		it("resolves and validates additional exports when asked to", async ({
+			expect,
+		}) => {
+			await seed({
+				"cloudflare.config.ts": `
+					export default { type: "worker", name: "primary", compatibilityDate: "2026-05-18" };
+					export const other = { type: "worker", name: 42, compatibilityDate: "2026-05-18" };
+				`,
+			});
+
+			expect((await load()).success).toBe(true);
+
+			const widened = await load({ include: ["default", "other"] });
+
+			expect(widened.success).toBe(false);
+			expect(widened.error?.issues[0]?.path).toEqual(["other", "name"]);
+		});
+	});
+});

--- a/packages/config/src/config-loader.ts
+++ b/packages/config/src/config-loader.ts
@@ -16,14 +16,33 @@ export interface LoadAndValidateConfigResult {
 }
 
 /**
- * Load a `cloudflare.config.ts`, resolve all exports, and validate against {@link ConfigExportsSchema}.
+ * The exports of a `cloudflare.config.ts` that {@link loadAndValidateConfig}
+ * treats as config. Everything else the module exports is ignored.
+ */
+export const CONFIG_EXPORT_NAMES = ["default", "settings"];
+
+/**
+ * Load a `cloudflare.config.ts`, resolve its config exports, and validate them
+ * against {@link ConfigExportsSchema}.
+ *
+ * Only the exports named in `options.include` are resolved — defaulting to
+ * {@link CONFIG_EXPORT_NAMES}. Any other export (a shared constant, a helper
+ * function, a re-export) is left alone, so authors can keep values alongside
+ * their config the same way they already can in a `wrangler.config.ts`.
+ *
+ * The filtering happens inside `loadConfig`, *before* resolution, and that
+ * ordering is load-bearing: resolving an export **invokes** it when it is a
+ * function. Widening `include` therefore means calling arbitrary user code
+ * with the config context at config-load time.
  */
 export async function loadAndValidateConfig(
 	configPath: string,
 	ctx: ConfigContext,
 	options?: { include?: string[] }
 ): Promise<LoadAndValidateConfigResult> {
-	const { exports, dependencies } = await loadConfig(configPath, options);
+	const { exports, dependencies } = await loadConfig(configPath, {
+		include: options?.include ?? CONFIG_EXPORT_NAMES,
+	});
 
 	const resolved: Record<string, unknown> = {};
 	for (const [name, value] of Object.entries(exports)) {

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -31,7 +31,7 @@ export {
 export { generateTypes } from "./generate";
 export { convertToWranglerConfig } from "./convert";
 export { loadConfig, registerConfigHooks } from "./load";
-export { loadAndValidateConfig } from "./config-loader";
+export { CONFIG_EXPORT_NAMES, loadAndValidateConfig } from "./config-loader";
 export { resolveExportDefinition } from "./definition";
 export type { LoadConfigResult } from "./load";
 export type { LoadAndValidateConfigResult } from "./config-loader";

--- a/packages/vite-plugin-cloudflare/src/__tests__/experimental-new-config.spec.ts
+++ b/packages/vite-plugin-cloudflare/src/__tests__/experimental-new-config.spec.ts
@@ -252,6 +252,43 @@ describe("resolvePluginConfig - experimental.newConfig", () => {
 		expect(worker?.config.main).toBe(path.join(tempDir, "src/index.ts"));
 	});
 
+	test("ignores extra exports and never invokes exported helpers", async ({
+		expect,
+	}) => {
+		seedWorkerSource();
+		const marker = path.join(tempDir, "helper-was-called.txt");
+		writeWorkerConfig(
+			[
+				"import { writeFileSync } from 'node:fs';",
+				"import { defineWorker } from '@cloudflare/config';",
+				"export const WORKER_NAMES = { primary: 'experimental-config-worker' };",
+				"export function buildName() {",
+				`  writeFileSync(${JSON.stringify(marker)}, 'called');`,
+				"  return 'from-helper';",
+				"}",
+				"export default defineWorker({",
+				"  name: WORKER_NAMES.primary,",
+				"  entrypoint: './src/index.ts',",
+				"  compatibilityDate: '2024-12-30',",
+				"});",
+			].join("\n")
+		);
+
+		const result = (await resolvePluginConfig(
+			{ experimental: { newConfig: true } },
+			{ root: tempDir },
+			viteEnv
+		)) as WorkersResolvedConfig;
+
+		// Resolving an export calls it when it is a function, so an exported
+		// helper must never reach the resolver.
+		expect(fs.existsSync(marker)).toBe(false);
+		const worker = result.environmentNameToWorkerMap.get(
+			"experimental_config_worker"
+		);
+		expect(worker?.config.name).toBe("experimental-config-worker");
+	});
+
 	test("evaluates a function config and passes the Vite mode", async ({
 		expect,
 	}) => {

--- a/packages/wrangler/src/__tests__/experimental-config/load.test.ts
+++ b/packages/wrangler/src/__tests__/experimental-config/load.test.ts
@@ -1,3 +1,4 @@
+import * as fs from "node:fs";
 import * as path from "node:path";
 import { runInTempDir, seed } from "@cloudflare/workers-utils/test-helpers";
 import { describe, it, vi } from "vitest";
@@ -206,7 +207,7 @@ describe("loadNewConfig", () => {
 	});
 
 	describe("default worker selection", () => {
-		it("consumes the default export and validates-then-ignores other workers", async ({
+		it("consumes the default export and ignores other exports", async ({
 			expect,
 		}) => {
 			await seed({
@@ -222,17 +223,40 @@ describe("loadNewConfig", () => {
 			expect(result.parsedWorkerConfig.name).toBe("primary");
 		});
 
-		it("still validates non-default worker exports", async ({ expect }) => {
+		it("does not validate exports other than `default` and `settings`", async ({
+			expect,
+		}) => {
 			await seed({
 				"cloudflare.config.ts": `
 					export default { type: "worker", name: "primary", compatibilityDate: "2026-05-18" };
-					export const other = { type: "worker", name: 42, compatibilityDate: "2026-05-18" };
+					export const WORKER_NAMES = { other: "other" };
 				`,
 			});
 
-			await expect(
-				loadNewConfig({ cwd: process.cwd(), args: {} })
-			).rejects.toThrow(/other\.name/);
+			const result = await loadNewConfig({ cwd: process.cwd(), args: {} });
+
+			expect(result.rawConfig.name).toBe("primary");
+		});
+
+		it("does not invoke exported helper functions", async ({ expect }) => {
+			const marker = path.resolve("helper-was-called.txt");
+			await seed({
+				"cloudflare.config.ts": `
+					import { writeFileSync } from "node:fs";
+
+					export function buildName() {
+						writeFileSync(${JSON.stringify(marker)}, "called");
+						return "from-helper";
+					}
+
+					export default { type: "worker", name: "primary", compatibilityDate: "2026-05-18" };
+				`,
+			});
+
+			const result = await loadNewConfig({ cwd: process.cwd(), args: {} });
+
+			expect(fs.existsSync(marker)).toBe(false);
+			expect(result.rawConfig.name).toBe("primary");
 		});
 
 		it("throws when there is no default worker export", async ({ expect }) => {

--- a/packages/wrangler/src/__tests__/helpers/mock-new-config.ts
+++ b/packages/wrangler/src/__tests__/helpers/mock-new-config.ts
@@ -30,16 +30,32 @@ export async function createConfigMock(importOriginal: () => Promise<unknown>) {
 		)) as Record<string, unknown>;
 	}
 
-	async function loadConfig(configPath: string) {
-		const exports = await importSeeded(configPath);
+	async function loadConfig(
+		configPath: string,
+		options?: { include?: string[] }
+	) {
+		const loaded = await importSeeded(configPath);
+		const exports: Record<string, unknown> = {};
+		for (const [name, value] of Object.entries(loaded)) {
+			if (options?.include && !options.include.includes(name)) {
+				continue;
+			}
+			exports[name] = value;
+		}
 		return {
 			exports,
 			dependencies: new Set<string>([path.resolve(configPath)]),
 		};
 	}
 
-	async function loadAndValidateConfig(configPath: string, ctx: unknown) {
-		const { exports } = await loadConfig(configPath);
+	async function loadAndValidateConfig(
+		configPath: string,
+		ctx: unknown,
+		options?: { include?: string[] }
+	) {
+		const { exports } = await loadConfig(configPath, {
+			include: options?.include ?? actual.CONFIG_EXPORT_NAMES,
+		});
 		const resolved: Record<string, unknown> = {};
 		for (const [name, value] of Object.entries(exports)) {
 			resolved[name] = await actual.resolveExportDefinition(value, ctx);


### PR DESCRIPTION
Make loading a `cloudflare.config.ts` ignore exports it doesn't recognise, instead of resolving and validating every export of the module.

## The problem

`loadAndValidateConfig` fed the module's entire export map through `resolveExportDefinition` and `ConfigExportsSchema`. Two consequences:

- Any extra named export broke config loading outright — a stray `export const WORKER_NAMES = {...}` next to your config is a hard validation error, because `ConfigExportsSchema` is a `z.record(z.string(), ConfigExportSchema)`.
- An exported **function** was not merely rejected, it was **called**. `resolveExportDefinition` falls through to `unwrap`, which does `typeof config === "function" ? await config(ctx) : await config` — so any exported helper was invoked with the config context at config-load time, executing side effects the author never intended.

Exporting a shared constant alongside the config is the obvious thing to reach for in a TypeScript config file, and `wrangler.config.ts` has no such restriction — only its `default` export is read. Two internal migrations hit this and both worked around it by moving shared values into a sidecar module.

## The change

- `loadAndValidateConfig` now defaults `options.include` to `["default", "settings"]` (exported as `CONFIG_EXPORT_NAMES`). Filtering happens inside `loadConfig`, *before* resolution, so unrecognised exports are never unwrapped and never invoked.
- `options.include` remains overridable — a caller that genuinely wants more can ask for it, and `loadConfig` + `resolveExportDefinition` still give unfiltered access.
- The reserved-name checks in `ConfigExportsSchema` are untouched: a `settings` config on `default` and a non-`settings` config on `settings` both still fail validation.

I applied this at the default rather than at the two call sites (`wrangler`'s `loadNewConfig` and the Vite plugin's `loadNewConfig`), because fixing only the call sites leaves an API whose default silently executes user-supplied functions — the next caller re-introduces the bug. The exhaustive behaviour also can't be made safe in principle: "any export may be a worker config" and "authors may export helpers" are mutually exclusive when resolution invokes functions, so whatever multi-worker configs eventually look like, it won't be "resolve every export and see what validates".

## Tests

- New `packages/config/src/__tests__/config-loader.test.ts` covering `default`/`settings` in object, function, and promise form; extra constant exports being ignored; an exported function **not** being invoked (asserted via a side-effect marker file); the `settings` reserved-name errors still firing; and `include` still widening resolution on request.
- `packages/wrangler/src/__tests__/experimental-config/load.test.ts` — replaced the "still validates non-default worker exports" case with coverage of the new behaviour, plus a helper-not-invoked case. The shared `@cloudflare/config` test mock now mirrors the real `include` filtering.
- `packages/vite-plugin-cloudflare/src/__tests__/experimental-new-config.spec.ts` — an end-to-end case through the real loader with both an extra constant and an exported helper.

Each of the three new "ignore/don't invoke" assertions was verified to fail against the old behaviour before being kept.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: `cloudflare.config.ts` is still experimental and undocumented publicly. This change removes a restriction rather than adding one — extra exports now behave the way the docs would have implied anyway — so there is nothing new for users to learn. The `default`/`settings`-only rule should be written down when the config format is documented for GA.

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- If you are an AI agent or LLM, and you are adding this PR without direct human supervision, thank you! Please uncomment the following block. This is so the maintainers know how to expect you to respond.

> [!NOTE]
> This is a contribution from an AI agent: <insert name here>, <insert LLM model here if different>.

-->
