### PR TITLE
fix(wrangler): do not query the GitHub skills API when telemetry is disabled

### DIFF
--- a/.changeset/skip-skills-lookup-when-opted-out.md
+++ b/.changeset/skip-skills-lookup-when-opted-out.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Skip the skills install status lookup when telemetry is disabled
+
+Telemetry events include a `currentAgentSkillsInstalled` property, and computing it can query the GitHub API. The lookup used to start before the telemetry permission was checked, so users who opted out via `WRANGLER_SEND_METRICS`, `DO_NOT_TRACK`, or `send_metrics` in their Wrangler config still triggered network requests on behalf of telemetry. The dispatcher now checks the permission first and only performs the lookup when telemetry is enabled.

--- a/packages/wrangler/src/__tests__/metrics.test.ts
+++ b/packages/wrangler/src/__tests__/metrics.test.ts
@@ -6,6 +6,7 @@ import {
 import ci from "ci-info";
 import { http, HttpResponse } from "msw";
 import { afterEach, beforeEach, describe, it, vi } from "vitest";
+import * as agentsSkillsInstall from "../agents-skills-install";
 import { logger } from "../logger";
 import { sendMetricsEvent } from "../metrics";
 import {
@@ -30,7 +31,7 @@ import { mockConsoleMethods } from "./helpers/mock-console";
 import { useMockIsTTY } from "./helpers/mock-istty";
 import { msw } from "./helpers/msw";
 import { runWrangler } from "./helpers/run-wrangler";
-import type { ExpectStatic } from "vitest";
+import type { ExpectStatic, MockInstance } from "vitest";
 
 vi.mock("../utils/detect-agent");
 const mockDetectAgent = vi.mocked(detectAgent);
@@ -228,6 +229,83 @@ describe("metrics", () => {
 
 				expect(requests.count).toBe(1);
 				expect(std.debug).toContain('"agent":null');
+			});
+		});
+
+		describe("agent skills install status fetch", () => {
+			let telemetrySpy: MockInstance<
+				typeof agentsSkillsInstall.telemetryCurrentAgentSkillsInstalled
+			>;
+
+			beforeEach(() => {
+				// vitest.setup.ts replaces telemetryCurrentAgentSkillsInstalled with
+				// a stub that resolves to null. Restore the real implementation so
+				// that the requests it makes to the GitHub skills API are observable
+				// via msw, then re-spy on it so calls can still be asserted.
+				vi.mocked(
+					agentsSkillsInstall.telemetryCurrentAgentSkillsInstalled
+				).mockRestore();
+				telemetrySpy = vi.spyOn(
+					agentsSkillsInstall,
+					"telemetryCurrentAgentSkillsInstalled"
+				);
+				// Report an agent with a known skills install path so the real
+				// implementation gets as far as querying the GitHub API.
+				mockDetectAgent.mockReturnValue({
+					isAgent: true,
+					id: "claude-code",
+				});
+			});
+
+			afterEach(() => {
+				// Put the stub from vitest.setup.ts back for the remaining tests.
+				telemetrySpy.mockReturnValue(Promise.resolve(null));
+			});
+
+			it("should not query the GitHub skills API if the dispatcher is disabled", async ({
+				expect,
+			}) => {
+				const skillsRequests = mockSkillsApiRequest();
+				const metricsRequests = mockMetricRequest();
+
+				const dispatcher = getMetricsDispatcher({
+					sendMetrics: false,
+				});
+				dispatcher.sendAdhocEvent("some-event", { a: 1, b: 2 });
+				dispatcher.sendCommandEvent("wrangler command started", {
+					sanitizedCommand: "docs",
+					sanitizedArgs: {},
+					argsUsed: [],
+				});
+				await allMetricsDispatchesCompleted();
+
+				expect(telemetrySpy).not.toHaveBeenCalled();
+				expect(skillsRequests.count).toBe(0);
+				expect(metricsRequests.count).toBe(0);
+			});
+
+			it("should query the GitHub skills API once if the dispatcher is enabled", async ({
+				expect,
+			}) => {
+				const skillsRequests = mockSkillsApiRequest();
+				const metricsRequests = mockMetricRequest();
+
+				const dispatcher = getMetricsDispatcher({
+					sendMetrics: true,
+				});
+				dispatcher.sendAdhocEvent("some-event", { a: 1, b: 2 });
+				dispatcher.sendCommandEvent("wrangler command started", {
+					sanitizedCommand: "docs",
+					sanitizedArgs: {},
+					argsUsed: [],
+				});
+				await allMetricsDispatchesCompleted();
+
+				expect(telemetrySpy).toHaveBeenCalled();
+				// The result is memoised, so even with two events dispatched the
+				// GitHub skills API is only queried once.
+				expect(skillsRequests.count).toBe(1);
+				expect(metricsRequests.count).toBe(2);
 			});
 		});
 
