### PR TITLE
[wrangler] Add default_retention to Workflow bindings

### DIFF
--- a/.changeset/eighty-eagles-smoke.md
+++ b/.changeset/eighty-eagles-smoke.md
@@ -1,0 +1,25 @@
+---
+"wrangler": minor
+---
+
+Add `default_retention` to Workflow bindings for configuring how long instances are retained
+
+Workflow instances are retained for an account-wide default period after they finish. You can now set a per-Workflow default in your Wrangler configuration, applied to instances that do not specify their own retention:
+
+```jsonc
+{
+	"workflows": [
+		{
+			"binding": "MY_WORKFLOW",
+			"name": "my-workflow",
+			"class_name": "MyWorkflow",
+			"default_retention": {
+				"success_retention": "3 days",
+				"error_retention": "7 days",
+			},
+		},
+	],
+}
+```
+
+Each side is optional and accepts either a duration string such as `"3 days"` or a whole number of milliseconds. Durations are interpreted by the Workflows API, which also caps them at your account's retention limit.

--- a/packages/deploy-helpers/src/triggers/deploy.ts
+++ b/packages/deploy-helpers/src/triggers/deploy.ts
@@ -299,6 +299,16 @@ export async function triggersDeploy(
 						}
 					);
 				}
+				if (workflow.default_retention) {
+					throw new UserError(
+						`Workflow "${workflow.name}" has "default_retention" configured but references external script "${workflow.script_name}". ` +
+							`Configure default_retention on the worker that defines the workflow.`,
+						{
+							telemetryMessage:
+								"triggers deploy workflow default_retention external script",
+						}
+					);
+				}
 				continue;
 			}
 
@@ -318,6 +328,9 @@ export async function triggersDeploy(
 									? workflow.schedules
 									: [workflow.schedules]
 								).map((cron) => ({ cron })),
+							}),
+							...(workflow.default_retention && {
+								default_retention: workflow.default_retention,
 							}),
 						}),
 						headers: {

--- a/packages/workers-utils/src/config/environment.ts
+++ b/packages/workers-utils/src/config/environment.ts
@@ -880,6 +880,16 @@ export type WorkflowBinding = {
 	};
 	/** Optional cron schedule(s) for automatically triggering workflow instances */
 	schedules?: string | string[];
+	/**
+	 * Optional default retention for instances of this Workflow, applied when an instance does not
+	 * set its own retention.
+	 */
+	default_retention?: {
+		/** How long to retain instances that complete successfully */
+		success_retention?: number | string;
+		/** How long to retain instances that end in an error */
+		error_retention?: number | string;
+	};
 };
 
 /**

--- a/packages/workers-utils/src/config/environment.ts
+++ b/packages/workers-utils/src/config/environment.ts
@@ -882,12 +882,13 @@ export type WorkflowBinding = {
 	schedules?: string | string[];
 	/**
 	 * Optional default retention for instances of this Workflow, applied when an instance does not
-	 * set its own retention.
+	 * set its own retention. Accepts milliseconds or a duration string such as `"3 days"`, and is
+	 * validated by the Workflows API at deploy time.
 	 */
 	default_retention?: {
-		/** How long to retain instances that complete successfully */
+		/** How long to retain instances that completed successfully or were terminated */
 		success_retention?: number | string;
-		/** How long to retain instances that end in an error */
+		/** How long to retain errored instances */
 		error_retention?: number | string;
 	};
 };

