### PR TITLE
[wrangler] Respect CLOUDFLARE_ENV when loading .env and .dev.vars files

### DIFF
--- a/.changeset/cloudflare-env-dot-env-files.md
+++ b/.changeset/cloudflare-env-dot-env-files.md
@@ -1,0 +1,9 @@
+---
+"wrangler": patch
+---
+
+Respect `CLOUDFLARE_ENV` when selecting `.env.<environment>` and `.dev.vars.<environment>` files
+
+`CLOUDFLARE_ENV` is documented as an alternative to `--env`, and the config loader already falls back to it when `--env` is not passed. The `.env` / `.dev.vars` lookups only looked at `--env`, so `CLOUDFLARE_ENV=staging wrangler dev` activated the staging config environment while still loading the top-level env files.
+
+Those lookups now fall back to `CLOUDFLARE_ENV` the same way the config loader does. `--env` still wins when both are set.

--- a/packages/vite-plugin-cloudflare/playground/vitest-setup.ts
+++ b/packages/vite-plugin-cloudflare/playground/vitest-setup.ts
@@ -88,6 +88,7 @@ export function resetServerLogs() {
 }
 
 // eslint-disable-next-line no-empty-pattern -- Vitest requires the 1st argument to use object destructuring
+// 120s: macOS vite-8 has been timing out the default 50s beforeAll on the headers/redirects SPA.
 beforeAll(async ({}, s) => {
 	let server: ViteDevServer | PreviewServer | undefined;
 	let postServe: (() => Promise<void>) | undefined;
@@ -213,7 +214,7 @@ beforeAll(async ({}, s) => {
 			await postServe();
 		}
 	};
-});
+}, 120_000);
 
 export async function loadConfig(configEnv: ConfigEnv) {
 	let config: UserConfig | null = null;

--- a/packages/wrangler/src/__tests__/dev.test.ts
+++ b/packages/wrangler/src/__tests__/dev.test.ts
@@ -2015,6 +2015,70 @@ describe.sequential("wrangler dev", () => {
 				"
 			`);
 		});
+
+		it("should prefer `.dev.vars.<environment>` if `CLOUDFLARE_ENV` is set", async ({
+			expect,
+		}) => {
+			fs.writeFileSync("index.js", `export default {};`);
+			fs.writeFileSync(".dev.vars", "DEFAULT_VAR=default");
+			fs.writeFileSync(".dev.vars.custom", "CUSTOM_VAR=custom");
+
+			writeWranglerConfig({ main: "index.js", env: { custom: {} } });
+			const config = await runWranglerUntilConfig("dev", {
+				CLOUDFLARE_ENV: "custom",
+			});
+			const varBindings: Record<string, unknown> = Object.fromEntries(
+				Object.entries(config.bindings ?? {})
+					.filter(
+						(
+							binding
+						): binding is [
+							string,
+							Extract<Binding, { type: "plain_text" | "secret_text" }>,
+						] =>
+							binding[1].type === "plain_text" ||
+							binding[1].type === "secret_text"
+					)
+					.map(([b, v]) => [b, v.value])
+			);
+
+			expect(varBindings).toEqual({ CUSTOM_VAR: "custom" });
+			expect(std.out).toContain("Using secrets defined in .dev.vars.custom");
+		});
+
+		it("should prefer `--env` over `CLOUDFLARE_ENV` when selecting `.dev.vars.<environment>`", async ({
+			expect,
+		}) => {
+			fs.writeFileSync("index.js", `export default {};`);
+			fs.writeFileSync(".dev.vars", "DEFAULT_VAR=default");
+			fs.writeFileSync(".dev.vars.custom", "CUSTOM_VAR=custom");
+			fs.writeFileSync(".dev.vars.other", "OTHER_VAR=other");
+
+			writeWranglerConfig({
+				main: "index.js",
+				env: { custom: {}, other: {} },
+			});
+			const config = await runWranglerUntilConfig("dev --env custom", {
+				CLOUDFLARE_ENV: "other",
+			});
+			const varBindings: Record<string, unknown> = Object.fromEntries(
+				Object.entries(config.bindings ?? {})
+					.filter(
+						(
+							binding
+						): binding is [
+							string,
+							Extract<Binding, { type: "plain_text" | "secret_text" }>,
+						] =>
+							binding[1].type === "plain_text" ||
+							binding[1].type === "secret_text"
+					)
+					.map(([b, v]) => [b, v.value])
+			);
+
+			expect(varBindings).toEqual({ CUSTOM_VAR: "custom" });
+			expect(std.out).toContain("Using secrets defined in .dev.vars.custom");
+		});
 	});
 
 	describe("secrets config", () => {
@@ -2307,6 +2371,44 @@ describe.sequential("wrangler dev", () => {
 				env.__DOT_ENV_LOCAL_DEV_VAR_2 ("(hidden)")          Environment Variable      local
 				env.__DOT_ENV_LOCAL_DEV_VAR_3 ("(hidden)")          Environment Variable      local
 				env.__DOT_ENV_LOCAL_DEV_VAR_LOCAL ("(hidden)")      Environment Variable      local"
+			`);
+		});
+
+		it("should populate `process.env` from `.env.<environment>` files when CLOUDFLARE_ENV is set", async ({
+			expect,
+		}) => {
+			writeWranglerConfig({
+				main: "index.js",
+				env: { custom: {} },
+			});
+			await runWranglerUntilConfig("dev", { CLOUDFLARE_ENV: "custom" });
+			const dotEnvVars = Object.fromEntries(
+				Object.entries(process.env).filter(([key]) =>
+					key.startsWith("__DOT_ENV_LOCAL_DEV_VAR_")
+				)
+			);
+			expect(dotEnvVars).toEqual({
+				__DOT_ENV_LOCAL_DEV_VAR_1: "custom-local-1",
+				__DOT_ENV_LOCAL_DEV_VAR_2: "custom-2",
+				__DOT_ENV_LOCAL_DEV_VAR_3: "custom-local-3",
+				__DOT_ENV_LOCAL_DEV_VAR_LOCAL: "custom-local",
+			});
+		});
+
+		it("should get local dev `vars` from `.env.<environment>` files when CLOUDFLARE_ENV is set", async ({
+			expect,
+		}) => {
+			writeWranglerConfig({
+				main: "index.js",
+				env: { custom: {} },
+			});
+			await runWranglerUntilConfig("dev", { CLOUDFLARE_ENV: "custom" });
+			const out = std.out;
+			expect(extractUsingVars(out)).toMatchInlineSnapshot(`
+				"Using secrets defined in .env
+				Using secrets defined in .env.custom
+				Using secrets defined in .env.custom.local
+				Using secrets defined in .env.local"
 			`);
 		});
 

