### PR TITLE
[miniflare] Re-register a dev registry entry after the stale sweep removes it

### DIFF
--- a/.changeset/miniflare-dev-registry-reregister-after-sweep.md
+++ b/.changeset/miniflare-dev-registry-reregister-after-sweep.md
@@ -1,0 +1,7 @@
+---
+"miniflare": patch
+---
+
+Re-register a Worker in the dev registry after stale cleanup removes its entry
+
+A running Worker heartbeats its dev registry entry every 10 seconds, and any process reading the registry deletes entries older than 90 seconds. Both halves stop while the machine is suspended, so resuming from sleep leaves every entry stale and the first read deletes them — including entries whose owner is still running. The heartbeat then found its own entry missing and stood itself down, leaving the Worker invisible to service bindings in other `wrangler dev` / `vite dev` processes until an unrelated config update happened to re-register it; peers kept failing with `Worker "<name>" not found. Make sure it is running locally.` A Worker now writes its entry back when it finds it missing, while still standing down when another process has claimed the name.

--- a/.changeset/miniflare-dev-registry-reregister-after-sweep.md
+++ b/.changeset/miniflare-dev-registry-reregister-after-sweep.md
@@ -2,6 +2,6 @@
 "miniflare": patch
 ---
 
-Re-register a Worker in the dev registry after stale cleanup removes its entry
+Restore cross-process service bindings after a machine wakes from sleep
 
-A running Worker heartbeats its dev registry entry every 10 seconds, and any process reading the registry deletes entries older than 90 seconds. Both halves stop while the machine is suspended, so resuming from sleep leaves every entry stale and the first read deletes them — including entries whose owner is still running. The heartbeat then found its own entry missing and stood itself down, leaving the Worker invisible to service bindings in other `wrangler dev` / `vite dev` processes until an unrelated config update happened to re-register it; peers kept failing with `Worker "<name>" not found. Make sure it is running locally.` A Worker now writes its entry back when it finds it missing, while still standing down when another process has claimed the name.
+Workers running in separate `wrangler dev` or Vite dev sessions now reconnect automatically after the machine wakes. Previously, service bindings could return `Worker "<name>" not found` until the serving process reloaded or restarted.

--- a/packages/miniflare/src/shared/DEV_REGISTRY.md
+++ b/packages/miniflare/src/shared/DEV_REGISTRY.md
@@ -56,7 +56,7 @@ type WorkerDefinition = {
 };
 ```
 
-- **Heartbeat**: Every 30s, the file's mtime is touched to signal that the Worker is still running.
+- **Heartbeat**: Every 10s, the owning process touches its file's mtime to signal that the Worker is still running. If the entry has been deleted — stale cleanup removes a live Worker's entry whenever the machine suspends for longer than the stale window, since the heartbeat is frozen too — the owner writes it back rather than going dark. An entry claimed by a different `instanceId` is left alone and the heartbeat stands down.
 - **Registration**: Named workers are advertised by default. Workers with `unsafeRegisterWorker: false` are not advertised.
 - **Stale cleanup**: Workers heartbeat every 10 seconds and entries older than 90 seconds are deleted.
 - **Change detection**: Chokidar watches the registry directory. When a file changes, `refresh()` compares the new state against the previous JSON snapshot and fires `onUpdate` only if a watched external service actually changed.

--- a/packages/miniflare/src/shared/DEV_REGISTRY.md
+++ b/packages/miniflare/src/shared/DEV_REGISTRY.md
@@ -56,7 +56,7 @@ type WorkerDefinition = {
 };
 ```
 
