### PR TITLE
[wrangler] Add --json output to Workflows commands

### DIFF
--- a/.changeset/workflows-json-output.md
+++ b/.changeset/workflows-json-output.md
@@ -1,0 +1,11 @@
+---
+"wrangler": minor
+---
+
+Add a `--json` flag to the `wrangler workflows` commands
+
+Every `wrangler workflows` command now accepts `--json`, which emits the raw API payload instead of the human-readable rendering. The formatted output remains the default, so existing usage is unaffected:
+
+`wrangler workflows instances list my-workflow --json`
+
+The JSON output carries raw values rather than a serialisation of the formatted view: ISO timestamps instead of locale-formatted dates, plain status strings instead of emojified labels, and no presentation-only derived fields.

--- a/packages/wrangler/src/__tests__/workflows.test.ts
+++ b/packages/wrangler/src/__tests__/workflows.test.ts
@@ -274,6 +274,130 @@ describe("wrangler workflows", () => {
 			`
 			);
 		});
+
+		it("should output the raw workflows as JSON with --json", async ({
+			expect,
+		}) => {
+			writeWranglerConfig();
+			await mockGetWorkflows(mockWorkflows);
+
+			await runWrangler(`workflows list --json`);
+
+			expect(std.info).toMatchInlineSnapshot(`""`);
+			expect(JSON.parse(std.out)).toEqual(mockWorkflows);
+		});
+
+		it("should match the table ordering with --json", async ({ expect }) => {
+			writeWranglerConfig();
+			await mockGetWorkflows([
+				{
+					...mockWorkflows[0],
+					name: "older",
+					created_on: "2024-01-01T00:00:00Z",
+				},
+				{
+					...mockWorkflows[1],
+					name: "newer",
+					created_on: "2024-06-01T00:00:00Z",
+				},
+			]);
+
+			await runWrangler(`workflows list --json`);
+
+			// Newest first, same as the formatted table.
+			expect(
+				JSON.parse(std.out).map((workflow: Workflow) => workflow.name)
+			).toEqual(["newer", "older"]);
+		});
+
+		it("should output an empty array with --json when there are no workflows", async ({
+			expect,
+		}) => {
+			writeWranglerConfig();
+			await mockGetWorkflows([]);
+
+			await runWrangler(`workflows list --json`);
+
+			expect(JSON.parse(std.out)).toEqual([]);
+			expect(std.warn).toMatchInlineSnapshot(`""`);
+		});
+	});
+
+	describe("describe", () => {
+		const mockWorkflow: Workflow = {
+			class_name: "wf_class_1",
+			created_on: mockCreateDate.toISOString(),
+			id: "wf_id_1",
+			modified_on: mockModifiedDate.toISOString(),
+			name: "some-workflow",
+			script_name: "wf_script_1",
+		};
+
+		const mockVersions = [
+			{
+				id: "version_1",
+				created_on: mockCreateDate.toISOString(),
+				modified_on: mockModifiedDate.toISOString(),
+				workflow_id: "wf_id_1",
+			},
+		];
+
+		const mockDescribeWorkflow = async (versions = mockVersions) => {
+			msw.use(
+				http.get(
+					`*/accounts/:accountId/workflows/some-workflow`,
+					async () => {
+						return HttpResponse.json({
+							success: true,
+							errors: [],
+							messages: [],
+							result: mockWorkflow,
+						});
+					},
+					{ once: true }
+				),
+				http.get(
+					`*/accounts/:accountId/workflows/some-workflow/versions`,
+					async () => {
+						return HttpResponse.json({
+							success: true,
+							errors: [],
+							messages: [],
+							result: versions,
+						});
+					},
+					{ once: true }
+				)
+			);
+		};
+
+		// The default output is rendered with `logRaw`, which bypasses the console
+		// mock, so only the `--json` path is asserted on here.
+		it("should output the raw workflow as JSON with --json", async ({
+			expect,
+		}) => {
+			writeWranglerConfig();
+			await mockDescribeWorkflow();
+
+			await runWrangler(`workflows describe some-workflow --json`);
+			expect(JSON.parse(std.out)).toEqual({
+				...mockWorkflow,
+				latest_version: mockVersions[0],
+			});
+		});
+
+		it("should report a null latest_version when there are no versions", async ({
+			expect,
+		}) => {
+			writeWranglerConfig();
+			await mockDescribeWorkflow([]);
+
+			await runWrangler(`workflows describe some-workflow --json`);
+			expect(JSON.parse(std.out)).toEqual({
+				...mockWorkflow,
+				latest_version: null,
+			});
+		});
 	});
 
 	describe("instances list", () => {
@@ -698,6 +822,60 @@ describe("wrangler workflows", () => {
 				);
 			});
 		});
+
+		it("should output the raw instances as JSON with --json", async ({
+			expect,
+		}) => {
+			writeWranglerConfig();
+			await mockGetInstances(mockInstances);
+
+			await runWrangler(`workflows instances list some-workflow --json`);
+
+			expect(std.info).toMatchInlineSnapshot(`""`);
+			expect(JSON.parse(std.out)).toEqual(mockInstances);
+		});
+
+		it("should still honour --reverse with --json", async ({ expect }) => {
+			writeWranglerConfig();
+			await mockGetInstances([
+				{
+					id: "older",
+					created_on: mockCreateDate.toISOString(),
+					modified_on: mockModifiedDate.toISOString(),
+					workflow_id: "b",
+					version_id: "c",
+					status: "complete",
+				},
+				{
+					id: "newer",
+					created_on: mockModifiedDate.toISOString(),
+					modified_on: mockModifiedDate.toISOString(),
+					workflow_id: "b",
+					version_id: "c",
+					status: "complete",
+				},
+			]);
+
+			await runWrangler(
+				`workflows instances list some-workflow --json --reverse`
+			);
+
+			expect(
+				JSON.parse(std.out).map((instance: Instance) => instance.id)
+			).toEqual(["older", "newer"]);
+		});
+
+		it("should output an empty array with --json when there are no instances", async ({
+			expect,
+		}) => {
+			writeWranglerConfig();
+			await mockGetInstances([]);
+
+			await runWrangler(`workflows instances list some-workflow --json`);
+
+			expect(JSON.parse(std.out)).toEqual([]);
+			expect(std.warn).toMatchInlineSnapshot(`""`);
+		});
 	});
 
 	describe("instances describe", () => {
@@ -842,6 +1020,41 @@ describe("wrangler workflows", () => {
 				└─┴─┴─┴─┴─┘"
 			`);
 		});
+
+		it("should output the raw instance as JSON with --json", async ({
+			expect,
+		}) => {
+			writeWranglerConfig();
+			await mockDescribeInstances();
+
+			await runWrangler(
+				`workflows instances describe some-workflow bar --json`
+			);
+
+			const output = JSON.parse(std.out);
+			// The API payload omits the instance id, so it is added back.
+			expect(output.id).toEqual("bar");
+			expect(output.status).toEqual("queued");
+			expect(output.start).toEqual(mockStartDate.toISOString());
+			expect(output.trigger).toEqual({ source: "unknown" });
+			expect(output.steps).toHaveLength(2);
+			expect(output).not.toHaveProperty("Duration");
+		});
+
+		it("should ignore --truncate-output-limit with --json", async ({
+			expect,
+		}) => {
+			writeWranglerConfig();
+			await mockDescribeInstances();
+
+			await runWrangler(
+				`workflows instances describe some-workflow bar --json --truncate-output-limit 1`
+			);
+
+			const output = JSON.parse(std.out);
+			expect(output.steps[0].output).toEqual({});
+			expect(std.out).not.toContain("[...output truncated]");
+		});
 	});
 
 	describe("instances send-event", () => {
@@ -918,6 +1131,20 @@ describe("wrangler workflows", () => {
 			expect(std.info).toMatchInlineSnapshot(
 				`"⏸️ The instance "bar" from some-workflow was paused successfully"`
 			);
+		});
+
+		it("should output JSON with --json", async ({ expect }) => {
+			writeWranglerConfig();
+			await mockGetInstances(mockInstances);
+			await mockChangeStatusRequest(expect, "bar");
+
+			await runWrangler(`workflows instances pause some-workflow bar --json`);
+			expect(std.info).toMatchInlineSnapshot(`""`);
+			expect(JSON.parse(std.out)).toEqual({
+				name: "some-workflow",
+				id: "bar",
+				success: true,
+			});
 		});
 	});
 