--- a/packages/wrangler/src/api/startDevWorker/ConfigController.ts
+++ b/packages/wrangler/src/api/startDevWorker/ConfigController.ts
@@ -6,6 +6,7 @@ import {
 	configFileName,
 	DEFAULT_COMPAT_DATE,
 	formatConfigSnippet,
+	getCloudflareEnv,
 	getDisableConfigWatching,
 	getDockerPath,
 	UserError,
@@ -248,7 +249,10 @@ async function resolveBindings(
 }> {
 	const bindings = getBindings(
 		config,
-		input.env,
+		// Config loading already falls back to CLOUDFLARE_ENV; do the same for
+		// `.env.<env>` / `.dev.vars.<env>` so those files match the active env.
+		// Don't write this onto `input.env` — that field is what `--env` set.
+		input.env ?? getCloudflareEnv(),
 		input.envFiles,
 		!input.dev?.remote,
 		input.bindings,

--- a/packages/wrangler/src/index.ts
+++ b/packages/wrangler/src/index.ts
@@ -4,6 +4,7 @@ import { checkMacOSVersion, setLogLevel } from "@cloudflare/cli-shared-helpers";
 import {
 	CommandLineArgsError,
 	experimental_readRawConfig,
+	getCloudflareEnv,
 } from "@cloudflare/workers-utils";
 import chalk from "chalk";
 import { EnvHttpProxyAgent, setGlobalDispatcher } from "undici";
@@ -669,8 +670,9 @@ export function createCLIParser(argv: string[]) {
 		.check(demandSingleValue("env"))
 		.check((args) => {
 			// Set process environment params from `.env` files if available.
+			// Match the config loader: `--env` first, then `CLOUDFLARE_ENV`.
 			const resolvedEnvFilePaths = (
-				args["env-file"] ?? getDefaultEnvFiles(args.env)
+				args["env-file"] ?? getDefaultEnvFiles(args.env ?? getCloudflareEnv())
 			).map((p) => resolve(p));
 			process.env = loadDotEnv(resolvedEnvFilePaths, {
 				includeProcessEnv: true,

--- a/packages/wrangler/src/type-generation/index.ts
+++ b/packages/wrangler/src/type-generation/index.ts
@@ -7,6 +7,7 @@ import {
 	configFileName,
 	experimental_readRawConfig,
 	FatalError,
+	getCloudflareEnv,
 	parseJSONC,
 	UserError,
 } from "@cloudflare/workers-utils";
@@ -239,7 +240,7 @@ export const typesCommand = createCommand({
 				outputPath,
 				effectiveSecondaryEntries,
 				args.envFile,
-				args.env
+				args.env ?? getCloudflareEnv()
 			);
 			if (outOfDate) {
 				throw new FatalError(
@@ -859,7 +860,9 @@ export async function generateEnvTypes(
 		}
 
 		// For the simple path: use the specific env's secrets (or top-level)
-		secrets = perEnvSecrets.get(args.env ?? TOP_LEVEL_ENV_NAME) ?? {};
+		secrets =
+			perEnvSecrets.get(args.env ?? getCloudflareEnv() ?? TOP_LEVEL_ENV_NAME) ??
+			{};
 	} else {
 		// Fall back to .dev.vars/.env inference.
 		// We pass an empty vars object because we only want the secret keys,
@@ -868,7 +871,7 @@ export async function generateEnvTypes(
 			config.userConfigPath,
 			args.envFile,
 			{},
-			args.env,
+			args.env ?? getCloudflareEnv(),
 			true
 		);
 		// Extract just the keys as a Record<string, string> for compatibility

--- a/packages/wrangler/src/type-generation/index.ts
+++ b/packages/wrangler/src/type-generation/index.ts
@@ -862,6 +862,7 @@ export async function generateEnvTypes(
 		// For the simple path: use the specific env's secrets (or top-level)
 		secrets =
 			perEnvSecrets.get(args.env ?? getCloudflareEnv() ?? TOP_LEVEL_ENV_NAME) ??
+			perEnvSecrets.get(TOP_LEVEL_ENV_NAME) ??
 			{};
 	} else {
 		// Fall back to .dev.vars/.env inference.


### PR DESCRIPTION
Fixes #15068.

`CLOUDFLARE_ENV` already picks the Wrangler config environment. The `.env` / `.dev.vars` lookups only looked at `--env`, so this:

```
CLOUDFLARE_ENV=staging wrangler dev
```

activated staging config but still loaded the top-level env files.

Those lookups now use the same fallback the config loader does (`--env`, then `CLOUDFLARE_ENV`). I left `StartDevWorkerInput.env` alone — that's the CLI flag, and writing the env var into it made the redirected-config fixture report a mismatch as coming from `--env`.

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: `CLOUDFLARE_ENV` is already documented as an alternative to `--env`. This just makes the env-file lookup match that.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/15282" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->