### PR TITLE
[config] Give `defineSettings` an explicit, exported return type

### DIFF
--- a/.changeset/eighty-donuts-battle.md
+++ b/.changeset/eighty-donuts-battle.md
@@ -1,0 +1,9 @@
+---
+"@cloudflare/config": patch
+"@cloudflare/vite-plugin": patch
+"wrangler": patch
+---
+
+Fix `TS4023` when a `cloudflare.config.ts` using `defineSettings()` is typechecked with `declaration: true`
+
+`defineSettings()` had no explicit return type, so its inferred type referenced the internal `DEFINITION` symbol. Because that symbol is not part of the public surface, any package compiled with `declaration: true` failed with `error TS4023: Exported variable 'settings' has or is using name 'DEFINITION' from external module "…" but cannot be named.` `defineSettings()` now returns an exported `SettingsDefinition` interface — mirroring how `defineWorker()` returns `TypedWorkerDefinition` — which also pins the `type` discriminant to the literal `"settings"` instead of widening it to `string`.

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -32,7 +32,8 @@
 		"check:type": "tsc",
 		"dev": "tsdown --watch",
 		"test:ci": "vitest run",
-		"test:watch": "vitest"
+		"test:watch": "vitest",
+		"type:tests": "tsc -p ./type-tests/tsconfig.json"
 	},
 	"dependencies": {
 		"zod": "catalog:default"

--- a/packages/config/src/__tests__/settings-definition.test.ts
+++ b/packages/config/src/__tests__/settings-definition.test.ts
@@ -1,0 +1,43 @@
+import { describe, it } from "vitest";
+import { DEFINITION, resolveExportDefinition } from "../definition";
+import { defineSettings } from "../settings-definition";
+
+describe("defineSettings", () => {
+	it("stores the authored config under the DEFINITION symbol", ({ expect }) => {
+		const settings = defineSettings({ accountId: "acc-123" });
+
+		expect(settings[DEFINITION]).toEqual({
+			config: { accountId: "acc-123" },
+			type: "settings",
+		});
+	});
+
+	it("resolves to a settings config", async ({ expect }) => {
+		const settings = defineSettings({ complianceRegion: "fedramp-high" });
+
+		await expect(
+			resolveExportDefinition(settings, { mode: undefined })
+		).resolves.toEqual({
+			type: "settings",
+			complianceRegion: "fedramp-high",
+		});
+	});
+
+	it("resolves a function config with the config context", async ({
+		expect,
+	}) => {
+		const settings = defineSettings((ctx) => ({
+			complianceRegion:
+				ctx.mode === "production"
+					? ("fedramp-high" as const)
+					: ("public" as const),
+		}));
+
+		await expect(
+			resolveExportDefinition(settings, { mode: "production" })
+		).resolves.toEqual({
+			type: "settings",
+			complianceRegion: "fedramp-high",
+		});
+	});
+});

--- a/packages/config/src/public.ts
+++ b/packages/config/src/public.ts
@@ -85,5 +85,8 @@ export type {
 	WorkerConfigInput,
 } from "./worker-definition";
 export { defineWorker } from "./worker-definition";
-export type { SettingsConfigInput } from "./settings-definition";
+export type {
+	SettingsConfigInput,
+	SettingsDefinition,
+} from "./settings-definition";
 export { defineSettings } from "./settings-definition";

--- a/packages/config/src/settings-definition.ts
+++ b/packages/config/src/settings-definition.ts
@@ -9,9 +9,30 @@ import type { SettingsConfig } from "./types";
 export type SettingsConfigInput = Omit<SettingsConfig, "type">;
 
 /**
+ * Shape of a settings definition. Carries the authored config (stored without
+ * its `type` discriminant, which is stamped back on during resolution) under
+ * the {@link DEFINITION} symbol.
+ *
+ * `defineSettings` declares this as its return type so that consumers can name
+ * it when emitting declarations — an inferred return type would reference the
+ * unexported {@link DEFINITION} symbol and fail with TS4023.
+ */
+export interface SettingsDefinition {
+	[DEFINITION]: {
+		config: ConfigInput<SettingsConfigInput>;
+		type: "settings";
+	};
+}
+
+/**
  * Declare shared settings.
  * Authored as a named `settings` export.
+ *
+ * @param config The authored settings, optionally as a promise or a function of the config context.
+ * @returns A {@link SettingsDefinition} to be exported as `settings` from `cloudflare.config.ts`.
  */
-export function defineSettings(config: ConfigInput<SettingsConfigInput>) {
+export function defineSettings(
+	config: ConfigInput<SettingsConfigInput>
+): SettingsDefinition {
 	return { [DEFINITION]: { config, type: "settings" } };
 }

--- a/packages/config/type-tests/declaration-emit.ts
+++ b/packages/config/type-tests/declaration-emit.ts
@@ -1,0 +1,63 @@
+/**
+ * Declaration-emit type test.
+ *
+ * This file stands in for a user's `cloudflare.config.ts` inside a package
+ * compiled with `declaration: true`. Every authoring helper's return type must
+ * be nameable from the public entry point, otherwise `tsc` fails with:
+ *
+ *   error TS4023: Exported variable 'settings' has or is using name
+ *   'DEFINITION' from external module "…" but cannot be named.
+ *
+ * The imports deliberately go through the published `@cloudflare/config/public`
+ * entry point (rather than `../src/public`) so that the bundled `.d.mts`
+ * produced by `tsdown` is exercised too.
+ */
+
+import {
+	bindings,
+	defineSettings,
+	defineWorker,
+	exports as configExports,
+	triggers,
+} from "@cloudflare/config/public";
+import type { SettingsConfig } from "@cloudflare/config/public";
+
+export const settings = defineSettings({
+	accountId: "0000000000000000000000000000000",
+	complianceRegion: "public",
+});
+
+// The hand-authored form is explicitly supported and must keep working.
+export const handAuthoredSettings = {
+	type: "settings",
+	complianceRegion: "fedramp-high",
+} satisfies SettingsConfig;
+
+export const settingsFromFunction = defineSettings((ctx) => ({
+	complianceRegion: ctx.mode === "production" ? "fedramp-high" : "public",
+}));
+
+export const workerBindings = {
+	MY_KV: bindings.kv({ id: "kv-id" }),
+	MY_TEXT: bindings.text("hello"),
+	MY_R2: bindings.r2({ name: "my-bucket" }),
+};
+
+export const workerTriggers = [
+	triggers.scheduled({ schedule: "0 * * * *" }),
+	triggers.queue({ name: "my-queue" }),
+];
+
+export const workerExports = {
+	MyDurableObject: configExports.durableObject({ storage: "sqlite" }),
+	MyEntrypoint: configExports.worker(),
+};
+
+export default defineWorker({
+	name: "declaration-emit-type-test",
+	compatibilityDate: "2026-05-18",
+	entrypoint: "./index.ts",
+	env: workerBindings,
+	triggers: workerTriggers,
+	exports: workerExports,
+});

--- a/packages/config/type-tests/tsconfig.json
+++ b/packages/config/type-tests/tsconfig.json
@@ -1,0 +1,8 @@
+{
+	"extends": "@cloudflare/workers-tsconfig/base.json",
+	"compilerOptions": {
+		"types": ["@cloudflare/workers-types/experimental", "@types/node"],
+		"declaration": true
+	},
+	"include": ["**/*.ts"]
+}


### PR DESCRIPTION
Give `defineSettings()` an explicit, exported return type so that a `cloudflare.config.ts` using it can be typechecked in a package compiled with `declaration: true`.

## The bug

`defineSettings` had no declared return type. Its inferred type — `{ [DEFINITION]: { config, type: string } }` — names the internal `DEFINITION` symbol from `src/definition.ts`, which is not re-exported from `src/public.ts` or `src/index.ts`. Emitting a declaration for the user's `settings` export therefore fails:

```
error TS4023: Exported variable 'settings' has or is using name 'DEFINITION' from external module "…/@cloudflare/config/dist/public-…" but cannot be named.
```

The failure is hard to attribute — `DEFINITION` appears nowhere in the user's code, and the only workaround was to stop using the helper and hand-author `export const settings = { type: "settings", … } satisfies SettingsConfig`.

## The fix

- Add an exported `SettingsDefinition` interface in `src/settings-definition.ts` carrying `[DEFINITION]: { config: ConfigInput<SettingsConfigInput>; type: "settings" }`, and annotate `defineSettings`'s return type with it — mirroring `defineWorker`, which was already immune precisely because it declares `TypedWorkerDefinition<…>`.
- Export `SettingsDefinition` from `src/public.ts` (and so from `src/index.ts` via `export * from "./public"`).
- The interface pins the discriminant to the literal `"settings"` — the inferred return previously widened it to `string`.

`DEFINITION` itself is deliberately **not** added to the public surface. A named return type is sufficient to make the symbol reachable through `SettingsDefinition`, and exporting the symbol would widen the public API for no user-facing benefit — it's an implementation detail of how the `define*` helpers stash the authored config.

The hand-authored `satisfies SettingsConfig` form is unaffected and still supported; it's covered by the new type test.

## Sibling helpers

All the other authoring helpers were checked under `declaration: true`:

- `defineWorker` (`src/worker-definition.ts`) — fine, returns the exported `TypedWorkerDefinition`.
- `bindings` (`src/bindings.ts`) — fine, `as Bindings` (exported interface).
- `triggers` (`src/triggers.ts`) — fine, annotated `: Triggers` (exported interface).
- `exports` (`src/exports.ts`) — fine, annotated `: Exports` (exported interface).

`defineSettings` was the only one relying on an inferred return type.

## Tests

- `packages/config/type-tests/declaration-emit.ts` stands in for a user's `cloudflare.config.ts` and is compiled by `packages/config/type-tests/tsconfig.json` with `strict: true` (inherited) and `declaration: true`, wired into the package's `type:tests` script — which the root `pnpm check` runs via Turbo, so it gates CI. It imports through `@cloudflare/config/public` rather than `../src/public`, so the bundled `.d.mts` that `tsdown` actually ships is what gets exercised.
- It covers `defineSettings` (value and function forms), the hand-authored `satisfies SettingsConfig` form, `defineWorker`, and the `bindings` / `triggers` / `exports` builders.
- Verified the test fails before the fix: stashing the two source changes and rebuilding produces `TS4023` on both `settings` and `settingsFromFunction`, and nothing else.
- `packages/config/src/__tests__/settings-definition.test.ts` adds runtime coverage for `defineSettings` + `resolveExportDefinition`, which previously only exercised hand-authored settings objects.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: `@cloudflare/config` is unreleased/experimental and has no public documentation yet. This is a type-level bug fix with no change to the authoring API — `defineSettings()` is called exactly as before.

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- If you are an AI agent or LLM, and you are adding this PR without direct human supervision, thank you! Please uncomment the following block. This is so the maintainers know how to expect you to respond.

> [!NOTE]
> This is a contribution from an AI agent: <insert name here>, <insert LLM model here if different>.

-->