@@ -1061,6 +1288,44 @@ describe("wrangler workflows", () => {
 				"Failed to delete 1 workflow instance(s):\n  - bar: delete failed"
 			);
 			expect(std.info).toContain('"foo"');
+		});
+
+		it("should output the raw batch result as JSON with --json", async ({
+			expect,
+		}) => {
+			writeWranglerConfig();
+			mockDeleteInstances(expect, ["foo", "bar"]);
+
+			await runWrangler(
+				`workflows instances delete some-workflow foo bar --json`
+			);
+			expect(std.info).toMatchInlineSnapshot(`""`);
+			expect(JSON.parse(std.out)).toEqual({
+				deleted: [{ id: "foo" }, { id: "bar" }],
+				errors: [],
+			});
+		});
+
+		it("should emit JSON and still fail on a partial delete with --json", async ({
+			expect,
+		}) => {
+			writeWranglerConfig();
+			mockDeleteInstances(expect, ["foo", "bar"], {
+				deleted: [{ id: "foo" }],
+				errors: [{ id: "bar", code: 500, message: "delete failed" }],
+			});
+
+			// The payload carries the per-instance errors, but the command must
+			// still exit non-zero so scripts notice the partial failure.
+			await expect(
+				runWrangler(`workflows instances delete some-workflow foo bar --json`)
+			).rejects.toThrow(
+				"Failed to delete 1 workflow instance(s):\n  - bar: delete failed"
+			);
+			expect(JSON.parse(std.out)).toEqual({
+				deleted: [{ id: "foo" }],
+				errors: [{ id: "bar", code: 500, message: "delete failed" }],
+			});
 		});
 
 		it("should read instance IDs from a JSON file", async ({ expect }) => {
@@ -1216,6 +1481,26 @@ describe("wrangler workflows", () => {
 			);
 		});
 
+		it("should output the raw job status as JSON with --json", async ({
+			expect,
+		}) => {
+			writeWranglerConfig();
+			await mockInstancesTerminateAll(
+				expect,
+				"some-workflow",
+				"already_running"
+			);
+
+			await runWrangler(
+				`workflows instances terminate-all some-workflow --json`
+			);
+			expect(std.info).toMatchInlineSnapshot(`""`);
+			expect(JSON.parse(std.out)).toEqual({
+				name: "some-workflow",
+				status: "already_running",
+			});
+		});
+
 		it("should be able to terminate - job exists", async ({ expect }) => {
 			writeWranglerConfig();
 			await mockInstancesTerminateAll(expect, "some-workflow", "ok");
@@ -1311,6 +1596,23 @@ describe("wrangler workflows", () => {
 				`"🚀 Workflow instance "3c70754a-8435-4498-92ad-22e2e2c90853" has been queued successfully"`
 			);
 		});
+
+		it("should output the raw created instance as JSON with --json", async ({
+			expect,
+		}) => {
+			writeWranglerConfig();
+			await mockTriggerWorkflow();
+
+			await runWrangler(`workflows trigger some-workflow --json`);
+
+			expect(std.info).toMatchInlineSnapshot(`""`);
+			expect(JSON.parse(std.out)).toEqual({
+				id: "3c70754a-8435-4498-92ad-22e2e2c90853",
+				status: "queued",
+				version_id: "9e94c502-ca41-4342-a7f7-af96b444512c",
+				workflow_id: "03e70e31-d7a4-4401-a629-6a4b6096cdfe",
+			});
+		});
 	});
 
 	describe("delete", () => {
@@ -1329,6 +1631,18 @@ describe("wrangler workflows", () => {
 				 Note that running instances might take a few minutes to be properly terminated."
 			`
 			);
+		});
+
+		it("should output JSON with --json", async ({ expect }) => {
+			writeWranglerConfig();
+
+			await mockDeleteWorkflowRequest(expect, "some-workflow");
+
+			await runWrangler(`workflows delete some-workflow --json`);
+			expect(JSON.parse(std.out)).toEqual({
+				name: "some-workflow",
+				success: true,
+			});
 		});
 	});
 
@@ -2014,6 +2328,40 @@ describe("wrangler workflows", () => {
 				);
 			});
 
+			it("should output a deployed-compatible subset as JSON with --json", async ({
+				expect,
+			}) => {
+				writeWranglerConfig();
+
+				msw.use(
+					http.get(`${LOCAL_BASE}/workflows`, () => {
+						return HttpResponse.json({
+							success: true,
+							errors: [],
+							messages: [],
+							result: [
+								{
+									name: "my-workflow",
+									class_name: "MyWorkflow",
+									script_name: "my-worker",
+								},
+							],
+							result_info: { count: 1 },
+						});
+					})
+				);
+
+				await runWrangler("workflows list --local --json");
+
+				expect(JSON.parse(std.out)).toEqual([
+					{
+						name: "my-workflow",
+						class_name: "MyWorkflow",
+						script_name: "my-worker",
+					},
+				]);
+			});
+
 			it("should warn when no local workflows exist", async ({ expect }) => {
 				writeWranglerConfig();
 
@@ -2072,6 +2420,37 @@ describe("wrangler workflows", () => {
 				// logRaw writes to process.stdout directly, not captured by std.out
 				// Verify the command completes successfully without error
 				expect(std.err).toBe("");
+			});
+
+			it("should output a deployed-compatible subset as JSON with --json", async ({
+				expect,
+			}) => {
+				writeWranglerConfig();
+
+				msw.use(
+					http.get(`${LOCAL_BASE}/workflows/:workflowName`, () => {
+						return HttpResponse.json({
+							success: true,
+							errors: [],
+							messages: [],
+							result: {
+								name: "my-workflow",
+								class_name: "MyWorkflow",
+								script_name: "my-worker",
+								instances: { complete: 2, errored: 1 },
+							},
+						});
+					})
+				);
+
+				await runWrangler("workflows describe my-workflow --local --json");
+
+				expect(JSON.parse(std.out)).toEqual({
+					name: "my-workflow",
+					script_name: "my-worker",
+					class_name: "MyWorkflow",
+					instances: { complete: 2, errored: 1 },
+				});
 			});
 		});
 
@@ -2194,6 +2573,42 @@ describe("wrangler workflows", () => {
 				expect(std.info).toMatchInlineSnapshot(
 					`"Showing 2 instances from page 1:"`
 				);
+			});
+
+			it("should output a deployed-compatible subset as JSON with --json", async ({
+				expect,
+			}) => {
+				writeWranglerConfig();
+
+				msw.use(
+					http.get(`${LOCAL_BASE}/workflows/:workflowName/instances`, () => {
+						return HttpResponse.json({
+							success: true,
+							errors: [],
+							messages: [],
+							result: [
+								{
+									id: "instance-1",
+									status: "running",
+									created_on: mockCreateDate.toISOString(),
+								},
+							],
+							result_info: { page: 1, per_page: 25 },
+						});
+					})
+				);
+
+				await runWrangler(
+					"workflows instances list my-workflow --local --json"
+				);
+
+				expect(JSON.parse(std.out)).toEqual([
+					{
+						id: "instance-1",
+						status: "running",
+						created_on: mockCreateDate.toISOString(),
+					},
+				]);
 			});
 
 			it("should warn when no local instances exist", async ({ expect }) => {
@@ -2695,6 +3110,54 @@ describe("wrangler workflows", () => {
 					"workflows instances pause my-workflow latest --local"
 				);
 				expect(std.info).toContain("newest-instance");
+			});
+
+			it("should not emit the 'Latest instance is' notice with --json", async ({
+				expect,
+			}) => {
+				writeWranglerConfig();
+
+				msw.use(
+					http.get(`${LOCAL_BASE}/workflows/:workflowName/instances`, () => {
+						return HttpResponse.json({
+							success: true,
+							errors: [],
+							messages: [],
+							result: [
+								{
+									id: "newest-instance",
+									status: "running",
+									created_on: "2024-06-01T00:00:00Z",
+								},
+							],
+							result_info: { page: 1, per_page: 25 },
+						});
+					}),
+					http.patch(
+						`${LOCAL_BASE}/workflows/:workflowName/instances/:instanceId/status`,
+						() => {
+							return HttpResponse.json({
+								success: true,
+								errors: [],
+								messages: [],
+								result: { success: true },
+							});
+						}
+					)
+				);
+
+				await runWrangler(
+					"workflows instances pause my-workflow latest --local --json"
+				);
+
+				// The resolved id is reported through the payload rather than a
+				// human-readable notice, so stdout stays parseable.
+				expect(std.info).toMatchInlineSnapshot(`""`);
+				expect(JSON.parse(std.out)).toEqual({
+					name: "my-workflow",
+					id: "newest-instance",
+					success: true,
+				});
 			});
 		});
 	});

--- a/packages/wrangler/src/__tests__/workflows.test.ts
+++ b/packages/wrangler/src/__tests__/workflows.test.ts
@@ -50,7 +50,8 @@ describe("wrangler workflows", () => {
 	const mockChangeStatusRequest = async (
 		expect: ExpectStatic,
 		expectedInstance: string,
-		expectedBody?: Record<string, unknown>
+		expectedBody?: Record<string, unknown>,
+		result: unknown = {}
 	) => {
 		msw.use(
 			http.patch(
@@ -64,7 +65,7 @@ describe("wrangler workflows", () => {
 						success: true,
 						errors: [],
 						messages: [],
-						result: {},
+						result,
 					});
 				},
 				{ once: true }
@@ -75,7 +76,8 @@ describe("wrangler workflows", () => {
 	const mockSendEventRequest = async (
 		expect: ExpectStatic,
 		expectedInstance: string,
-		event: string
+		event: string,
+		result: unknown = {}
 	) => {
 		msw.use(
 			http.post(
@@ -87,7 +89,7 @@ describe("wrangler workflows", () => {
 						success: true,
 						errors: [],
 						messages: [],
-						result: {},
+						result,
 					});
 				},
 				{ once: true }
@@ -97,7 +99,8 @@ describe("wrangler workflows", () => {
 
 	const mockDeleteWorkflowRequest = async (
 		expect: ExpectStatic,
-		workflowName: string
+		workflowName: string,
+		result: unknown = {}
 	) => {
 		msw.use(
 			http.delete(
@@ -108,7 +111,7 @@ describe("wrangler workflows", () => {
 						success: true,
 						errors: [],
 						messages: [],
-						result: {},
+						result,
 					});
 				},
 				{ once: true }
@@ -1098,6 +1101,20 @@ describe("wrangler workflows", () => {
 				`"📤 The event with type "my-event" and payload "{"key": "value"}" was sent to the instance "bar" from some-workflow"`
 			);
 		});
+
+		it("should output the API response as JSON with --json", async ({
+			expect,
+		}) => {
+			writeWranglerConfig();
+			const response = { accepted: true, event_id: "event-123" };
+			await mockSendEventRequest(expect, "bar", "my-event", response);
+
+			await runWrangler(
+				"workflows instances send-event some-workflow bar --type my-event --json"
+			);
+
+			expect(JSON.parse(std.out)).toEqual(response);
+		});
 	});
 
 	describe("instances pause", () => {
@@ -1136,15 +1153,12 @@ describe("wrangler workflows", () => {
 		it("should output JSON with --json", async ({ expect }) => {
 			writeWranglerConfig();
 			await mockGetInstances(mockInstances);
-			await mockChangeStatusRequest(expect, "bar");
+			const response = { id: "bar", status: "paused" };
+			await mockChangeStatusRequest(expect, "bar", undefined, response);
 
 			await runWrangler(`workflows instances pause some-workflow bar --json`);
 			expect(std.info).toMatchInlineSnapshot(`""`);
-			expect(JSON.parse(std.out)).toEqual({
-				name: "some-workflow",
-				id: "bar",
-				success: true,
-			});
+			expect(JSON.parse(std.out)).toEqual(response);
 		});
 	});
 
@@ -1179,6 +1193,18 @@ describe("wrangler workflows", () => {
 			expect(std.info).toMatchInlineSnapshot(
 				`"🔄 The instance "bar" from some-workflow was resumed successfully"`
 			);
+		});
+
+		it("should output the API response as JSON with --json", async ({
+			expect,
+		}) => {
+			writeWranglerConfig();
+			const response = { id: "bar", status: "running" };
+			await mockChangeStatusRequest(expect, "bar", undefined, response);
+
+			await runWrangler(`workflows instances resume some-workflow bar --json`);
+
+			expect(JSON.parse(std.out)).toEqual(response);
 		});
 	});
 
@@ -1231,6 +1257,25 @@ describe("wrangler workflows", () => {
 			expect(std.info).toMatchInlineSnapshot(
 				`"🥷 The instance "bar" from some-workflow was terminated successfully"`
 			);
+		});
+
+		it("should output the API response as JSON with --json", async ({
+			expect,
+		}) => {
+			writeWranglerConfig();
+			const response = { id: "bar", status: "terminated" };
+			await mockChangeStatusRequest(
+				expect,
+				"bar",
+				{ status: "terminate" },
+				response
+			);
+
+			await runWrangler(
+				`workflows instances terminate some-workflow bar --json`
+			);
+
+			expect(JSON.parse(std.out)).toEqual(response);
 		});
 	});
 
@@ -1405,6 +1450,18 @@ describe("wrangler workflows", () => {
 			);
 		});
 
+		it("should output the API response as JSON with --json", async ({
+			expect,
+		}) => {
+			writeWranglerConfig();
+			const response = { id: "bar", status: "queued" };
+			await mockChangeStatusRequest(expect, "bar", undefined, response);
+
+			await runWrangler(`workflows instances restart some-workflow bar --json`);
+
+			expect(JSON.parse(std.out)).toEqual(response);
+		});
+
 		it("should restart an instance from a specific step", async ({
 			expect,
 		}) => {
@@ -1496,7 +1553,6 @@ describe("wrangler workflows", () => {
 			);
 			expect(std.info).toMatchInlineSnapshot(`""`);
 			expect(JSON.parse(std.out)).toEqual({
-				name: "some-workflow",
 				status: "already_running",
 			});
 		});
@@ -1635,14 +1691,11 @@ describe("wrangler workflows", () => {
 
 		it("should output JSON with --json", async ({ expect }) => {
 			writeWranglerConfig();
-
-			await mockDeleteWorkflowRequest(expect, "some-workflow");
+			const response = { deleted: true, workflow_id: "workflow-123" };
+			await mockDeleteWorkflowRequest(expect, "some-workflow", response);
 
 			await runWrangler(`workflows delete some-workflow --json`);
-			expect(JSON.parse(std.out)).toEqual({
-				name: "some-workflow",
-				success: true,
-			});
+			expect(JSON.parse(std.out)).toEqual(response);
 		});
 	});
 
@@ -2531,6 +2584,26 @@ describe("wrangler workflows", () => {
 					'Workflow "my-workflow" instances removed successfully from local dev session.'
 				);
 			});
+
+			it("should output the local API response as JSON", async ({ expect }) => {
+				writeWranglerConfig();
+				const response = { status: "ok", success: true };
+
+				msw.use(
+					http.delete(`${LOCAL_BASE}/workflows/:workflowName`, () => {
+						return HttpResponse.json({
+							success: true,
+							errors: [],
+							messages: [],
+							result: response,
+						});
+					})
+				);
+
+				await runWrangler("workflows delete my-workflow --local --json");
+
+				expect(JSON.parse(std.out)).toEqual(response);
+			});
 		});
 
 		describe("workflows instances list --local", () => {
@@ -3058,6 +3131,31 @@ describe("wrangler workflows", () => {
 					`"📤 The event with type "my-event" was sent to the instance "instance-123" from my-workflow"`
 				);
 			});
+
+			it("should output the local API response as JSON", async ({ expect }) => {
+				writeWranglerConfig();
+				const response = { accepted: true };
+
+				msw.use(
+					http.post(
+						`${LOCAL_BASE}/workflows/:workflowName/instances/:instanceId/events/:eventType`,
+						() => {
+							return HttpResponse.json({
+								success: true,
+								errors: [],
+								messages: [],
+								result: response,
+							});
+						}
+					)
+				);
+
+				await runWrangler(
+					"workflows instances send-event my-workflow instance-123 --type my-event --local --json"
+				);
+
+				expect(JSON.parse(std.out)).toEqual(response);
+			});
 		});
 
 		describe("latest instance resolution --local", () => {
@@ -3112,7 +3210,7 @@ describe("wrangler workflows", () => {
 				expect(std.info).toContain("newest-instance");
 			});
 
-			it("should not emit the 'Latest instance is' notice with --json", async ({
+			it("should output the local API response without a latest notice", async ({
 				expect,
 			}) => {
 				writeWranglerConfig();
@@ -3150,14 +3248,8 @@ describe("wrangler workflows", () => {
 					"workflows instances pause my-workflow latest --local --json"
 				);
 
-				// The resolved id is reported through the payload rather than a
-				// human-readable notice, so stdout stays parseable.
 				expect(std.info).toMatchInlineSnapshot(`""`);
-				expect(JSON.parse(std.out)).toEqual({
-					name: "my-workflow",
-					id: "newest-instance",
-					success: true,
-				});
+				expect(JSON.parse(std.out)).toEqual({ success: true });
 			});
 		});
 	});

--- a/packages/wrangler/src/workflows/commands/delete.ts
+++ b/packages/wrangler/src/workflows/commands/delete.ts
@@ -3,6 +3,7 @@ import { createCommand } from "../../core/create-command";
 import { logger } from "../../logger";
 import { requireAuth } from "../../user";
 import { fetchLocalResult, localWorkflowArgs } from "../local";
+import { jsonWorkflowArgs } from "../utils";
 
 export const workflowsDeleteCommand = createCommand({
 	metadata: {
@@ -13,6 +14,7 @@ export const workflowsDeleteCommand = createCommand({
 	},
 	args: {
 		...localWorkflowArgs,
+		...jsonWorkflowArgs,
 		name: {
 			describe: "Name of the workflow",
 			type: "string",
@@ -20,6 +22,9 @@ export const workflowsDeleteCommand = createCommand({
 		},
 	},
 	positionalArgs: ["name"],
+	behaviour: {
+		printBanner: (args) => !args.json,
+	},
 
 	async handler(args, { config }) {
 		if (args.local) {
@@ -28,6 +33,11 @@ export const workflowsDeleteCommand = createCommand({
 				`/workflows/${encodeURIComponent(args.name)}`,
 				{ method: "DELETE" }
 			);
+
+			if (args.json) {
+				logger.json({ name: args.name, success: true });
+				return;
+			}
 
 			logger.log(
 				`✅ Workflow "${args.name}" instances removed successfully from local dev session.`
@@ -40,6 +50,11 @@ export const workflowsDeleteCommand = createCommand({
 				`/accounts/${accountId}/workflows/${args.name}`,
 				{ method: "DELETE" }
 			);
+
+			if (args.json) {
+				logger.json({ name: args.name, success: true });
+				return;
+			}
 
 			logger.log(
 				`✅ Workflow "${args.name}" removed successfully. \n Note that running instances might take a few minutes to be properly terminated.`

--- a/packages/wrangler/src/workflows/commands/delete.ts
+++ b/packages/wrangler/src/workflows/commands/delete.ts
@@ -27,15 +27,17 @@ export const workflowsDeleteCommand = createCommand({
 	},
 
 	async handler(args, { config }) {
+		let result: unknown;
+
 		if (args.local) {
-			await fetchLocalResult(
+			result = await fetchLocalResult(
 				args.port,
 				`/workflows/${encodeURIComponent(args.name)}`,
 				{ method: "DELETE" }
 			);
 
 			if (args.json) {
-				logger.json({ name: args.name, success: true });
+				logger.json(result);
 				return;
 			}
 
@@ -45,14 +47,14 @@ export const workflowsDeleteCommand = createCommand({
 		} else {
 			const accountId = await requireAuth(config);
 
-			await fetchResult(
+			result = await fetchResult(
 				config,
 				`/accounts/${accountId}/workflows/${args.name}`,
 				{ method: "DELETE" }
 			);
 
 			if (args.json) {
-				logger.json({ name: args.name, success: true });
+				logger.json(result);
 				return;
 			}
 

--- a/packages/wrangler/src/workflows/commands/describe.ts
+++ b/packages/wrangler/src/workflows/commands/describe.ts
@@ -2,6 +2,7 @@ import { logRaw } from "@cloudflare/cli-shared-helpers";
 import { white } from "@cloudflare/cli-shared-helpers/colors";
 import { fetchResult } from "../../cfetch";
 import { createCommand } from "../../core/create-command";
+import { logger } from "../../logger";
 import { requireAuth } from "../../user";
 import formatLabelledValues from "../../utils/render-labelled-values";
 import {
@@ -9,6 +10,7 @@ import {
 	localWorkflowArgs,
 	type LocalWorkflowDetails,
 } from "../local";
+import { jsonWorkflowArgs } from "../utils";
 import type { Version, Workflow } from "../types";
 
 export const workflowsDescribeCommand = createCommand({
@@ -19,6 +21,7 @@ export const workflowsDescribeCommand = createCommand({
 	},
 	args: {
 		...localWorkflowArgs,
+		...jsonWorkflowArgs,
 		name: {
 			describe: "Name of the workflow",
 			type: "string",
@@ -26,12 +29,25 @@ export const workflowsDescribeCommand = createCommand({
 		},
 	},
 	positionalArgs: ["name"],
+	behaviour: {
+		printBanner: (args) => !args.json,
+	},
 	async handler(args, { config }) {
 		if (args.local) {
 			const workflow = await fetchLocalResult<LocalWorkflowDetails>(
 				args.port,
 				`/workflows/${encodeURIComponent(args.name)}`
 			);
+
+			if (args.json) {
+				logger.json({
+					name: workflow.name,
+					script_name: workflow.script_name,
+					class_name: workflow.class_name,
+					instances: workflow.instances,
+				});
+				return;
+			}
 
 			logRaw(
 				formatLabelledValues({
@@ -69,6 +85,11 @@ export const workflowsDescribeCommand = createCommand({
 			);
 
 			const latestVersion = versions[0];
+
+			if (args.json) {
+				logger.json({ ...workflow, latest_version: latestVersion ?? null });
+				return;
+			}
 
 			logRaw(
 				formatLabelledValues({

--- a/packages/wrangler/src/workflows/commands/instances/delete.ts
+++ b/packages/wrangler/src/workflows/commands/instances/delete.ts
@@ -8,7 +8,7 @@ import {
 	getLocalInstanceIdFromArgs,
 	localWorkflowArgs,
 } from "../../local";
-import { getInstanceIdFromArgs } from "../../utils";
+import { getInstanceIdFromArgs, jsonWorkflowArgs } from "../../utils";
 
 type WorkflowBatchDeleteResult = {
 	deleted: { id: string }[];
@@ -24,6 +24,7 @@ export const workflowsInstancesDeleteCommand = createCommand({
 	positionalArgs: ["name", "id"],
 	args: {
 		...localWorkflowArgs,
+		...jsonWorkflowArgs,
 		name: {
 			describe: "Name of the workflow",
 			type: "string",
@@ -39,6 +40,9 @@ export const workflowsInstancesDeleteCommand = createCommand({
 			describe: "Path to a JSON file containing an array of instance IDs",
 			type: "string",
 		},
+	},
+	behaviour: {
+		printBanner: (args) => !args.json,
 	},
 
 	async handler(args, { config }) {
@@ -77,10 +81,11 @@ export const workflowsInstancesDeleteCommand = createCommand({
 
 		if (args.local) {
 			if (ids.includes("latest")) {
-				const latestId = await getLocalInstanceIdFromArgs(args.port, {
-					id: "latest",
-					name: args.name,
-				});
+				const latestId = await getLocalInstanceIdFromArgs(
+					args.port,
+					{ id: "latest", name: args.name },
+					{ quiet: args.json }
+				);
 				ids = ids.map((id) => (id === "latest" ? latestId : id));
 			}
 			result = await fetchLocalResult<WorkflowBatchDeleteResult>(
@@ -113,7 +118,16 @@ export const workflowsInstancesDeleteCommand = createCommand({
 			);
 		}
 
-		if (result.deleted.length > 0) {
+		// Emitted before the error below is thrown so that a partial failure still
+		// exits non-zero while the payload describing it reaches stdout.
+		if (args.json) {
+			logger.json(result);
+			if (result.errors.length === 0) {
+				return;
+			}
+		}
+
+		if (!args.json && result.deleted.length > 0) {
 			logger.info(
 				`🗑️  Deleted workflow instances from "${args.name}": ${result.deleted.map(({ id }) => `"${id}"`).join(", ")}`
 			);

--- a/packages/wrangler/src/workflows/commands/instances/describe.ts
+++ b/packages/wrangler/src/workflows/commands/instances/describe.ts
@@ -22,6 +22,7 @@ import {
 	emojifyInstanceTriggerName,
 	emojifyStepType,
 	getInstanceIdFromArgs,
+	jsonWorkflowArgs,
 } from "../../utils";
 import type {
 	InstanceSleepLog,
@@ -41,6 +42,7 @@ export const workflowsInstancesDescribeCommand = createCommand({
 	positionalArgs: ["name", "id"],
 	args: {
 		...localWorkflowArgs,
+		...jsonWorkflowArgs,
 		name: {
 			describe: "Name of the workflow",
 			type: "string",
@@ -65,13 +67,18 @@ export const workflowsInstancesDescribeCommand = createCommand({
 			default: 5000,
 		},
 	},
+	behaviour: {
+		printBanner: (args) => !args.json,
+	},
 
 	async handler(args, { config }) {
 		let id: string;
 		let instance: InstanceStatusAndLogs;
 
 		if (args.local) {
-			id = await getLocalInstanceIdFromArgs(args.port, args);
+			id = await getLocalInstanceIdFromArgs(args.port, args, {
+				quiet: args.json,
+			});
 			instance = await fetchLocalResult<InstanceStatusAndLogs>(
 				args.port,
 				`/workflows/${encodeURIComponent(args.name)}/instances/${encodeURIComponent(id)}`
@@ -83,6 +90,15 @@ export const workflowsInstancesDescribeCommand = createCommand({
 				config,
 				`/accounts/${accountId}/workflows/${args.name}/instances/${id}`
 			);
+		}
+
+		if (args.json) {
+			// The API payload omits `id`, leaving `--id latest` callers no way to
+			// learn which instance was resolved. `--step-output` and
+			// `--truncate-output-limit` are ignored here because truncating would
+			// hand invalid step output to a machine-readable consumer.
+			logger.json({ id, ...instance });
+			return;
 		}
 
 		renderInstanceDetails(args, id, instance);

--- a/packages/wrangler/src/workflows/commands/instances/list.ts
+++ b/packages/wrangler/src/workflows/commands/instances/list.ts
@@ -7,6 +7,7 @@ import { fetchLocalResult, localWorkflowArgs } from "../../local";
 import {
 	emojifyInstanceStatus,
 	validateInstanceDate,
+	jsonWorkflowArgs,
 	validateStatus,
 } from "../../utils";
 import type { Instance } from "../../types";
@@ -52,6 +53,7 @@ export const workflowsInstancesListCommand = createCommand({
 	positionalArgs: ["name"],
 	args: {
 		...localWorkflowArgs,
+		...jsonWorkflowArgs,
 		name: {
 			describe: "Name of the workflow",
 			type: "string",
@@ -89,6 +91,9 @@ export const workflowsInstancesListCommand = createCommand({
 			describe: "Configure the maximum number of instances to show per page",
 			type: "number",
 		},
+	},
+	behaviour: {
+		printBanner: (args) => !args.json,
 	},
 
 	async handler(args, { config }) {
@@ -130,6 +135,17 @@ export const workflowsInstancesListCommand = createCommand({
 				Array<{ id: string; status?: string; created_on?: string }>
 			>(args.port, path);
 
+			const sortedInstances = instances.sort((a, b) =>
+				args.reverse
+					? (a.created_on ?? "").localeCompare(b.created_on ?? "")
+					: (b.created_on ?? "").localeCompare(a.created_on ?? "")
+			);
+
+			if (args.json) {
+				logger.json(sortedInstances);
+				return;
+			}
+
 			if (instances.length === 0 && args.page === 1) {
 				logger.warn(
 					hasFilters
@@ -148,12 +164,6 @@ export const workflowsInstancesListCommand = createCommand({
 
 			logger.info(
 				`Showing ${instances.length} instance${instances.length > 1 ? "s" : ""} from page ${args.page}:`
-			);
-
-			const sortedInstances = instances.sort((a, b) =>
-				args.reverse
-					? (a.created_on ?? "").localeCompare(b.created_on ?? "")
-					: (b.created_on ?? "").localeCompare(a.created_on ?? "")
 			);
 
 			const prettierInstances = sortedInstances.map((instance) => ({
@@ -200,6 +210,17 @@ export const workflowsInstancesListCommand = createCommand({
 				URLParams
 			);
 
+			const sortedInstances = instances.sort((a, b) =>
+				args.reverse
+					? a.created_on.localeCompare(b.created_on)
+					: b.created_on.localeCompare(a.created_on)
+			);
+
+			if (args.json) {
+				logger.json(sortedInstances);
+				return;
+			}
+
 			if (instances.length === 0 && args.page === 1) {
 				logger.warn(
 					hasFilters
@@ -220,19 +241,13 @@ export const workflowsInstancesListCommand = createCommand({
 				`Showing ${instances.length} instance${instances.length > 1 ? "s" : ""} from page ${args.page}:`
 			);
 
-			const prettierInstances = instances
-				.sort((a, b) =>
-					args.reverse
-						? a.created_on.localeCompare(b.created_on)
-						: b.created_on.localeCompare(a.created_on)
-				)
-				.map((instance) => ({
-					"Instance ID": instance.id,
-					Version: instance.version_id,
-					Created: new Date(instance.created_on).toLocaleString(),
-					Modified: new Date(instance.modified_on).toLocaleString(),
-					Status: emojifyInstanceStatus(instance.status),
-				}));
+			const prettierInstances = sortedInstances.map((instance) => ({
+				"Instance ID": instance.id,
+				Version: instance.version_id,
+				Created: new Date(instance.created_on).toLocaleString(),
+				Modified: new Date(instance.modified_on).toLocaleString(),
+				Status: emojifyInstanceStatus(instance.status),
+			}));
 
 			logger.table(prettierInstances);
 		}

--- a/packages/wrangler/src/workflows/commands/instances/pause.ts
+++ b/packages/wrangler/src/workflows/commands/instances/pause.ts
@@ -6,7 +6,11 @@ import {
 	localWorkflowArgs,
 	updateLocalInstanceStatus,
 } from "../../local";
-import { getInstanceIdFromArgs, updateInstanceStatus } from "../../utils";
+import {
+	getInstanceIdFromArgs,
+	jsonWorkflowArgs,
+	updateInstanceStatus,
+} from "../../utils";
 
 export const workflowsInstancesPauseCommand = createCommand({
 	metadata: {
@@ -17,6 +21,7 @@ export const workflowsInstancesPauseCommand = createCommand({
 	positionalArgs: ["name", "id"],
 	args: {
 		...localWorkflowArgs,
+		...jsonWorkflowArgs,
 		name: {
 			describe: "Name of the workflow",
 			type: "string",
@@ -30,16 +35,27 @@ export const workflowsInstancesPauseCommand = createCommand({
 		},
 	},
 
+	behaviour: {
+		printBanner: (args) => !args.json,
+	},
+
 	async handler(args, { config }) {
 		let id: string;
 
 		if (args.local) {
-			id = await getLocalInstanceIdFromArgs(args.port, args);
+			id = await getLocalInstanceIdFromArgs(args.port, args, {
+				quiet: args.json,
+			});
 			await updateLocalInstanceStatus(args.port, args.name, id, "pause");
 		} else {
 			const accountId = await requireAuth(config);
 			id = await getInstanceIdFromArgs(accountId, args, config);
 			await updateInstanceStatus(config, accountId, args.name, id, "pause");
+		}
+
+		if (args.json) {
+			logger.json({ name: args.name, id, success: true });
+			return;
 		}
 
 		logger.info(

--- a/packages/wrangler/src/workflows/commands/instances/pause.ts
+++ b/packages/wrangler/src/workflows/commands/instances/pause.ts
@@ -41,20 +41,32 @@ export const workflowsInstancesPauseCommand = createCommand({
 
 	async handler(args, { config }) {
 		let id: string;
+		let result: unknown;
 
 		if (args.local) {
 			id = await getLocalInstanceIdFromArgs(args.port, args, {
 				quiet: args.json,
 			});
-			await updateLocalInstanceStatus(args.port, args.name, id, "pause");
+			result = await updateLocalInstanceStatus(
+				args.port,
+				args.name,
+				id,
+				"pause"
+			);
 		} else {
 			const accountId = await requireAuth(config);
 			id = await getInstanceIdFromArgs(accountId, args, config);
-			await updateInstanceStatus(config, accountId, args.name, id, "pause");
+			result = await updateInstanceStatus(
+				config,
+				accountId,
+				args.name,
+				id,
+				"pause"
+			);
 		}
 
 		if (args.json) {
-			logger.json({ name: args.name, id, success: true });
+			logger.json(result);
 			return;
 		}
 

--- a/packages/wrangler/src/workflows/commands/instances/restart.ts
+++ b/packages/wrangler/src/workflows/commands/instances/restart.ts
@@ -7,7 +7,11 @@ import {
 	localWorkflowArgs,
 	updateLocalInstanceStatus,
 } from "../../local";
-import { getInstanceIdFromArgs, updateInstanceStatus } from "../../utils";
+import {
+	getInstanceIdFromArgs,
+	jsonWorkflowArgs,
+	updateInstanceStatus,
+} from "../../utils";
 import type { WorkflowInstanceRestartFrom } from "../../types";
 
 function getRestartFrom(args: {
@@ -54,6 +58,7 @@ export const workflowsInstancesRestartCommand = createCommand({
 	positionalArgs: ["name", "id"],
 	args: {
 		...localWorkflowArgs,
+		...jsonWorkflowArgs,
 		name: {
 			describe: "Name of the workflow",
 			type: "string",
@@ -85,12 +90,18 @@ export const workflowsInstancesRestartCommand = createCommand({
 		},
 	},
 
+	behaviour: {
+		printBanner: (args) => !args.json,
+	},
+
 	async handler(args, { config }) {
 		let id: string;
 		const from = getRestartFrom(args);
 
 		if (args.local) {
-			id = await getLocalInstanceIdFromArgs(args.port, args);
+			id = await getLocalInstanceIdFromArgs(args.port, args, {
+				quiet: args.json,
+			});
 			await updateLocalInstanceStatus(
 				args.port,
 				args.name,
@@ -109,6 +120,11 @@ export const workflowsInstancesRestartCommand = createCommand({
 				"restart",
 				from
 			);
+		}
+
+		if (args.json) {
+			logger.json({ name: args.name, id, success: true });
+			return;
 		}
 
 		logger.info(

--- a/packages/wrangler/src/workflows/commands/instances/restart.ts
+++ b/packages/wrangler/src/workflows/commands/instances/restart.ts
@@ -96,13 +96,14 @@ export const workflowsInstancesRestartCommand = createCommand({
 
 	async handler(args, { config }) {
 		let id: string;
+		let result: unknown;
 		const from = getRestartFrom(args);
 
 		if (args.local) {
 			id = await getLocalInstanceIdFromArgs(args.port, args, {
 				quiet: args.json,
 			});
-			await updateLocalInstanceStatus(
+			result = await updateLocalInstanceStatus(
 				args.port,
 				args.name,
 				id,
@@ -112,7 +113,7 @@ export const workflowsInstancesRestartCommand = createCommand({
 		} else {
 			const accountId = await requireAuth(config);
 			id = await getInstanceIdFromArgs(accountId, args, config);
-			await updateInstanceStatus(
+			result = await updateInstanceStatus(
 				config,
 				accountId,
 				args.name,
@@ -123,7 +124,7 @@ export const workflowsInstancesRestartCommand = createCommand({
 		}
 
 		if (args.json) {
-			logger.json({ name: args.name, id, success: true });
+			logger.json(result);
 			return;
 		}
 

--- a/packages/wrangler/src/workflows/commands/instances/resume.ts
+++ b/packages/wrangler/src/workflows/commands/instances/resume.ts
@@ -6,7 +6,11 @@ import {
 	localWorkflowArgs,
 	updateLocalInstanceStatus,
 } from "../../local";
-import { getInstanceIdFromArgs, updateInstanceStatus } from "../../utils";
+import {
+	getInstanceIdFromArgs,
+	jsonWorkflowArgs,
+	updateInstanceStatus,
+} from "../../utils";
 
 export const workflowsInstancesResumeCommand = createCommand({
 	metadata: {
@@ -17,6 +21,7 @@ export const workflowsInstancesResumeCommand = createCommand({
 	positionalArgs: ["name", "id"],
 	args: {
 		...localWorkflowArgs,
+		...jsonWorkflowArgs,
 		name: {
 			describe: "Name of the workflow",
 			type: "string",
@@ -30,16 +35,27 @@ export const workflowsInstancesResumeCommand = createCommand({
 		},
 	},
 
+	behaviour: {
+		printBanner: (args) => !args.json,
+	},
+
 	async handler(args, { config }) {
 		let id: string;
 
 		if (args.local) {
-			id = await getLocalInstanceIdFromArgs(args.port, args);
+			id = await getLocalInstanceIdFromArgs(args.port, args, {
+				quiet: args.json,
+			});
 			await updateLocalInstanceStatus(args.port, args.name, id, "resume");
 		} else {
 			const accountId = await requireAuth(config);
 			id = await getInstanceIdFromArgs(accountId, args, config);
 			await updateInstanceStatus(config, accountId, args.name, id, "resume");
+		}
+
+		if (args.json) {
+			logger.json({ name: args.name, id, success: true });
+			return;
 		}
 
 		logger.info(

--- a/packages/wrangler/src/workflows/commands/instances/resume.ts
+++ b/packages/wrangler/src/workflows/commands/instances/resume.ts
@@ -41,20 +41,32 @@ export const workflowsInstancesResumeCommand = createCommand({
 
 	async handler(args, { config }) {
 		let id: string;
+		let result: unknown;
 
 		if (args.local) {
 			id = await getLocalInstanceIdFromArgs(args.port, args, {
 				quiet: args.json,
 			});
-			await updateLocalInstanceStatus(args.port, args.name, id, "resume");
+			result = await updateLocalInstanceStatus(
+				args.port,
+				args.name,
+				id,
+				"resume"
+			);
 		} else {
 			const accountId = await requireAuth(config);
 			id = await getInstanceIdFromArgs(accountId, args, config);
-			await updateInstanceStatus(config, accountId, args.name, id, "resume");
+			result = await updateInstanceStatus(
+				config,
+				accountId,
+				args.name,
+				id,
+				"resume"
+			);
 		}
 
 		if (args.json) {
-			logger.json({ name: args.name, id, success: true });
+			logger.json(result);
 			return;
 		}
 

--- a/packages/wrangler/src/workflows/commands/instances/send-event.ts
+++ b/packages/wrangler/src/workflows/commands/instances/send-event.ts
@@ -8,7 +8,7 @@ import {
 	getLocalInstanceIdFromArgs,
 	localWorkflowArgs,
 } from "../../local";
-import { getInstanceIdFromArgs } from "../../utils";
+import { getInstanceIdFromArgs, jsonWorkflowArgs } from "../../utils";
 
 export const workflowsInstancesSendEventCommand = createCommand({
 	metadata: {
@@ -19,6 +19,7 @@ export const workflowsInstancesSendEventCommand = createCommand({
 	positionalArgs: ["name", "id"],
 	args: {
 		...localWorkflowArgs,
+		...jsonWorkflowArgs,
 		name: {
 			describe: "Name of the workflow",
 			type: "string",
@@ -43,6 +44,9 @@ export const workflowsInstancesSendEventCommand = createCommand({
 			default: "{}",
 		},
 	},
+	behaviour: {
+		printBanner: (args) => !args.json,
+	},
 
 	async handler(args, { config }) {
 		let payload;
@@ -58,7 +62,9 @@ export const workflowsInstancesSendEventCommand = createCommand({
 		let id: string;
 
 		if (args.local) {
-			id = await getLocalInstanceIdFromArgs(args.port, args);
+			id = await getLocalInstanceIdFromArgs(args.port, args, {
+				quiet: args.json,
+			});
 
 			await fetchLocalResult(
 				args.port,
@@ -83,6 +89,11 @@ export const workflowsInstancesSendEventCommand = createCommand({
 					body: args.payload,
 				}
 			);
+		}
+
+		if (args.json) {
+			logger.json({ name: args.name, id, type: args.type, success: true });
+			return;
 		}
 
 		const payloadInfo =

--- a/packages/wrangler/src/workflows/commands/instances/send-event.ts
+++ b/packages/wrangler/src/workflows/commands/instances/send-event.ts
@@ -60,13 +60,14 @@ export const workflowsInstancesSendEventCommand = createCommand({
 		}
 
 		let id: string;
+		let result: unknown;
 
 		if (args.local) {
 			id = await getLocalInstanceIdFromArgs(args.port, args, {
 				quiet: args.json,
 			});
 
-			await fetchLocalResult(
+			result = await fetchLocalResult(
 				args.port,
 				`/workflows/${encodeURIComponent(args.name)}/instances/${encodeURIComponent(id)}/events/${encodeURIComponent(args.type)}`,
 				{
@@ -80,7 +81,7 @@ export const workflowsInstancesSendEventCommand = createCommand({
 
 			id = await getInstanceIdFromArgs(accountId, args, config);
 
-			await fetchResult(
+			result = await fetchResult(
 				config,
 				`/accounts/${accountId}/workflows/${args.name}/instances/${id}/events/${args.type}`,
 				{
@@ -92,7 +93,7 @@ export const workflowsInstancesSendEventCommand = createCommand({
 		}
 
 		if (args.json) {
-			logger.json({ name: args.name, id, type: args.type, success: true });
+			logger.json(result);
 			return;
 		}
 

--- a/packages/wrangler/src/workflows/commands/instances/terminate-all.ts
+++ b/packages/wrangler/src/workflows/commands/instances/terminate-all.ts
@@ -3,6 +3,7 @@ import { fetchResult } from "../../../cfetch";
 import { createCommand } from "../../../core/create-command";
 import { logger } from "../../../logger";
 import { requireAuth } from "../../../user";
+import { jsonWorkflowArgs } from "../../utils";
 
 export const workflowsInstancesTerminateAllCommand = createCommand({
 	metadata: {
@@ -15,6 +16,7 @@ export const workflowsInstancesTerminateAllCommand = createCommand({
 	positionalArgs: ["name"],
 
 	args: {
+		...jsonWorkflowArgs,
 		name: {
 			describe: "Name of the workflow",
 			type: "string",
@@ -24,6 +26,9 @@ export const workflowsInstancesTerminateAllCommand = createCommand({
 			describe: "Filter instances to be terminated by status",
 			type: "string",
 		},
+	},
+	behaviour: {
+		printBanner: (args) => !args.json,
 	},
 	validateArgs: (args) => {
 		const validStatusToTerminate = [
@@ -61,6 +66,11 @@ export const workflowsInstancesTerminateAllCommand = createCommand({
 			},
 			maybeURLQueryString
 		);
+
+		if (args.json) {
+			logger.json({ name: args.name, status: result.status });
+			return;
+		}
 
 		if (result.status === "ok") {
 			logger.info(

--- a/packages/wrangler/src/workflows/commands/instances/terminate-all.ts
+++ b/packages/wrangler/src/workflows/commands/instances/terminate-all.ts
@@ -68,7 +68,7 @@ export const workflowsInstancesTerminateAllCommand = createCommand({
 		);
 
 		if (args.json) {
-			logger.json({ name: args.name, status: result.status });
+			logger.json(result);
 			return;
 		}
 

--- a/packages/wrangler/src/workflows/commands/instances/terminate.ts
+++ b/packages/wrangler/src/workflows/commands/instances/terminate.ts
@@ -6,7 +6,11 @@ import {
 	localWorkflowArgs,
 	updateLocalInstanceStatus,
 } from "../../local";
-import { getInstanceIdFromArgs, updateInstanceStatus } from "../../utils";
+import {
+	getInstanceIdFromArgs,
+	jsonWorkflowArgs,
+	updateInstanceStatus,
+} from "../../utils";
 
 export const workflowsInstancesTerminateCommand = createCommand({
 	metadata: {
@@ -17,6 +21,7 @@ export const workflowsInstancesTerminateCommand = createCommand({
 	positionalArgs: ["name", "id"],
 	args: {
 		...localWorkflowArgs,
+		...jsonWorkflowArgs,
 		name: {
 			describe: "Name of the workflow",
 			type: "string",
@@ -35,11 +40,17 @@ export const workflowsInstancesTerminateCommand = createCommand({
 		},
 	},
 
+	behaviour: {
+		printBanner: (args) => !args.json,
+	},
+
 	async handler(args, { config }) {
 		let id: string;
 
 		if (args.local) {
-			id = await getLocalInstanceIdFromArgs(args.port, args);
+			id = await getLocalInstanceIdFromArgs(args.port, args, {
+				quiet: args.json,
+			});
 			await updateLocalInstanceStatus(
 				args.port,
 				args.name,
@@ -60,6 +71,11 @@ export const workflowsInstancesTerminateCommand = createCommand({
 				undefined,
 				args.rollback
 			);
+		}
+
+		if (args.json) {
+			logger.json({ name: args.name, id, success: true });
+			return;
 		}
 
 		logger.info(

--- a/packages/wrangler/src/workflows/commands/instances/terminate.ts
+++ b/packages/wrangler/src/workflows/commands/instances/terminate.ts
@@ -46,12 +46,13 @@ export const workflowsInstancesTerminateCommand = createCommand({
 
 	async handler(args, { config }) {
 		let id: string;
+		let result: unknown;
 
 		if (args.local) {
 			id = await getLocalInstanceIdFromArgs(args.port, args, {
 				quiet: args.json,
 			});
-			await updateLocalInstanceStatus(
+			result = await updateLocalInstanceStatus(
 				args.port,
 				args.name,
 				id,
@@ -62,7 +63,7 @@ export const workflowsInstancesTerminateCommand = createCommand({
 		} else {
 			const accountId = await requireAuth(config);
 			id = await getInstanceIdFromArgs(accountId, args, config);
-			await updateInstanceStatus(
+			result = await updateInstanceStatus(
 				config,
 				accountId,
 				args.name,
@@ -74,7 +75,7 @@ export const workflowsInstancesTerminateCommand = createCommand({
 		}
 
 		if (args.json) {
-			logger.json({ name: args.name, id, success: true });
+			logger.json(result);
 			return;
 		}
 

--- a/packages/wrangler/src/workflows/commands/list.ts
+++ b/packages/wrangler/src/workflows/commands/list.ts
@@ -7,6 +7,7 @@ import {
 	localWorkflowArgs,
 	type LocalWorkflow,
 } from "../local";
+import { jsonWorkflowArgs } from "../utils";
 import type { Workflow } from "../types";
 
 export const workflowsListCommand = createCommand({
@@ -17,6 +18,7 @@ export const workflowsListCommand = createCommand({
 	},
 	args: {
 		...localWorkflowArgs,
+		...jsonWorkflowArgs,
 		page: {
 			describe:
 				'Show a sepecific page from the listing, can configure page size using "per-page"',
@@ -28,12 +30,20 @@ export const workflowsListCommand = createCommand({
 			type: "number",
 		},
 	},
+	behaviour: {
+		printBanner: (args) => !args.json,
+	},
 	async handler(args, { config }) {
 		if (args.local) {
 			const workflows = await fetchLocalResult<LocalWorkflow[]>(
 				args.port,
 				"/workflows"
 			);
+
+			if (args.json) {
+				logger.json(workflows);
+				return;
+			}
 
 			if (workflows.length === 0) {
 				logger.warn("There are no Workflows in the local dev session");
@@ -68,6 +78,15 @@ export const workflowsListCommand = createCommand({
 				URLParams
 			);
 
+			const sortedWorkflows = workflows.sort((a, b) =>
+				b.created_on.localeCompare(a.created_on)
+			);
+
+			if (args.json) {
+				logger.json(sortedWorkflows);
+				return;
+			}
+
 			if (workflows.length === 0 && args.page === 1) {
 				logger.warn("There are no deployed Workflows in this account");
 				return;
@@ -84,15 +103,13 @@ export const workflowsListCommand = createCommand({
 				`Showing ${workflows.length} workflow${workflows.length > 1 ? "s" : ""} from page ${args.page}:`
 			);
 
-			const prettierWorkflows = workflows
-				.sort((a, b) => b.created_on.localeCompare(a.created_on))
-				.map((workflow) => ({
-					Name: workflow.name,
-					"Script name": workflow.script_name,
-					"Class name": workflow.class_name,
-					Created: new Date(workflow.created_on).toLocaleString(),
-					Modified: new Date(workflow.modified_on).toLocaleString(),
-				}));
+			const prettierWorkflows = sortedWorkflows.map((workflow) => ({
+				Name: workflow.name,
+				"Script name": workflow.script_name,
+				"Class name": workflow.class_name,
+				Created: new Date(workflow.created_on).toLocaleString(),
+				Modified: new Date(workflow.modified_on).toLocaleString(),
+			}));
 			logger.table(prettierWorkflows);
 		}
 	},

--- a/packages/wrangler/src/workflows/commands/trigger.ts
+++ b/packages/wrangler/src/workflows/commands/trigger.ts
@@ -3,6 +3,7 @@ import { fetchResult } from "../../cfetch";
 import { createCommand } from "../../core/create-command";
 import { requireAuth } from "../../user";
 import { fetchLocalResult, localWorkflowArgs } from "../local";
+import { jsonWorkflowArgs } from "../utils";
 import type { InstanceWithoutDates } from "../types";
 
 export const workflowsTriggerCommand = createCommand({
@@ -14,6 +15,7 @@ export const workflowsTriggerCommand = createCommand({
 	},
 	args: {
 		...localWorkflowArgs,
+		...jsonWorkflowArgs,
 		name: {
 			describe: "Name of the workflow",
 			type: "string",
@@ -32,6 +34,9 @@ export const workflowsTriggerCommand = createCommand({
 		},
 	},
 	positionalArgs: ["name", "params"],
+	behaviour: {
+		printBanner: (args) => !args.json,
+	},
 
 	async handler(args, { config, logger }) {
 		if (args.params.length != 0) {
@@ -65,6 +70,11 @@ export const workflowsTriggerCommand = createCommand({
 			);
 			instanceId = response.id;
 
+			if (args.json) {
+				logger.json(response);
+				return;
+			}
+
 			logger.info(
 				`🚀 Workflow instance "${instanceId}" has been triggered successfully`
 			);
@@ -84,6 +94,11 @@ export const workflowsTriggerCommand = createCommand({
 				}
 			);
 			instanceId = response.id;
+
+			if (args.json) {
+				logger.json(response);
+				return;
+			}
 
 			logger.info(
 				`🚀 Workflow instance "${instanceId}" has been queued successfully`

--- a/packages/wrangler/src/workflows/local.ts
+++ b/packages/wrangler/src/workflows/local.ts
@@ -104,10 +104,15 @@ export async function fetchLocalResult<T>(
 /**
  * List all workflow instances locally and resolve "latest" to an actual ID.
  * Mirrors `getInstanceIdFromArgs` but uses the local explorer API.
+ *
+ * @param options.quiet Suppress the informational "Latest instance is ..."
+ * message. Callers rendering JSON must set this so that the resolved id is not
+ * written to stdout ahead of the payload.
  */
 export async function getLocalInstanceIdFromArgs(
 	port: number,
-	args: { id: string; name: string }
+	args: { id: string; name: string },
+	options: { quiet?: boolean } = {}
 ): Promise<string> {
 	let id = args.id;
 
@@ -128,7 +133,9 @@ export async function getLocalInstanceIdFromArgs(
 		);
 
 		id = sorted[0].id;
-		logger.info(`Latest instance is "${id}"`);
+		if (!options.quiet) {
+			logger.info(`Latest instance is "${id}"`);
+		}
 	}
 
 	return id;

--- a/packages/wrangler/src/workflows/local.ts
+++ b/packages/wrangler/src/workflows/local.ts
@@ -152,14 +152,14 @@ export async function updateLocalInstanceStatus(
 	action: "pause" | "resume" | "restart" | "terminate",
 	from?: WorkflowInstanceRestartFrom,
 	rollback?: boolean
-): Promise<void> {
+): Promise<{ success: boolean }> {
 	const body = {
 		action,
 		...(from ? { from } : {}),
 		...(action === "terminate" && rollback === true ? { rollback: true } : {}),
 	};
 
-	await fetchLocalResult<{ success: boolean }>(
+	return fetchLocalResult<{ success: boolean }>(
 		port,
 		`/workflows/${encodeURIComponent(workflowName)}/instances/${encodeURIComponent(instanceId)}/status`,
 		{

--- a/packages/wrangler/src/workflows/utils.ts
+++ b/packages/wrangler/src/workflows/utils.ts
@@ -8,6 +8,25 @@ import type {
 } from "./types";
 import type { Config } from "@cloudflare/workers-utils";
 
+/**
+ * Shared `--json` CLI arg for Workflows commands.
+ *
+ * Workflows commands render human-readable output by default. Passing `--json`
+ * opts in to machine-readable output carrying the raw API payload: ISO
+ * timestamps rather than locale-formatted dates, plain status strings rather
+ * than emojified labels, and no derived presentation-only fields.
+ *
+ * Under `--local` the payload keeps the deployed key names but omits the fields
+ * a local dev session does not track, such as ids, timestamps and versions.
+ */
+export const jsonWorkflowArgs = {
+	json: {
+		describe: "Output the raw API response as JSON",
+		type: "boolean" as const,
+		default: false,
+	},
+};
+
 export const emojifyInstanceStatus = (status: InstanceStatus) => {
 	switch (status) {
 		case "complete":

--- a/packages/wrangler/src/workflows/utils.ts
+++ b/packages/wrangler/src/workflows/utils.ts
@@ -214,14 +214,14 @@ export async function updateInstanceStatus(
 	status: "pause" | "resume" | "restart" | "terminate",
 	from?: WorkflowInstanceRestartFrom,
 	rollback?: boolean
-): Promise<void> {
+): Promise<unknown> {
 	const body = {
 		status,
 		...(from ? { from } : {}),
 		...(status === "terminate" && rollback === true ? { rollback: true } : {}),
 	};
 
-	await fetchResult(
+	return fetchResult<unknown>(
 		config,
 		`/accounts/${accountId}/workflows/${workflowName}/instances/${instanceId}/status`,
 		{


### PR DESCRIPTION
Fixes WOR-108.

All `wrangler workflows` commands now accept `--json`, which emits the raw API payload instead of the formatted output. The human-readable rendering remains the default.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: It's automatic

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- If you are an AI agent or LLM, and you are adding this PR without direct human supervision, thank you! Please uncomment the following block. This is so the maintainers know how to expect you to respond.

> [!NOTE]
> This is a contribution from an AI agent: <insert name here>, <insert LLM model here if different>.

-->

<!-- devin-review-badge-begin -->

---

<a href="https://cloudflare.devinenterprise.com/review/cloudflare/workers-sdk/pull/15358" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->