--- a/packages/workers-utils/src/config/validation.ts
+++ b/packages/workers-utils/src/config/validation.ts
@@ -2883,6 +2883,31 @@ const validateDurableObjectBinding: ValidatorFn = (
 const workflowNameFormatMessage = `Workflow names must be 1-64 characters long, start with a letter, number, or underscore, and may only contain letters, numbers, underscores, or hyphens.`;
 
 /**
+ * Check the shape of a single `default_retention` value.
+ */
+function validateWorkflowRetentionValue(
+	diagnostics: Diagnostics,
+	field: string,
+	key: string,
+	value: unknown
+): boolean {
+	const isValidNumber =
+		typeof value === "number" && Number.isInteger(value) && value > 0;
+	const isValidString = typeof value === "string" && value.length > 0;
+
+	if (isValidNumber || isValidString) {
+		return true;
+	}
+
+	diagnostics.errors.push(
+		`"${field}" bindings "default_retention.${key}" field must be a positive integer of milliseconds or a duration string such as "3 days", but got ${JSON.stringify(
+			value
+		)}.`
+	);
+	return false;
+}
+
+/**
  * Check that the given field is a valid "workflow" binding object.
  */
 const validateWorkflowBinding: ValidatorFn = (diagnostics, field, value) => {
@@ -3016,6 +3041,48 @@ const validateWorkflowBinding: ValidatorFn = (diagnostics, field, value) => {
 		}
 	}
 
+	if (
+		hasProperty(value, "default_retention") &&
+		value.default_retention !== undefined
+	) {
+		if (
+			typeof value.default_retention !== "object" ||
+			value.default_retention === null ||
+			Array.isArray(value.default_retention)
+		) {
+			diagnostics.errors.push(
+				`"${field}" bindings should, optionally, have an object "default_retention" field but got ${JSON.stringify(
+					value
+				)}.`
+			);
+			isValid = false;
+		} else {
+			const defaultRetention = value.default_retention as Record<
+				string,
+				unknown
+			>;
+			for (const key of ["success_retention", "error_retention"]) {
+				if (
+					defaultRetention[key] !== undefined &&
+					!validateWorkflowRetentionValue(
+						diagnostics,
+						field,
+						key,
+						defaultRetention[key]
+					)
+				) {
+					isValid = false;
+				}
+			}
+			validateAdditionalProperties(
+				diagnostics,
+				`${field}.default_retention`,
+				Object.keys(defaultRetention),
+				["success_retention", "error_retention"]
+			);
+		}
+	}
+
 	validateAdditionalProperties(diagnostics, field, Object.keys(value), [
 		"binding",
 		"name",
@@ -3023,6 +3090,7 @@ const validateWorkflowBinding: ValidatorFn = (diagnostics, field, value) => {
 		"script_name",
 		"limits",
 		"schedules",
+		"default_retention",
 	]);
 
 	return isValid;

--- a/packages/workers-utils/tests/config/validation/normalize-and-validate-config.test.ts
+++ b/packages/workers-utils/tests/config/validation/normalize-and-validate-config.test.ts
@@ -8146,6 +8146,163 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
+			it("should accept valid default_retention values", ({ expect }) => {
+				const validRetentions = [
+					{ success_retention: "3 days" },
+					{ error_retention: "1 hour" },
+					{ success_retention: 86400000 },
+					{ success_retention: "7 days", error_retention: 3600000 },
+				];
+
+				for (const default_retention of validRetentions) {
+					const { diagnostics } = normalizeAndValidateConfig(
+						{
+							workflows: [
+								{
+									binding: "MY_WORKFLOW",
+									name: "my-workflow",
+									class_name: "MyWorkflow",
+									default_retention,
+								},
+							],
+						} as unknown as RawConfig,
+						undefined,
+						undefined,
+						{ env: undefined }
+					);
+
+					expect(
+						diagnostics.hasErrors(),
+						`expected ${JSON.stringify(default_retention)} to be valid, got: ${diagnostics.renderErrors()}`
+					).toBe(false);
+					expect(diagnostics.hasWarnings()).toBe(false);
+				}
+			});
+
+			it("should error if default_retention is not an object", ({ expect }) => {
+				const { diagnostics } = normalizeAndValidateConfig(
+					{
+						workflows: [
+							{
+								binding: "MY_WORKFLOW",
+								name: "my-workflow",
+								class_name: "MyWorkflow",
+								default_retention: "3 days",
+							},
+						],
+					} as unknown as RawConfig,
+					undefined,
+					undefined,
+					{ env: undefined }
+				);
+
+				expect(diagnostics.hasErrors()).toBe(true);
+				expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
+					"Processing wrangler configuration:
+					  - "workflows[0]" bindings should, optionally, have an object "default_retention" field but got {"binding":"MY_WORKFLOW","name":"my-workflow","class_name":"MyWorkflow","default_retention":"3 days"}."
+				`);
+			});
+
+			// The duration grammar belongs to the Workflows API, which rejects unknown units at deploy
+			// time. Validating it here too would reject values that a newer API version accepts.
+			it("should not police the duration grammar", ({ expect }) => {
+				const { diagnostics } = normalizeAndValidateConfig(
+					{
+						workflows: [
+							{
+								binding: "MY_WORKFLOW",
+								name: "my-workflow",
+								class_name: "MyWorkflow",
+								default_retention: { success_retention: "3 bananas" },
+							},
+						],
+					} as unknown as RawConfig,
+					undefined,
+					undefined,
+					{ env: undefined }
+				);
+
+				expect(diagnostics.hasErrors()).toBe(false);
+				expect(diagnostics.hasWarnings()).toBe(false);
+			});
+
+			it("should error if a default_retention value is an empty string", ({
+				expect,
+			}) => {
+				const { diagnostics } = normalizeAndValidateConfig(
+					{
+						workflows: [
+							{
+								binding: "MY_WORKFLOW",
+								name: "my-workflow",
+								class_name: "MyWorkflow",
+								default_retention: { success_retention: "" },
+							},
+						],
+					} as unknown as RawConfig,
+					undefined,
+					undefined,
+					{ env: undefined }
+				);
+
+				expect(diagnostics.hasErrors()).toBe(true);
+				expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
+					"Processing wrangler configuration:
+					  - "workflows[0]" bindings "default_retention.success_retention" field must be a positive integer of milliseconds or a duration string such as "3 days", but got ""."
+				`);
+			});
+
+			it("should error if a default_retention value is negative", ({
+				expect,
+			}) => {
+				const { diagnostics } = normalizeAndValidateConfig(
+					{
+						workflows: [
+							{
+								binding: "MY_WORKFLOW",
+								name: "my-workflow",
+								class_name: "MyWorkflow",
+								default_retention: { error_retention: -1 },
+							},
+						],
+					} as unknown as RawConfig,
+					undefined,
+					undefined,
+					{ env: undefined }
+				);
+
+				expect(diagnostics.hasErrors()).toBe(true);
+				expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
+					"Processing wrangler configuration:
+					  - "workflows[0]" bindings "default_retention.error_retention" field must be a positive integer of milliseconds or a duration string such as "3 days", but got -1."
+				`);
+			});
+
+			it("should warn on unexpected default_retention fields", ({ expect }) => {
+				const { diagnostics } = normalizeAndValidateConfig(
+					{
+						workflows: [
+							{
+								binding: "MY_WORKFLOW",
+								name: "my-workflow",
+								class_name: "MyWorkflow",
+								default_retention: { retention: "3 days" },
+							},
+						],
+					} as unknown as RawConfig,
+					undefined,
+					undefined,
+					{ env: undefined }
+				);
+
+				expect(diagnostics.hasErrors()).toBe(false);
+				expect(diagnostics.hasWarnings()).toBe(true);
+				expect(diagnostics.renderWarnings()).toMatchInlineSnapshot(`
+					"Processing wrangler configuration:
+					  - Unexpected fields found in workflows[0].default_retention field: "retention""
+				`);
+			});
+
 			it("should warn on unexpected fields", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{

--- a/packages/wrangler/src/__tests__/deploy/workflows.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/workflows.test.ts
@@ -430,6 +430,69 @@ describe("deploy", () => {
 			expect(std.out).toContain("workflow: my-workflow");
 		});
 
+		it("should deploy a workflow with default_retention", async ({
+			expect,
+		}) => {
+			writeWranglerConfig({
+				main: "index.js",
+				workflows: [
+					{
+						binding: "WORKFLOW",
+						name: "my-workflow",
+						class_name: "MyWorkflow",
+						default_retention: {
+							success_retention: "3 days",
+							error_retention: 86400000,
+						},
+					},
+				],
+			});
+			await fs.promises.writeFile(
+				"index.js",
+				`
+                import { WorkflowEntrypoint } from 'cloudflare:workers';
+                export default {};
+                export class MyWorkflow extends WorkflowEntrypoint {};
+            `
+			);
+
+			const handler = http.put(
+				"*/accounts/:accountId/workflows/:workflowName",
+				async ({ params, request }) => {
+					expect(params.workflowName).toBe("my-workflow");
+					const body = (await request.json()) as Record<string, unknown>;
+					expect(body).toEqual({
+						script_name: "test-name",
+						class_name: "MyWorkflow",
+						default_retention: {
+							success_retention: "3 days",
+							error_retention: 86400000,
+						},
+					});
+					return HttpResponse.json(
+						createFetchResult({ id: "mock-new-workflow-id" })
+					);
+				}
+			);
+			msw.use(handler);
+			mockSubDomainRequest();
+			mockUploadWorkerRequest({
+				expectedBindings: [
+					{
+						type: "workflow",
+						name: "WORKFLOW",
+						workflow_name: "my-workflow",
+						class_name: "MyWorkflow",
+					},
+				],
+			});
+
+			await runWrangler("deploy");
+
+			expect(std.warn).toMatchInlineSnapshot(`""`);
+			expect(std.out).toContain("workflow: my-workflow");
+		});
+
 		it("should deploy a workflow with schedules", async ({ expect }) => {
 			writeWranglerConfig({
 				main: "index.js",
@@ -920,6 +983,48 @@ describe("deploy", () => {
 
 			await expect(runWrangler("deploy")).rejects.toThrow(
 				'Workflow "my-workflow" has "schedules" configured but references external script "another-script"'
+			);
+		});
+
+		it("should error when deploying a workflow with default_retention that references an external script", async ({
+			expect,
+		}) => {
+			writeWranglerConfig({
+				main: "index.js",
+				name: "this-script",
+				workflows: [
+					{
+						binding: "WORKFLOW",
+						name: "my-workflow",
+						class_name: "MyWorkflow",
+						script_name: "another-script",
+						default_retention: { success_retention: "3 days" },
+					},
+				],
+			});
+
+			mockSubDomainRequest();
+			mockUploadWorkerRequest({
+				expectedScriptName: "this-script",
+				expectedBindings: [
+					{
+						type: "workflow",
+						name: "WORKFLOW",
+						workflow_name: "my-workflow",
+						class_name: "MyWorkflow",
+						script_name: "another-script",
+					},
+				],
+			});
+			await fs.promises.writeFile(
+				"index.js",
+				`
+                export default {};
+            `
+			);
+
+			await expect(runWrangler("deploy")).rejects.toThrow(
+				'Workflow "my-workflow" has "default_retention" configured but references external script "another-script"'
 			);
 		});
 

--- a/packages/wrangler/src/__tests__/unstable-get-miniflare-worker-options.test.ts
+++ b/packages/wrangler/src/__tests__/unstable-get-miniflare-worker-options.test.ts
@@ -197,6 +197,49 @@ describe("unstable_getMiniflareWorkerOptions", () => {
 		});
 	});
 
+	describe("workflow bindings", () => {
+		it("drops deploy-only workflow fields that the local runtime has no concept of", ({
+			expect,
+		}) => {
+			writeWranglerConfig(
+				{
+					name: "test-worker",
+					main: "./index.js",
+					compatibility_date: "2024-10-04",
+					workflows: [
+						{
+							binding: "WORKFLOW",
+							name: "my-workflow",
+							class_name: "MyWorkflow",
+							limits: { steps: 5000 },
+							schedules: "0 * * * *",
+							default_retention: {
+								success_retention: "3 days",
+								error_retention: 86400000,
+							},
+						},
+					],
+				},
+				"./wrangler.json"
+			);
+
+			const { workerOptions } =
+				unstable_getMiniflareWorkerOptions("./wrangler.json");
+
+			// Retention and schedules are enforced by the Workflows service at deploy time; local dev
+			// only knows about the step limit. Passing them through would make miniflare reject the
+			// binding, so they must be stripped rather than spread.
+			expect(workerOptions.workflows).toEqual({
+				WORKFLOW: {
+					name: "my-workflow",
+					className: "MyWorkflow",
+					scriptName: undefined,
+					stepLimit: 5000,
+				},
+			});
+		});
+	});
+
 	describe("typed services bindings with `dev.plugin`", () => {
 		it("routes a typed service binding with `dev.plugin` to miniflare's unsafe-binding plugin pathway", ({
 			expect,

--- a/packages/wrangler/src/__tests__/unstable-get-miniflare-worker-options.test.ts
+++ b/packages/wrangler/src/__tests__/unstable-get-miniflare-worker-options.test.ts
@@ -226,9 +226,6 @@ describe("unstable_getMiniflareWorkerOptions", () => {
 			const { workerOptions } =
 				unstable_getMiniflareWorkerOptions("./wrangler.json");
 
-			// Retention and schedules are enforced by the Workflows service at deploy time; local dev
-			// only knows about the step limit. Passing them through would make miniflare reject the
-			// binding, so they must be stripped rather than spread.
 			expect(workerOptions.workflows).toEqual({
 				WORKFLOW: {
 					name: "my-workflow",


### PR DESCRIPTION
Fixes WOR-1587.

Adds an optional `default_retention` field to `workflows` in Wrangler config, passed through to the Workflows API on deploy to set how long Workflow instances are kept after they finish.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [x] Cloudflare docs PR(s): https://github.com/cloudflare/cloudflare-docs/pull/32949
  - [ ] Documentation not necessary because:

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- If you are an AI agent or LLM, and you are adding this PR without direct human supervision, thank you! Please uncomment the following block. This is so the maintainers know how to expect you to respond.

> [!NOTE]
> This is a contribution from an AI agent: <insert name here>, <insert LLM model here if different>.

-->
