### PR TITLE
Reject conflicting destination restrictions in send-email bindings

### DIFF
--- a/.changeset/tidy-mails-agree.md
+++ b/.changeset/tidy-mails-agree.md
@@ -1,0 +1,7 @@
+---
+"@cloudflare/config": minor
+---
+
+Reject conflicting destination restrictions in send-email bindings
+
+Send-email bindings now match Wrangler validation by allowing either `destinationAddress` or `allowedDestinationAddresses`, but not both. `allowedSenderAddresses` remains an independent restriction that can accompany either destination mode.

--- a/packages/config/src/__tests__/convert.test.ts
+++ b/packages/config/src/__tests__/convert.test.ts
@@ -461,13 +461,17 @@ describe("convertToWranglerConfig", () => {
 			]);
 		});
 
-		it("maps send-email with all address fields", ({ expect }) => {
+		it("maps send-email address restrictions", ({ expect }) => {
 			const result = convertToWranglerConfig({
 				...baseConfig,
 				env: {
-					EM: {
+					EM_DESTINATION: {
 						type: "send-email",
 						destinationAddress: "dest@example.com",
+						allowedSenderAddresses: ["sender@x.com"],
+					},
+					EM_ALLOWLIST: {
+						type: "send-email",
 						allowedDestinationAddresses: ["a@x.com", "b@x.com"],
 						allowedSenderAddresses: ["sender@x.com"],
 					},
@@ -475,8 +479,12 @@ describe("convertToWranglerConfig", () => {
 			});
 			expect(result.send_email).toEqual([
 				{
-					name: "EM",
+					name: "EM_DESTINATION",
 					destination_address: "dest@example.com",
+					allowed_sender_addresses: ["sender@x.com"],
+				},
+				{
+					name: "EM_ALLOWLIST",
 					allowed_destination_addresses: ["a@x.com", "b@x.com"],
 					allowed_sender_addresses: ["sender@x.com"],
 				},

--- a/packages/config/src/__tests__/schema.test.ts
+++ b/packages/config/src/__tests__/schema.test.ts
@@ -1,6 +1,7 @@
 import { describe, it } from "vitest";
 import { exports as exportConfig } from "../exports";
 import {
+	BindingSchema,
 	ConfigExportsSchema,
 	InputWorkerSchema,
 	OutputWorkerSchema,
@@ -219,6 +220,66 @@ describe("InputWorkerSchema", () => {
 			if (!result.success) {
 				expect(result.error.issues[0]?.message).toBe(
 					"ai bindings can only be defined once"
+				);
+			}
+		});
+	});
+
+	describe("send-email bindings", () => {
+		it.for([
+			["no address restrictions", { type: "send-email" }],
+			[
+				"a destination address",
+				{
+					type: "send-email",
+					destinationAddress: "destination@example.com",
+				},
+			],
+			[
+				"allowed destination addresses",
+				{
+					type: "send-email",
+					allowedDestinationAddresses: ["destination@example.com"],
+				},
+			],
+			[
+				"sender restrictions without destination restrictions",
+				{
+					type: "send-email",
+					allowedSenderAddresses: ["sender@example.com"],
+				},
+			],
+			[
+				"a destination address and sender restrictions",
+				{
+					type: "send-email",
+					destinationAddress: "destination@example.com",
+					allowedSenderAddresses: ["sender@example.com"],
+				},
+			],
+			[
+				"allowed destination addresses and sender restrictions",
+				{
+					type: "send-email",
+					allowedDestinationAddresses: ["destination@example.com"],
+					allowedSenderAddresses: ["sender@example.com"],
+				},
+			],
+		] as const)("accepts %s", ([, binding], { expect }) => {
+			expect(BindingSchema.safeParse(binding).success).toBe(true);
+		});
+
+		it("rejects both destination restriction forms", ({ expect }) => {
+			const result = BindingSchema.safeParse({
+				type: "send-email",
+				destinationAddress: "destination@example.com",
+				allowedDestinationAddresses: ["destination@example.com"],
+			});
+
+			expect(result.success).toBe(false);
+			if (!result.success) {
+				expect(result.error.issues[0]?.message).toBe(
+					'"send-email" bindings cannot specify both "destinationAddress" and "allowedDestinationAddresses"'
 				);
 			}
 		});

--- a/packages/config/src/bindings.ts
+++ b/packages/config/src/bindings.ts
@@ -446,25 +446,37 @@ export interface SecretsStoreSecretBinding extends SecretsStoreSecretBindingOpti
 	type: "secrets-store-secret";
 }
 
-interface SendEmailBindingOptions {
-	/** If this binding should be restricted to a specific verified address. */
-	destinationAddress?: string;
-	/** If this binding should be restricted to a set of verified addresses. */
-	allowedDestinationAddresses?: string[];
+type SendEmailDestinationOptions =
+	| {
+			/** If this binding should be restricted to a specific verified address. */
+			destinationAddress: string;
+			allowedDestinationAddresses?: never;
+	  }
+	| {
+			destinationAddress?: never;
+			/** If this binding should be restricted to a set of verified addresses. */
+			allowedDestinationAddresses: string[];
+	  }
+	| {
+			destinationAddress?: never;
+			allowedDestinationAddresses?: never;
+	  };
+
+type SendEmailBindingOptions = SendEmailDestinationOptions & {
 	/** If this binding should be restricted to a set of sender addresses. */
 	allowedSenderAddresses?: string[];
 	/** Options that only apply during local development. */
 	dev?: BindingDevOptions;
-}
+};
 
 /**
  * Binding for sending email from inside the Worker.
  *
  * For reference, see https://developers.cloudflare.com/workers/wrangler/configuration/#email-bindings
  */
-export interface SendEmailBinding extends SendEmailBindingOptions {
+export type SendEmailBinding = SendEmailBindingOptions & {
 	type: "send-email";
-}
+};
 
 interface StreamBindingOptions {
 	/** Options that only apply during local development. */

--- a/packages/config/src/bindings.ts
+++ b/packages/config/src/bindings.ts
@@ -548,10 +548,12 @@ type VpcNetworkBindingOptions =
 	| {
 			/** The tunnel ID of the Cloudflare Tunnel to route traffic through. Mutually exclusive with `networkId`. */
 			tunnelId: string;
+			networkId?: never;
 			/** Options that only apply during local development. */
 			dev?: BindingDevOptions;
 	  }
 	| {
+			tunnelId?: never;
 			/** The network ID to route traffic through. Mutually exclusive with `tunnelId`. */
 			networkId: string;
 			/** Options that only apply during local development. */

--- a/packages/config/src/schema.ts
+++ b/packages/config/src/schema.ts
@@ -693,25 +693,28 @@ const _assertSchemaMatchesWorkerConfig: _AssertSchemaMatchesWorkerConfig = [
 void _assertSchemaMatchesWorkerConfig;
 
 /**
- * Unidirectional drift check for `env`. The public binding return types
- * (e.g. `AiBinding`) carry phantom `__typeParams` / `__config` fields for
- * inference helpers that the schema does not (and cannot) validate at
- * runtime, so a bidirectional check would always fail in that direction.
+ * Drift checks between the schema and public `env` types. Schema input is
+ * intentionally broader for bindings with cross-field validation, so only
+ * assert that every public binding is accepted as input. After parsing, the
+ * schema output and public types should match bidirectionally.
  *
- * We therefore only assert that `WorkerConfig['env']` is assignable to
- * `z.input<typeof InputWorkerSchema>['env']` — i.e. every binding shape
- * the public type accepts is something the schema is willing to parse.
- * This catches drift where the public type drops a field the schema
- * still requires, renames a field, changes a field's type to one the
- * schema rejects, or adds a binding the schema doesn't know about.
+ * These checks catch fields or bindings that are missing, renamed, or typed
+ * differently between the public definitions and the schema.
  */
-type _AssertWorkerConfigEnvExtendsSchema = WorkerConfig["env"] extends z.input<
-	typeof InputWorkerSchema
->["env"]
-	? true
-	: false;
-const _assertWorkerConfigEnvExtendsSchema: _AssertWorkerConfigEnvExtendsSchema = true;
-void _assertWorkerConfigEnvExtendsSchema;
+type _AssertSchemaEnvMatchesWorkerConfig = [
+	WorkerConfig["env"] extends z.input<typeof InputWorkerSchema>["env"]
+		? true
+		: false,
+	z.output<typeof InputWorkerSchema>["env"] extends WorkerConfig["env"]
+		? true
+		: false,
+	WorkerConfig["env"] extends z.output<typeof InputWorkerSchema>["env"]
+		? true
+		: false,
+];
+const _assertSchemaEnvMatchesWorkerConfig: _AssertSchemaEnvMatchesWorkerConfig =
+	[true, true, true];
+void _assertSchemaEnvMatchesWorkerConfig;
 
 /**
  * Bidirectional drift check between {@link SettingsSchema} and the public

--- a/packages/config/src/schema.ts
+++ b/packages/config/src/schema.ts
@@ -1,4 +1,5 @@
 import * as z from "zod";
+import type { SendEmailBinding, VpcNetworkBinding } from "./bindings";
 import type { SettingsConfig, WorkerConfig } from "./types";
 
 const RemoteBindingDevSchema = z.strictObject({
@@ -179,18 +180,15 @@ export const KnownBindingSchema = z.discriminatedUnion("type", [
 			allowedSenderAddresses: z.array(z.string()).optional(),
 			dev: RemoteBindingDevSchema.optional(),
 		})
-		.superRefine((value, ctx) => {
-			if (
-				value.destinationAddress !== undefined &&
-				value.allowedDestinationAddresses !== undefined
-			) {
-				ctx.addIssue({
-					code: "custom",
-						message:
-							'"send-email" bindings cannot specify both "destinationAddress" and "allowedDestinationAddresses"',
-					});
-				}
-			}),
+		.refine(
+			(value): value is SendEmailBinding =>
+				value.destinationAddress === undefined ||
+				value.allowedDestinationAddresses === undefined,
+			{
+				message:
+					'"send-email" bindings cannot specify both "destinationAddress" and "allowedDestinationAddresses"',
+			}
+		),
 	z.strictObject({
 		type: z.literal("stream"),
 		dev: RemoteBindingDevSchema.optional(),
@@ -214,18 +212,21 @@ export const KnownBindingSchema = z.discriminatedUnion("type", [
 			networkId: z.string().optional(),
 			dev: RemoteBindingDevSchema.optional(),
 		})
-		.superRefine((value, ctx) => {
-			const hasTunnel = value.tunnelId !== undefined;
-			const hasNetwork = value.networkId !== undefined;
-			if (hasTunnel === hasNetwork) {
-				ctx.addIssue({
-					code: "custom",
-					message: hasTunnel
+		.refine(
+			(value): value is VpcNetworkBinding =>
+				(value.tunnelId !== undefined) !== (value.networkId !== undefined),
+			{
+				error: ({ input }) => {
+					const value = input as {
+						tunnelId?: string;
+						networkId?: string;
+					};
+					return value.tunnelId !== undefined && value.networkId !== undefined
 						? `"vpc-network" bindings must specify exactly one of "tunnelId" or "networkId", not both`
-						: `"vpc-network" bindings must specify either "tunnelId" or "networkId"`,
-				});
+						: `"vpc-network" bindings must specify either "tunnelId" or "networkId"`;
+				},
 			}
-		}),
+		),
 	z.strictObject({
 		type: z.literal("web-search"),
 		dev: RemoteBindingDevSchema.optional(),

--- a/packages/config/src/schema.ts
+++ b/packages/config/src/schema.ts
@@ -171,13 +171,26 @@ export const KnownBindingSchema = z.discriminatedUnion("type", [
 		storeId: z.string(),
 		secretName: z.string(),
 	}),
-	z.strictObject({
-		type: z.literal("send-email"),
-		destinationAddress: z.string().optional(),
-		allowedDestinationAddresses: z.array(z.string()).optional(),
-		allowedSenderAddresses: z.array(z.string()).optional(),
-		dev: RemoteBindingDevSchema.optional(),
-	}),
+	z
+		.strictObject({
+			type: z.literal("send-email"),
+			destinationAddress: z.string().optional(),
+			allowedDestinationAddresses: z.array(z.string()).optional(),
+			allowedSenderAddresses: z.array(z.string()).optional(),
+			dev: RemoteBindingDevSchema.optional(),
+		})
+		.superRefine((value, ctx) => {
+			if (
+				value.destinationAddress !== undefined &&
+				value.allowedDestinationAddresses !== undefined
+			) {
+				ctx.addIssue({
+					code: "custom",
+						message:
+							'"send-email" bindings cannot specify both "destinationAddress" and "allowedDestinationAddresses"',
+					});
+				}
+			}),
 	z.strictObject({
 		type: z.literal("stream"),
 		dev: RemoteBindingDevSchema.optional(),

--- a/packages/deploy-helpers/src/deploy/helpers/binding-utils.ts
+++ b/packages/deploy-helpers/src/deploy/helpers/binding-utils.ts
@@ -62,8 +62,25 @@ export function convertConfigToBindings(
 				if (pages) {
 					break;
 				}
-				for (const { name, ...x } of info) {
-					output[name] = { type: "send_email", ...x };
+				for (const {
+					name,
+					destination_address,
+					allowed_destination_addresses,
+					allowed_sender_addresses,
+					remote,
+				} of info) {
+					const shared = {
+						type: "send_email" as const,
+						allowed_sender_addresses,
+						remote,
+					};
+					if (destination_address !== undefined) {
+						output[name] = { ...shared, destination_address };
+					} else if (allowed_destination_addresses !== undefined) {
+						output[name] = { ...shared, allowed_destination_addresses };
+					} else {
+						output[name] = shared;
+					}
 				}
 				break;
 			}

--- a/packages/deploy-helpers/src/deploy/helpers/create-worker-upload-form.ts
+++ b/packages/deploy-helpers/src/deploy/helpers/create-worker-upload-form.ts
@@ -219,25 +219,25 @@ export function createWorkerUploadForm(
 	});
 
 	send_email.forEach((emailBinding: CfSendEmailBindings) => {
-		const destination_address =
-			"destination_address" in emailBinding
-				? emailBinding.destination_address
-				: undefined;
-		const allowed_destination_addresses =
-			"allowed_destination_addresses" in emailBinding
-				? emailBinding.allowed_destination_addresses
-				: undefined;
-		const allowed_sender_addresses =
-			"allowed_sender_addresses" in emailBinding
-				? emailBinding.allowed_sender_addresses
-				: undefined;
-		metadataBindings.push({
+		const shared = {
 			name: emailBinding.name,
-			type: "send_email",
-			destination_address,
-			allowed_destination_addresses,
-			allowed_sender_addresses,
-		});
+			type: "send_email" as const,
+			allowed_sender_addresses: emailBinding.allowed_sender_addresses,
+		};
+		if (emailBinding.destination_address !== undefined) {
+			metadataBindings.push({
+				...shared,
+				destination_address: emailBinding.destination_address,
+			});
+		} else if (emailBinding.allowed_destination_addresses !== undefined) {
+			metadataBindings.push({
+				...shared,
+				allowed_destination_addresses:
+					emailBinding.allowed_destination_addresses,
+			});
+		} else {
+			metadataBindings.push(shared);
+		}
 	});
 
 	durable_objects.forEach(({ name, class_name, script_name, environment }) => {

--- a/packages/workers-utils/src/types.ts
+++ b/packages/workers-utils/src/types.ts
@@ -440,8 +440,11 @@ export type Trigger =
 			address?: string;
 	  };
 
-type BindingOmit<T> = Omit<T, "binding">;
-type NameOmit<T> = Omit<T, "name">;
+type DistributiveOmit<T, K extends PropertyKey> = T extends unknown
+	? Omit<T, K>
+	: never;
+type BindingOmit<T> = DistributiveOmit<T, "binding">;
+type NameOmit<T> = DistributiveOmit<T, "name">;
 export type Binding =
 	| {
 			type: "plain_text";

--- a/packages/workers-utils/src/worker.ts
+++ b/packages/workers-utils/src/worker.ts
@@ -94,10 +94,20 @@ export interface CfKvNamespace {
 export type CfSendEmailBindings = {
 	name: string;
 	remote?: boolean;
+	allowed_sender_addresses?: string[];
 } & (
-	| { destination_address?: string }
-	| { allowed_destination_addresses?: string[] }
-	| { allowed_sender_addresses?: string[] }
+	| {
+			destination_address: string;
+			allowed_destination_addresses?: never;
+	  }
+	| {
+			destination_address?: never;
+			allowed_destination_addresses: string[];
+	  }
+	| {
+			destination_address?: never;
+			allowed_destination_addresses?: never;
+	  }
 );
 
 /**

--- a/packages/workers-utils/tests/map-worker-metadata-bindings.test.ts
+++ b/packages/workers-utils/tests/map-worker-metadata-bindings.test.ts
@@ -382,12 +382,17 @@ describe("mapWorkerMetadataBindings", () => {
 	});
 
 	describe("send_email", () => {
-		it("maps send_email binding", ({ expect }) => {
+		it("maps send_email bindings", ({ expect }) => {
 			const bindings: WorkerMetadataBinding[] = [
 				{
 					type: "send_email",
-					name: "EMAIL",
+					name: "EMAIL_DESTINATION",
 					destination_address: "test@example.com",
+					allowed_sender_addresses: ["sender@example.com"],
+				},
+				{
+					type: "send_email",
+					name: "EMAIL_ALLOWLIST",
 					allowed_destination_addresses: ["a@b.com", "c@d.com"],
 					allowed_sender_addresses: ["sender@example.com"],
 				},
@@ -395,8 +400,12 @@ describe("mapWorkerMetadataBindings", () => {
 			const result = mapWorkerMetadataBindings(bindings);
 			expect(result.send_email).toEqual([
 				{
-					name: "EMAIL",
+					name: "EMAIL_DESTINATION",
 					destination_address: "test@example.com",
+					allowed_sender_addresses: ["sender@example.com"],
+				},
+				{
+					name: "EMAIL_ALLOWLIST",
 					allowed_destination_addresses: ["a@b.com", "c@d.com"],
 					allowed_sender_addresses: ["sender@example.com"],
 				},

--- a/packages/wrangler/src/__tests__/init.test.ts
+++ b/packages/wrangler/src/__tests__/init.test.ts
@@ -358,7 +358,6 @@ describe("init", () => {
 				{
 					type: "send_email",
 					name: "EMAIL_BINDING",
-					destination_address: "some@address.com",
 					allowed_destination_addresses: ["some2@address.com"],
 					allowed_sender_addresses: ["some2@address.com"],
 				},
@@ -543,7 +542,6 @@ describe("init", () => {
 				{
 					allowed_sender_addresses: ["some2@address.com"],
 					allowed_destination_addresses: ["some2@address.com"],
-					destination_address: "some@address.com",
 					name: "EMAIL_BINDING",
 				},
 			],
@@ -1131,7 +1129,6 @@ describe("init", () => {
 					  "send_email": [
 					    {
 					      "name": "EMAIL_BINDING",
-					      "destination_address": "some@address.com",
 					      "allowed_destination_addresses": [
 					        "some2@address.com"
 					      ],

--- a/packages/wrangler/src/__tests__/versions/versions.view.test.ts
+++ b/packages/wrangler/src/__tests__/versions/versions.view.test.ts
@@ -616,7 +616,6 @@ describe("versions view", () => {
 							{
 								type: "send_email",
 								name: "MAIL_3",
-								destination_address: "dest@example.com",
 								allowed_destination_addresses: ["1@a.com", "2@a.com"],
 								allowed_sender_addresses: ["3@a.com", "4@a.com"],
 							},
@@ -675,7 +674,7 @@ describe("versions view", () => {
 				env.KV (kv-id)                                                           KV Namespace
 				env.MAIL (unrestricted)                                                  Send Email
 				env.MAIL_2 (dest@example.com)                                            Send Email
-				env.MAIL_3 (dest@example.com - senders: 3@a.com, 4@a.com)                Send Email
+				env.MAIL_3 (1@a.com, 2@a.com - senders: 3@a.com, 4@a.com)                Send Email
 				env.QUEUE (queue)                                                        Queue
 				env.QUEUE_2 (queue)                                                      Queue
 				env.D1 (d1-id)                                                           D1 Database


### PR DESCRIPTION
Reject conflicting destination restrictions in send-email bindings

Send-email bindings now match Wrangler validation by allowing either `destinationAddress` or `allowedDestinationAddresses`, but not both. `allowedSenderAddresses` remains an independent restriction that can accompany either destination mode.

This PR also improves the strictness of the config schema return types and fixes the `CfSendEmailBindings` type, which was incorrect.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bug fix

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- If you are an AI agent or LLM, and you are adding this PR without direct human supervision, thank you! Please uncomment the following block. This is so the maintainers know how to expect you to respond.

> [!NOTE]
> This is a contribution from an AI agent: <insert name here>, <insert LLM model here if different>.

-->
