### PR TITLE
fix(auth): detect an installed secret tool on Linux regardless of its exit status

### DIFF
--- a/.changeset/linux-secret-tool-probe.md
+++ b/.changeset/linux-secret-tool-probe.md
@@ -3,8 +3,6 @@
 "wrangler": patch
 ---
 
-Detect an installed `secret-tool` on Linux even though it has no `--version` flag
+Fix `wrangler login --use-keyring` incorrectly reporting that `secret-tool` is missing on Linux
 
-`wrangler login --use-keyring` on Linux reported that `secret-tool` was not installed even when it was on `PATH`. The availability probe ran `secret-tool --version` and required an exit status of 0, but libsecret's `secret-tool` does not implement `--version`: it prints its usage and exits 2, so every real install was treated as missing.
-
-The probe now treats `secret-tool` as available whenever the process could be spawned at all, regardless of its exit status, and only reports it missing when spawning fails (for example with `ENOENT` because it is not on `PATH`).
+Libsecret's `secret-tool` does not support `--version`; it prints usage and exits 2, which Wrangler previously interpreted as unavailable. Wrangler now reports it missing only when launching the executable fails.

--- a/.changeset/linux-secret-tool-probe.md
+++ b/.changeset/linux-secret-tool-probe.md
@@ -1,0 +1,10 @@
+---
+"@cloudflare/workers-auth": patch
+"wrangler": patch
+---
+
+Detect an installed `secret-tool` on Linux even though it has no `--version` flag
+
+`wrangler login --use-keyring` on Linux reported that `secret-tool` was not installed even when it was on `PATH`. The availability probe ran `secret-tool --version` and required an exit status of 0, but libsecret's `secret-tool` does not implement `--version`: it prints its usage and exits 2, so every real install was treated as missing.
+
+The probe now treats `secret-tool` as available whenever the process could be spawned at all, regardless of its exit status, and only reports it missing when spawning fails (for example with `ENOENT` because it is not on `PATH`).

