### PR TITLE
[wrangler] Add date filters to workflows instances list

### DIFF
--- a/.changeset/purple-otters-filter.md
+++ b/.changeset/purple-otters-filter.md
@@ -1,0 +1,12 @@
+---
+"wrangler": minor
+"miniflare": minor
+---
+
+Add `--date-start` and `--date-end` filters to `wrangler workflows instances list`
+
+You can now narrow an instance listing to a creation-time window:
+
+`wrangler workflows instances list my-workflow --date-start 2026-01-01 --date-end 2026-01-31`
+
+Both flags accept any ISO 8601 date or timestamp and are normalised to UTC before being sent, so a date-only value such as `2026-01-01` works as well as a full `2026-01-01T13:00:00Z`. The bounds are inclusive and compose with the existing `--status` filter.

--- a/.changeset/purple-otters-filter.md
+++ b/.changeset/purple-otters-filter.md
@@ -9,4 +9,4 @@ You can now narrow an instance listing to a creation-time window:
 
 `wrangler workflows instances list my-workflow --date-start 2026-01-01 --date-end 2026-01-31`
 
-Both flags accept an ISO 8601 date or timestamp and are normalised to UTC before being sent, so a date-only value such as `2026-01-01` works as well as a full `2026-01-01T13:00:00Z`. The bounds are inclusive and compose with the existing `--status` filter.
+Either flag can be used independently. Both accept an ISO 8601 date or timestamp and are normalised to UTC before being sent, so a date-only value such as `2026-01-01` works as well as a full `2026-01-01T13:00:00Z`. The bounds are inclusive and compose with the existing `--status` filter.

--- a/.changeset/purple-otters-filter.md
+++ b/.changeset/purple-otters-filter.md
@@ -9,4 +9,4 @@ You can now narrow an instance listing to a creation-time window:
 
 `wrangler workflows instances list my-workflow --date-start 2026-01-01 --date-end 2026-01-31`
 
-Both flags accept any ISO 8601 date or timestamp and are normalised to UTC before being sent, so a date-only value such as `2026-01-01` works as well as a full `2026-01-01T13:00:00Z`. The bounds are inclusive and compose with the existing `--status` filter.
+Both flags accept an ISO 8601 date or timestamp and are normalised to UTC before being sent, so a date-only value such as `2026-01-01` works as well as a full `2026-01-01T13:00:00Z`. The bounds are inclusive and compose with the existing `--status` filter.

--- a/packages/miniflare/scripts/openapi-filter-config.ts
+++ b/packages/miniflare/scripts/openapi-filter-config.ts
@@ -1122,6 +1122,26 @@ const config = {
 								description: "Filter instances by status.",
 							},
 						},
+						{
+							in: "query",
+							name: "date_start",
+							schema: {
+								type: "string",
+								format: "date-time",
+								description:
+									"Only return instances created at or after this time. Accepts ISO 8601 with no timezone offsets and in UTC.",
+							},
+						},
+						{
+							in: "query",
+							name: "date_end",
+							schema: {
+								type: "string",
+								format: "date-time",
+								description:
+									"Only return instances created at or before this time. Accepts ISO 8601 with no timezone offsets and in UTC.",
+							},
+						},
 					],
 					responses: {
 						"200": {

--- a/packages/miniflare/src/workers/local-explorer/generated/types.gen.ts
+++ b/packages/miniflare/src/workers/local-explorer/generated/types.gen.ts
@@ -2162,6 +2162,14 @@ export type WorkflowsListInstancesData = {
 			| "complete"
 			| "waitingForPause"
 			| "waiting";
+		/**
+		 * Only return instances created at or after this time. Accepts ISO 8601 with no timezone offsets and in UTC.
+		 */
+		date_start?: string;
+		/**
+		 * Only return instances created at or before this time. Accepts ISO 8601 with no timezone offsets and in UTC.
+		 */
+		date_end?: string;
 	};
 	url: "/workflows/{workflow_name}/instances";
 };

--- a/packages/miniflare/src/workers/local-explorer/generated/zod.gen.ts
+++ b/packages/miniflare/src/workers/local-explorer/generated/zod.gen.ts
@@ -1328,6 +1328,8 @@ export const zWorkflowsListInstancesData = z.object({
 					"waiting",
 				])
 				.optional(),
+			date_start: z.iso.datetime().optional(),
+			date_end: z.iso.datetime().optional(),
 		})
 		.optional(),
 });

--- a/packages/miniflare/src/workers/local-explorer/openapi.local.json
+++ b/packages/miniflare/src/workers/local-explorer/openapi.local.json
@@ -1787,6 +1787,24 @@
 							],
 							"description": "Filter instances by status."
 						}
+					},
+					{
+						"in": "query",
+						"name": "date_start",
+						"schema": {
+							"type": "string",
+							"format": "date-time",
+							"description": "Only return instances created at or after this time. Accepts ISO 8601 with no timezone offsets and in UTC."
+						}
+					},
+					{
+						"in": "query",
+						"name": "date_end",
+						"schema": {
+							"type": "string",
+							"format": "date-time",
+							"description": "Only return instances created at or before this time. Accepts ISO 8601 with no timezone offsets and in UTC."
+						}
 					}
 				],
 				"responses": {

--- a/packages/miniflare/src/workers/local-explorer/resources/workflows.ts
+++ b/packages/miniflare/src/workers/local-explorer/resources/workflows.ts
@@ -23,6 +23,7 @@ import type { z } from "zod";
 // ============================================================================
 
 const WORKFLOW_ERROR_NOT_FOUND = 10501;
+const WORKFLOW_ERROR_INVALID_DATE_RANGE = 10502;
 
 // ============================================================================
 // Types
@@ -386,7 +387,23 @@ export async function listWorkflowInstances(
 	workflowName: string,
 	query: ListInstancesQuery
 ): Promise<Response> {
-	const { page = 1, per_page: perPage = 25, status: statusFilter } = query;
+	const {
+		page = 1,
+		per_page: perPage = 25,
+		status: statusFilter,
+		date_start: dateStart,
+		date_end: dateEnd,
+	} = query;
+
+	if (dateStart !== undefined && dateEnd !== undefined) {
+		if (Date.parse(dateStart) > Date.parse(dateEnd)) {
+			return errorResponse(
+				400,
+				WORKFLOW_ERROR_INVALID_DATE_RANGE,
+				"'date_start' must not be after 'date_end'."
+			);
+		}
+	}
 
 	const workflowExists =
 		c.env.LOCAL_EXPLORER_BINDING_MAP.workflows[workflowName];
@@ -396,6 +413,8 @@ export async function listWorkflowInstances(
 			page,
 			perPage,
 			statusFilter,
+			dateStart,
+			dateEnd,
 		});
 	}
 
