### PR TITLE
Rename Worker target fields from workerName to worker

### DIFF
--- a/.changeset/rename-worker-target.md
+++ b/.changeset/rename-worker-target.md
@@ -1,0 +1,8 @@
+---
+"@cloudflare/config": minor
+"miniflare": minor
+---
+
+Rename Worker target fields from `workerName` to `worker`
+
+The experimental `@cloudflare/config` and Miniflare configuration APIs now use `worker` consistently for Worker, Durable Object, Workflow, dispatch namespace, and tail consumer targets.

--- a/packages/config/src/__tests__/convert.test.ts
+++ b/packages/config/src/__tests__/convert.test.ts
@@ -424,7 +424,7 @@ describe("convertToWranglerConfig", () => {
 					DN: {
 						type: "dispatch-namespace",
 						namespace: "ns-1",
-						outbound: { workerName: "out-worker", parameters: ["p1", "p2"] },
+						outbound: { worker: "out-worker", parameters: ["p1", "p2"] },
 					},
 				},
 			});
@@ -557,7 +557,7 @@ describe("convertToWranglerConfig", () => {
 				env: {
 					W: {
 						type: "worker",
-						workerName: "other-worker",
+						worker: "other-worker",
 						exportName: "MyEntry",
 						props: { foo: "bar" },
 						dev: { remote: true },
@@ -603,7 +603,7 @@ describe("convertToWranglerConfig", () => {
 				env: {
 					DO: {
 						type: "durable-object",
-						workerName: "other-worker",
+						worker: "other-worker",
 						exportName: "MyDO",
 					},
 				},
@@ -1152,7 +1152,7 @@ describe("convertToWranglerConfig", () => {
 		it("maps non-streaming consumers to tail_consumers", ({ expect }) => {
 			const result = convertToWranglerConfig({
 				...baseConfig,
-				tailConsumers: [{ workerName: "tail-worker" }],
+				tailConsumers: [{ worker: "tail-worker" }],
 			});
 			expect(result.tail_consumers).toEqual([{ service: "tail-worker" }]);
 			expect(result.streaming_tail_consumers).toBeUndefined();
@@ -1161,7 +1161,7 @@ describe("convertToWranglerConfig", () => {
 		it("maps streaming consumers to streaming_tail_consumers", ({ expect }) => {
 			const result = convertToWranglerConfig({
 				...baseConfig,
-				tailConsumers: [{ workerName: "stream-worker", streaming: true }],
+				tailConsumers: [{ worker: "stream-worker", streaming: true }],
 			});
 			expect(result.streaming_tail_consumers).toEqual([
 				{ service: "stream-worker" },
@@ -1173,9 +1173,9 @@ describe("convertToWranglerConfig", () => {
 			const result = convertToWranglerConfig({
 				...baseConfig,
 				tailConsumers: [
-					{ workerName: "a" },
-					{ workerName: "b", streaming: true },
-					{ workerName: "c", streaming: false },
+					{ worker: "a" },
+					{ worker: "b", streaming: true },
+					{ worker: "c", streaming: false },
 				],
 			});
 			expect(result.tail_consumers).toEqual([

--- a/packages/config/src/bindings.ts
+++ b/packages/config/src/bindings.ts
@@ -160,7 +160,7 @@ interface DispatchNamespaceBindingOptions {
 	/** Details about the outbound Worker which will handle outbound requests from your namespace. */
 	outbound?: {
 		/** Name of the Worker handling the outbound requests. */
-		workerName: string;
+		worker: string;
 		/** (Optional) List of parameter names, for sending context from your dispatch Worker to the outbound handler. */
 		parameters?: string[];
 	};
@@ -179,13 +179,13 @@ export interface DispatchNamespaceBinding extends DispatchNamespaceBindingOption
 
 interface DurableObjectBindingOptions {
 	/** The name of the Worker that defines the Durable Object class. */
-	workerName: string;
+	worker: string;
 	/** The exported class name of the Durable Object. */
 	exportName: string;
 }
 
 /**
- * Binding to a Durable Object class. `workerName` is the name of the Worker
+ * Binding to a Durable Object class. `worker` is the name of the Worker
  * that defines the class; `exportName` is the exported class name.
  *
  * For reference, see https://developers.cloudflare.com/workers/wrangler/configuration/#durable-objects
@@ -195,7 +195,7 @@ export interface DurableObjectBinding extends DurableObjectBindingOptions {
 }
 
 /**
- * Binding to a Durable Object class. `workerName` is the name of the Worker
+ * Binding to a Durable Object class. `worker` is the name of the Worker
  * that defines the class; `exportName` is the exported class name.
  *
  * For reference, see https://developers.cloudflare.com/workers/wrangler/configuration/#durable-objects
@@ -204,7 +204,7 @@ export interface TypedDurableObjectBinding<
 	TConfig,
 	TExportName extends string,
 > extends DurableObjectBinding {
-	workerName: string;
+	worker: string;
 	exportName: TExportName;
 	/** @internal Carries the config type for inference */
 	__config: TConfig;
@@ -592,7 +592,7 @@ export interface WebSearchBinding extends WebSearchBindingOptions {
 
 interface WorkerBindingOptions {
 	/** The name of the bound Worker. */
-	workerName: string;
+	worker: string;
 	/** The named export to bind to (defaults to the default export). */
 	exportName?: string;
 	/** Optional properties that will be made available to the service via `ctx.props`. */
@@ -602,7 +602,7 @@ interface WorkerBindingOptions {
 }
 
 /**
- * Service binding (Worker-to-Worker). `workerName` is the name of the bound
+ * Service binding (Worker-to-Worker). `worker` is the name of the bound
  * Worker; `exportName` selects a named `WorkerEntrypoint` export (defaults to
  * the default export).
  *
@@ -613,7 +613,7 @@ export interface WorkerBinding extends WorkerBindingOptions {
 }
 
 /**
- * Service binding (Worker-to-Worker). `workerName` is the name of the bound
+ * Service binding (Worker-to-Worker). `worker` is the name of the bound
  * Worker; `exportName` selects a named `WorkerEntrypoint` export (defaults to
  * the default export).
  *
@@ -623,7 +623,7 @@ export interface TypedWorkerBinding<
 	TConfig,
 	TExportName extends string,
 > extends WorkerBinding {
-	workerName: string;
+	worker: string;
 	exportName: TExportName;
 	/** @internal Carries the config type for inference */
 	__config: TConfig;
@@ -636,13 +636,13 @@ export interface WorkerLoaderBinding {
 
 interface WorkflowBindingOptions {
 	/** The name of the Worker that defines the Workflow. */
-	workerName: string;
+	worker: string;
 	/** The exported class name of the Workflow. */
 	exportName: string;
 }
 
 /**
- * Binding to a Workflow. `workerName` is the name of the Worker that defines
+ * Binding to a Workflow. `worker` is the name of the Worker that defines
  * the Workflow; `exportName` is the exported `WorkflowEntrypoint` class name.
  */
 export interface WorkflowBinding extends WorkflowBindingOptions {
@@ -650,14 +650,14 @@ export interface WorkflowBinding extends WorkflowBindingOptions {
 }
 
 /**
- * Binding to a Workflow. `workerName` is the name of the Worker that defines
+ * Binding to a Workflow. `worker` is the name of the Worker that defines
  * the Workflow; `exportName` is the exported `WorkflowEntrypoint` class name.
  */
 export interface TypedWorkflowBinding<
 	TConfig,
 	TExportName extends string,
 > extends WorkflowBinding {
-	workerName: string;
+	worker: string;
 	exportName: TExportName;
 	/** @internal Carries the config type for inference */
 	__config: TConfig;
@@ -733,7 +733,7 @@ export interface Bindings {
 		options?: DispatchNamespaceBindingOptions
 	): DispatchNamespaceBinding;
 	/**
-	 * Binding to a Durable Object class. `workerName` is the name of the Worker
+	 * Binding to a Durable Object class. `worker` is the name of the Worker
 	 * that defines the class; `exportName` is the exported class name.
 	 *
 	 * For reference, see https://developers.cloudflare.com/workers/wrangler/configuration/#durable-objects
@@ -846,7 +846,7 @@ export interface Bindings {
 	 */
 	webSearch(options?: WebSearchBindingOptions): WebSearchBinding;
 	/**
-	 * Service binding (Worker-to-Worker). `workerName` is the name of the bound
+	 * Service binding (Worker-to-Worker). `worker` is the name of the bound
 	 * Worker; `exportName` selects a named `WorkerEntrypoint` export (defaults to
 	 * the default export).
 	 *
@@ -858,7 +858,7 @@ export interface Bindings {
 	// TODO: re-enable when workflow bindings return.
 	// /**
 	//  * Create a Workflow binding.
-	//  * `workerName` must match a known config's name (or any `string` for untyped bindings).
+	//  * `worker` must match a known config's name (or any `string` for untyped bindings).
 	//  * `exportName` must be a valid `WorkflowEntrypoint` export for the given Worker.
 	//  */
 	// workflow(options: WorkflowBindingOptions): WorkflowBinding;

--- a/packages/config/src/convert.ts
+++ b/packages/config/src/convert.ts
@@ -341,7 +341,7 @@ function convertBindingsAndAssets(
 				};
 				if (binding.outbound) {
 					entry.outbound = omitUndefined({
-						service: binding.outbound.workerName,
+						service: binding.outbound.worker,
 						parameters: binding.outbound.parameters,
 					});
 				}
@@ -355,7 +355,7 @@ function convertBindingsAndAssets(
 				durableObjectBindings.push({
 					name,
 					class_name: binding.exportName,
-					script_name: binding.workerName,
+					script_name: binding.worker,
 				});
 				break;
 			}
@@ -562,7 +562,7 @@ function convertBindingsAndAssets(
 				services.push(
 					omitUndefined({
 						binding: name,
-						service: binding.workerName,
+						service: binding.worker,
 						entrypoint: binding.exportName,
 						props: binding.props,
 						remote: binding.dev?.remote,
@@ -580,7 +580,7 @@ function convertBindingsAndAssets(
 			// 		omitUndefined({
 			// 			binding: name,
 			// 			class_name: binding.exportName,
-			// 			script_name: binding.workerName,
+			// 			script_name: binding.worker,
 			// 		})
 			// 	);
 			// 	break;
@@ -910,9 +910,9 @@ function convertTailConsumers(
 	const streaming: NonNullable<RawConfig["streaming_tail_consumers"]> = [];
 	for (const consumer of consumers) {
 		if (consumer.streaming) {
-			streaming.push({ service: consumer.workerName });
+			streaming.push({ service: consumer.worker });
 		} else {
-			tail.push({ service: consumer.workerName });
+			tail.push({ service: consumer.worker });
 		}
 	}
 	if (tail.length) {

--- a/packages/config/src/schema.ts
+++ b/packages/config/src/schema.ts
@@ -28,7 +28,7 @@ export const BrowserBindingSchema = z.strictObject({
 
 export const WorkerBindingSchema = z.strictObject({
 	type: z.literal("worker"),
-	workerName: z.string(),
+	worker: z.string(),
 	exportName: z.string().optional(),
 	props: z.record(z.string(), z.unknown()).optional(),
 	dev: RemoteBindingDevSchema.optional(),
@@ -122,7 +122,7 @@ export const KnownBindingSchema = z.discriminatedUnion("type", [
 		namespace: z.string().optional(),
 		outbound: z
 			.strictObject({
-				workerName: z.string(),
+				worker: z.string(),
 				parameters: z.array(z.string()).optional(),
 			})
 			.optional(),
@@ -130,7 +130,7 @@ export const KnownBindingSchema = z.discriminatedUnion("type", [
 	}),
 	z.strictObject({
 		type: z.literal("durable-object"),
-		workerName: z.string(),
+		worker: z.string(),
 		exportName: z.string(),
 	}),
 	FlagshipBindingSchema,
@@ -236,7 +236,7 @@ export const KnownBindingSchema = z.discriminatedUnion("type", [
 	// TODO: support Workflows
 	// z.strictObject({
 	// 	type: z.literal("workflow"),
-	// 	workerName: z.string(),
+	// 	worker: z.string(),
 	// 	exportName: z.string(),
 	// }),
 ]);
@@ -465,7 +465,7 @@ const PlacementSchema = z.union([
 ]);
 
 export const TailConsumerSchema = z.strictObject({
-	workerName: z.string(),
+	worker: z.string(),
 	streaming: z.boolean().optional(),
 });
 

--- a/packages/config/src/types.ts
+++ b/packages/config/src/types.ts
@@ -237,7 +237,7 @@ export interface WorkerConfig {
 	 */
 	tailConsumers?: Array<{
 		/** The name of the service tail events will be forwarded to. */
-		workerName: string;
+		worker: string;
 		/** Whether to stream tail events in real time. */
 		streaming?: boolean;
 	}>;

--- a/packages/config/src/worker-definition.ts
+++ b/packages/config/src/worker-definition.ts
@@ -34,17 +34,17 @@ export interface TypedWorkerDefinition<
 	TWorkerName extends string = InferWorkerName<TConfig>,
 > extends WorkerDefinition<TConfig> {
 	/**
-	 * Binding to a Durable Object class. `workerName` is the name of the Worker
+	 * Binding to a Durable Object class. `worker` is the name of the Worker
 	 * that defines the class; `exportName` is the exported class name.
 	 *
 	 * For reference, see https://developers.cloudflare.com/workers/wrangler/configuration/#durable-objects
 	 */
 	durableObject<TExportName extends InferDurableNamespaces<TConfig>>(options: {
-		workerName: TWorkerName;
+		worker: TWorkerName;
 		exportName: TExportName;
 	}): TypedDurableObjectBinding<TConfig, TExportName>;
 	/**
-	 * Service binding (Worker-to-Worker). `workerName` is the name of the bound
+	 * Service binding (Worker-to-Worker). `worker` is the name of the bound
 	 * Worker; `exportName` selects a named `WorkerEntrypoint` export (defaults to
 	 * the default export).
 	 *
@@ -54,7 +54,7 @@ export interface TypedWorkerDefinition<
 		TExportName extends InferWorkerEntrypointExports<TConfig> | undefined =
 			undefined,
 	>(options: {
-		workerName: TWorkerName;
+		worker: TWorkerName;
 		exportName?: TExportName;
 		props?: Record<string, unknown>;
 		dev?: BindingDevOptions;
@@ -66,7 +66,7 @@ export interface TypedWorkerDefinition<
 	// workflow<
 	// 	TExportName extends InferExportsByType<TConfig, "workflow">,
 	// >(options: {
-	// 	workerName: TWorkerName;
+	// 	worker: TWorkerName;
 	// 	exportName: TExportName;
 	// }): TypedWorkflowBinding<TConfig, TExportName>;
 }

--- a/packages/miniflare/src/config/schema.ts
+++ b/packages/miniflare/src/config/schema.ts
@@ -184,11 +184,11 @@ const MiniflareHyperdriveBindingSchema = HyperdriveBindingSchema.extend({
 });
 
 /**
- * Extended worker (service) binding. `workerName` may be `kCurrentWorker`
+ * Extended worker (service) binding. `worker` may be `kCurrentWorker`
  * (the SELF marker) in addition to a plain worker name.
  */
 const MiniflareWorkerBindingSchema = WorkerBindingSchema.extend({
-	workerName: z.union([
+	worker: z.union([
 		z.string(),
 		z.custom<typeof kCurrentWorker>((v) => v === kCurrentWorker),
 	]),
@@ -206,7 +206,7 @@ const HelloWorldBindingSchema = z.strictObject({
 const MiniflareWorkflowBindingSchema = z.strictObject({
 	type: z.literal("workflow"),
 	name: z.string(),
-	workerName: z.string(),
+	worker: z.string(),
 	exportName: z.string(),
 	limits: z.strictObject({ steps: z.number().optional() }).optional(),
 });

--- a/packages/miniflare/src/config/v4-convert.ts
+++ b/packages/miniflare/src/config/v4-convert.ts
@@ -411,7 +411,7 @@ function addDurableObjectBindings(
 		const targetWorkerName = objectOptions.scriptName ?? workerName;
 		env[bindingName] = {
 			type: "durable-object",
-			workerName: targetWorkerName,
+			worker: targetWorkerName,
 			exportName: objectOptions.className,
 		};
 		isRemote(objectOptions.remoteProxyConnectionString);
@@ -516,15 +516,12 @@ function addServiceBindingArray(
 			throwUnsupportedOption(`${option}[].remoteProxyConnectionString`);
 		}
 		const converted = convertServiceDesignator(binding, () => false);
-		if (
-			converted.type !== "worker" ||
-			typeof converted.workerName !== "string"
-		) {
+		if (converted.type !== "worker" || typeof converted.worker !== "string") {
 			throwUnsupportedOption(option);
 		}
 		config.tailConsumers ??= [];
 		config.tailConsumers.push({
-			workerName: converted.workerName,
+			worker: converted.worker,
 			entrypoint: converted.exportName,
 			props: converted.props,
 			streaming,
@@ -554,10 +551,10 @@ function convertOutboundService(
 	if (converted.type === "fetcher" || converted.type === "node-handler") {
 		return converted;
 	}
-	if (converted.type === "worker" && typeof converted.workerName === "string") {
+	if (converted.type === "worker" && typeof converted.worker === "string") {
 		return {
 			type: "worker",
-			workerName: converted.workerName,
+			worker: converted.worker,
 			exportName: converted.exportName,
 			props: converted.props,
 			dev: converted.dev,
@@ -574,24 +571,24 @@ function convertServiceDesignator(
 		return { type: "fetcher", handler: binding };
 	}
 	if (typeof binding === "string") {
-		return { type: "worker", workerName: binding };
+		return { type: "worker", worker: binding };
 	}
 	if (binding === kCurrentWorker) {
 		return {
 			type: "worker",
-			workerName: getCurrentWorkerBindingName(),
+			worker: getCurrentWorkerBindingName(),
 		};
 	}
 	if (typeof binding !== "object" || binding === null) {
 		return {
 			type: "worker",
-			workerName: getCurrentWorkerBindingName(),
+			worker: getCurrentWorkerBindingName(),
 		};
 	}
 	if ("name" in binding) {
 		return {
 			type: "worker",
-			workerName: convertWorkerName(binding.name),
+			worker: convertWorkerName(binding.name),
 			exportName: binding.entrypoint,
 			props: binding.props,
 			dev: { remote: isRemote(binding.remoteProxyConnectionString) },
@@ -609,13 +606,11 @@ function convertServiceDesignator(
 	return { type: "node-handler", handler: binding.node };
 }
 
-function getCurrentWorkerBindingName(): ServiceBinding["workerName"] {
+function getCurrentWorkerBindingName(): ServiceBinding["worker"] {
 	return kCurrentWorker;
 }
 
-function convertWorkerName(
-	name: string | symbol
-): ServiceBinding["workerName"] {
+function convertWorkerName(name: string | symbol): ServiceBinding["worker"] {
 	return typeof name === "string" ? name : getCurrentWorkerBindingName();
 }
 
@@ -786,7 +781,7 @@ function addProductBindings(
 		env[bindingName] = {
 			type: "workflow",
 			name: workflow.name,
-			workerName: targetWorkerName,
+			worker: targetWorkerName,
 			exportName: workflow.className,
 			limits:
 				workflow.stepLimit === undefined

--- a/packages/miniflare/src/index.ts
+++ b/packages/miniflare/src/index.ts
@@ -407,11 +407,11 @@ function getExternalServiceEntrypoints(allWorkerOpts: ParsedWorkerOptions[]) {
 		if (tailConsumers !== undefined) {
 			for (let i = 0; i < tailConsumers.length; i++) {
 				const consumer = tailConsumers[i];
-				const serviceName = consumer.workerName;
+				const serviceName = consumer.worker;
 				if (serviceName && !allWorkerNames.includes(serviceName)) {
 					getEntrypoints(serviceName).entrypoints.add(consumer.entrypoint);
 					tailConsumers[i] = {
-						workerName: SERVICE_DEV_REGISTRY_PROXY,
+						worker: SERVICE_DEV_REGISTRY_PROXY,
 						streaming: consumer.streaming,
 						entrypoint: "ExternalServiceProxy",
 						// User-supplied `props` are preserved in `userProps` so the proxy
@@ -450,7 +450,7 @@ function getExternalServiceEntrypoints(allWorkerOpts: ParsedWorkerOptions[]) {
 				// remote entrypoint via the debug port.
 				env[name] = {
 					type: "worker",
-					workerName: SERVICE_DEV_REGISTRY_PROXY,
+					worker: SERVICE_DEV_REGISTRY_PROXY,
 					exportName: "ExternalServiceProxy",
 					props: {
 						service: serviceName,
@@ -466,29 +466,29 @@ function getExternalServiceEntrypoints(allWorkerOpts: ParsedWorkerOptions[]) {
 			config,
 			"durable-object"
 		)) {
-			const { workerName, exportName } = binding;
-			if (!allWorkerNames.includes(workerName)) {
+			const { worker, exportName } = binding;
+			if (!allWorkerNames.includes(worker)) {
 				// Point it at the outbound DO proxy class on the dev-registry proxy
 				// worker. The proxy worker registers the namespace (with a matching
 				// unique key) itself, so no extra config is needed on the binding.
 				env[bindingName] = {
 					type: "durable-object",
-					workerName: SERVICE_DEV_REGISTRY_PROXY,
-					exportName: getOutboundDoProxyClassName(workerName, exportName),
+					worker: SERVICE_DEV_REGISTRY_PROXY,
+					exportName: getOutboundDoProxyClassName(worker, exportName),
 				};
-				getEntrypoints(workerName).classNames.add(exportName);
+				getEntrypoints(worker).classNames.add(exportName);
 			}
 		}
 
-		// Cross-worker workflow bindings: when `workerName` refers to a worker
+		// Cross-worker workflow bindings: when `worker` refers to a worker
 		// outside this Miniflare instance (registered in the dev registry), record
 		// its entrypoint so the dev-registry proxy exposes it. The workflows plugin
 		// reroutes the engine's USER_WORKFLOW binding through the proxy itself; here
 		// we only register the external entrypoint. Mirrors the DO block above.
 		for (const [, binding] of getEnvBindingsOfType(config, "workflow")) {
-			const { workerName, exportName } = binding;
-			if (!allWorkerNames.includes(workerName)) {
-				getEntrypoints(workerName).entrypoints.add(exportName);
+			const { worker, exportName } = binding;
+			if (!allWorkerNames.includes(worker)) {
+				getEntrypoints(worker).entrypoints.add(exportName);
 			}
 		}
 	}
@@ -3331,7 +3331,7 @@ export class Miniflare {
 		const binding = workerOpts.config.env?.[classNameOrBindingName];
 		if (binding?.type === "durable-object") {
 			className = binding.exportName;
-			scriptName = binding.workerName;
+			scriptName = binding.worker;
 		} else if (
 			getExportsOfType(workerOpts.config, "durable-object").some(
 				([exportName]) => exportName === classNameOrBindingName

--- a/packages/miniflare/src/plugins/core/explorer.ts
+++ b/packages/miniflare/src/plugins/core/explorer.ts
@@ -389,7 +389,7 @@ export function constructExplorerWorkerOpts(
 			"durable-object"
 		)) {
 			const className = binding.exportName;
-			const scriptName = binding.workerName;
+			const scriptName = binding.worker;
 			const serviceName = getUserServiceName(scriptName);
 			const uniqueKey = `${scriptName}-${className}`;
 
@@ -414,7 +414,7 @@ export function constructExplorerWorkerOpts(
 				id: workflow.name,
 				bindingName,
 				className: workflow.exportName,
-				scriptName: workflow.workerName ?? workerName,
+				scriptName: workflow.worker ?? workerName,
 			});
 		}
 

--- a/packages/miniflare/src/plugins/core/index.ts
+++ b/packages/miniflare/src/plugins/core/index.ts
@@ -186,14 +186,14 @@ function getCustomServiceDesignator(
 			serviceName = `${CORE_PLUGIN_NAME}:remote-proxy-service:${workerIndex}:${name}`;
 			// Remote config travels via props to a generic proxy worker.
 			props = buildRemoteProxyProps(remoteProxyConnectionString, name);
-		} else if (service.workerName === kCurrentWorker) {
+		} else if (service.worker === kCurrentWorker) {
 			serviceName = getUserServiceName(refererName);
 			entrypoint = service.exportName;
 			if (service.props) {
 				props = { json: JSON.stringify(service.props) };
 			}
 		} else {
-			serviceName = getUserServiceName(service.workerName);
+			serviceName = getUserServiceName(service.worker);
 			entrypoint = service.exportName;
 			if (service.props) {
 				props = { json: JSON.stringify(service.props) };
@@ -333,12 +333,12 @@ function getGlobalOutbound(
 }
 
 function getTailServiceDesignator(consumer: {
-	workerName: string;
+	worker: string;
 	entrypoint?: string;
 	props?: Record<string, unknown>;
 }): ServiceDesignator {
 	return {
-		name: getUserServiceName(consumer.workerName),
+		name: getUserServiceName(consumer.worker),
 		entrypoint: consumer.entrypoint,
 		props:
 			consumer.props !== undefined
@@ -573,7 +573,7 @@ export const CORE_PLUGIN: Plugin = {
 					// how the collector attributes each captured invocation to its worker
 					// (each worker streams to the collector with its own props).
 					{
-						workerName: OBSERVABILITY_COLLECTOR_SERVICE_NAME,
+						worker: OBSERVABILITY_COLLECTOR_SERVICE_NAME,
 						streaming: true,
 						props: { worker: config.name },
 					},
@@ -975,7 +975,7 @@ export function getGlobalServices({
 				workflowOptions.set(binding.name, {
 					name: binding.name,
 					className: binding.exportName,
-					scriptName: binding.workerName,
+					scriptName: binding.worker,
 				});
 			}
 		}

--- a/packages/miniflare/src/plugins/do/index.ts
+++ b/packages/miniflare/src/plugins/do/index.ts
@@ -31,7 +31,7 @@ export const DURABLE_OBJECTS_PLUGIN: Plugin = {
 			name,
 			durableObjectNamespace: {
 				className: binding.exportName,
-				serviceName: getUserServiceName(binding.workerName),
+				serviceName: getUserServiceName(binding.worker),
 			},
 		}));
 	},

--- a/packages/miniflare/src/plugins/workflows/index.ts
+++ b/packages/miniflare/src/plugins/workflows/index.ts
@@ -95,7 +95,7 @@ export const WORKFLOWS_PLUGIN: Plugin = {
 
 		// this creates one miniflare service per workflow that the user's script has. we should dedupe engine definition later
 		const services = workflows.map<Service>(([bindingName, binding]) => {
-			const external = !workerNames.includes(binding.workerName);
+			const external = !workerNames.includes(binding.worker);
 			const stepLimit = binding.limits?.steps;
 			// NOTE(lduarte): the engine unique namespace key must be unique per workflow definition
 			// otherwise workerd will crash because there's two equal DO namespaces
@@ -159,7 +159,7 @@ export const WORKFLOWS_PLUGIN: Plugin = {
 										entrypoint: "ExternalServiceProxy",
 										props: {
 											json: JSON.stringify({
-												service: binding.workerName,
+												service: binding.worker,
 												entrypoint: binding.exportName,
 											}),
 										},
@@ -168,7 +168,7 @@ export const WORKFLOWS_PLUGIN: Plugin = {
 							: {
 									name: "USER_WORKFLOW",
 									service: {
-										name: getUserServiceName(binding.workerName),
+										name: getUserServiceName(binding.worker),
 										entrypoint: binding.exportName,
 									},
 								},

--- a/packages/miniflare/src/shared/external-service.ts
+++ b/packages/miniflare/src/shared/external-service.ts
@@ -18,8 +18,7 @@ export function normaliseServiceDesignator(
 	remoteProxyConnectionString: RemoteProxyConnectionString | undefined;
 } {
 	return {
-		serviceName:
-			binding.workerName !== kCurrentWorker ? binding.workerName : undefined,
+		serviceName: binding.worker !== kCurrentWorker ? binding.worker : undefined,
 		entrypoint: binding.exportName,
 		props: binding.props,
 		remoteProxyConnectionString: getRemoteProxyConnectionString(binding, dev),

--- a/packages/miniflare/test/config/schema.spec.ts
+++ b/packages/miniflare/test/config/schema.spec.ts
@@ -242,7 +242,7 @@ describe("MiniflareWorkerConfigSchema", () => {
 				WORKFLOW: {
 					type: "workflow",
 					name: "workflow",
-					workerName: "api",
+					worker: "api",
 					exportName: "Workflow",
 					dev: { remote: true },
 				},

--- a/packages/miniflare/test/config/v4-convert.spec.ts
+++ b/packages/miniflare/test/config/v4-convert.spec.ts
@@ -35,17 +35,17 @@ describe("convertV4MiniflareOptions", () => {
 		expect(converted.workers[0].config.env).toMatchObject({
 			LOCAL: {
 				type: "durable-object",
-				workerName: "worker",
+				worker: "worker",
 				exportName: "LocalObject",
 			},
 			EXTERNAL: {
 				type: "durable-object",
-				workerName: "external-worker",
+				worker: "external-worker",
 				exportName: "ExternalObject",
 			},
 			SELF_EXPLICIT: {
 				type: "durable-object",
-				workerName: "worker",
+				worker: "worker",
 				exportName: "SelfExplicitObject",
 			},
 		});
@@ -137,20 +137,20 @@ describe("convertV4MiniflareOptions", () => {
 					},
 				},
 				QUEUE: { type: "queue", name: "queue" },
-				SERVICE: { type: "worker", workerName: "other-worker" },
+				SERVICE: { type: "worker", worker: "other-worker" },
 				ASSETS: { type: "assets" },
 				BROWSER: { type: "browser", headful: true },
 				WORKFLOW: {
 					type: "workflow",
 					name: "workflow",
-					workerName: "worker",
+					worker: "worker",
 					exportName: "Workflow",
 					limits: { steps: 5 },
 				},
 				SELF_EXPLICIT_WORKFLOW: {
 					type: "workflow",
 					name: "self-explicit-workflow",
-					workerName: "worker",
+					worker: "worker",
 					exportName: "SelfExplicitWorkflow",
 				},
 			},

--- a/packages/miniflare/test/dev-registry.spec.ts
+++ b/packages/miniflare/test/dev-registry.spec.ts
@@ -259,7 +259,7 @@ describe.sequential("DevRegistry", () => {
 				}
 			`),
 						env: {
-							SERVICE: { type: "worker", workerName: "remote-worker" },
+							SERVICE: { type: "worker", worker: "remote-worker" },
 						},
 					},
 				},
@@ -311,7 +311,7 @@ describe.sequential("DevRegistry", () => {
 				}
 			`),
 						env: {
-							SERVICE: { type: "worker", workerName: "remote-worker" },
+							SERVICE: { type: "worker", worker: "remote-worker" },
 						},
 					},
 				},
@@ -407,7 +407,7 @@ describe.sequential("DevRegistry", () => {
 				}
 			`),
 						env: {
-							SERVICE: { type: "worker", workerName: "remote-worker" },
+							SERVICE: { type: "worker", worker: "remote-worker" },
 						},
 					},
 				},
@@ -490,7 +490,7 @@ describe.sequential("DevRegistry", () => {
 				}
 			`),
 						env: {
-							SERVICE: { type: "worker", workerName: "remote-worker" },
+							SERVICE: { type: "worker", worker: "remote-worker" },
 						},
 					},
 				},
@@ -575,7 +575,7 @@ describe.sequential("DevRegistry", () => {
 						env: {
 							SERVICE: {
 								type: "worker",
-								workerName: "remote-worker",
+								worker: "remote-worker",
 								exportName: "TestEntrypoint",
 							},
 						},
@@ -681,7 +681,7 @@ describe.sequential("DevRegistry", () => {
 						env: {
 							SERVICE: {
 								type: "worker",
-								workerName: "remote-worker",
+								worker: "remote-worker",
 								exportName: "PropsEntrypoint",
 								props: { foo: 123, bar: { baz: "hello from props" } },
 							},
@@ -725,7 +725,7 @@ describe.sequential("DevRegistry", () => {
 				}
 			`),
 						env: {
-							SERVICE: { type: "worker", workerName: "remote-worker" },
+							SERVICE: { type: "worker", worker: "remote-worker" },
 						},
 					},
 				},
@@ -820,7 +820,7 @@ describe.sequential("DevRegistry", () => {
 				}
 			`),
 						env: {
-							SERVICE: { type: "worker", workerName: "remote-worker" },
+							SERVICE: { type: "worker", worker: "remote-worker" },
 						},
 					},
 				},
@@ -920,7 +920,7 @@ describe.sequential("DevRegistry", () => {
 						env: {
 							DO: {
 								type: "durable-object",
-								workerName: "remote-worker",
+								worker: "remote-worker",
 								exportName: "MyDurableObject",
 							},
 						},
@@ -957,7 +957,7 @@ describe.sequential("DevRegistry", () => {
 						env: {
 							DO: {
 								type: "durable-object",
-								workerName: "remote-worker",
+								worker: "remote-worker",
 								exportName: "MyDurableObject",
 							},
 						},
@@ -1000,7 +1000,7 @@ describe.sequential("DevRegistry", () => {
 						env: {
 							DO: {
 								type: "durable-object",
-								workerName: "remote-worker",
+								worker: "remote-worker",
 								exportName: "MyDurableObject",
 							},
 						},
@@ -1043,7 +1043,7 @@ describe.sequential("DevRegistry", () => {
 						env: {
 							DO: {
 								type: "durable-object",
-								workerName: "remote-worker",
+								worker: "remote-worker",
 								exportName: "MyDurableObject",
 							},
 						},
@@ -1089,7 +1089,7 @@ describe.sequential("DevRegistry", () => {
 						env: {
 							DO: {
 								type: "durable-object",
-								workerName: "remote-worker",
+								worker: "remote-worker",
 								exportName: "MyDurableObject",
 							},
 						},
@@ -1132,7 +1132,7 @@ describe.sequential("DevRegistry", () => {
 						env: {
 							DO: {
 								type: "durable-object",
-								workerName: "remote-worker",
+								worker: "remote-worker",
 								exportName: "MyDurableObject",
 							},
 						},
@@ -1186,7 +1186,7 @@ describe.sequential("DevRegistry", () => {
 						env: {
 							DO: {
 								type: "durable-object",
-								workerName: "remote-worker",
+								worker: "remote-worker",
 								exportName: "MyDurableObject",
 							},
 						},
@@ -1223,7 +1223,7 @@ describe.sequential("DevRegistry", () => {
 						env: {
 							DO: {
 								type: "durable-object",
-								workerName: "remote-worker",
+								worker: "remote-worker",
 								exportName: "MyDurableObject",
 							},
 						},
@@ -1262,7 +1262,7 @@ describe.sequential("DevRegistry", () => {
 							MY_WORKFLOW: {
 								type: "workflow",
 								name: "MY_WORKFLOW",
-								workerName: "remote-worker",
+								worker: "remote-worker",
 								exportName: "MyWorkflow",
 							},
 						},
@@ -1343,7 +1343,7 @@ describe.sequential("DevRegistry", () => {
 						env: {
 							DO: {
 								type: "durable-object",
-								workerName: "remote-worker",
+								worker: "remote-worker",
 								exportName: "MyDurableObject",
 							},
 						},
@@ -1385,7 +1385,7 @@ describe.sequential("DevRegistry", () => {
 						env: {
 							DO: {
 								type: "durable-object",
-								workerName: "remote-worker",
+								worker: "remote-worker",
 								exportName: "MyDurableObject",
 							},
 						},
@@ -1426,7 +1426,7 @@ describe.sequential("DevRegistry", () => {
 						env: {
 							DO: {
 								type: "durable-object",
-								workerName: "remote-worker",
+								worker: "remote-worker",
 								exportName: "MyDurableObject",
 							},
 						},
@@ -1501,7 +1501,7 @@ describe.sequential("DevRegistry", () => {
 				}
 			`),
 						env: {
-							SERVICE: { type: "worker", workerName: "remote-worker" },
+							SERVICE: { type: "worker", worker: "remote-worker" },
 						},
 					},
 				},
@@ -1614,7 +1614,7 @@ describe.sequential("DevRegistry", () => {
 				}
 			`),
 						env: {
-							REMOTE: { type: "worker", workerName: "remote-worker" },
+							REMOTE: { type: "worker", worker: "remote-worker" },
 						},
 					},
 				},
@@ -1694,9 +1694,9 @@ describe.sequential("DevRegistry", () => {
 					}
 				}
 			`),
-						tailConsumers: [{ workerName: "remote-worker" }],
+						tailConsumers: [{ worker: "remote-worker" }],
 						env: {
-							remote: { type: "worker", workerName: "remote-worker" },
+							remote: { type: "worker", worker: "remote-worker" },
 						},
 					},
 				},
@@ -1737,9 +1737,9 @@ describe.sequential("DevRegistry", () => {
 					}
 				}
 			`),
-						tailConsumers: [{ workerName: "remote-worker" }],
+						tailConsumers: [{ worker: "remote-worker" }],
 						env: {
-							remote: { type: "worker", workerName: "remote-worker" },
+							remote: { type: "worker", worker: "remote-worker" },
 						},
 					},
 				},
@@ -1825,7 +1825,7 @@ describe.sequential("DevRegistry", () => {
 			`),
 						tailConsumers: [
 							{
-								workerName: "remote-worker",
+								worker: "remote-worker",
 								entrypoint: "TailCollector",
 								props: { tailKey: "from-tail-binding" },
 							},
@@ -1879,7 +1879,7 @@ describe.sequential("DevRegistry", () => {
 				}
 			`),
 						env: {
-							SERVICE: { type: "worker", workerName: "remote-worker" },
+							SERVICE: { type: "worker", worker: "remote-worker" },
 						},
 					},
 				},
@@ -1988,7 +1988,7 @@ describe.sequential("DevRegistry", () => {
 				}
 			`),
 						env: {
-							SERVICE: { type: "worker", workerName: "remote-worker" },
+							SERVICE: { type: "worker", worker: "remote-worker" },
 						},
 					},
 				},
@@ -2069,7 +2069,7 @@ describe.sequential("DevRegistry", () => {
 						env: {
 							DO: {
 								type: "durable-object",
-								workerName: "remote-worker",
+								worker: "remote-worker",
 								exportName: "MyDurableObject",
 							},
 						},
@@ -2113,7 +2113,7 @@ describe.sequential("DevRegistry", () => {
 						env: {
 							DO: {
 								type: "durable-object",
-								workerName: "remote-worker",
+								worker: "remote-worker",
 								exportName: "MyDurableObject",
 							},
 						},
@@ -2172,7 +2172,7 @@ describe.sequential("DevRegistry", () => {
 				}
 			`),
 						env: {
-							SERVICE: { type: "worker", workerName: "remote-worker" },
+							SERVICE: { type: "worker", worker: "remote-worker" },
 						},
 					},
 				},
@@ -2294,7 +2294,7 @@ describe.sequential("DevRegistry", () => {
 				}
 			`),
 						env: {
-							SERVICE: { type: "worker", workerName: "remote-worker" },
+							SERVICE: { type: "worker", worker: "remote-worker" },
 						},
 					},
 				},
@@ -2440,7 +2440,7 @@ describe.sequential("DevRegistry", () => {
 					}
 				}
 			`),
-						tailConsumers: [{ workerName: "remote-worker" }],
+						tailConsumers: [{ worker: "remote-worker" }],
 					},
 				},
 			],

--- a/packages/miniflare/test/index.spec.ts
+++ b/packages/miniflare/test/index.spec.ts
@@ -1042,7 +1042,7 @@ test("Miniflare: service binding to current worker", async ({ expect }) => {
 					type: "worker",
 					name: "",
 					compatibilityDate: "2025-05-01",
-					env: { SELF: { type: "worker", workerName: kCurrentWorker } },
+					env: { SELF: { type: "worker", worker: kCurrentWorker } },
 					manifest: singleModuleManifest(`export default {
 			async fetch(request, env) {
 				const { pathname } = new URL(request.url);
@@ -1154,17 +1154,17 @@ test("Miniflare: service binding to named entrypoint", async ({ expect }) => {
 					env: {
 						A_RPC_SERVICE: {
 							type: "worker",
-							workerName: kCurrentWorker,
+							worker: kCurrentWorker,
 							exportName: "RpcEntrypoint",
 						},
 						A_NAMED_SERVICE: {
 							type: "worker",
-							workerName: "a",
+							worker: "a",
 							exportName: "namedEntrypoint",
 						},
 						B_NAMED_SERVICE: {
 							type: "worker",
-							workerName: "b",
+							worker: "b",
 							exportName: "anotherNamedEntrypoint",
 						},
 					},
@@ -1227,7 +1227,7 @@ test("Miniflare: service binding to named entrypoint that implements a method re
 					env: {
 						RPC_SERVICE: {
 							type: "worker",
-							workerName: "b",
+							worker: "b",
 							exportName: "RpcEntrypoint",
 						},
 					},
@@ -1283,7 +1283,7 @@ test("Miniflare: service binding to named entrypoint that implements a method re
 					env: {
 						RPC_SERVICE: {
 							type: "worker",
-							workerName: "b",
+							worker: "b",
 							exportName: "RpcEntrypoint",
 						},
 					},
@@ -1343,10 +1343,10 @@ test("Miniflare: tail consumer called", async ({ expect }) => {
 				config: {
 					type: "worker",
 					name: "a",
-					tailConsumers: [{ workerName: "b" }],
+					tailConsumers: [{ worker: "b" }],
 					compatibilityDate: "2025-04-28",
 					env: {
-						B: { type: "worker", workerName: "b" },
+						B: { type: "worker", worker: "b" },
 					},
 					manifest: singleModuleManifest(`
 
@@ -1407,7 +1407,7 @@ test("Miniflare: custom outbound service", async ({ expect }) => {
 				}`),
 				},
 				dev: {
-					outboundService: { type: "worker", workerName: "b" },
+					outboundService: { type: "worker", worker: "b" },
 				},
 			},
 			{
@@ -2990,11 +2990,11 @@ test("Miniflare: getBindings() returns all bindings", async ({
 					env: {
 						STRING: { type: "text", value: "hello" },
 						OBJECT: { type: "json", value: { a: 1, b: { c: 2 } } },
-						SELF: { type: "worker", workerName: "" },
+						SELF: { type: "worker", worker: "" },
 						DB: { type: "d1", id: "DB" },
 						DO: {
 							type: "durable-object",
-							workerName: "",
+							worker: "",
 							exportName: "DurableObject",
 						},
 						KV: { type: "kv", id: "KV" },
@@ -3235,7 +3235,7 @@ test("Miniflare: getBindings() and friends return bindings for different workers
 						DB: { type: "d1", id: "DB" },
 						DO: {
 							type: "durable-object",
-							workerName: "a",
+							worker: "a",
 							exportName: "DurableObject",
 						},
 					},
@@ -3384,7 +3384,7 @@ test("Miniflare: unsafeEvictDurableObject() resets in-memory state and preserves
 					env: {
 						COUNTER: {
 							type: "durable-object",
-							workerName: "do-worker",
+							worker: "do-worker",
 							exportName: "Counter",
 						},
 					},

--- a/packages/miniflare/test/plugins/core/inspector-proxy/index.spec.ts
+++ b/packages/miniflare/test/plugins/core/inspector-proxy/index.spec.ts
@@ -503,7 +503,7 @@ test("InspectorProxy: should allow debugging multiple workers", async ({
 						}
 					`),
 					env: {
-						WORKER_B: { type: "worker", workerName: "worker-b" },
+						WORKER_B: { type: "worker", worker: "worker-b" },
 					},
 				},
 				dev: { unsafeInspectorProxy: true },
@@ -663,7 +663,7 @@ test("InspectorProxy: should allow debugging workers created via setOptions", as
 						}
 					`),
 					env: {
-						WORKER_B: { type: "worker", workerName: "worker-b" },
+						WORKER_B: { type: "worker", worker: "worker-b" },
 					},
 				},
 				dev: { unsafeInspectorProxy: true },

--- a/packages/miniflare/test/plugins/core/observability.spec.ts
+++ b/packages/miniflare/test/plugins/core/observability.spec.ts
@@ -215,12 +215,12 @@ function storeWorker(): WorkerOptions {
 			env: {
 				TRACE_STORE: {
 					type: "durable-object",
-					workerName: OBSERVABILITY_COLLECTOR_SERVICE_NAME,
+					worker: OBSERVABILITY_COLLECTOR_SERVICE_NAME,
 					exportName: "TraceStore",
 				},
 				WOBS: {
 					type: "worker",
-					workerName: OBSERVABILITY_COLLECTOR_SERVICE_NAME,
+					worker: OBSERVABILITY_COLLECTOR_SERVICE_NAME,
 				},
 			},
 		},
@@ -474,7 +474,7 @@ function captureWorker(): WorkerOptions {
 				CACHE: { type: "kv", id: "cache-namespace" },
 				WOBS: {
 					type: "worker",
-					workerName: OBSERVABILITY_COLLECTOR_SERVICE_NAME,
+					worker: OBSERVABILITY_COLLECTOR_SERVICE_NAME,
 				},
 			},
 		},
@@ -612,10 +612,10 @@ function multiWorkerSetup(): WorkerOptions[] {
 				compatibilityDate: "2026-06-01",
 				manifest: singleModuleManifest(UPSTREAM_WORKER),
 				env: {
-					DOWNSTREAM: { type: "worker", workerName: "downstream" },
+					DOWNSTREAM: { type: "worker", worker: "downstream" },
 					WOBS: {
 						type: "worker",
-						workerName: OBSERVABILITY_COLLECTOR_SERVICE_NAME,
+						worker: OBSERVABILITY_COLLECTOR_SERVICE_NAME,
 					},
 				},
 			},
@@ -688,12 +688,12 @@ describe("unsafeObservability (workflows)", () => {
 							CAPTURE_WORKFLOW: {
 								type: "workflow",
 								name: "capture-workflow",
-								workerName: "wf-user",
+								worker: "wf-user",
 								exportName: "CaptureWorkflow",
 							},
 							WOBS: {
 								type: "worker",
-								workerName: OBSERVABILITY_COLLECTOR_SERVICE_NAME,
+								worker: OBSERVABILITY_COLLECTOR_SERVICE_NAME,
 							},
 						},
 					},

--- a/packages/miniflare/test/plugins/core/proxy/client.spec.ts
+++ b/packages/miniflare/test/plugins/core/proxy/client.spec.ts
@@ -295,7 +295,7 @@ describe("ProxyClient", () => {
 						env: {
 							OBJECT: {
 								type: "durable-object",
-								workerName: "",
+								worker: "",
 								exportName: "DurableObject",
 							},
 						},

--- a/packages/miniflare/test/plugins/do/index.spec.ts
+++ b/packages/miniflare/test/plugins/do/index.spec.ts
@@ -75,7 +75,7 @@ test("persists Durable Object data in-memory between options reloads", async ({
 					env: {
 						COUNTER: {
 							type: "durable-object",
-							workerName: "",
+							worker: "",
 							exportName: "Counter",
 						},
 					},
@@ -138,7 +138,7 @@ test("persists Durable Object data on file-system", async ({ expect }) => {
 					env: {
 						COUNTER: {
 							type: "durable-object",
-							workerName: "worker",
+							worker: "worker",
 							exportName: "Counter",
 						},
 					},
@@ -199,7 +199,7 @@ test("lists Durable Object ids with persisted storage", async ({ expect }) => {
 					env: {
 						COUNTER: {
 							type: "durable-object",
-							workerName: "worker",
+							worker: "worker",
 							exportName: "Counter",
 						},
 					},
@@ -252,8 +252,8 @@ test("multiple Workers access same Durable Object data", async ({ expect }) => {
           }
         }`),
 					env: {
-						A: { type: "worker", workerName: "a" },
-						B: { type: "worker", workerName: "b" },
+						A: { type: "worker", worker: "a" },
+						B: { type: "worker", worker: "b" },
 					},
 				},
 			},
@@ -266,12 +266,12 @@ test("multiple Workers access same Durable Object data", async ({ expect }) => {
 					env: {
 						COUNTER_A: {
 							type: "durable-object",
-							workerName: "a",
+							worker: "a",
 							exportName: "Counter",
 						},
 						COUNTER_B: {
 							type: "durable-object",
-							workerName: "b",
+							worker: "b",
 							exportName: "Counter",
 						},
 					},
@@ -289,12 +289,12 @@ test("multiple Workers access same Durable Object data", async ({ expect }) => {
 					env: {
 						COUNTER_A: {
 							type: "durable-object",
-							workerName: "a",
+							worker: "a",
 							exportName: "Counter",
 						},
 						COUNTER_B: {
 							type: "durable-object",
-							workerName: "b",
+							worker: "b",
 							exportName: "Counter",
 						},
 					},
@@ -358,7 +358,7 @@ test("can use Durable Object ID from one object in another", async ({
 					env: {
 						OBJECT_B: {
 							type: "durable-object",
-							workerName: "a",
+							worker: "a",
 							exportName: "b_B",
 						},
 					},
@@ -403,7 +403,7 @@ test("can use Durable Object ID from one object in another", async ({
 					env: {
 						OBJECT_B: {
 							type: "durable-object",
-							workerName: "b",
+							worker: "b",
 							exportName: "B",
 						},
 					},
@@ -436,7 +436,7 @@ test("proxies Durable Object methods", async ({ expect }) => {
 					env: {
 						COUNTER: {
 							type: "durable-object",
-							workerName: "",
+							worker: "",
 							exportName: "Counter",
 						},
 					},
@@ -495,7 +495,7 @@ test("proxies Durable Object methods", async ({ expect }) => {
 					env: {
 						WEBSOCKET: {
 							type: "durable-object",
-							workerName: "",
+							worker: "",
 							exportName: "WebSocketObject",
 						},
 					},
@@ -536,7 +536,7 @@ describe("evictions", { concurrent: true }, () => {
 						env: {
 							DURABLE_OBJECT: {
 								type: "durable-object",
-								workerName: "",
+								worker: "",
 								exportName: "DurableObject",
 							},
 						},
@@ -578,7 +578,7 @@ describe("evictions", { concurrent: true }, () => {
 						env: {
 							DURABLE_OBJECT: {
 								type: "durable-object",
-								workerName: "",
+								worker: "",
 								exportName: "DurableObject",
 							},
 						},
@@ -639,7 +639,7 @@ const MINIFLARE_WITH_SQLITE = (useSQLite: boolean) =>
 					env: {
 						SQLITE_DURABLE_OBJECT: {
 							type: "durable-object",
-							workerName: "",
+							worker: "",
 							exportName: "SQLiteDurableObject",
 						},
 					},
@@ -718,7 +718,7 @@ test("gets SQLite storage for Durable Objects", async ({ expect }) => {
 					env: {
 						OBJECT: {
 							type: "durable-object",
-							workerName: "worker",
+							worker: "worker",
 							exportName: "TestObject",
 						},
 					},
@@ -816,7 +816,7 @@ test("colo-local actors", async ({ expect }) => {
 					env: {
 						OBJECT: {
 							type: "durable-object",
-							workerName: "",
+							worker: "",
 							exportName: "TestObject",
 						},
 					},
@@ -882,7 +882,7 @@ test("multiple workers with DO useSQLite true and undefined does not cause optio
 						env: {
 							MY_DO: {
 								type: "durable-object",
-								workerName: "worker-a",
+								worker: "worker-a",
 								exportName: "MyDo",
 							},
 						},
@@ -900,7 +900,7 @@ test("multiple workers with DO useSQLite true and undefined does not cause optio
 						env: {
 							MY_DO: {
 								type: "durable-object",
-								workerName: "worker-a",
+								worker: "worker-a",
 								exportName: "MyDo",
 							},
 						},
@@ -951,7 +951,7 @@ test("Durable Object RPC calls do not block Node.js event loop", async ({
 					env: {
 						BLOCKING_DO: {
 							type: "durable-object",
-							workerName: "",
+							worker: "",
 							exportName: "BlockingDO",
 						},
 					},
@@ -995,7 +995,7 @@ test("Durable Object RPC calls complete when unblocked", async ({ expect }) => {
 					env: {
 						BLOCKING_DO: {
 							type: "durable-object",
-							workerName: "",
+							worker: "",
 							exportName: "BlockingDO",
 						},
 					},

--- a/packages/miniflare/test/plugins/local-explorer/aggregation.spec.ts
+++ b/packages/miniflare/test/plugins/local-explorer/aggregation.spec.ts
@@ -65,7 +65,7 @@ describe("Cross-process aggregation", () => {
 							DB_A: { type: "d1", id: "db-a" },
 							MY_DO: {
 								type: "durable-object",
-								workerName: "worker-a",
+								worker: "worker-a",
 								exportName: "MyDO",
 							},
 							BUCKET_A: { type: "r2", name: "bucket-a" },
@@ -101,7 +101,7 @@ describe("Cross-process aggregation", () => {
 							DB_B: { type: "d1", id: "db-b" },
 							OTHER_DO: {
 								type: "durable-object",
-								workerName: "worker-b",
+								worker: "worker-b",
 								exportName: "OtherDO",
 							},
 							BUCKET_B: { type: "r2", name: "bucket-b" },
@@ -567,7 +567,7 @@ describe("Same ID across multiple instances with different persistence directori
 							MY_DB: { type: "d1", id: "shared-db-id" },
 							MY_DO: {
 								type: "durable-object",
-								workerName: "worker-a",
+								worker: "worker-a",
 								exportName: "MyDO",
 							},
 						},
@@ -598,7 +598,7 @@ describe("Same ID across multiple instances with different persistence directori
 							MY_DB: { type: "d1", id: "shared-db-id" },
 							MY_DO: {
 								type: "durable-object",
-								workerName: "worker-a",
+								worker: "worker-a",
 								exportName: "MyDO",
 							},
 						},

--- a/packages/miniflare/test/plugins/local-explorer/do-wrapper.spec.ts
+++ b/packages/miniflare/test/plugins/local-explorer/do-wrapper.spec.ts
@@ -80,7 +80,7 @@ describe("Durable Object Wrapper", () => {
 							env: {
 								TEST_DO: {
 									type: "durable-object",
-									workerName: "",
+									worker: "",
 									exportName: "TestDO",
 								},
 							},

--- a/packages/miniflare/test/plugins/local-explorer/do.spec.ts
+++ b/packages/miniflare/test/plugins/local-explorer/do.spec.ts
@@ -74,12 +74,12 @@ describe("Durable Objects API", () => {
 						env: {
 							TEST_DO: {
 								type: "durable-object",
-								workerName: "my-worker",
+								worker: "my-worker",
 								exportName: "TestDO",
 							},
 							ANOTHER_DO: {
 								type: "durable-object",
-								workerName: "my-worker",
+								worker: "my-worker",
 								exportName: "AnotherDO",
 							},
 							// check that we're not including internal DOs used to implement other bindings
@@ -215,7 +215,7 @@ describe("Durable Objects API", () => {
 							env: {
 								TEST_DO: {
 									type: "durable-object",
-									workerName: "worker-with-do",
+									worker: "worker-with-do",
 									exportName: "TestDO",
 								},
 							},
@@ -331,13 +331,13 @@ describe("Durable Objects API", () => {
 							env: {
 								LOCAL_DO: {
 									type: "durable-object",
-									workerName: "my-worker",
+									worker: "my-worker",
 									exportName: "LocalDO",
 								},
 								// This DO references a worker not in this miniflare instance
 								EXTERNAL_DO: {
 									type: "durable-object",
-									workerName: "remote-worker",
+									worker: "remote-worker",
 									exportName: "ExternalDO",
 								},
 							},
@@ -395,7 +395,7 @@ describe("Durable Objects API", () => {
 							env: {
 								MY_DO: {
 									type: "durable-object",
-									workerName: "worker-a",
+									worker: "worker-a",
 									exportName: "SharedDO",
 								},
 							},
@@ -416,7 +416,7 @@ describe("Durable Objects API", () => {
 								// References the DO in worker-a
 								MY_DO: {
 									type: "durable-object",
-									workerName: "worker-a",
+									worker: "worker-a",
 									exportName: "SharedDO",
 								},
 							},
@@ -467,7 +467,7 @@ describe("Durable Objects API", () => {
 							env: {
 								BOUND_DO: {
 									type: "durable-object",
-									workerName: "my-worker",
+									worker: "my-worker",
 									exportName: "BoundDO",
 								},
 							},
@@ -592,12 +592,12 @@ describe("Durable Objects API", () => {
 							env: {
 								SQLITE_DO: {
 									type: "durable-object",
-									workerName: "query-worker",
+									worker: "query-worker",
 									exportName: "SqliteDO",
 								},
 								NON_SQLITE_DO: {
 									type: "durable-object",
-									workerName: "query-worker",
+									worker: "query-worker",
 									exportName: "NonSqliteDO",
 								},
 							},

--- a/packages/miniflare/test/plugins/local-explorer/index.spec.ts
+++ b/packages/miniflare/test/plugins/local-explorer/index.spec.ts
@@ -663,7 +663,7 @@ describe("Local Explorer /api/local/workers endpoint", () => {
 							SEND_EMAIL_SECONDARY: { type: "send-email" },
 							MY_DO: {
 								type: "durable-object",
-								workerName: "worker-a1",
+								worker: "worker-a1",
 								exportName: "TestDO",
 							},
 						},

--- a/packages/miniflare/test/plugins/local-explorer/observability.spec.ts
+++ b/packages/miniflare/test/plugins/local-explorer/observability.spec.ts
@@ -84,7 +84,7 @@ describe("Observability API", () => {
 						env: {
 							TRACE_STORE: {
 								type: "durable-object",
-								workerName: OBSERVABILITY_COLLECTOR_SERVICE_NAME,
+								worker: OBSERVABILITY_COLLECTOR_SERVICE_NAME,
 								exportName: "TraceStore",
 							},
 						},

--- a/packages/miniflare/test/plugins/shared/remote-bindings-access-warning.spec.ts
+++ b/packages/miniflare/test/plugins/shared/remote-bindings-access-warning.spec.ts
@@ -62,7 +62,7 @@ describe("remote-bindings proxy client: Cloudflare Access warning", () => {
 						env: {
 							SERVICE: {
 								type: "worker",
-								workerName: "some-remote-service",
+								worker: "some-remote-service",
 								dev: { remote: true },
 							},
 						},
@@ -124,7 +124,7 @@ describe("remote-bindings proxy client: Cloudflare Access warning", () => {
 						env: {
 							SERVICE: {
 								type: "worker",
-								workerName: "some-remote-service",
+								worker: "some-remote-service",
 								dev: { remote: true },
 							},
 						},
@@ -183,7 +183,7 @@ describe("remote-bindings proxy client: Cloudflare Access warning", () => {
 						env: {
 							SERVICE: {
 								type: "worker",
-								workerName: "some-remote-service",
+								worker: "some-remote-service",
 								dev: { remote: true },
 							},
 						},
@@ -233,7 +233,7 @@ describe("remote-bindings proxy client: Cloudflare Access warning", () => {
 						env: {
 							SERVICE: {
 								type: "worker",
-								workerName: "some-remote-service",
+								worker: "some-remote-service",
 								dev: { remote: true },
 							},
 						},

--- a/packages/miniflare/test/plugins/shared/remote-bindings-connect.spec.ts
+++ b/packages/miniflare/test/plugins/shared/remote-bindings-connect.spec.ts
@@ -254,7 +254,7 @@ function makeEdge(targetScript: string, directSockets = false): Miniflare {
 							},
 						},
 					},
-					env: { VPC: { type: "worker", workerName: "vpc-target" } },
+					env: { VPC: { type: "worker", worker: "vpc-target" } },
 				},
 			},
 			{

--- a/packages/miniflare/test/plugins/workflows/index.spec.ts
+++ b/packages/miniflare/test/plugins/workflows/index.spec.ts
@@ -46,7 +46,7 @@ test("starts Workflows with user-provided experimental compatibility flag", asyn
 						MY_WORKFLOW: {
 							type: "workflow",
 							name: "MY_WORKFLOW",
-							workerName: "workflow-compatibility-flags-worker",
+							worker: "workflow-compatibility-flags-worker",
 							exportName: "MyWorkflow",
 						},
 					},
@@ -79,7 +79,7 @@ test("persists Workflow data on file-system between runs", async ({
 						MY_WORKFLOW: {
 							type: "workflow",
 							name: "MY_WORKFLOW",
-							workerName: "worker",
+							worker: "worker",
 							exportName: "MyWorkflow",
 						},
 					},
@@ -236,7 +236,7 @@ function lifecycleMiniflareOpts(tmp: string): MiniflareOptions {
 						LIFECYCLE_WORKFLOW: {
 							type: "workflow",
 							name: "LIFECYCLE_WORKFLOW",
-							workerName: "lifecycle-worker",
+							worker: "lifecycle-worker",
 							exportName: "LifecycleWorkflow",
 						},
 					},

--- a/packages/wrangler/e2e/remote-binding/miniflare-remote-resources.test.ts
+++ b/packages/wrangler/e2e/remote-binding/miniflare-remote-resources.test.ts
@@ -185,12 +185,12 @@ const testCases: TestCase[] = [
 				miniflareConfig: (connection) => ({
 					SERVICE: {
 						type: "worker",
-						workerName: targetWorkerName,
+						worker: targetWorkerName,
 						dev: { remote: remote(connection) },
 					},
 					SERVICE_WITH_ENTRYPOINT: {
 						type: "worker",
-						workerName: targetWorkerName,
+						worker: targetWorkerName,
 						exportName: "CustomEntrypoint",
 						dev: { remote: remote(connection) },
 					},

--- a/packages/wrangler/e2e/remote-binding/remote-bindings-api.test.ts
+++ b/packages/wrangler/e2e/remote-binding/remote-bindings-api.test.ts
@@ -65,7 +65,7 @@ describe.skipIf(!CLOUDFLARE_ACCOUNT_ID)(
 							env: {
 								MY_SERVICE: {
 									type: "worker",
-									workerName: remoteWorkerName,
+									worker: remoteWorkerName,
 									dev: { remote: true },
 								},
 							},


### PR DESCRIPTION
Rename Worker target fields from `workerName` to `worker`

The experimental `@cloudflare/config` and Miniflare configuration APIs now use `worker` consistently for Worker, Durable Object, Workflow, dispatch namespace, and tail consumer targets.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: experimental feature

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- If you are an AI agent or LLM, and you are adding this PR without direct human supervision, thank you! Please uncomment the following block. This is so the maintainers know how to expect you to respond.

> [!NOTE]
> This is a contribution from an AI agent: <insert name here>, <insert LLM model here if different>.

-->