-- **Heartbeat**: Every 10s, the owning process touches its file's mtime to signal that the Worker is still running. If the entry has been deleted — stale cleanup removes a live Worker's entry whenever the machine suspends for longer than the stale window, since the heartbeat is frozen too — the owner writes it back rather than going dark. An entry claimed by a different `instanceId` is left alone and the heartbeat stands down.
+- **Heartbeat**: Every 10s, the owning process touches its file's mtime. If the entry is missing, the owner recreates it; if another instance owns the name, the heartbeat stops.
 - **Registration**: Named workers are advertised by default. Workers with `unsafeRegisterWorker: false` are not advertised.
 - **Stale cleanup**: Workers heartbeat every 10 seconds and entries older than 90 seconds are deleted.
 - **Change detection**: Chokidar watches the registry directory. When a file changes, `refresh()` compares the new state against the previous JSON snapshot and fires `onUpdate` only if a watched external service actually changed.

--- a/packages/miniflare/src/shared/dev-registry.ts
+++ b/packages/miniflare/src/shared/dev-registry.ts
@@ -245,6 +245,16 @@ export class DevRegistry {
 		this.refresh();
 	}
 
+	private writeWorkerDefinition(
+		definitionPath: string,
+		definition: WorkerDefinition
+	): void {
+		writeFileSync(
+			definitionPath,
+			JSON.stringify({ ...definition, instanceId: this.instanceId }, null, 2)
+		);
+	}
+
 	private registerWorker(name: string, definition: WorkerDefinition): void {
 		assert(this.registryPath);
 		const definitionPath = path.join(this.registryPath, name);
@@ -293,33 +303,18 @@ export class DevRegistry {
 			clearInterval(existingHeartbeat);
 		}
 
-		writeFileSync(
-			definitionPath,
-			JSON.stringify({ ...definition, instanceId: this.instanceId }, null, 2)
-		);
+		this.writeWorkerDefinition(definitionPath, definition);
 		this.registeredWorkers.add(name);
 		this.heartbeats.set(
 			name,
 			setInterval(
 				() => {
 					if (!existsSync(definitionPath)) {
-						// The entry is gone while this Worker is still serving. A machine
-						// that suspends for longer than the stale window freezes this
-						// heartbeat, so on resume the sweep in `getWorkerRegistry()`
-						// deletes an entry whose owner is very much alive. Nobody else
-						// holds the name, so take it back — otherwise the branch below
-						// stands the heartbeat down and this Worker stays invisible to
-						// its peers until an unrelated config update re-registers it.
+						// Stale cleanup may remove a live Worker's entry after system sleep.
+						// Recreate it so peers can discover this Worker again.
 						try {
 							mkdirSync(path.dirname(definitionPath), { recursive: true });
-							writeFileSync(
-								definitionPath,
-								JSON.stringify(
-									{ ...definition, instanceId: this.instanceId },
-									null,
-									2
-								)
-							);
+							this.writeWorkerDefinition(definitionPath, definition);
 						} catch (e) {
 							this.log.debug(`Failed to re-register Worker "${name}": ${e}`);
 						}

--- a/packages/miniflare/src/shared/dev-registry.ts
+++ b/packages/miniflare/src/shared/dev-registry.ts
@@ -313,7 +313,6 @@ export class DevRegistry {
 						// Stale cleanup may remove a live Worker's entry after system sleep.
 						// Recreate it so peers can discover this Worker again.
 						try {
-							mkdirSync(path.dirname(definitionPath), { recursive: true });
 							this.writeWorkerDefinition(definitionPath, definition);
 						} catch (e) {
 							this.log.debug(`Failed to re-register Worker "${name}": ${e}`);

--- a/packages/miniflare/src/shared/dev-registry.ts
+++ b/packages/miniflare/src/shared/dev-registry.ts
@@ -302,6 +302,30 @@ export class DevRegistry {
 			name,
 			setInterval(
 				() => {
+					if (!existsSync(definitionPath)) {
+						// The entry is gone while this Worker is still serving. A machine
+						// that suspends for longer than the stale window freezes this
+						// heartbeat, so on resume the sweep in `getWorkerRegistry()`
+						// deletes an entry whose owner is very much alive. Nobody else
+						// holds the name, so take it back — otherwise the branch below
+						// stands the heartbeat down and this Worker stays invisible to
+						// its peers until an unrelated config update re-registers it.
+						try {
+							mkdirSync(path.dirname(definitionPath), { recursive: true });
+							writeFileSync(
+								definitionPath,
+								JSON.stringify(
+									{ ...definition, instanceId: this.instanceId },
+									null,
+									2
+								)
+							);
+						} catch (e) {
+							this.log.debug(`Failed to re-register Worker "${name}": ${e}`);
+						}
+						return;
+					}
+
 					const currentDefinition = readDefinition(definitionPath);
 					if (currentDefinition?.instanceId === this.instanceId) {
 						utimesSync(definitionPath, new Date(), new Date());

--- a/packages/miniflare/test/dev-registry.spec.ts
+++ b/packages/miniflare/test/dev-registry.spec.ts
@@ -171,7 +171,7 @@ describe.sequential("DevRegistry", () => {
 				})
 			);
 
-			await vi.advanceTimersByTimeAsync(30_001);
+			await vi.advanceTimersByTimeAsync(10_001);
 
 			expect(JSON.parse(await fs.readFile(definitionPath, "utf8"))).toEqual({
 				...definition,

--- a/packages/miniflare/test/dev-registry.spec.ts
+++ b/packages/miniflare/test/dev-registry.spec.ts
@@ -87,6 +87,103 @@ describe.sequential("DevRegistry", () => {
 		}
 	});
 
+	test("re-registers its entry after stale cleanup removes it", async ({
+		expect,
+	}) => {
+		const unsafeDevRegistryPath = await useTmp();
+		const definitionPath = path.join(unsafeDevRegistryPath, "worker");
+		const definition: WorkerDefinition = {
+			debugPortAddress: "127.0.0.1:1234",
+			defaultEntrypointService: "core:user:worker",
+			userWorkerService: "core:user:worker",
+		};
+
+		const registry = new DevRegistry(
+			unsafeDevRegistryPath,
+			undefined,
+			new TestLog()
+		);
+		vi.useFakeTimers();
+		try {
+			registry.register({ worker: definition });
+			expect(
+				JSON.parse(await fs.readFile(definitionPath, "utf8")).instanceId
+			).toBe(registry.instanceId);
+
+			// Suspending the machine for longer than the stale window freezes this
+			// process's heartbeat as well, so on resume the sweep deletes an entry
+			// whose owner is still running.
+			const stale = new Date(Date.now() - 91_000);
+			await fs.utimes(definitionPath, stale, stale);
+			expect(getWorkerRegistry(unsafeDevRegistryPath)).toEqual({});
+			await expect(fs.stat(definitionPath)).rejects.toMatchObject({
+				code: "ENOENT",
+			});
+
+			await vi.advanceTimersByTimeAsync(10_001);
+
+			expect(JSON.parse(await fs.readFile(definitionPath, "utf8"))).toEqual({
+				...definition,
+				instanceId: registry.instanceId,
+			});
+			expect(getWorkerRegistry(unsafeDevRegistryPath)).toEqual(
+				expect.objectContaining({
+					worker: expect.objectContaining({
+						debugPortAddress: "127.0.0.1:1234",
+					}),
+				})
+			);
+		} finally {
+			await registry.dispose();
+			vi.useRealTimers();
+		}
+	});
+
+	test("leaves an entry claimed by another process alone", async ({
+		expect,
+	}) => {
+		const unsafeDevRegistryPath = await useTmp();
+		const definitionPath = path.join(unsafeDevRegistryPath, "worker");
+		const definition: WorkerDefinition = {
+			debugPortAddress: "127.0.0.1:1234",
+			defaultEntrypointService: "core:user:worker",
+			userWorkerService: "core:user:worker",
+		};
+
+		const registry = new DevRegistry(
+			unsafeDevRegistryPath,
+			undefined,
+			new TestLog()
+		);
+		vi.useFakeTimers();
+		try {
+			registry.register({ worker: definition });
+			expect(
+				JSON.parse(await fs.readFile(definitionPath, "utf8")).instanceId
+			).toBe(registry.instanceId);
+
+			await fs.writeFile(
+				definitionPath,
+				JSON.stringify({
+					...definition,
+					debugPortAddress: "127.0.0.1:5678",
+					instanceId: "another-instance",
+				})
+			);
+
+			await vi.advanceTimersByTimeAsync(30_001);
+
+			expect(JSON.parse(await fs.readFile(definitionPath, "utf8"))).toEqual({
+				...definition,
+				debugPortAddress: "127.0.0.1:5678",
+				instanceId: "another-instance",
+			});
+		} finally {
+			await registry.dispose();
+			vi.useRealTimers();
+		}
+	});
+
 	test("registers workers by default unless opted out", async ({ expect }) => {
 		const unsafeDevRegistryPath = await useTmp();
 		const worker = {


### PR DESCRIPTION
Fixes #15315.

A running Worker heartbeats its dev registry entry every `WORKER_HEARTBEAT_MS` (10s), and any process reading the registry deletes entries older than `WORKER_STALE_MS` (90s). Suspending the machine freezes the heartbeat timers but not the wall clock the sweep compares against, so on resume every entry is stale and the first read deletes them all — including entries whose owner is still running and serving.

The owner could not recover. Its heartbeat read its own missing file as "another instance owns this name" and stood itself down:

```ts
const currentDefinition = readDefinition(definitionPath);
if (currentDefinition?.instanceId === this.instanceId) {
	utimesSync(definitionPath, new Date(), new Date());
} else {
	// entry was swept while we slept -> clearInterval, never try again
}
```

`readDefinition` returns `undefined` both for an absent file and for one held by a different instance, and the optional chain collapses those two states into one branch. The only route back was `register()` on a Miniflare reload, which is why the symptom looks intermittent rather than deterministic: **the Workers you happen to be editing silently heal, and the ones you aren't editing stay dead.** In a repo with several sites plus shared services, the shared services are the ones nobody edits, so they are the ones that keep 503ing with `Worker "<name>" not found. Make sure it is running locally.`

This PR separates the two cases. An absent file means nobody holds the name and this Worker is still serving, so it writes its entry back; a file carrying a different `instanceId` still stands the heartbeat down, unchanged. The write is guarded so a failure logs at debug rather than throwing inside a timer.

Liveness is not weakened by this. The re-registration only ever runs from inside the owner's own interval, so it carries exactly the signal the existing `utimesSync` carried — a live event loop. A process killed with `SIGKILL` takes its interval with it and nothing rewrites the entry; a clean exit still withdraws it via `dispose()` → `unregisterWorkers()`.

I raised this as an issue first rather than going straight to a PR, since this is code you have recently reworked and I did not want to presume the fix shape. If you would rather change the sweep so that a reader never deletes another process's entry, or move liveness off wall-clock time, I am happy to redo it that way.

### Testing

Two tests added to `packages/miniflare/test/dev-registry.spec.ts`, following the existing `DevRegistry` + fake-timer tests in that file:

- `re-registers its entry after stale cleanup removes it` — backdates the entry past the stale window, confirms the sweep deletes it, advances one heartbeat, asserts the entry is back with this instance's `instanceId` and visible via `getWorkerRegistry()`. Verified this **fails on unmodified `main`** (`ENOENT` on the definition file) and passes with the fix.
- `leaves an entry claimed by another process alone` — characterises the ownership stand-down, guarding the new branch against over-reaching into names another instance holds.

`vitest run test/dev-registry.spec.ts` is green (34 passed), as are `tsc`, `oxlint --deny-warnings` and `oxfmt --check` on the changed files.

`packages/miniflare/src/shared/DEV_REGISTRY.md` is also updated: its heartbeat bullet still said 30s (the constant is 10s) and did not mention the reclaim path.

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: this is dev-server-internal behaviour with no user-facing API change; the package's own `DEV_REGISTRY.md` is updated here.

🦔

> [!NOTE]
> This is a contribution from an AI agent: Claude (Opus 5), via Claude Code, at the direction of the repository owner who hit this bug.
