### PR TITLE
fix: skip mkdir when C3 parent dir already exists

### DIFF
--- a/.changeset/c3-mkdir-drive-root.md
+++ b/.changeset/c3-mkdir-drive-root.md
@@ -1,0 +1,5 @@
+---
+"create-cloudflare": patch
+---
+
+Skip `mkdir` when the project parent directory already exists, so `create-cloudflare` works at a Windows drive root (`E:\`) instead of throwing `EPERM`.

--- a/packages/create-cloudflare/src/__tests__/project-directory.test.ts
+++ b/packages/create-cloudflare/src/__tests__/project-directory.test.ts
@@ -1,0 +1,50 @@
+import { existsSync, mkdirSync } from "node:fs";
+import { chdir } from "node:process";
+import { resolve } from "node:path";
+import { beforeEach, describe, test, vi } from "vitest";
+import { setupProjectDirectory } from "../project-directory";
+import type { C3Context } from "types";
+
+vi.mock("node:fs");
+vi.mock("node:process", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("node:process")>();
+	return { ...actual, chdir: vi.fn() };
+});
+
+const ctxFor = (projectPath: string): C3Context =>
+	({
+		args: {},
+		project: { name: "my-app", path: projectPath },
+		template: {},
+		deployment: {},
+		originalCWD: "/",
+		gitRepoAlreadyExisted: false,
+	}) as unknown as C3Context;
+
+describe("setupProjectDirectory", () => {
+	beforeEach(() => {
+		vi.resetAllMocks();
+	});
+
+	test("does not mkdir when the parent already exists", ({ expect }) => {
+		const projectPath = resolve("already-there", "my-app");
+		const parent = resolve("already-there");
+		vi.mocked(existsSync).mockImplementation((p) => String(p) === parent);
+
+		setupProjectDirectory(ctxFor(projectPath));
+
+		expect(mkdirSync).not.toHaveBeenCalled();
+		expect(chdir).toHaveBeenCalledWith(parent);
+	});
+
+	test("creates the parent when it is missing", ({ expect }) => {
+		const projectPath = resolve("new-parent", "my-app");
+		const parent = resolve("new-parent");
+		vi.mocked(existsSync).mockReturnValue(false);
+
+		setupProjectDirectory(ctxFor(projectPath));
+
+		expect(mkdirSync).toHaveBeenCalledWith(parent, { recursive: true });
+		expect(chdir).toHaveBeenCalledWith(parent);
+	});
+});

--- a/packages/create-cloudflare/src/__tests__/project-directory.test.ts
+++ b/packages/create-cloudflare/src/__tests__/project-directory.test.ts
@@ -1,6 +1,6 @@
 import { existsSync, mkdirSync } from "node:fs";
-import { chdir } from "node:process";
 import { resolve } from "node:path";
+import { chdir } from "node:process";
 import { beforeEach, describe, test, vi } from "vitest";
 import { setupProjectDirectory } from "../project-directory";
 import type { C3Context } from "types";

--- a/packages/create-cloudflare/src/cli.ts
+++ b/packages/create-cloudflare/src/cli.ts
@@ -31,6 +31,7 @@ import { gitCommit, offerGit } from "./git";
 import { showHelp } from "./help";
 import { reporter, runTelemetryCommand } from "./metrics";
 import { createProject } from "./pages";
+import { setupProjectDirectory } from "./project-directory";
 import {
 	copyTemplateFiles,
 	createContext,
@@ -38,7 +39,6 @@ import {
 	updatePackageScripts,
 	writeAgentsMd,
 } from "./templates";
-import { setupProjectDirectory } from "./project-directory";
 import { addTypes } from "./workers";
 import { updateWranglerConfig } from "./wrangler/config";
 import type { C3Args, C3Context } from "types";

--- a/packages/create-cloudflare/src/cli.ts
+++ b/packages/create-cloudflare/src/cli.ts
@@ -1,6 +1,4 @@
 #!/usr/bin/env node
-import { existsSync, mkdirSync } from "node:fs";
-import { dirname } from "node:path";
 import { chdir } from "node:process";
 import {
 	cancel,
@@ -40,7 +38,7 @@ import {
 	updatePackageScripts,
 	writeAgentsMd,
 } from "./templates";
-import { validateProjectDirectory } from "./validators";
+import { setupProjectDirectory } from "./project-directory";
 import { addTypes } from "./workers";
 import { updateWranglerConfig } from "./wrangler/config";
 import type { C3Args, C3Context } from "types";
@@ -113,25 +111,6 @@ export const runCli = async (args: Partial<C3Args>) => {
 
 	printSummary(ctx);
 	logRaw("");
-};
-
-export const setupProjectDirectory = (ctx: C3Context) => {
-	// Crash if the directory already exists
-	const path = ctx.project.path;
-	const err = validateProjectDirectory(path, ctx.args);
-	if (err) {
-		throw new Error(err);
-	}
-
-	const directory = dirname(path);
-
-	// Creating a Windows drive root (`E:\`) throws EPERM. Skip if it already exists.
-	if (!existsSync(directory)) {
-		mkdirSync(directory, { recursive: true });
-	}
-
-	// Change to the parent directory
-	chdir(directory);
 };
 
 const create = async (ctx: C3Context) => {

--- a/packages/create-cloudflare/src/cli.ts
+++ b/packages/create-cloudflare/src/cli.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { mkdirSync } from "node:fs";
+import { existsSync, mkdirSync } from "node:fs";
 import { dirname } from "node:path";
 import { chdir } from "node:process";
 import {
@@ -125,8 +125,10 @@ export const setupProjectDirectory = (ctx: C3Context) => {
 
 	const directory = dirname(path);
 
-	// If the target is a nested directory, create the parent
-	mkdirSync(directory, { recursive: true });
+	// Creating a Windows drive root (`E:\`) throws EPERM. Skip if it already exists.
+	if (!existsSync(directory)) {
+		mkdirSync(directory, { recursive: true });
+	}
 
 	// Change to the parent directory
 	chdir(directory);

--- a/packages/create-cloudflare/src/project-directory.ts
+++ b/packages/create-cloudflare/src/project-directory.ts
@@ -1,0 +1,22 @@
+import { existsSync, mkdirSync } from "node:fs";
+import { dirname } from "node:path";
+import { chdir } from "node:process";
+import { validateProjectDirectory } from "./validators";
+import type { C3Context } from "types";
+
+export const setupProjectDirectory = (ctx: C3Context) => {
+	const path = ctx.project.path;
+	const err = validateProjectDirectory(path, ctx.args);
+	if (err) {
+		throw new Error(err);
+	}
+
+	const directory = dirname(path);
+
+	// Creating a Windows drive root (`E:\`) throws EPERM. Skip if it already exists.
+	if (!existsSync(directory)) {
+		mkdirSync(directory, { recursive: true });
+	}
+
+	chdir(directory);
+};

--- a/packages/create-cloudflare/src/project-directory.ts
+++ b/packages/create-cloudflare/src/project-directory.ts
@@ -4,6 +4,13 @@ import { chdir } from "node:process";
 import { validateProjectDirectory } from "./validators";
 import type { C3Context } from "types";
 
+/**
+ * Validates the target project directory and ensures its parent exists before
+ * changing into it. Skips `mkdir` when the parent already exists so a Windows
+ * drive root (`E:\`) does not throw `EPERM`.
+ *
+ * @param ctx - The C3 context containing the resolved project path and args
+ */
 export const setupProjectDirectory = (ctx: C3Context) => {
 	const path = ctx.project.path;
 	const err = validateProjectDirectory(path, ctx.args);

--- a/packages/create-cloudflare/src/project-directory.ts
+++ b/packages/create-cloudflare/src/project-directory.ts
@@ -20,7 +20,6 @@ export const setupProjectDirectory = (ctx: C3Context) => {
 
 	const directory = dirname(path);
 
-	// Creating a Windows drive root (`E:\`) throws EPERM. Skip if it already exists.
 	if (!existsSync(directory)) {
 		mkdirSync(directory, { recursive: true });
 	}


### PR DESCRIPTION
Fixes https://github.com/cloudflare/workers-sdk/issues/5448

`create-cloudflare` always `mkdirSync`s the parent of the project path. On Windows that parent can be a drive root (`E:\`), which already exists and throws `EPERM`. Skip mkdir when the parent is already there.

- Tests
  - [x] Tests included/updated
- Public documentation
  - [x] Documentation not necessary because: this is internal `mkdir` behavior; no user-facing docs or CLI flag changed.

I used an assistant on the edit.

<!-- devin-review-badge-begin -->

---

<a href="https://cloudflare.devinenterprise.com/review/cloudflare/workers-sdk/pull/15288" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->