### PR TITLE
chore: switch Bonk workflows to GPT-5.6 Terra

### DIFF
--- a/.github/opencode.json
+++ b/.github/opencode.json
@@ -6,8 +6,8 @@
 	"provider": {
 		"cloudflare-ai-gateway": {
 			"models": {
-				"anthropic/claude-opus-4-8": {},
 				"anthropic/claude-sonnet-4-5": {},
+				"openai/gpt-5.6-terra": {},
 				"workers-ai/@cf/moonshotai/kimi-k2.6": {}
 			}
 		}

--- a/.github/workflows/bonk-pr-review.yml
+++ b/.github/workflows/bonk-pr-review.yml
@@ -55,17 +55,19 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Run Bonk
-        uses: ask-bonk/ask-bonk/github@24832587005550860c8ad13fd96519e731ca632a # main
+        uses: ask-bonk/ask-bonk/github@d00cbcf581a5463f7adc2d81e470234b1727f8dd # main
         env:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_AI_GATEWAY_ACCOUNT_ID }}
           CLOUDFLARE_GATEWAY_ID: ${{ secrets.CF_AI_GATEWAY_NAME }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_AI_GATEWAY_TOKEN }}
-          OPENCODE_CONFIG_CONTENT: '{"provider":{"cloudflare-ai-gateway":{"models":{"anthropic/claude-opus-4-8":{}}}}}'
+          OPENCODE_CONFIG_CONTENT: '{"permission":{"external_directory":{"/home/runner/work/**":"allow"},"edit":"deny","question":"deny","doom_loop":"deny"}}'
         with:
           oidc_base_url: https://ask-bonk.cloudflare-exponent.workers.dev/auth
-          model: "cloudflare-ai-gateway/anthropic/claude-opus-4-8"
+          model: "cloudflare-ai-gateway/openai/gpt-5.6-terra"
           variant: "high"
           forks: "false"
           permissions: write
-          opencode_version: 1.18.18
+          opencode_dev: true
+          opencode_version: "latest"
+          token_permissions: "NO_PUSH"
           prompt: ${{ steps.prompt.outputs.value }}

--- a/.github/workflows/bonk.yml
+++ b/.github/workflows/bonk.yml
@@ -65,18 +65,19 @@ jobs:
           COMMENT_URL: ${{ github.event.comment.html_url }}
 
       - name: Run Bonk
-        uses: ask-bonk/ask-bonk/github@c39e982defd0114385df54e72012a3fc4333c4d4
+        uses: ask-bonk/ask-bonk/github@d00cbcf581a5463f7adc2d81e470234b1727f8dd # main
         env:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_AI_GATEWAY_ACCOUNT_ID }}
           CLOUDFLARE_GATEWAY_ID: ${{ secrets.CF_AI_GATEWAY_NAME }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_AI_GATEWAY_TOKEN }}
-          OPENCODE_CONFIG_CONTENT: '{"provider":{"cloudflare-ai-gateway":{"models":{"anthropic/claude-opus-4-8":{}}}}}'
+          OPENCODE_CONFIG_CONTENT: '{"permission":{"external_directory":{"/home/runner/work/**":"allow"},"question":"deny","doom_loop":"deny"}}'
         with:
           oidc_base_url: https://ask-bonk.cloudflare-exponent.workers.dev/auth
-          model: "cloudflare-ai-gateway/anthropic/claude-opus-4-8"
+          model: "cloudflare-ai-gateway/openai/gpt-5.6-terra"
           variant: "high"
           mentions: "/bonk,@ask-bonk"
           permissions: write
           agent: bonk
-          opencode_version: 1.18.18
+          opencode_dev: true
+          opencode_version: "latest"
           prompt: ${{ steps.prompt.outputs.value }}

--- a/.opencode/agents/bonk.md
+++ b/.opencode/agents/bonk.md
@@ -1,7 +1,7 @@
 ---
 description: Cloudflare Workers SDK engineer. Triages issues, reviews PRs, and implements fixes.
 mode: primary
-model: anthropic/claude-opus-4-8
+model: cloudflare-ai-gateway/openai/gpt-5.6-terra
 temperature: 0.2
 ---
 


### PR DESCRIPTION
Addresses the internal request to migrate Bonk away from Claude Opus before it is disabled for OpenCode.

Switches the on-demand Bonk workflow, automatic PR reviewer, agent configuration, and model allowlist to GPT-5.6 Terra with high reasoning. It also adopts the Bonk/OpenCode configuration validated in Vinext and Workerd, including non-interactive permissions and `NO_PUSH` enforcement for automatic reviews.

Validation completed with `pnpm prettify`, `pnpm check:workflows`, direct JSON/YAML parsing, and `git diff --check`. The full `pnpm check` reached the workspace build but failed in the unrelated `auto-triage-bot` package because its installed dependencies could not resolve `@babel/runtime-corejs3/core-js/instance/trim`.

Changes based on cloudflare/vinext#2987

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: This only changes internal OpenCode and GitHub Actions configuration; the relevant formatting, workflow, JSON, and YAML checks pass.
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: This is an internal CI agent configuration change with no user-facing behavior.

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
