### PR TITLE
[autoconfig] Finalize cf command detection

### DIFF
--- a/.changeset/fresh-dogs-configure.md
+++ b/.changeset/fresh-dogs-configure.md
@@ -5,4 +5,4 @@
 
 Prepare autoconfig for multiple configuration targets
 
-Add target-specific configuration output while preserving Wrangler's existing setup and deployment behavior.
+Add target-specific configuration output and command detection while preserving Wrangler's existing setup and deployment behavior.

--- a/packages/autoconfig/src/details/framework-detection.ts
+++ b/packages/autoconfig/src/details/framework-detection.ts
@@ -96,6 +96,16 @@ export async function detectFramework(
 		buildSettings,
 		context
 	);
+	if (maybeDetectedFramework) {
+		// @netlify/build-info prefers package.json dev scripts over the framework's
+		// built-in command. cf needs the direct command so that `cf dev` can delegate
+		// without invoking a script that may itself call `cf dev`.
+		maybeDetectedFramework.devCommand = project.frameworks
+			.get(maybeDetectedFramework.baseDirectory ?? "")
+			?.find(
+				({ id }) => id === maybeDetectedFramework.framework.id
+			)?.dev?.command;
+	}
 
 	if (
 		await isPagesProject(
@@ -215,7 +225,13 @@ function throwMultipleFrameworksNonInteractiveError(
 	);
 }
 
+/**
+ * Mirrors the relevant fields from @netlify/build-info's `Settings` type.
+ * Framework detections come from `Project.getBuildSettings()`, while
+ * autoconfig also creates synthetic Static and Cloudflare Pages values.
+ */
 type DetectedFramework = {
+	baseDirectory?: string;
 	framework: {
 		name: string;
 		id: string;

--- a/packages/autoconfig/src/details/framework-detection.ts
+++ b/packages/autoconfig/src/details/framework-detection.ts
@@ -225,11 +225,6 @@ function throwMultipleFrameworksNonInteractiveError(
 	);
 }
 
-/**
- * Mirrors the relevant fields from @netlify/build-info's `Settings` type.
- * Framework detections come from `Project.getBuildSettings()`, while
- * autoconfig also creates synthetic Static and Cloudflare Pages values.
- */
 type DetectedFramework = {
 	baseDirectory?: string;
 	framework: {

--- a/packages/autoconfig/src/details/index.ts
+++ b/packages/autoconfig/src/details/index.ts
@@ -101,17 +101,8 @@ export async function getDetailsForAutoConfig({
 
 	logger.debug(`Running autoconfig detection in ${projectPath}...`);
 
-	if (
-		target === "cf" &&
-		existsSync(resolve(projectPath, CLOUDFLARE_CONFIG_FILE))
-	) {
-		return {
-			configured: true,
-			projectPath,
-			workerName: getWorkerName(undefined, projectPath),
-			packageManager: NpmPackageManager,
-		};
-	}
+	const hasCloudflareConfig =
+		target === "cf" && existsSync(resolve(projectPath, CLOUDFLARE_CONFIG_FILE));
 
 	if (
 		target === "wrangler" &&
@@ -146,7 +137,8 @@ export async function getDetailsForAutoConfig({
 		logger.debug("No package.json found when running autoconfig");
 	}
 
-	const configured = framework.isConfigured(projectPath, { target });
+	const configured =
+		hasCloudflareConfig || framework.isConfigured(projectPath, { target });
 
 	const outputDir =
 		detectedFramework?.dist ?? (await findAssetsDir(projectPath));

--- a/packages/autoconfig/src/run.ts
+++ b/packages/autoconfig/src/run.ts
@@ -155,15 +155,23 @@ export async function runAutoConfig(
 	}
 
 	const { npx } = packageManager;
+	let buildCommand =
+		dryRunConfigurationResults.buildCommandOverride ??
+		autoConfigDetails.buildCommand;
+
+	if (
+		target === "cf" &&
+		autoConfigDetails.packageJson?.scripts?.build !== undefined
+	) {
+		buildCommand = `${packageManager.type} run build`;
+	}
 
 	const autoConfigSummary = await buildOperationsSummary(
 		{ ...autoConfigDetails, outputDir: autoConfigDetails.outputDir },
 		dryRunWorkerConfig,
 		dryRunConfigurationResults,
 		{
-			build:
-				dryRunConfigurationResults.buildCommandOverride ??
-				autoConfigDetails.buildCommand,
+			build: buildCommand,
 			deploy:
 				dryRunConfigurationResults.deployCommandOverride ??
 				`${npx} ${target} deploy`,
@@ -295,9 +303,6 @@ export async function runAutoConfig(
 			`${autoConfigDetails.projectPath}/.assetsignore`
 		);
 	}
-
-	const buildCommand =
-		configurationResults.buildCommandOverride ?? autoConfigDetails.buildCommand;
 
 	if (buildCommand && runBuild) {
 		await context.runCommand(

--- a/packages/autoconfig/tests/details/get-details-for-auto-config.test.ts
+++ b/packages/autoconfig/tests/details/get-details-for-auto-config.test.ts
@@ -45,14 +45,27 @@ describe("autoconfig details - getDetailsForAutoConfig()", () => {
 		).resolves.toMatchObject({ configured: false });
 	});
 
-	it("should default to cloudflare.config.ts configuration detection", async ({
+	it("should detect commands without using the package dev script when a Cloudflare config exists", async ({
 		expect,
 	}) => {
-		await writeFile("cloudflare.config.ts", "export default {};");
+		await seed({
+			"cloudflare.config.ts": "export default {};",
+			"package.json": JSON.stringify({
+				scripts: { build: "astro build", dev: "cf dev" },
+				dependencies: { astro: "5" },
+			}),
+			"package-lock.json": JSON.stringify({ lockfileVersion: 3 }),
+		});
 
 		await expect(
 			details.getDetailsForAutoConfig({ context })
-		).resolves.toMatchObject({ configured: true });
+		).resolves.toMatchObject({
+			configured: true,
+			framework: { id: "astro" },
+			buildCommand: "npm run build",
+			devCommand: "npx astro dev",
+			packageManager: { type: "npm" },
+		});
 	});
 
 	// Check that Astro is detected. We don't want to duplicate the tests of @netlify/build-info

--- a/packages/autoconfig/tests/run.test.ts
+++ b/packages/autoconfig/tests/run.test.ts
@@ -11,7 +11,10 @@ import { Framework } from "../src/frameworks/framework-class";
 import { Static } from "../src/frameworks/static";
 import { runAutoConfig } from "../src/run";
 import { createMockContext } from "./helpers/mock-context";
-import type { ConfigurationResults } from "../src/frameworks/framework-class";
+import type {
+	ConfigurationOptions,
+	ConfigurationResults,
+} from "../src/frameworks/framework-class";
 
 class ExternalWorkerConfigFramework extends Framework {
 	configure(): ConfigurationResults {
@@ -28,6 +31,15 @@ class ViteBuildToolFramework extends Framework {
 		return {
 			buildTool: "vite",
 			workerConfig: { entrypoint: "src/index.ts" },
+		};
+	}
+}
+
+class BuildCommandOverrideFramework extends Static {
+	configure(options: ConfigurationOptions): ConfigurationResults {
+		return {
+			...super.configure(options),
+			buildCommandOverride: "npx framework build",
 		};
 	}
 }
@@ -50,22 +62,25 @@ describe("runAutoConfig()", () => {
 			"package.json": JSON.stringify(packageJson),
 			"public/index.html": "<h1>Hello World</h1>",
 		});
+		const context = createMockContext();
 
 		const summary = await runAutoConfig(
 			{
 				configured: false,
 				projectPath: process.cwd(),
 				workerName: "my-static-app",
-				framework: new Static({ id: "static", name: "Static" }),
+				framework: new BuildCommandOverrideFramework({
+					id: "static",
+					name: "Static",
+				}),
 				buildCommand: "npm run build",
 				outputDir: "public",
 				packageJson,
 				packageManager: NpmPackageManager,
 			},
 			{
-				context: createMockContext(),
+				context,
 				skipConfirmations: true,
-				runBuild: false,
 				enableTargetCliInstallation: false,
 			}
 		);
@@ -75,6 +90,7 @@ describe("runAutoConfig()", () => {
 			observability: { enabled: true },
 		});
 		expect(summary.buildConfig).toEqual({ assetsDirectory: "public" });
+		expect(summary.buildCommand).toBe("npm run build");
 		expect(summary.deployCommand).toBe("npx cf deploy");
 		expect(summary.versionCommand).toBe("npx cf versions upload");
 		expect(readFileSync("cloudflare.config.ts", "utf8")).toContain(
@@ -85,6 +101,11 @@ describe("runAutoConfig()", () => {
 		);
 		expect(existsSync("wrangler.jsonc")).toBe(false);
 		expect(installWrangler).toHaveBeenCalledWith("npm", false);
+		expect(context.runCommand).toHaveBeenCalledWith(
+			"npm run build",
+			process.cwd(),
+			"[build]"
+		);
 		expect(JSON.parse(readFileSync("package.json", "utf8"))).toMatchObject({
 			scripts: {
 				build: "generate && vite build",


### PR DESCRIPTION
Follow-up to #15246 for cloudflare/cf#50.

This aligns autoconfig command detection with the `cf` command flow:

- continue framework and command analysis when `cloudflare.config.ts` already exists
- infer the framework's direct development command without consulting `package.json#dev`
- prefer a user-defined `package.json#build` script for `cf` autoconfig while preserving Wrangler's existing behavior

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: this refines prerelease autoconfig behavior for the upcoming `cf` integration