@@ -406,6 +425,12 @@ export async function listWorkflowInstances(
 		params.set("per_page", String(perPage));
 		if (statusFilter) {
 			params.set("status", statusFilter);
+		}
+		if (dateStart !== undefined) {
+			params.set("date_start", dateStart);
+		}
+		if (dateEnd !== undefined) {
+			params.set("date_end", dateEnd);
 		}
 		const peerPath = `/workflows/${encodeURIComponent(workflowName)}/instances?${params.toString()}`;
 		const response = await fetchFromPeer(ownerMiniflare, peerPath);
@@ -432,9 +457,15 @@ export async function listWorkflowInstances(
 async function executeListWorkflowInstances(
 	c: AppContext,
 	workflowName: string,
-	options: { page: number; perPage: number; statusFilter?: string }
+	options: {
+		page: number;
+		perPage: number;
+		statusFilter?: string;
+		dateStart?: string;
+		dateEnd?: string;
+	}
 ): Promise<Response> {
-	const { page, perPage, statusFilter } = options;
+	const { page, perPage, statusFilter, dateStart, dateEnd } = options;
 
 	if (c.env.MINIFLARE_LOOPBACK === undefined) {
 		return errorResponse(500, 10001, "Loopback service not available");
@@ -512,10 +543,40 @@ async function executeListWorkflowInstances(
 	let instances: Array<{ id: string; status?: string; created_on?: string }>;
 	let totalCount: number;
 
-	if (statusFilter) {
-		// Status filter requires resolving ALL instances to filter server-side
+	const dateStartMs =
+		dateStart !== undefined ? Date.parse(dateStart) : undefined;
+	const dateEndMs = dateEnd !== undefined ? Date.parse(dateEnd) : undefined;
+	const hasDateFilter = dateStartMs !== undefined || dateEndMs !== undefined;
+
+	if (statusFilter || hasDateFilter) {
+		// Neither status nor creation date is known from the filesystem, so
+		// filtering has to resolve ALL instances server-side
+
 		const allResolved = await Promise.all(sqliteFiles.map(resolveInstance));
-		const filtered = allResolved.filter((inst) => inst.status === statusFilter);
+		const filtered = allResolved.filter((inst) => {
+			if (statusFilter && inst.status !== statusFilter) {
+				return false;
+			}
+			if (!hasDateFilter) {
+				return true;
+			}
+			// An instance with unknown creation time cannot be confirmed to fall
+			// within the range, so exclude it rather than reporting a false match.
+			if (inst.created_on === undefined) {
+				return false;
+			}
+			const createdMs = Date.parse(inst.created_on);
+			if (Number.isNaN(createdMs)) {
+				return false;
+			}
+			if (dateStartMs !== undefined && createdMs < dateStartMs) {
+				return false;
+			}
+			if (dateEndMs !== undefined && createdMs > dateEndMs) {
+				return false;
+			}
+			return true;
+		});
 		totalCount = filtered.length;
 		const offset = (page - 1) * perPage;
 		instances = filtered.slice(offset, offset + perPage);

--- a/packages/miniflare/src/workers/local-explorer/resources/workflows.ts
+++ b/packages/miniflare/src/workers/local-explorer/resources/workflows.ts
@@ -400,7 +400,7 @@ export async function listWorkflowInstances(
 			return errorResponse(
 				400,
 				WORKFLOW_ERROR_INVALID_DATE_RANGE,
-				"'date_start' must not be after 'date_end'."
+				"'date_start' must not be after 'date_end'. Update 'date_start' or 'date_end' so 'date_start' is before or equal to 'date_end'."
 			);
 		}
 	}

--- a/packages/miniflare/src/workers/local-explorer/resources/workflows.ts
+++ b/packages/miniflare/src/workers/local-explorer/resources/workflows.ts
@@ -447,6 +447,26 @@ export async function listWorkflowInstances(
 }
 
 /**
+ * Bounds are inclusive and an unbounded range matches everything. A missing or
+ * unparseable creation time is excluded rather than reported as a match.
+ */
+function isWithinDateRange(
+	createdOn: string | undefined,
+	startMs: number | undefined,
+	endMs: number | undefined
+): boolean {
+	if (startMs === undefined && endMs === undefined) {
+		return true;
+	}
+	const createdMs = Date.parse(createdOn ?? "");
+	return (
+		!Number.isNaN(createdMs) &&
+		createdMs >= (startMs ?? -Infinity) &&
+		createdMs <= (endMs ?? Infinity)
+	);
+}
+
+/**
  * List workflow instances with server-side pagination.
  *
  * 1. Loopback returns all .sqlite files with birthtimeMs (cheap fs.stat)
@@ -551,32 +571,12 @@ async function executeListWorkflowInstances(
 	if (statusFilter || hasDateFilter) {
 		// Neither status nor creation date is known from the filesystem, so
 		// filtering has to resolve ALL instances server-side
-
 		const allResolved = await Promise.all(sqliteFiles.map(resolveInstance));
-		const filtered = allResolved.filter((inst) => {
-			if (statusFilter && inst.status !== statusFilter) {
-				return false;
-			}
-			if (!hasDateFilter) {
-				return true;
-			}
-			// An instance with unknown creation time cannot be confirmed to fall
-			// within the range, so exclude it rather than reporting a false match.
-			if (inst.created_on === undefined) {
-				return false;
-			}
-			const createdMs = Date.parse(inst.created_on);
-			if (Number.isNaN(createdMs)) {
-				return false;
-			}
-			if (dateStartMs !== undefined && createdMs < dateStartMs) {
-				return false;
-			}
-			if (dateEndMs !== undefined && createdMs > dateEndMs) {
-				return false;
-			}
-			return true;
-		});
+		const filtered = allResolved.filter(
+			(instance) =>
+				(statusFilter === undefined || instance.status === statusFilter) &&
+				isWithinDateRange(instance.created_on, dateStartMs, dateEndMs)
+		);
 		totalCount = filtered.length;
 		const offset = (page - 1) * perPage;
 		instances = filtered.slice(offset, offset + perPage);

--- a/packages/miniflare/test/plugins/workflows/index.spec.ts
+++ b/packages/miniflare/test/plugins/workflows/index.spec.ts
@@ -1,3 +1,4 @@
+import assert from "node:assert";
 import * as fs from "node:fs/promises";
 import path from "node:path";
 import { scheduler } from "node:timers/promises";
@@ -605,5 +606,173 @@ describe("workflow instance lifecycle methods", () => {
 		// After restart, the workflow restarts from scratch and runs to completion
 		const finalStatus = await waitForStatus(mf, "restart-test", "complete");
 		expect(finalStatus.output).toBe("workflow-complete");
+	});
+});
+
+describe("listing workflow instances by creation date", () => {
+	interface ListedInstance {
+		id: string;
+		status?: string;
+		created_on?: string;
+	}
+
+	interface ListResponse {
+		result: ListedInstance[];
+		result_info: { total_count: number };
+	}
+
+	async function listInstances(
+		mf: Miniflare,
+		query: Record<string, string> = {}
+	): Promise<{ status: number; body: ListResponse }> {
+		const params = new URLSearchParams(query);
+		const response = await mf.dispatchFetch(
+			`http://localhost${CorePaths.EXPLORER}/api/workflows/LIFECYCLE_WORKFLOW/instances?${params.toString()}`
+		);
+		return {
+			status: response.status,
+			body: (await response.json()) as ListResponse,
+		};
+	}
+
+	/**
+	 * Creates instances sequentially so that each has a distinct `created_on`,
+	 * and returns them keyed by instance id.
+	 */
+	async function createInstances(
+		mf: Miniflare,
+		ids: string[]
+	): Promise<Map<string, string>> {
+		for (const id of ids) {
+			const response = await mf.dispatchFetch(
+				`http://localhost/create?id=${id}`
+			);
+			await response.text();
+			// Creation timestamps have millisecond resolution, so separate them
+			// enough that the ordering is unambiguous.
+			await scheduler.wait(25);
+		}
+
+		const { body } = await listInstances(mf, { per_page: "100" });
+		const createdOnById = new Map<string, string>();
+		for (const instance of body.result) {
+			if (instance.created_on !== undefined) {
+				createdOnById.set(instance.id, instance.created_on);
+			}
+		}
+		return createdOnById;
+	}
+
+	test("filters instances by date_start and date_end", async ({ expect }) => {
+		const tmp = await useTmp();
+		const mf = new Miniflare({
+			...lifecycleMiniflareOpts(tmp),
+			unsafeLocalExplorer: true,
+		});
+		useDispose(mf);
+
+		const createdOn = await createInstances(mf, ["first", "second", "third"]);
+		expect(createdOn.size).toBe(3);
+
+		const firstCreatedOn = createdOn.get("first");
+		const secondCreatedOn = createdOn.get("second");
+		const thirdCreatedOn = createdOn.get("third");
+		assert(
+			firstCreatedOn !== undefined &&
+				secondCreatedOn !== undefined &&
+				thirdCreatedOn !== undefined
+		);
+
+		// date_start is inclusive, so the second instance bounds itself.
+		const fromSecond = await listInstances(mf, {
+			date_start: secondCreatedOn,
+		});
+		expect(fromSecond.status).toBe(200);
+		expect(fromSecond.body.result.map((i) => i.id).sort()).toEqual([
+			"second",
+			"third",
+		]);
+		expect(fromSecond.body.result_info.total_count).toBe(2);
+
+		// date_end is inclusive too.
+		const untilSecond = await listInstances(mf, { date_end: secondCreatedOn });
+		expect(untilSecond.body.result.map((i) => i.id).sort()).toEqual([
+			"first",
+			"second",
+		]);
+
+		// Both bounds together select only the middle instance.
+		const onlySecond = await listInstances(mf, {
+			date_start: secondCreatedOn,
+			date_end: secondCreatedOn,
+		});
+		expect(onlySecond.body.result.map((i) => i.id)).toEqual(["second"]);
+
+		// A range that predates every instance matches nothing.
+		const beforeAll = await listInstances(mf, {
+			date_end: new Date(Date.parse(firstCreatedOn) - 1000).toISOString(),
+		});
+		expect(beforeAll.body.result).toEqual([]);
+		expect(beforeAll.body.result_info.total_count).toBe(0);
+	});
+
+	test("combines a date filter with a status filter", async ({ expect }) => {
+		const tmp = await useTmp();
+		const mf = new Miniflare({
+			...lifecycleMiniflareOpts(tmp),
+			unsafeLocalExplorer: true,
+		});
+		useDispose(mf);
+
+		const createdOn = await createInstances(mf, ["done-1", "done-2"]);
+		await waitForStatus(mf, "done-1", "complete");
+		await waitForStatus(mf, "done-2", "complete");
+
+		const firstCreatedOn = createdOn.get("done-1");
+		const secondCreatedOn = createdOn.get("done-2");
+		assert(firstCreatedOn !== undefined && secondCreatedOn !== undefined);
+
+		const completeFromSecond = await listInstances(mf, {
+			status: "complete",
+			date_start: secondCreatedOn,
+		});
+		expect(completeFromSecond.body.result.map((i) => i.id)).toEqual(["done-2"]);
+
+		// The status filter still excludes instances inside the date range.
+		const erroredFromFirst = await listInstances(mf, {
+			status: "errored",
+			date_start: firstCreatedOn,
+		});
+		expect(erroredFromFirst.body.result).toEqual([]);
+	});
+
+	test("rejects an inverted date range", async ({ expect }) => {
+		const tmp = await useTmp();
+		const mf = new Miniflare({
+			...lifecycleMiniflareOpts(tmp),
+			unsafeLocalExplorer: true,
+		});
+		useDispose(mf);
+
+		const { status, body } = await listInstances(mf, {
+			date_start: "2026-02-01T00:00:00.000Z",
+			date_end: "2026-01-01T00:00:00.000Z",
+		});
+		expect(status).toBe(400);
+		expect(JSON.stringify(body)).toContain(
+			"'date_start' must not be after 'date_end'."
+		);
+	});
+
+	test("rejects a malformed date", async ({ expect }) => {
+		const tmp = await useTmp();
+		const mf = new Miniflare({
+			...lifecycleMiniflareOpts(tmp),
+			unsafeLocalExplorer: true,
+		});
+		useDispose(mf);
+
+		const { status } = await listInstances(mf, { date_start: "yesterday" });
+		expect(status).toBe(400);
 	});
 });

--- a/packages/miniflare/test/plugins/workflows/index.spec.ts
+++ b/packages/miniflare/test/plugins/workflows/index.spec.ts
@@ -1,9 +1,8 @@
-import assert from "node:assert";
 import * as fs from "node:fs/promises";
 import path from "node:path";
 import { scheduler } from "node:timers/promises";
 import { Miniflare, WORKFLOWS_PLUGIN_NAME } from "miniflare";
-import { describe, test, vi } from "vitest";
+import { assert, describe, test, vi } from "vitest";
 import { CorePaths } from "../../../src/workers/core/constants";
 import { singleModuleManifest, useDispose, useTmp } from "../../test-shared";
 import type { MiniflareOptions } from "miniflare";
@@ -760,7 +759,7 @@ describe("listing workflow instances by creation date", () => {
 		});
 		expect(status).toBe(400);
 		expect(JSON.stringify(body)).toContain(
-			"'date_start' must not be after 'date_end'."
+			"Update 'date_start' or 'date_end' so 'date_start' is before or equal to 'date_end'."
 		);
 	});
 

--- a/packages/wrangler/src/__tests__/workflows.test.ts
+++ b/packages/wrangler/src/__tests__/workflows.test.ts
@@ -379,6 +379,204 @@ describe("wrangler workflows", () => {
 			`
 			);
 		});
+
+		describe("date filtering", () => {
+			/** Captures the query string the command sends to the Workflows API. */
+			const mockGetInstancesCapturingQuery = (
+				instances: Instance[] = []
+			): { getSearchParams: () => URLSearchParams | undefined } => {
+				let searchParams: URLSearchParams | undefined;
+				msw.use(
+					http.get(
+						`*/accounts/:accountId/workflows/some-workflow/instances`,
+						async ({ request }) => {
+							searchParams = new URL(request.url).searchParams;
+							return HttpResponse.json({
+								success: true,
+								errors: [],
+								messages: [],
+								result: instances,
+							});
+						},
+						{ once: true }
+					)
+				);
+				return { getSearchParams: () => searchParams };
+			};
+
+			it("sends date_start and date_end as UTC ISO 8601", async ({
+				expect,
+			}) => {
+				writeWranglerConfig();
+				const { getSearchParams } = mockGetInstancesCapturingQuery([
+					mockInstances[0],
+				]);
+
+				await runWrangler(
+					`workflows instances list some-workflow --date-start 2026-01-01T13:00:00Z --date-end 2026-01-31T13:00:00Z`
+				);
+
+				const searchParams = getSearchParams();
+				expect(searchParams?.get("date_start")).toEqual(
+					"2026-01-01T13:00:00.000Z"
+				);
+				expect(searchParams?.get("date_end")).toEqual(
+					"2026-01-31T13:00:00.000Z"
+				);
+			});
+
+			it("normalises a date-only value to a UTC timestamp", async ({
+				expect,
+			}) => {
+				writeWranglerConfig();
+				const { getSearchParams } = mockGetInstancesCapturingQuery([
+					mockInstances[0],
+				]);
+
+				await runWrangler(
+					`workflows instances list some-workflow --date-start 2026-01-01`
+				);
+
+				expect(getSearchParams()?.get("date_start")).toEqual(
+					"2026-01-01T00:00:00.000Z"
+				);
+			});
+
+			it("omits date params when the flags are not provided", async ({
+				expect,
+			}) => {
+				writeWranglerConfig();
+				const { getSearchParams } = mockGetInstancesCapturingQuery([
+					mockInstances[0],
+				]);
+
+				await runWrangler(`workflows instances list some-workflow`);
+
+				const searchParams = getSearchParams();
+				expect(searchParams?.has("date_start")).toBe(false);
+				expect(searchParams?.has("date_end")).toBe(false);
+			});
+
+			it("combines a date filter with a status filter", async ({ expect }) => {
+				writeWranglerConfig();
+				const { getSearchParams } = mockGetInstancesCapturingQuery([
+					mockInstances[0],
+				]);
+
+				await runWrangler(
+					`workflows instances list some-workflow --status complete --date-start 2026-01-01`
+				);
+
+				const searchParams = getSearchParams();
+				expect(searchParams?.get("status")).toEqual("complete");
+				expect(searchParams?.get("date_start")).toEqual(
+					"2026-01-01T00:00:00.000Z"
+				);
+			});
+
+			it("errors on an unparseable date", async ({ expect }) => {
+				writeWranglerConfig();
+
+				await expect(
+					runWrangler(
+						`workflows instances list some-workflow --date-start yesterday`
+					)
+				).rejects.toThrowErrorMatchingInlineSnapshot(
+					`[Error: Looks like you have provided an invalid date "yesterday" for --date-start. Provide an ISO 8601 date or timestamp, for example 2026-01-01 or 2026-01-01T13:00:00Z.]`
+				);
+			});
+
+			it("errors on a non-ISO date that Date.parse would accept", async ({
+				expect,
+			}) => {
+				writeWranglerConfig();
+
+				await expect(
+					runWrangler(
+						`workflows instances list some-workflow --date-start "January 1, 2026"`
+					)
+				).rejects.toThrowErrorMatchingInlineSnapshot(
+					`[Error: Looks like you have provided an invalid date "January 1, 2026" for --date-start. Provide an ISO 8601 date or timestamp, for example 2026-01-01 or 2026-01-01T13:00:00Z.]`
+				);
+			});
+
+			const impossibleDates = [
+				{ date: "2026-02-30", reason: "a day beyond the end of the month" },
+				{ date: "2026-02-29", reason: "Feb 29 in a non-leap year" },
+				{ date: "2026-04-31", reason: "April 31" },
+			];
+
+			for (const { date, reason } of impossibleDates) {
+				it(`errors rather than silently shifting the window for ${date} (${reason})`, async ({
+					expect,
+				}) => {
+					writeWranglerConfig();
+
+					await expect(
+						runWrangler(
+							`workflows instances list some-workflow --date-start ${date}`
+						)
+					).rejects.toThrow(
+						`The date "${date}" provided for --date-start is not a real calendar date, so it would filter on a different date than intended. Check the month and day.`
+					);
+				});
+			}
+
+			it("accepts a real leap day", async ({ expect }) => {
+				writeWranglerConfig();
+				const { getSearchParams } = mockGetInstancesCapturingQuery([
+					mockInstances[0],
+				]);
+
+				await runWrangler(
+					`workflows instances list some-workflow --date-start 2024-02-29`
+				);
+
+				expect(getSearchParams()?.get("date_start")).toEqual(
+					"2024-02-29T00:00:00.000Z"
+				);
+			});
+
+			it("converts a timestamp with a UTC offset", async ({ expect }) => {
+				writeWranglerConfig();
+				const { getSearchParams } = mockGetInstancesCapturingQuery([
+					mockInstances[0],
+				]);
+
+				await runWrangler(
+					`workflows instances list some-workflow --date-start 2026-01-01T23:00:00-05:00`
+				);
+
+				expect(getSearchParams()?.get("date_start")).toEqual(
+					"2026-01-02T04:00:00.000Z"
+				);
+			});
+
+			it("errors when date-start is after date-end", async ({ expect }) => {
+				writeWranglerConfig();
+
+				await expect(
+					runWrangler(
+						`workflows instances list some-workflow --date-start 2026-02-01 --date-end 2026-01-01`
+					)
+				).rejects.toThrowErrorMatchingInlineSnapshot(
+					`[Error: --date-start (2026-02-01T00:00:00.000Z) must not be after --date-end (2026-01-01T00:00:00.000Z).]`
+				);
+			});
+
+			it("warns that no instances matched the filters", async ({ expect }) => {
+				writeWranglerConfig();
+				mockGetInstancesCapturingQuery([]);
+
+				await runWrangler(
+					`workflows instances list some-workflow --date-start 2026-01-01`
+				);
+
+				expect(std.warn).toContain(
+					'No instances in workflow "some-workflow" matched the provided filters.'
+				);
+			});
+		});
 	});
 
 	describe("instances describe", () => {

--- a/packages/wrangler/src/__tests__/workflows.test.ts
+++ b/packages/wrangler/src/__tests__/workflows.test.ts
@@ -638,7 +638,7 @@ describe("wrangler workflows", () => {
 							`workflows instances list some-workflow --date-start ${date}`
 						)
 					).rejects.toThrow(
-						`The date "${date}" provided for --date-start is not a real calendar date, so it would filter on a different date than intended. Check the month and day.`
+						`The date "${date}" provided for --date-start is not a real calendar date. Check the month and day.`
 					);
 				});
 			}
@@ -681,7 +681,7 @@ describe("wrangler workflows", () => {
 						`workflows instances list some-workflow --date-start 2026-02-01 --date-end 2026-01-01`
 					)
 				).rejects.toThrowErrorMatchingInlineSnapshot(
-					`[Error: --date-start (2026-02-01T00:00:00.000Z) must not be after --date-end (2026-01-01T23:59:59.999Z).]`
+					`[Error: --date-start (2026-02-01T00:00:00.000Z) must not be after --date-end (2026-01-01T23:59:59.999Z). Update --date-start or --date-end so --date-start is before or equal to --date-end.]`
 				);
 			});
 

--- a/packages/wrangler/src/__tests__/workflows.test.ts
+++ b/packages/wrangler/src/__tests__/workflows.test.ts
@@ -442,6 +442,127 @@ describe("wrangler workflows", () => {
 				);
 			});
 
+			it("expands a date-only end bound to cover the whole UTC day", async ({
+				expect,
+			}) => {
+				writeWranglerConfig();
+				const { getSearchParams } = mockGetInstancesCapturingQuery([
+					mockInstances[0],
+				]);
+
+				await runWrangler(
+					`workflows instances list some-workflow --date-start 2026-01-01 --date-end 2026-01-31`
+				);
+
+				const searchParams = getSearchParams();
+				expect(searchParams?.get("date_start")).toEqual(
+					"2026-01-01T00:00:00.000Z"
+				);
+				// Without this an instance created on Jan 31 at 09:00 would be omitted.
+				expect(searchParams?.get("date_end")).toEqual(
+					"2026-01-31T23:59:59.999Z"
+				);
+			});
+
+			it("treats the same date for both bounds as that whole day", async ({
+				expect,
+			}) => {
+				writeWranglerConfig();
+				const { getSearchParams } = mockGetInstancesCapturingQuery([
+					mockInstances[0],
+				]);
+
+				await runWrangler(
+					`workflows instances list some-workflow --date-start 2026-01-31 --date-end 2026-01-31`
+				);
+
+				const searchParams = getSearchParams();
+				expect(searchParams?.get("date_start")).toEqual(
+					"2026-01-31T00:00:00.000Z"
+				);
+				expect(searchParams?.get("date_end")).toEqual(
+					"2026-01-31T23:59:59.999Z"
+				);
+			});
+
+			/** Runs `fn` with a fixed non-UTC host timezone. */
+			const withHostTimezone = async (tz: string, fn: () => Promise<void>) => {
+				const original = process.env.TZ;
+				process.env.TZ = tz;
+				try {
+					await fn();
+				} finally {
+					if (original === undefined) {
+						delete process.env.TZ;
+					} else {
+						process.env.TZ = original;
+					}
+				}
+			};
+
+			it("treats an offset-less time as UTC regardless of host timezone", async ({
+				expect,
+			}) => {
+				writeWranglerConfig();
+
+				// Date.parse would read this as local time, shifting the bound by the
+				// host offset, so the result must not depend on the runner's zone.
+				for (const tz of ["Asia/Tokyo", "America/New_York", "UTC"]) {
+					await withHostTimezone(tz, async () => {
+						const { getSearchParams } = mockGetInstancesCapturingQuery([
+							mockInstances[0],
+						]);
+
+						await runWrangler(
+							`workflows instances list some-workflow --date-start 2026-01-01T13:00:00`
+						);
+
+						expect(getSearchParams()?.get("date_start")).toEqual(
+							"2026-01-01T13:00:00.000Z"
+						);
+					});
+				}
+			});
+
+			it("honours an explicit UTC offset regardless of host timezone", async ({
+				expect,
+			}) => {
+				writeWranglerConfig();
+
+				for (const tz of ["Asia/Tokyo", "UTC"]) {
+					await withHostTimezone(tz, async () => {
+						const { getSearchParams } = mockGetInstancesCapturingQuery([
+							mockInstances[0],
+						]);
+
+						await runWrangler(
+							`workflows instances list some-workflow --date-start 2026-01-01T13:00:00-05:00`
+						);
+
+						expect(getSearchParams()?.get("date_start")).toEqual(
+							"2026-01-01T18:00:00.000Z"
+						);
+					});
+				}
+			});
+
+			it("leaves an end bound with an explicit time exact", async ({
+				expect,
+			}) => {
+				writeWranglerConfig();
+				const { getSearchParams } = mockGetInstancesCapturingQuery([
+					mockInstances[0],
+				]);
+
+				await runWrangler(
+					`workflows instances list some-workflow --date-end 2026-01-31T09:00:00Z`
+				);
+
+				expect(getSearchParams()?.get("date_end")).toEqual(
+					"2026-01-31T09:00:00.000Z"
+				);
+			});
+
 			it("omits date params when the flags are not provided", async ({
 				expect,
 			}) => {
@@ -560,7 +681,7 @@ describe("wrangler workflows", () => {
 						`workflows instances list some-workflow --date-start 2026-02-01 --date-end 2026-01-01`
 					)
 				).rejects.toThrowErrorMatchingInlineSnapshot(
-					`[Error: --date-start (2026-02-01T00:00:00.000Z) must not be after --date-end (2026-01-01T00:00:00.000Z).]`
+					`[Error: --date-start (2026-02-01T00:00:00.000Z) must not be after --date-end (2026-01-01T23:59:59.999Z).]`
 				);
 			});
 
@@ -1902,6 +2023,45 @@ describe("wrangler workflows", () => {
 				await runWrangler("workflows instances list my-workflow --local");
 				expect(std.warn).toContain(
 					'There are no instances in workflow "my-workflow"'
+				);
+			});
+
+			it("sends the same normalised date bounds as the remote path", async ({
+				expect,
+			}) => {
+				writeWranglerConfig();
+
+				let searchParams: URLSearchParams | undefined;
+				msw.use(
+					http.get(
+						`${LOCAL_BASE}/workflows/:workflowName/instances`,
+						({ request }) => {
+							searchParams = new URL(request.url).searchParams;
+							return HttpResponse.json({
+								success: true,
+								errors: [],
+								messages: [],
+								result: [],
+								result_info: {
+									page: 1,
+									per_page: 25,
+									total_count: 0,
+									total_pages: 0,
+								},
+							});
+						}
+					)
+				);
+
+				await runWrangler(
+					"workflows instances list my-workflow --local --date-start 2026-01-01 --date-end 2026-01-31"
+				);
+
+				expect(searchParams?.get("date_start")).toEqual(
+					"2026-01-01T00:00:00.000Z"
+				);
+				expect(searchParams?.get("date_end")).toEqual(
+					"2026-01-31T23:59:59.999Z"
 				);
 			});
 		});

--- a/packages/wrangler/src/workflows/commands/instances/list.ts
+++ b/packages/wrangler/src/workflows/commands/instances/list.ts
@@ -34,7 +34,7 @@ function validateDateRange(
 		Date.parse(dateStart) > Date.parse(dateEnd)
 	) {
 		throw new UserError(
-			`--date-start (${dateStart}) must not be after --date-end (${dateEnd}).`,
+			`--date-start (${dateStart}) must not be after --date-end (${dateEnd}). Update --date-start or --date-end so --date-start is before or equal to --date-end.`,
 			{ telemetryMessage: "workflows instances list inverted date range" }
 		);
 	}

--- a/packages/wrangler/src/workflows/commands/instances/list.ts
+++ b/packages/wrangler/src/workflows/commands/instances/list.ts
@@ -22,11 +22,11 @@ function validateDateRange(
 	const dateStart =
 		rawDateStart === undefined
 			? undefined
-			: validateInstanceDate(rawDateStart, "--date-start");
+			: validateInstanceDate(rawDateStart, "--date-start", "start");
 	const dateEnd =
 		rawDateEnd === undefined
 			? undefined
-			: validateInstanceDate(rawDateEnd, "--date-end");
+			: validateInstanceDate(rawDateEnd, "--date-end", "end");
 
 	if (
 		dateStart !== undefined &&
@@ -75,7 +75,7 @@ export const workflowsInstancesListCommand = createCommand({
 		},
 		"date-end": {
 			describe:
-				"Only list instances created at or before this date (ISO 8601, e.g. 2026-01-31 or 2026-01-31T13:00:00Z)",
+				"Only list instances created at or before this date (ISO 8601). A date without a time covers the whole UTC day, so 2026-01-31 includes everything up to 2026-01-31T23:59:59.999Z",
 			type: "string",
 			requiresArg: true,
 		},

--- a/packages/wrangler/src/workflows/commands/instances/list.ts
+++ b/packages/wrangler/src/workflows/commands/instances/list.ts
@@ -1,10 +1,46 @@
+import { UserError } from "@cloudflare/workers-utils";
 import { fetchCursorPage } from "../../../cfetch";
 import { createCommand } from "../../../core/create-command";
 import { logger } from "../../../logger";
 import { requireAuth } from "../../../user";
 import { fetchLocalResult, localWorkflowArgs } from "../../local";
-import { emojifyInstanceStatus, validateStatus } from "../../utils";
+import {
+	emojifyInstanceStatus,
+	validateInstanceDate,
+	validateStatus,
+} from "../../utils";
 import type { Instance } from "../../types";
+
+/**
+ * Normalises the `--date-start` / `--date-end` pair to UTC ISO 8601 strings,
+ * rejecting a range that ends before it starts.
+ */
+function validateDateRange(
+	rawDateStart: string | undefined,
+	rawDateEnd: string | undefined
+): { dateStart: string | undefined; dateEnd: string | undefined } {
+	const dateStart =
+		rawDateStart === undefined
+			? undefined
+			: validateInstanceDate(rawDateStart, "--date-start");
+	const dateEnd =
+		rawDateEnd === undefined
+			? undefined
+			: validateInstanceDate(rawDateEnd, "--date-end");
+
+	if (
+		dateStart !== undefined &&
+		dateEnd !== undefined &&
+		Date.parse(dateStart) > Date.parse(dateEnd)
+	) {
+		throw new UserError(
+			`--date-start (${dateStart}) must not be after --date-end (${dateEnd}).`,
+			{ telemetryMessage: "workflows instances list inverted date range" }
+		);
+	}
+
+	return { dateStart, dateEnd };
+}
 
 export const workflowsInstancesListCommand = createCommand({
 	metadata: {
@@ -31,6 +67,18 @@ export const workflowsInstancesListCommand = createCommand({
 				"Filters list by instance status (can be one of: queued, running, paused, errored, terminated, complete)",
 			type: "string",
 		},
+		"date-start": {
+			describe:
+				"Only list instances created at or after this date (ISO 8601, e.g. 2026-01-01 or 2026-01-01T13:00:00Z)",
+			type: "string",
+			requiresArg: true,
+		},
+		"date-end": {
+			describe:
+				"Only list instances created at or before this date (ISO 8601, e.g. 2026-01-31 or 2026-01-31T13:00:00Z)",
+			type: "string",
+			requiresArg: true,
+		},
 		page: {
 			describe:
 				'Show a sepecific page from the listing, can configure page size using "per-page"',
@@ -44,12 +92,29 @@ export const workflowsInstancesListCommand = createCommand({
 	},
 
 	async handler(args, { config }) {
+		const { dateStart, dateEnd } = validateDateRange(
+			args.dateStart,
+			args.dateEnd
+		);
+		const hasFilters =
+			args.status !== undefined ||
+			dateStart !== undefined ||
+			dateEnd !== undefined;
+
 		if (args.local) {
 			const URLParams = new URLSearchParams();
 
 			if (args.status !== undefined) {
 				const validatedStatus = validateStatus(args.status);
 				URLParams.set("status", validatedStatus);
+			}
+
+			if (dateStart !== undefined) {
+				URLParams.set("date_start", dateStart);
+			}
+
+			if (dateEnd !== undefined) {
+				URLParams.set("date_end", dateEnd);
 			}
 
 			if (args.perPage !== undefined) {
@@ -67,7 +132,9 @@ export const workflowsInstancesListCommand = createCommand({
 
 			if (instances.length === 0 && args.page === 1) {
 				logger.warn(
-					`There are no instances in workflow "${args.name}". You can trigger it with "wrangler workflows trigger ${args.name} --local"`
+					hasFilters
+						? `No instances in workflow "${args.name}" matched the provided filters.`
+						: `There are no instances in workflow "${args.name}". You can trigger it with "wrangler workflows trigger ${args.name} --local"`
 				);
 				return;
 			}
@@ -110,6 +177,14 @@ export const workflowsInstancesListCommand = createCommand({
 				URLParams.set("status", validatedStatus);
 			}
 
+			if (dateStart !== undefined) {
+				URLParams.set("date_start", dateStart);
+			}
+
+			if (dateEnd !== undefined) {
+				URLParams.set("date_end", dateEnd);
+			}
+
 			if (args.perPage !== undefined) {
 				URLParams.set("per_page", args.perPage.toString());
 			}
@@ -127,7 +202,9 @@ export const workflowsInstancesListCommand = createCommand({
 
 			if (instances.length === 0 && args.page === 1) {
 				logger.warn(
-					`There are no instances in workflow "${args.name}". You can trigger it with "wrangler workflows trigger ${args.name}"`
+					hasFilters
+						? `No instances in workflow "${args.name}" matched the provided filters.`
+						: `There are no instances in workflow "${args.name}". You can trigger it with "wrangler workflows trigger ${args.name}"`
 				);
 				return;
 			}

--- a/packages/wrangler/src/workflows/utils.ts
+++ b/packages/wrangler/src/workflows/utils.ts
@@ -92,6 +92,24 @@ export const validateStatus = (status: string): InstanceStatus => {
 /** Matches the `YYYY-MM-DD` date portion of an ISO 8601 date or timestamp. */
 const ISO_DATE_PREFIX_REG_EXP = /^(\d{4})-(\d{2})-(\d{2})(?:T|$)/;
 
+/** Matches a trailing `Z` or a `+HH:MM` / `-HHMM` / `+HH` style UTC offset. */
+const UTC_DESIGNATOR_REG_EXP = /(?:[Zz]|[+-]\d{2}(?::?\d{2})?)$/;
+
+/**
+ * `Date.parse` reads an offset-less date-time as local time but a date-only
+ * value as UTC, so `Z` is added to keep every bound machine-independent.
+ */
+function withUtcDesignator(value: string): string {
+	const timeIndex = value.indexOf("T");
+	if (
+		timeIndex === -1 ||
+		UTC_DESIGNATOR_REG_EXP.test(value.slice(timeIndex + 1))
+	) {
+		return value;
+	}
+	return `${value}Z`;
+}
+
 /**
  * `Date` rolls `2026-02-30` over to 2026-03-02 instead of failing, so the
  * result is compared back to the input. `Date.UTC` remaps years 0-99.
@@ -107,12 +125,16 @@ function isRealCalendarDate(year: number, month: number, day: number): boolean {
 }
 
 /**
- * Normalises an ISO 8601 date or timestamp to UTC, the only format the
- * Workflows API accepts. Rejects locale formats such as `January 1, 2026`.
+ * Normalises an ISO 8601 date or timestamp to UTC. A date-only value covers the
+ * whole UTC day, so an `end` bound becomes 23:59:59.999 rather than midnight.
  */
-export function validateInstanceDate(value: string, flag: string): string {
+export function validateInstanceDate(
+	value: string,
+	flag: string,
+	bound: "start" | "end"
+): string {
 	const dateParts = ISO_DATE_PREFIX_REG_EXP.exec(value);
-	const parsed = Date.parse(value);
+	const parsed = Date.parse(withUtcDesignator(value));
 
 	if (dateParts === null || Number.isNaN(parsed)) {
 		throw new UserError(
@@ -129,7 +151,13 @@ export function validateInstanceDate(value: string, flag: string): string {
 		);
 	}
 
-	return new Date(parsed).toISOString();
+	const normalised = new Date(parsed);
+	// `2026-01-31` as an end bound should include everything that happened that
+	// day, not just the instant at midnight.
+	if (bound === "end" && !value.includes("T")) {
+		normalised.setUTCHours(23, 59, 59, 999);
+	}
+	return normalised.toISOString();
 }
 
 export async function getInstanceIdFromArgs(

--- a/packages/wrangler/src/workflows/utils.ts
+++ b/packages/wrangler/src/workflows/utils.ts
@@ -89,6 +89,49 @@ export const validateStatus = (status: string): InstanceStatus => {
 	}
 };
 
+/** Matches the `YYYY-MM-DD` date portion of an ISO 8601 date or timestamp. */
+const ISO_DATE_PREFIX_REG_EXP = /^(\d{4})-(\d{2})-(\d{2})(?:T|$)/;
+
+/**
+ * `Date` rolls `2026-02-30` over to 2026-03-02 instead of failing, so the
+ * result is compared back to the input. `Date.UTC` remaps years 0-99.
+ */
+function isRealCalendarDate(year: number, month: number, day: number): boolean {
+	const date = new Date(0);
+	date.setUTCFullYear(year, month - 1, day);
+	return (
+		date.getUTCFullYear() === year &&
+		date.getUTCMonth() === month - 1 &&
+		date.getUTCDate() === day
+	);
+}
+
+/**
+ * Normalises an ISO 8601 date or timestamp to UTC, the only format the
+ * Workflows API accepts. Rejects locale formats such as `January 1, 2026`.
+ */
+export function validateInstanceDate(value: string, flag: string): string {
+	const dateParts = ISO_DATE_PREFIX_REG_EXP.exec(value);
+	const parsed = Date.parse(value);
+
+	if (dateParts === null || Number.isNaN(parsed)) {
+		throw new UserError(
+			`Looks like you have provided an invalid date "${value}" for ${flag}. Provide an ISO 8601 date or timestamp, for example 2026-01-01 or 2026-01-01T13:00:00Z.`,
+			{ telemetryMessage: "workflows instances list invalid date" }
+		);
+	}
+
+	const [, year, month, day] = dateParts;
+	if (!isRealCalendarDate(Number(year), Number(month), Number(day))) {
+		throw new UserError(
+			`The date "${value}" provided for ${flag} is not a real calendar date, so it would filter on a different date than intended. Check the month and day.`,
+			{ telemetryMessage: "workflows instances list invalid date" }
+		);
+	}
+
+	return new Date(parsed).toISOString();
+}
+
 export async function getInstanceIdFromArgs(
 	accountId: string,
 	args: { id: string; name: string },

--- a/packages/wrangler/src/workflows/utils.ts
+++ b/packages/wrangler/src/workflows/utils.ts
@@ -146,7 +146,7 @@ export function validateInstanceDate(
 	const [, year, month, day] = dateParts;
 	if (!isRealCalendarDate(Number(year), Number(month), Number(day))) {
 		throw new UserError(
-			`The date "${value}" provided for ${flag} is not a real calendar date, so it would filter on a different date than intended. Check the month and day.`,
+			`The date "${value}" provided for ${flag} is not a real calendar date. Check the month and day.`,
 			{ telemetryMessage: "workflows instances list invalid date" }
 		);
 	}


### PR DESCRIPTION
Fixes WOR-180.

Adds `--date-start` and `--date-end` to `wrangler workflows instances list`, exposing the Workflows API's existing `date_start`/`date_end` query params and implementing equivalent filtering in Miniflare's local explorer so `--local` behaves the same as remote.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: It's automatic

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- If you are an AI agent or LLM, and you are adding this PR without direct human supervision, thank you! Please uncomment the following block. This is so the maintainers know how to expect you to respond.

> [!NOTE]
> This is a contribution from an AI agent: <insert name here>, <insert LLM model here if different>.

-->

<!-- devin-review-badge-begin -->

---

<a href="https://cloudflare.devinenterprise.com/review/cloudflare/workers-sdk/pull/15353" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->