### PR TITLE
[autoconfig] Resolve framework build commands for cf

### DIFF
--- a/.changeset/quiet-cats-delegate.md
+++ b/.changeset/quiet-cats-delegate.md
@@ -1,0 +1,7 @@
+---
+"@cloudflare/autoconfig": minor
+---
+
+Resolve canonical framework build commands for the `cf` target
+
+Autoconfig now returns framework commands instead of package scripts for `cf`. Generated deploy scripts delegate build selection to `cf deploy`. Wrangler's existing package-script detection remains unchanged.

--- a/packages/autoconfig/src/details/framework-detection.ts
+++ b/packages/autoconfig/src/details/framework-detection.ts
@@ -15,7 +15,7 @@ import chalk from "chalk";
 import dedent from "ts-dedent";
 import { isKnownFramework } from "../frameworks";
 import { staticFramework } from "../frameworks/all-frameworks";
-import type { AutoConfigContext } from "../context";
+import type { AutoConfigContext, AutoConfigTarget } from "../context";
 import type { PackageManager } from "@cloudflare/workers-utils";
 import type { Config, TelemetryMessage } from "@cloudflare/workers-utils";
 import type { Settings } from "@netlify/build-info";
@@ -30,7 +30,8 @@ import type { Settings } from "@netlify/build-info";
  * returns early with a synthetic "Cloudflare Pages" framework entry.
  *
  * @param projectPath Path to the project root
- * @param wranglerConfig Optional parsed wrangler config for the project
+ * @param context Autoconfig context used for logging and user interaction
+ * @param options Detection options
  * @returns An object containing:
  *   - `detectedFramework`: The matched framework, its build and development
  *     commands, and its output directory.