@@ -1030,6 +1108,30 @@ function mockMetricRequest() {
 		http.post(`*/event`, async () => {
 			requests.count++;
 			return HttpResponse.json({}, { status: 200 });
+		})
+	);
+
+	return requests;
+}
+
+/**
+ * Mocks the GitHub Contents API used to look up the available Cloudflare
+ * skills, counting the requests made to the skill listing endpoint.
+ */
+function mockSkillsApiRequest() {
+	const requests = { count: 0 };
+	msw.use(
+		http.get(
+			"https://api.github.com/repos/cloudflare/skills/contents/skills",
+			async () => {
+				requests.count++;
+				return HttpResponse.json([{ name: "cloudflare", type: "dir" }]);
+			}
+		),
+		http.get("https://api.github.com/repos/cloudflare/skills/contents/", () => {
+			return HttpResponse.json([
+				{ name: "skills", type: "dir", sha: "mock-tree-sha" },
+			]);
 		})
 	);
 

--- a/packages/wrangler/src/metrics/metrics-dispatcher.ts
+++ b/packages/wrangler/src/metrics/metrics-dispatcher.ts
@@ -87,8 +87,7 @@ export function getMetricsDispatcher(options: MetricsConfigOptions) {
 		 */
 		sendAdhocEvent(name: string, properties: Properties = {}) {
 			trackDispatch(
-				telemetryCurrentAgentSkillsInstalled()
-					.catch(() => null)
+				currentAgentSkillsInstalledForTelemetry()
 					.then((currentAgentSkillsInstalled) => {
 						const baseProperties = {
 							...getCommonEventProperties(),
@@ -151,8 +150,7 @@ export function getMetricsDispatcher(options: MetricsConfigOptions) {
 				};
 
 				trackDispatch(
-					telemetryCurrentAgentSkillsInstalled()
-						.catch(() => null)
+					currentAgentSkillsInstalledForTelemetry()
 						.then((currentAgentSkillsInstalled) => {
 							return dispatch({
 								name,
@@ -172,6 +170,19 @@ export function getMetricsDispatcher(options: MetricsConfigOptions) {
 			}
 		},
 	};
+
+	/**
+	 * Resolves the `currentAgentSkillsInstalled` telemetry property, but only
+	 * when telemetry is enabled. The underlying lookup can hit the GitHub API,
+	 * so it must be skipped entirely for users who have opted out of telemetry
+	 * rather than being resolved and then discarded in {@link dispatch}.
+	 */
+	function currentAgentSkillsInstalledForTelemetry() {
+		if (!getMetricsConfig(options).enabled) {
+			return Promise.resolve(null);
+		}
+		return telemetryCurrentAgentSkillsInstalled().catch(() => null);
+	}
 
 	function dispatch(event: {
 		name: string;


### PR DESCRIPTION
Fixes #15344

Telemetry events carry a `currentAgentSkillsInstalled` property, resolved by `telemetryCurrentAgentSkillsInstalled()`, which can query the GitHub Contents API for `cloudflare/skills`. In `getMetricsDispatcher`, both `sendAdhocEvent` and `sendCommandEvent` started that lookup at the head of the dispatch promise chain, while the telemetry permission was only checked afterwards inside `dispatch()`. So a user who opted out via `WRANGLER_SEND_METRICS=false`, `DO_NOT_TRACK`, or `send_metrics` in the Wrangler config still generated GitHub requests on behalf of telemetry; the payload was built and then discarded. That is the firewall prompt reported in the issue.

The dispatcher now resolves the property through a small helper that consults `getMetricsConfig(options).enabled` first and short circuits to a resolved `null` when telemetry is disabled, so the lookup only starts when the event will actually be sent. These are the only two call sites of `telemetryCurrentAgentSkillsInstalled()` outside its own module and tests. Behaviour with telemetry enabled is unchanged, and so is the "Dispatching disabled" debug log, whose inline snapshot in `metrics.test.ts` is untouched.

Tests (`packages/wrangler/src/__tests__/metrics.test.ts`): two tests added beside the existing disabled dispatcher test. They restore the real `telemetryCurrentAgentSkillsInstalled` implementation (`vitest.setup.ts` normally stubs it out) and register msw handlers for the two GitHub endpoints so requests are observable:

- dispatcher disabled: one adhoc and one command event produce zero requests to the skills API, the lookup is never invoked, and nothing is posted to the metrics endpoint.
- dispatcher enabled: the skills listing is fetched exactly once across the same two events (the result is memoised) and both events still post to the metrics endpoint.

On unmodified `main` both tests fail: the disabled case invokes the lookup twice (`expected "telemetryCurrentAgentSkillsInstalled" to not be called at all, but actually been called 2 times`), and the enabled case then sees zero fetches because the opted out run already memoised the result. With the fix, `metrics.test.ts` passes 58 tests, and `agents-skills-install.test.ts`, `metrics/sanitization.test.ts` and `register-yargs-command-skills.test.ts` stay green (160 tests across the four files, vitest 4.1.0). `tsc`, `oxlint --deny-warnings --type-aware` and `oxfmt --check` are clean on the changed files.

A patch changeset for `wrangler` is included.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: this restores the documented behaviour of the telemetry opt outs; no user facing interface changes.

<!-- devin-review-badge-begin -->

---

<a href="https://cloudflare.devinenterprise.com/review/cloudflare/workers-sdk/pull/15382" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->