### PR TITLE
[wrangler] Ignore EPIPE from closed output consumers

### DIFF
--- a/.changeset/quiet-streams-survive.md
+++ b/.changeset/quiet-streams-survive.md
@@ -1,0 +1,8 @@
+---
+"wrangler": patch
+---
+
+Prevent Wrangler from exiting when a process capturing its output closes the pipe.
+
+Wrangler now ignores broken-pipe errors from stdout and stderr while preserving
+the existing failure behavior for other output errors.

--- a/.changeset/quiet-streams-survive.md
+++ b/.changeset/quiet-streams-survive.md
@@ -4,5 +4,4 @@
 
 Prevent Wrangler from exiting when a process capturing its output closes the pipe.
 
-Wrangler now ignores broken-pipe errors from stdout and stderr while preserving
-the existing failure behavior for other output errors.
+Wrangler now ignores broken-pipe errors from stdout and stderr while preserving the existing failure behavior for other output errors.

--- a/packages/wrangler/src/__tests__/core/output-stream-errors.test.ts
+++ b/packages/wrangler/src/__tests__/core/output-stream-errors.test.ts
@@ -1,0 +1,24 @@
+import { PassThrough } from "node:stream";
+import { registerOutputStreamErrorHandler } from "../../output-stream-errors";
+
+describe("registerOutputStreamErrorHandler", () => {
+	it("keeps the process alive when an output consumer closes the pipe", ({
+		expect,
+	}) => {
+		const stream = new PassThrough();
+		registerOutputStreamErrorHandler(stream);
+
+		const error = Object.assign(new Error("write EPIPE"), { code: "EPIPE" });
+
+		expect(() => stream.emit("error", error)).not.toThrow();
+	});
+
+	it("does not swallow unrelated output errors", ({ expect }) => {
+		const stream = new PassThrough();
+		registerOutputStreamErrorHandler(stream);
+
+		const error = Object.assign(new Error("write failed"), { code: "EIO" });
+
+		expect(() => stream.emit("error", error)).toThrow(error);
+	});
+});

--- a/packages/wrangler/src/__tests__/core/output-stream-errors.test.ts
+++ b/packages/wrangler/src/__tests__/core/output-stream-errors.test.ts
@@ -1,4 +1,5 @@
 import { PassThrough } from "node:stream";
+import { describe, it } from "vitest";
 import { registerOutputStreamErrorHandler } from "../../output-stream-errors";
 
 describe("registerOutputStreamErrorHandler", () => {

--- a/packages/wrangler/src/cli.ts
+++ b/packages/wrangler/src/cli.ts
@@ -24,6 +24,7 @@ import {
 	unstable_pages,
 	unstable_readConfig,
 } from "./api";
+import { registerOutputStreamErrorHandler } from "./output-stream-errors";
 import { main } from "./index";
 import type {
 	Binding,
@@ -52,6 +53,9 @@ import type { Request, Response } from "miniflare";
  * main only gets called when the script is run directly, not when it's imported as a module.
  */
 if (typeof vitest === "undefined" && require.main === module) {
+	registerOutputStreamErrorHandler(process.stdout);
+	registerOutputStreamErrorHandler(process.stderr);
+
 	main(hideBin(process.argv)).catch((e) => {
 		// The logging of any error that was thrown from `main()` is handled in the `yargs.fail()` handler.
 		// Here we just want to ensure that the process exits with a non-zero code.

--- a/packages/wrangler/src/output-stream-errors.ts
+++ b/packages/wrangler/src/output-stream-errors.ts
@@ -1,0 +1,16 @@
+/**
+ * Prevent a disconnected output consumer from terminating the CLI.
+ *
+ * Long-running commands such as `wrangler dev` can outlive tools that capture
+ * their output. Node emits `EPIPE` on the corresponding output stream when the
+ * consumer closes its pipe; without a listener, that error terminates Wrangler.
+ */
+export function registerOutputStreamErrorHandler(
+	stream: NodeJS.WritableStream
+): void {
+	stream.on("error", (error: NodeJS.ErrnoException) => {
+		if (error.code !== "EPIPE") {
+			throw error;
+		}
+	});
+}


### PR DESCRIPTION
Fixes #15202.

Wrangler currently has no `error` listener on its process output streams. If a tool capturing `wrangler dev` output closes its pipe, Node emits an unhandled `EPIPE`, terminates the CLI, and the dev server becomes unreachable.

This registers output-stream error handlers at the real CLI entry point. Broken-pipe errors are ignored so long-running commands can continue serving, while unrelated output errors retain their existing failure behavior.

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: this only changes internal CLI error handling.

Validation:

- Focused Vitest regression: 2 tests passed
- Wrangler TypeScript checks passed
- Focused oxfmt and oxlint checks passed with no warnings
- Built the Wrangler CLI and verified a real `wrangler dev` process remains alive and serves a request after its stdout consumer is closed

> [!NOTE]
> This is a contribution from an AI agent: OpenAI Codex.