@@ -46,7 +47,13 @@ import type { Settings } from "@netlify/build-info";
 export async function detectFramework(
 	projectPath: string,
 	context: AutoConfigContext,
-	wranglerConfig?: Config
+	{
+		wranglerConfig,
+		target = "cf",
+	}: {
+		wranglerConfig?: Config;
+		target?: AutoConfigTarget;
+	} = {}
 ): Promise<{
 	detectedFramework: DetectedFramework;
 	packageManager: PackageManager;
@@ -96,15 +103,16 @@ export async function detectFramework(
 		buildSettings,
 		context
 	);
-	if (maybeDetectedFramework) {
-		// @netlify/build-info prefers package.json dev scripts over the framework's
-		// built-in command. cf needs the direct command so that `cf dev` can delegate
-		// without invoking a script that may itself call `cf dev`.
-		maybeDetectedFramework.devCommand = project.frameworks
+	if (maybeDetectedFramework && target === "cf") {
+		// @netlify/build-info prefers package.json scripts over the framework's
+		// built-in commands. cf needs the direct commands so it can delegate without
+		// invoking a script that may itself call cf.
+		const detectedFrameworkSettings = project.frameworks
 			.get(maybeDetectedFramework.baseDirectory ?? "")
-			?.find(
-				({ id }) => id === maybeDetectedFramework.framework.id
-			)?.dev?.command;
+			?.find(({ id }) => id === maybeDetectedFramework.framework.id);
+		maybeDetectedFramework.devCommand = detectedFrameworkSettings?.dev?.command;
+		maybeDetectedFramework.buildCommand =
+			detectedFrameworkSettings?.build?.command;
 	}
 
 	if (

--- a/packages/autoconfig/src/details/index.ts
+++ b/packages/autoconfig/src/details/index.ts
@@ -121,7 +121,7 @@ export async function getDetailsForAutoConfig({
 	}
 
 	const { detectedFramework, packageManager, isWorkspaceRoot } =
-		await detectFramework(projectPath, context, wranglerConfig);
+		await detectFramework(projectPath, context, { wranglerConfig, target });
 
 	const framework = getFrameworkClassInstance(detectedFramework.framework.id);
 	const packageJsonPath = resolve(projectPath, "package.json");
@@ -153,6 +153,7 @@ export async function getDetailsForAutoConfig({
 			detectedFramework.buildCommand,
 			packageManager
 		),
+		env: framework.env,
 		workerName: getWorkerName(packageJson?.name, projectPath),
 	};
 

--- a/packages/autoconfig/src/frameworks/framework-class.ts
+++ b/packages/autoconfig/src/frameworks/framework-class.ts
@@ -10,6 +10,7 @@ import type { PackageManager } from "@cloudflare/workers-utils";
 export abstract class Framework {
 	readonly id: FrameworkInfo["id"];
 	readonly name: FrameworkInfo["name"];
+	declare readonly env?: Readonly<Record<string, string>>;
 
 	#frameworkVersion: string | undefined;
 	get frameworkVersion(): string {

--- a/packages/autoconfig/src/frameworks/react-router.ts
+++ b/packages/autoconfig/src/frameworks/react-router.ts
@@ -469,6 +469,10 @@ function writeEntryServerTsx(
 }
 
 export class ReactRouter extends Framework {
+	readonly env = {
+		CLOUDFLARE_VITE_FORCE_BUILD_OUTPUT: "true",
+	} as const;
+
 	async configure({
 		dryRun,
 		projectPath,

--- a/packages/autoconfig/src/frameworks/tanstack.ts
+++ b/packages/autoconfig/src/frameworks/tanstack.ts
@@ -7,6 +7,10 @@ import type {
 } from "./framework-class";
 
 export class TanstackStart extends Framework {
+	readonly env = {
+		CLOUDFLARE_VITE_FORCE_BUILD_OUTPUT: "true",
+	} as const;
+
 	async configure({
 		dryRun,
 		projectPath,

--- a/packages/autoconfig/src/frameworks/vike.ts
+++ b/packages/autoconfig/src/frameworks/vike.ts
@@ -18,6 +18,10 @@ const b = recast.types.builders;
 const t = recast.types.namedTypes;
 
 export class Vike extends Framework {
+	readonly env = {
+		CLOUDFLARE_VITE_FORCE_BUILD_OUTPUT: "true",
+	} as const;
+
 	async configure({
 		projectPath,
 		dryRun,

--- a/packages/autoconfig/src/frameworks/vite.ts
+++ b/packages/autoconfig/src/frameworks/vite.ts
@@ -15,6 +15,10 @@ import type {
 } from "./framework-class";
 
 export class Vite extends Framework {
+	readonly env = {
+		CLOUDFLARE_VITE_FORCE_BUILD_OUTPUT: "true",
+	} as const;
+
 	isConfigured(
 		projectPath: string,
 		{ target = "cf" }: { target?: AutoConfigTarget } = {}

--- a/packages/autoconfig/src/run.ts
+++ b/packages/autoconfig/src/run.ts
@@ -155,16 +155,9 @@ export async function runAutoConfig(
 	}
 
 	const { npx } = packageManager;
-	let buildCommand =
+	const buildCommand =
 		dryRunConfigurationResults.buildCommandOverride ??
 		autoConfigDetails.buildCommand;
-
-	if (
-		target === "cf" &&
-		autoConfigDetails.packageJson?.scripts?.build !== undefined
-	) {
-		buildCommand = `${packageManager.type} run build`;
-	}
 
 	const autoConfigSummary = await buildOperationsSummary(
 		{ ...autoConfigDetails, outputDir: autoConfigDetails.outputDir },
@@ -575,18 +568,14 @@ export async function buildOperationsSummary(
 	if (autoConfigDetails.packageJson) {
 		const scriptOverrides =
 			target === "wrangler" ? packageJsonScriptsOverrides : undefined;
-		const buildCommandPrefix = autoConfigDetails.buildCommand
-			? `${autoConfigDetails.buildCommand} && `
-			: "";
+		const buildCommandPrefix =
+			target === "wrangler" && autoConfigDetails.buildCommand
+				? `${autoConfigDetails.buildCommand} && `
+				: "";
 		summary.scripts = {
 			deploy:
-				scriptOverrides?.deploy ??
-				`${buildCommandPrefix}${target} deploy${
-					target === "cf" && autoConfigDetails.buildCommand ? " --no-build" : ""
-				}`,
-			preview:
-				scriptOverrides?.preview ??
-				`${target === "wrangler" ? buildCommandPrefix : ""}${target} dev`,
+				scriptOverrides?.deploy ?? `${buildCommandPrefix}${target} deploy`,
+			preview: scriptOverrides?.preview ?? `${buildCommandPrefix}${target} dev`,
 		};
 
 		const containsServerSideCode =

--- a/packages/autoconfig/src/run.ts
+++ b/packages/autoconfig/src/run.ts
@@ -204,10 +204,15 @@ export async function runAutoConfig(
 
 	if (autoConfigDetails.packageJson && enableTargetCliInstallation) {
 		if (target === "cf") {
-			await installPackages(packageManager.type, ["cf@latest"], {
-				dev: true,
-				isWorkspaceRoot,
-			});
+			const hasCfDependency =
+				autoConfigDetails.packageJson.dependencies?.cf !== undefined ||
+				autoConfigDetails.packageJson.devDependencies?.cf !== undefined;
+			if (!hasCfDependency) {
+				await installPackages(packageManager.type, ["cf@latest"], {
+					dev: true,
+					isWorkspaceRoot,
+				});
+			}
 		} else {
 			await installWrangler(packageManager.type, isWorkspaceRoot);
 		}

--- a/packages/autoconfig/src/types.ts
+++ b/packages/autoconfig/src/types.ts
@@ -23,6 +23,8 @@ type AutoConfigDetailsBase = {
 	devCommand?: string;
 	/** The build command used to build the project (if any) */
 	buildCommand?: string;
+	/** Environment required when running the detected dev or build commands. */
+	env?: Readonly<Record<string, string>>;
 	/** The output directory (if no framework is used, points to the raw asset files) */
 	outputDir: string;
 	/** The detected package manager for the project */

--- a/packages/autoconfig/tests/details/framework-detection/pages-project-detection.test.ts
+++ b/packages/autoconfig/tests/details/framework-detection/pages-project-detection.test.ts
@@ -18,8 +18,10 @@ describe("detectFramework() / Pages project detection", () => {
 		});
 
 		const result = await detectFramework(process.cwd(), context, {
-			pages_build_output_dir: "./dist",
-		} as Config);
+			wranglerConfig: {
+				pages_build_output_dir: "./dist",
+			} as Config,
+		});
 
 		expect(result.detectedFramework?.framework.id).toBe("cloudflare-pages");
 		expect(result.detectedFramework?.framework.name).toBe("Cloudflare Pages");

--- a/packages/autoconfig/tests/details/get-details-for-auto-config.test.ts
+++ b/packages/autoconfig/tests/details/get-details-for-auto-config.test.ts
@@ -62,7 +62,7 @@ describe("autoconfig details - getDetailsForAutoConfig()", () => {
 		).resolves.toMatchObject({
 			configured: true,
 			framework: { id: "astro" },
-			buildCommand: "npm run build",
+			buildCommand: "npx astro build",
 			devCommand: "npx astro dev",
 			packageManager: { type: "npm" },
 		});
@@ -204,7 +204,7 @@ describe("autoconfig details - getDetailsForAutoConfig()", () => {
 		expect(std.warn).toContain("project is part of a workspace");
 	});
 
-	it("should use npm build instead of framework build if present", async ({
+	it("should use the direct framework build instead of an npm script for cf", async ({
 		expect,
 	}) => {
 		await writeFile(
@@ -222,7 +222,48 @@ describe("autoconfig details - getDetailsForAutoConfig()", () => {
 		await expect(
 			details.getDetailsForAutoConfig({ context })
 		).resolves.toMatchObject({
+			buildCommand: "npx astro build",
+		});
+	});
+
+	it("should preserve npm build script detection for Wrangler", async ({
+		expect,
+	}) => {
+		await writeFile(
+			"package.json",
+			JSON.stringify({
+				scripts: {
+					build: "echo build",
+				},
+				dependencies: {
+					astro: "5",
+				},
+			})
+		);
+
+		await expect(
+			details.getDetailsForAutoConfig({ target: "wrangler", context })
+		).resolves.toMatchObject({
 			buildCommand: "npm run build",
+		});
+	});
+
+	it("should include the Vite plugin command environment for cf", async ({
+		expect,
+	}) => {
+		await seed({
+			"package.json": JSON.stringify({ dependencies: { vite: "8" } }),
+			"package-lock.json": JSON.stringify({ lockfileVersion: 3 }),
+		});
+
+		await expect(
+			details.getDetailsForAutoConfig({ context })
+		).resolves.toMatchObject({
+			framework: { id: "vite" },
+			buildCommand: "npx vite build",
+			env: {
+				CLOUDFLARE_VITE_FORCE_BUILD_OUTPUT: "true",
+			},
 		});
 	});
 

--- a/packages/autoconfig/tests/run-summary.test.ts
+++ b/packages/autoconfig/tests/run-summary.test.ts
@@ -232,7 +232,7 @@ describe("autoconfig run - buildOperationsSummary()", () => {
 			);
 
 			expect(summary.scripts).toEqual({
-				deploy: "npm run build && cf deploy --no-build",
+				deploy: "cf deploy",
 				preview: "cf dev",
 			});
 			expect(std.out).toContain(

--- a/packages/autoconfig/tests/run.test.ts
+++ b/packages/autoconfig/tests/run.test.ts
@@ -152,6 +152,40 @@ describe("runAutoConfig()", () => {
 		expect(installWrangler).toHaveBeenCalledWith("npm", false);
 	});
 
+	it("does not reinstall an existing cf dependency", async ({ expect }) => {
+		const installPackages = vi
+			.spyOn(cliPackages, "installPackages")
+			.mockResolvedValue();
+		vi.spyOn(cliPackages, "installWrangler").mockResolvedValue();
+		const packageJson = {
+			name: "my-static-app",
+			devDependencies: { cf: "^0.8.0" },
+		};
+		await seed({
+			"package.json": JSON.stringify(packageJson),
+			"public/index.html": "<h1>Hello World</h1>",
+		});
+
+		await runAutoConfig(
+			{
+				configured: false,
+				projectPath: process.cwd(),
+				workerName: "my-static-app",
+				framework: new Static({ id: "static", name: "Static" }),
+				outputDir: "public",
+				packageJson,
+				packageManager: NpmPackageManager,
+			},
+			{
+				context: createMockContext(),
+				skipConfirmations: true,
+				runBuild: false,
+			}
+		);
+
+		expect(installPackages).not.toHaveBeenCalled();
+	});
+
 	it("does not install Wrangler when cf delegates to Vite", async ({
 		expect,
 	}) => {

--- a/packages/autoconfig/tests/run.test.ts
+++ b/packages/autoconfig/tests/run.test.ts
@@ -90,7 +90,7 @@ describe("runAutoConfig()", () => {
 			observability: { enabled: true },
 		});
 		expect(summary.buildConfig).toEqual({ assetsDirectory: "public" });
-		expect(summary.buildCommand).toBe("npm run build");
+		expect(summary.buildCommand).toBe("npx framework build");
 		expect(summary.deployCommand).toBe("npx cf deploy");
 		expect(summary.versionCommand).toBe("npx cf versions upload");
 		expect(readFileSync("cloudflare.config.ts", "utf8")).toContain(
@@ -102,14 +102,14 @@ describe("runAutoConfig()", () => {
 		expect(existsSync("wrangler.jsonc")).toBe(false);
 		expect(installWrangler).toHaveBeenCalledWith("npm", false);
 		expect(context.runCommand).toHaveBeenCalledWith(
-			"npm run build",
+			"npx framework build",
 			process.cwd(),
 			"[build]"
 		);
 		expect(JSON.parse(readFileSync("package.json", "utf8"))).toMatchObject({
 			scripts: {
 				build: "generate && vite build",
-				deploy: "npm run build && cf deploy --no-build",
+				deploy: "cf deploy",
 				preview: "cf dev",
 			},
 		});


### PR DESCRIPTION
Follow-up to #15348.

For the `cf` target, return direct framework build commands instead of package scripts and make framework-specific overrides available during configured-project analysis. This lets configured Next.js projects resolve to OpenNext without special-casing Next in generic detection. Generated deploy scripts now compose with the same resolved build command. Wrangler command detection remains unchanged.

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: this adjusts the internal command-selection contract used by cf; cf documentation will describe the user-facing flow.