--- a/packages/workers-auth/src/credential-store/key-providers/linux-secret-tool.ts
+++ b/packages/workers-auth/src/credential-store/key-providers/linux-secret-tool.ts
@@ -77,8 +77,9 @@ export function probeSecretTool(): boolean {
 	try {
 		const r = runner(["--version"]);
 		// `spawnSync` does not throw when the executable is missing: it
-		// reports the failure via `error` and leaves `status` as `null`.
-		result = r.error === undefined && r.status !== null;
+		// reports the failure via `error`. A result without an error proves
+		// the executable was launched, even if a signal terminated it.
+		result = r.error === undefined;
 	} catch {
 		result = false;
 	}

--- a/packages/workers-auth/src/credential-store/key-providers/linux-secret-tool.ts
+++ b/packages/workers-auth/src/credential-store/key-providers/linux-secret-tool.ts
@@ -53,7 +53,11 @@ export function setLinuxSecretToolRunner(
 /**
  * Probe whether `secret-tool` is callable in the current environment.
  *
- * Returns `true` when `secret-tool --version` exits 0. The probe does not
+ * Returns `true` when `secret-tool` could be spawned at all, whatever its
+ * exit status. libsecret's `secret-tool` has no `--version` flag: it prints
+ * its usage and exits 2, so the exit status says nothing about whether the
+ * tool is installed. Only a failure to spawn the process (e.g. `ENOENT`
+ * when it is not on `PATH`) means it is missing. The probe does not
  * exercise the keyring backend itself — a missing D-Bus session surfaces
  * on the first real read/write rather than every consumer invocation, so
  * we avoid the extra latency on every command for users whose desktop
@@ -72,7 +76,9 @@ export function probeSecretTool(): boolean {
 	let result: boolean;
 	try {
 		const r = runner(["--version"]);
-		result = r.status === 0;
+		// `spawnSync` does not throw when the executable is missing: it
+		// reports the failure via `error` and leaves `status` as `null`.
+		result = r.error === undefined && r.status !== null;
 	} catch {
 		result = false;
 	}

--- a/packages/workers-auth/tests/credential-store/key-providers/linux-secret-tool.test.ts
+++ b/packages/workers-auth/tests/credential-store/key-providers/linux-secret-tool.test.ts
@@ -94,6 +94,16 @@ describe("LinuxSecretToolKeyProvider", () => {
 			expect(probeSecretTool()).toBe(true);
 		});
 
+		it("returns true when secret-tool was launched but terminated by a signal", ({
+			expect,
+		}) => {
+			setLinuxSecretToolRunner(() => ({
+				...mockResult({ status: null }),
+				signal: "SIGTERM",
+			}));
+			expect(probeSecretTool()).toBe(true);
+		});
+
 		it("returns false when spawnSync reports ENOENT instead of throwing", ({
 			expect,
 		}) => {

--- a/packages/workers-auth/tests/credential-store/key-providers/linux-secret-tool.test.ts
+++ b/packages/workers-auth/tests/credential-store/key-providers/linux-secret-tool.test.ts
@@ -14,10 +14,12 @@ function mockResult({
 	status = 0,
 	stdout = "",
 	stderr = "",
+	error,
 }: {
 	status?: number | null;
 	stdout?: string;
 	stderr?: string;
+	error?: Error;
 } = {}): SpawnSyncReturns<string> {
 	return {
 		status,
@@ -26,7 +28,20 @@ function mockResult({
 		signal: null,
 		output: [null, stdout, stderr],
 		pid: 1,
+		error,
 	} as SpawnSyncReturns<string>;
+}
+
+/**
+ * What `spawnSync` returns when `secret-tool` cannot be spawned at all (for
+ * example because it is not on `PATH`): it does not throw, it reports the
+ * failure via `error` and leaves `status` as `null`.
+ */
+function spawnErrorResult(code = "ENOENT"): SpawnSyncReturns<string> {
+	return mockResult({
+		status: null,
+		error: Object.assign(new Error(`spawn secret-tool ${code}`), { code }),
+	});
 }
 
 const SAMPLE_KEY = new Uint8Array(32).fill(0xab);
@@ -59,10 +74,30 @@ describe("LinuxSecretToolKeyProvider", () => {
 			expect(probeSecretTool()).toBe(false);
 		});
 
-		it("returns false when secret-tool --version exits non-zero", ({
+		it("returns true when secret-tool prints its usage and exits 2 (libsecret has no --version flag)", ({
+			expect,
+		}) => {
+			setLinuxSecretToolRunner(() =>
+				mockResult({
+					status: 2,
+					stderr:
+						"usage: secret-tool store --label='label' attribute value ...",
+				})
+			);
+			expect(probeSecretTool()).toBe(true);
+		});
+
+		it("returns true on any other non-zero exit status, since the process ran", ({
 			expect,
 		}) => {
 			setLinuxSecretToolRunner(() => mockResult({ status: 127 }));
+			expect(probeSecretTool()).toBe(true);
+		});
+
+		it("returns false when spawnSync reports ENOENT instead of throwing", ({
+			expect,
+		}) => {
+			setLinuxSecretToolRunner(() => spawnErrorResult());
 			expect(probeSecretTool()).toBe(false);
 		});
 
@@ -91,7 +126,7 @@ describe("LinuxSecretToolKeyProvider", () => {
 			setLinuxSecretToolRunner(() => mockResult({ status: 0 }));
 			expect(probeSecretTool()).toBe(true);
 
-			setLinuxSecretToolRunner(() => mockResult({ status: 127 }));
+			setLinuxSecretToolRunner(() => spawnErrorResult());
 			expect(probeSecretTool()).toBe(false);
 		});
 	});

--- a/packages/workers-auth/tests/credential-store/resolver.test.ts
+++ b/packages/workers-auth/tests/credential-store/resolver.test.ts
@@ -238,7 +238,14 @@ describe("createCredentialStorageContext — resolver", () => {
 		}) => {
 			stubPlatform("linux");
 			vi.stubEnv("CLOUDFLARE_AUTH_USE_KEYRING", "true");
-			setLinuxSecretToolRunner(() => mockResult({ status: 127 }));
+			// `spawnSync` reports a missing executable via `error` with a `null`
+			// status rather than by throwing.
+			setLinuxSecretToolRunner(() => ({
+				...mockResult({ status: null }),
+				error: Object.assign(new Error("spawn secret-tool ENOENT"), {
+					code: "ENOENT",
+				}),
+			}));
 
 			expect(() => resolveStore({ isKeyringEnabled: true })).toThrow(
 				/CLOUDFLARE_AUTH_USE_KEYRING is set but `secret-tool` is required/


### PR DESCRIPTION
Fixes #15306

On Linux, `wrangler login --use-keyring` reported that `secret-tool` was not installed even when it was on `PATH`, so keyring backed credential storage could never be enabled on a real Linux install.

The availability probe in `packages/workers-auth/src/credential-store/key-providers/linux-secret-tool.ts` ran `secret-tool --version` and returned `r.status === 0`. libsecret's `secret-tool` does not implement `--version`: in `tool/secret-tool.c`, `main()` only recognises `store`, `lookup`, `clear`, `search` and `lock`, and any other first argument falls through to `usage()`, which prints the usage text to stderr and calls `exit(2)`. So on every real install the probe saw exit status 2 and reported the tool as missing.

The exit status of the probe is therefore not a signal of whether the tool is installed. What does distinguish the two cases is whether the process could be spawned at all: `spawnSync` does not throw for a missing executable, it returns `{ error: <ENOENT error>, status: null }`. The probe now returns `r.error === undefined && r.status !== null`, which is true for any completed process regardless of exit status and false for a spawn failure such as `ENOENT` or `EACCES`. The existing `try/catch` is kept for runners that throw.

I kept `--version` as the probe argument to keep the diff small; with the new condition it is harmless on libsecret (usage, exit 2) and equally harmless on any implementation that does support the flag. A larger alternative would be to probe with a real subcommand such as `secret-tool lookup`, which would additionally detect a missing D Bus session up front, but that adds a keyring round trip to every command and changes the documented design of surfacing backend errors on the first real read or write, so I did not take that route. Invoking `secret-tool` with no arguments at all (which also prints usage and exits 2) would work just as well if you would prefer not to pass a flag the tool does not have.

Tests (`packages/workers-auth/tests/credential-store/key-providers/linux-secret-tool.test.ts`):

- The test "returns false when secret-tool --version exits non-zero" (exit 127) encoded the wrong assumption and has been replaced by two tests: usage plus exit 2 (the libsecret case) means present, and any other non zero exit (127) also means present.
- A new test covers the real `spawnSync` failure shape: `status: null` with `error` set to an `ENOENT` error, without throwing, means missing. `mockResult` gained an optional `error` field and a small `spawnErrorResult` helper builds that shape.
- The memoisation invalidation test now simulates the "missing" case via the spawn error rather than exit 127.
- `tests/credential-store/resolver.test.ts` had one test ("hard-errors with the CLOUDFLARE_AUTH_USE_KEYRING-prefixed message when forced and missing") that simulated a missing tool with exit 127; it now simulates a spawn failure. This is a consequence of the fix, not a pre existing failure.

Verification, all run locally in `packages/workers-auth` with vitest 4.1.0:

- Pristine `main`: the target file ran 15 tests, 15 passed.
- With only the test changes and the original source: 17 tests, 2 failed (the two "non zero exit means present" tests, each with `expected false to be true`), 15 passed. The `ENOENT` test passes on both old and new source because `status: null` was never `0`; it pins the contract rather than reproducing the bug.
- With the fix: 17 tests, 17 passed. Full package suite: 16 files, 175 passed, 3 skipped (the skipped tests are pre existing skips unrelated to this change).
- End to end through the real default runner: with a fake `secret-tool` script on `PATH` that mirrors libsecret (prints usage to stderr and exits 2 for anything but a known subcommand), `probeSecretTool()` returned `false` on `main` and `true` with the fix; with an empty `PATH` it returned `false` in both cases.
- `oxfmt --check`, `oxlint --deny-warnings --type-aware` and `tsc -p tsconfig.json` are clean for the changed files.

A changeset is included for `@cloudflare/workers-auth` and `wrangler` (both patch), since the user visible symptom is in `wrangler login`; if you prefer the `workers-auth` only convention used by #15223 I am happy to drop the `wrangler` line.

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: this restores the documented behaviour of `wrangler login --use-keyring` on Linux; no user facing interface changes.

