### PR TITLE
[wrangler] Pause automatic skills installation offers

### DIFF
--- a/.changeset/quiet-skills-update.md
+++ b/.changeset/quiet-skills-update.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Stop automatically offering to install Cloudflare skills for new users
+
+Wrangler will no longer prompt new users to install Cloudflare skills after commands complete. It will continue to offer updates to skills that Wrangler previously installed.

--- a/packages/wrangler/src/__tests__/register-yargs-command-skills.test.ts
+++ b/packages/wrangler/src/__tests__/register-yargs-command-skills.test.ts
@@ -30,14 +30,15 @@ describe("register-yargs-command skills integration", () => {
 		});
 	});
 
-	test("does not call runSkillsInstallFlow for commands without suggestSkillsAfterHandler", async ({
+	test("does not check skills for commands without suggestSkillsAfterHandler", async ({
 		expect,
 	}) => {
-		// `wrangler complete` intentionally does not suggest skills because
+		// `wrangler complete` intentionally does not check skills because
 		// its stdout is captured by shell eval.
 		await runWrangler("complete zsh");
 
 		expect(runSkillsInstallFlow).not.toHaveBeenCalled();
+		expect(runSkillsUpdateFlow).not.toHaveBeenCalled();
 	});
 
 	test("calls runSkillsInstallFlow with force: true and command when --install-skills is passed", async ({
@@ -53,30 +54,28 @@ describe("register-yargs-command skills integration", () => {
 		});
 	});
 
-	test("calls runSkillsInstallFlow after commands with suggestSkillsAfterHandler: true", async ({
+	test("calls runSkillsUpdateFlow after commands with suggestSkillsAfterHandler: true", async ({
 		expect,
 	}) => {
 		await runWrangler("setup");
 
-		expect(runSkillsInstallFlow).toHaveBeenCalledWith({
-			force: false,
+		expect(runSkillsInstallFlow).not.toHaveBeenCalled();
+		expect(runSkillsUpdateFlow).toHaveBeenCalledWith({
 			command: "setup",
-			promptMessage: expect.any(Function),
 		});
 	});
 
-	test("calls runSkillsInstallFlow after `wrangler whoami` (non-JSON)", async ({
+	test("calls runSkillsUpdateFlow after `wrangler whoami` (non-JSON)", async ({
 		expect,
 	}) => {
 		// whoami in non-JSON mode completes successfully even without auth
-		// (it just prints "You are not authenticated") — the suggest-skills
+		// (it just prints "You are not authenticated") — the skills update
 		// hook should still fire afterwards.
 		await runWrangler("whoami");
 
-		expect(runSkillsInstallFlow).toHaveBeenCalledWith({
-			force: false,
+		expect(runSkillsInstallFlow).not.toHaveBeenCalled();
+		expect(runSkillsUpdateFlow).toHaveBeenCalledWith({
 			command: "whoami",
-			promptMessage: expect.any(Function),
 		});
 	});
 
@@ -97,7 +96,7 @@ describe("register-yargs-command skills integration", () => {
 		expect(call.command).not.toContain("install-skills");
 	});
 
-	test("does not call runSkillsInstallFlow after `wrangler whoami --json`", async ({
+	test("does not check skills after `wrangler whoami --json`", async ({
 		expect,
 	}) => {
 		// whoami --json without auth throws (non-zero exit), so we catch it.
@@ -106,67 +105,35 @@ describe("register-yargs-command skills integration", () => {
 		await expect(runWrangler("whoami --json")).rejects.toThrow();
 
 		expect(runSkillsInstallFlow).not.toHaveBeenCalled();
-	});
-
-	test("does not fail the command when runSkillsInstallFlow throws", async ({
-		expect,
-	}) => {
-		// If the post-handler skills suggestion fails (e.g. EACCES writing
-		// the metadata file, or an I/O error from the confirm prompt), the
-		// command itself should still succeed — the error is swallowed and
-		// logged at debug level.
-		vi.mocked(runSkillsInstallFlow).mockRejectedValueOnce(
-			new Error("EACCES: permission denied")
-		);
-
-		// `setup` has suggestSkillsAfterHandler: true, so it triggers the flow.
-		// This should resolve successfully despite the skills flow throwing.
-		await runWrangler("setup");
-
-		expect(runSkillsInstallFlow).toHaveBeenCalled();
-	});
-
-	test("does not call runSkillsUpdateFlow when runSkillsInstallFlow just installed skills", async ({
-		expect,
-	}) => {
-		// When the install flow returns true it means it just performed a
-		// fresh install, so the update flow should be skipped — the newly
-		// installed skills are already the latest version.
-		vi.mocked(runSkillsInstallFlow).mockResolvedValueOnce(true);
-
-		await runWrangler("setup");
-
-		expect(runSkillsInstallFlow).toHaveBeenCalled();
 		expect(runSkillsUpdateFlow).not.toHaveBeenCalled();
 	});
 
-	test("calls runSkillsUpdateFlow when runSkillsInstallFlow did not install", async ({
+	test("does not fail the command when runSkillsUpdateFlow throws", async ({
 		expect,
 	}) => {
-		// When the install flow returns false (skills already installed or
-		// user was not prompted), the update flow should run to check
-		// whether the existing skills are out of date.
-		vi.mocked(runSkillsInstallFlow).mockResolvedValueOnce(false);
+		// If the post-handler skills update check fails (e.g. EACCES writing
+		// the metadata file, or an I/O error from the confirm prompt), the
+		// command itself should still succeed — the error is swallowed and
+		// logged at debug level.
+		vi.mocked(runSkillsUpdateFlow).mockRejectedValueOnce(
+			new Error("EACCES: permission denied")
+		);
 
+		// `setup` has suggestSkillsAfterHandler: true, so it triggers the check.
+		// This should resolve successfully despite the skills update check throwing.
 		await runWrangler("setup");
 
-		expect(runSkillsInstallFlow).toHaveBeenCalled();
-		expect(runSkillsUpdateFlow).toHaveBeenCalledWith(
-			expect.objectContaining({
-				command: "setup",
-			})
-		);
+		expect(runSkillsUpdateFlow).toHaveBeenCalled();
 	});
 
 	test("does not call runSkillsUpdateFlow when WRANGLER_NO_SKILLS_UPDATE_PROMPTS env var is set", async ({
 		expect,
 	}) => {
-		vi.mocked(runSkillsInstallFlow).mockResolvedValueOnce(false);
 		vi.stubEnv("WRANGLER_NO_SKILLS_UPDATE_PROMPTS", "true");
 
 		await runWrangler("setup");
 
-		expect(runSkillsInstallFlow).toHaveBeenCalled();
+		expect(runSkillsInstallFlow).not.toHaveBeenCalled();
 		expect(runSkillsUpdateFlow).not.toHaveBeenCalled();
 	});
 });

--- a/packages/wrangler/src/core/register-yargs-command.ts
+++ b/packages/wrangler/src/core/register-yargs-command.ts
@@ -359,6 +359,8 @@ function createHandler(def: InternalCommandDefinition, argv: string[]) {
 						shouldSuggestSkills === true ||
 						(typeof shouldSuggestSkills === "function" &&
 							shouldSuggestSkills(args) === true);
+					// We are currently not sure whether the automatic skills installation is beneficial
+					// so we are skipping it for the time being (we might potentially re-enable it later on) 
 					const shouldInstall = false;
 
 					if (suggestSkillsEnabled) {

--- a/packages/wrangler/src/core/register-yargs-command.ts
+++ b/packages/wrangler/src/core/register-yargs-command.ts
@@ -16,7 +16,6 @@ import chalk from "chalk";
 import {
 	runSkillsInstallFlow,
 	runSkillsUpdateFlow,
-	skillInstallPromptMessageAfterWranglerCommandHandler,
 } from "../agents-skills-install";
 import {
 	fetchKVGetValue,
@@ -353,37 +352,23 @@ function createHandler(def: InternalCommandDefinition, argv: string[]) {
 						def.behaviour
 					);
 
-					const shouldSuggestSkills =
+					const shouldCheckSkills =
 						def.behaviour?.suggestSkillsAfterHandler ?? false;
-					const suggestSkillsEnabled =
-						shouldSuggestSkills === true ||
-						(typeof shouldSuggestSkills === "function" &&
-							shouldSuggestSkills(args) === true);
+					const skillsCheckEnabled =
+						shouldCheckSkills === true ||
+						(typeof shouldCheckSkills === "function" &&
+							shouldCheckSkills(args) === true);
 
-					if (suggestSkillsEnabled) {
+					if (skillsCheckEnabled) {
 						try {
-							const justInstalled = await runSkillsInstallFlow({
-								force: false,
-								command: sanitizedCommand,
-								promptMessage:
-									skillInstallPromptMessageAfterWranglerCommandHandler,
-							});
-
-							// Only check for updates when the install flow did not
-							// just perform a fresh install — a brand-new install
-							// already has the latest content — and the user has
-							// not opted out via environment variable.
-							if (
-								!justInstalled &&
-								getNoSkillsUpdatePromptsFromEnv() !== true
-							) {
+							if (getNoSkillsUpdatePromptsFromEnv() !== true) {
 								await runSkillsUpdateFlow({
 									command: sanitizedCommand,
 								});
 							}
 						} catch (skillsErr) {
 							logger.debug(
-								`Skills suggestion failed: ${skillsErr instanceof Error ? skillsErr.message : skillsErr}`
+								`Skills update check failed: ${skillsErr instanceof Error ? skillsErr.message : skillsErr}`
 							);
 						}
 					}

--- a/packages/wrangler/src/core/register-yargs-command.ts
+++ b/packages/wrangler/src/core/register-yargs-command.ts
@@ -16,6 +16,7 @@ import chalk from "chalk";
 import {
 	runSkillsInstallFlow,
 	runSkillsUpdateFlow,
+	skillInstallPromptMessageAfterWranglerCommandHandler,
 } from "../agents-skills-install";
 import {
 	fetchKVGetValue,
@@ -352,23 +353,40 @@ function createHandler(def: InternalCommandDefinition, argv: string[]) {
 						def.behaviour
 					);
 
-					const shouldCheckSkills =
+					const shouldSuggestSkills =
 						def.behaviour?.suggestSkillsAfterHandler ?? false;
-					const skillsCheckEnabled =
-						shouldCheckSkills === true ||
-						(typeof shouldCheckSkills === "function" &&
-							shouldCheckSkills(args) === true);
+					const suggestSkillsEnabled =
+						shouldSuggestSkills === true ||
+						(typeof shouldSuggestSkills === "function" &&
+							shouldSuggestSkills(args) === true);
+					const shouldInstall = false;
 
-					if (skillsCheckEnabled) {
+					if (suggestSkillsEnabled) {
 						try {
-							if (getNoSkillsUpdatePromptsFromEnv() !== true) {
+							const justInstalled = shouldInstall
+								? await runSkillsInstallFlow({
+										force: false,
+										command: sanitizedCommand,
+										promptMessage:
+											skillInstallPromptMessageAfterWranglerCommandHandler,
+									})
+								: false;
+
+							// Only check for updates when the install flow did not
+							// just perform a fresh install — a brand-new install
+							// already has the latest content — and the user has
+							// not opted out via environment variable.
+							if (
+								!justInstalled &&
+								getNoSkillsUpdatePromptsFromEnv() !== true
+							) {
 								await runSkillsUpdateFlow({
 									command: sanitizedCommand,
 								});
 							}
 						} catch (skillsErr) {
 							logger.debug(
-								`Skills update check failed: ${skillsErr instanceof Error ? skillsErr.message : skillsErr}`
+								`Skills suggestion failed: ${skillsErr instanceof Error ? skillsErr.message : skillsErr}`
 							);
 						}
 					}

--- a/packages/wrangler/src/core/register-yargs-command.ts
+++ b/packages/wrangler/src/core/register-yargs-command.ts
@@ -360,7 +360,7 @@ function createHandler(def: InternalCommandDefinition, argv: string[]) {
 						(typeof shouldSuggestSkills === "function" &&
 							shouldSuggestSkills(args) === true);
 					// We are currently not sure whether the automatic skills installation is beneficial
-					// so we are skipping it for the time being (we might potentially re-enable it later on) 
+					// so we are skipping it for the time being (we might potentially re-enable it later on)
 					const shouldInstall = false;
 
 					if (suggestSkillsEnabled) {

--- a/packages/wrangler/src/core/types.ts
+++ b/packages/wrangler/src/core/types.ts
@@ -225,12 +225,12 @@ export type CommandDefinition<
 		sendMetrics?: boolean;
 
 		/**
-		 * After the command handler completes successfully, suggest installing
-		 * Cloudflare skills for detected AI coding agents that don't have them.
+		 * After the command handler completes successfully, check whether
+		 * Wrangler-installed Cloudflare skills have an available update.
 		 *
-		 * When set to `true`, the suggestion always runs after the handler.
+		 * When set to `true`, the check always runs after the handler.
 		 * When set to a function, it receives the parsed args and should return
-		 * `true` to enable the suggestion — use this to skip the prompt in modes
+		 * `true` to enable the check — use this to skip the prompt in modes
 		 * where interactive output is inappropriate (e.g. `--json`).
 		 *
 		 * @default false

--- a/packages/wrangler/src/core/types.ts
+++ b/packages/wrangler/src/core/types.ts
@@ -225,12 +225,12 @@ export type CommandDefinition<
 		sendMetrics?: boolean;
 
 		/**
-		 * After the command handler completes successfully, check whether
-		 * Wrangler-installed Cloudflare skills have an available update.
+		 * After the command handler completes successfully, suggest installing
+		 * Cloudflare skills for detected AI coding agents that don't have them.
 		 *
-		 * When set to `true`, the check always runs after the handler.
+		 * When set to `true`, the suggestion always runs after the handler.
 		 * When set to a function, it receives the parsed args and should return
-		 * `true` to enable the check — use this to skip the prompt in modes
+		 * `true` to enable the suggestion — use this to skip the prompt in modes
 		 * where interactive output is inappropriate (e.g. `--json`).
 		 *
 		 * @default false


### PR DESCRIPTION
Automatic skills-installation offers are an experiment that needs changes elsewhere before we can improve it, so this change gates them off for now rather than removing the implementation.

Wrangler still supports --install-skills and continues to offer updates for skills that it previously installed. Re-enabling the automatic offer only requires changing the local gate.

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: This pauses an existing Wrangler prompt without changing public documentation or configuration.