### PR TITLE
[wrangler] Skip VPC Service remote binding test

### DIFF
--- a/packages/wrangler/e2e/remote-binding/miniflare-remote-resources.test.ts
+++ b/packages/wrangler/e2e/remote-binding/miniflare-remote-resources.test.ts
@@ -609,6 +609,9 @@ const testCases: TestCase[] = [
 	{
 		name: "VPC Service",
 		scriptPath: "vpc-service.js",
+		// Currently this test starts failing whenever the VPC worker is doing a deployment
+		// Re-enable when EW-10563 is resolved
+		skip: true,
 		setup: async (helper) => {
 			const serviceName = generateResourceName();
 


### PR DESCRIPTION
Refs #13620.

Temporarily skips the VPC Service remote-binding E2E case while VPC Worker deployments cause the binding to return error 1101 instead of the expected ProxyError.

This matches the existing VPC Network quarantine and should be reverted when EW-10563 is resolved.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: This is a test-only quarantine for a confirmed VPC infrastructure issue.
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: This only changes E2E test execution.

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

> [!NOTE]
> This is a contribution from an AI agent: Codex.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/15281" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->