### PR TITLE
WC-5841 [wrangler] Explain unavailable Preview URLs

### DIFF
--- a/.changeset/preview-no-active-urls.md
+++ b/.changeset/preview-no-active-urls.md
@@ -1,0 +1,7 @@
+---
+"wrangler": minor
+---
+
+`[private beta]`: Explain unavailable Preview URLs after `wrangler preview` deployments
+
+When a Preview deployment has no active URLs, Wrangler now explains how to enable Preview Deployments on workers.dev or a custom domain.

--- a/.changeset/preview-no-active-urls.md
+++ b/.changeset/preview-no-active-urls.md
@@ -1,5 +1,5 @@
 ---
-"wrangler": minor
+"wrangler": patch
 ---
 
 `[private beta]`: Explain unavailable Preview URLs after `wrangler preview` deployments

--- a/packages/deploy-helpers/src/preview/preview.ts
+++ b/packages/deploy-helpers/src/preview/preview.ts
@@ -297,6 +297,9 @@ async function prepareContainersForPreview(
 	return { scopedContainerConfig, normalisedContainerConfig };
 }
 
+export const NO_ACTIVE_PREVIEW_URLS_MESSAGE =
+	"Note: This Preview deployment has no active URLs. To get one, enable Preview Deployments on workers.dev or a custom domain. See https://developers.cloudflare.com/workers/previews/custom-domains/ for more information";
+
 function toBase64(content: string | Uint8Array): string {
 	return Buffer.from(content).toString("base64");
 }
@@ -581,6 +584,9 @@ function formatPreviewDeploymentSummary(
 	const pullRequestNumber =
 		deployment.annotations?.["workers/pull_request_number"] ??
 		pullRequest?.number;
+	const hasActiveUrls =
+		(previewResource.urls?.length ?? 0) > 0 ||
+		(deployment.urls?.length ?? 0) > 0;
 
 	return [
 		`${chalk.bold("Preview:")} ${previewResource.name} ${statusLabel}`,
@@ -595,6 +601,7 @@ function formatPreviewDeploymentSummary(
 					}`,
 				]
 			: []),
+		...(hasActiveUrls ? [] : [NO_ACTIVE_PREVIEW_URLS_MESSAGE]),
 	].join("\n");
 }
 

--- a/packages/wrangler/src/__tests__/preview.test.ts
+++ b/packages/wrangler/src/__tests__/preview.test.ts
@@ -1771,11 +1771,10 @@ describe("wrangler preview", () => {
 			expect(std.out).toContain("Deployment URLs:");
 			expect(std.out).toContain("  https://dep-one.test-worker.cloudflare.app");
 			expect(std.out).toContain("  https://dep-two.test-worker.cloudflare.app");
+			expect(std.out).not.toContain("no active URLs");
 		});
 
-		test("should show compact success output when URL arrays are empty", async ({
-			expect,
-		}) => {
+		test("should note when URL arrays are empty", async ({ expect }) => {
 			msw.use(
 				http.get(
 					`*/accounts/:accountId/workers/workers/:workerId/previews/:previewId`,
@@ -1839,6 +1838,9 @@ describe("wrangler preview", () => {
 				"Preview: empty-urls-preview (new)",
 				"Deployment ID: deployment-id-empty-urls",
 			]);
+			expect(std.out).toContain(
+				"Note: This Preview deployment has no active URLs. To get one, enable Preview Deployments on workers.dev or a custom domain. See https://developers.cloudflare.com/workers/previews/custom-domains/ for more information"
+			);
 		});
 
 		test("should use the URL-encoded preview name as the Preview identifier in path params", async ({

--- a/packages/wrangler/src/preview/secrets/index.ts
+++ b/packages/wrangler/src/preview/secrets/index.ts
@@ -1,5 +1,6 @@
 import {
 	getBranchName,
+	NO_ACTIVE_PREVIEW_URLS_MESSAGE,
 	patchPreviewDeployment,
 } from "@cloudflare/deploy-helpers";
 import { APIError, UserError } from "@cloudflare/workers-utils";
@@ -46,8 +47,7 @@ export function toSecretBindingsPatch(
 export const NO_PREVIEW_DEPLOYMENT_PATCH_ERR_CODE = 10032;
 export const NO_PREVIEW_DEPLOYMENT_GET_ERR_CODE = 10222;
 export const PREVIEW_NOT_FOUND_ERR_CODE = 10025;
-export const NO_ACTIVE_PREVIEW_URLS_MESSAGE =
-	"Note: This Preview deployment has no active URLs. To get one, enable Preview Deployments on workers.dev or a custom domain. See https://developers.cloudflare.com/workers/previews/custom-domains/ for more information";
+export { NO_ACTIVE_PREVIEW_URLS_MESSAGE };
 
 export function noPreviewDeploymentPatchMessage(previewName: string) {
 	return `There are currently no deployments for the Preview "${previewName}". Please create a Preview deployment before modifying a secret.`;


### PR DESCRIPTION
Fixes WC-5841.

When `wrangler preview` successfully creates a Preview deployment with no active URLs, it now prints:

```text
Note: This Preview deployment has no active URLs. To get one, enable Preview Deployments on workers.dev or a custom domain. See https://developers.cloudflare.com/workers/previews/custom-domains/ for more information
```

This matches the guidance already shown by [Preview secret commands](https://github.com/cloudflare/workers-sdk/pull/15079/changes#diff-79e1ff48a24ff29fd48f37765a04982aceb4e5d65ee80973b8c3425ee052b650R49).

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [X] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [X] Documentation not necessary because: private beta

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- If you are an AI agent or LLM, and you are adding this PR without direct human supervision, thank you! Please uncomment the following block. This is so the maintainers know how to expect you to respond.

> [!NOTE]
> This is a contribution from an AI agent: <insert name here>, <insert LLM model here if different>.

-->
