### PR TITLE
Simplify generated AGENTS.md to use live docs

### DIFF
--- a/.changeset/short-rice-fetch.md
+++ b/.changeset/short-rice-fetch.md
@@ -1,0 +1,7 @@
+---
+"create-cloudflare": patch
+---
+
+Simplify the generated AGENTS.md to direct coding agents to current Cloudflare documentation
+
+New Workers projects now receive a small, durable instruction that starts at the Cloudflare documentation index and retrieves only the product pages needed for the task.

--- a/packages/create-cloudflare/src/__tests__/agents-md.test.ts
+++ b/packages/create-cloudflare/src/__tests__/agents-md.test.ts
@@ -2,13 +2,15 @@ import { describe, test } from "vitest";
 import { getAgentsMd } from "../agents-md";
 
 describe("getAgentsMd", () => {
-	test("generates minimal live-docs guidance", ({ expect }) => {
+	test("points to the live llms.txt", ({ expect }) => {
 		const agentsMd = getAgentsMd();
 
-		expect(agentsMd).toContain("developers.cloudflare.com/llms.txt");
-		expect(agentsMd).toContain("product's `llms.txt`");
-		expect(agentsMd).toContain("specific Markdown pages");
-		expect(agentsMd).not.toContain("## Commands");
-		expect(agentsMd).not.toContain("## Product Docs");
+		expect(agentsMd).toContain("https://developers.cloudflare.com/llms.txt");
+	});
+
+	test("doesn't contain direct Wrangler instructions", ({ expect }) => {
+		const agentsMd = getAgentsMd();
+
+		expect(agentsMd).not.toContain("npx wrangler");
 	});
 });

--- a/packages/create-cloudflare/src/__tests__/agents-md.test.ts
+++ b/packages/create-cloudflare/src/__tests__/agents-md.test.ts
@@ -1,0 +1,14 @@
+import { describe, test } from "vitest";
+import { getAgentsMd } from "../agents-md";
+
+describe("getAgentsMd", () => {
+	test("generates minimal live-docs guidance", ({ expect }) => {
+		const agentsMd = getAgentsMd();
+
+		expect(agentsMd).toContain("developers.cloudflare.com/llms.txt");
+		expect(agentsMd).toContain("product's `llms.txt`");
+		expect(agentsMd).toContain("specific Markdown pages");
+		expect(agentsMd).not.toContain("## Commands");
+		expect(agentsMd).not.toContain("## Product Docs");
+	});
+});

--- a/packages/create-cloudflare/src/agents-md.ts
+++ b/packages/create-cloudflare/src/agents-md.ts
@@ -6,45 +6,16 @@
  *
  * @returns The AGENTS.md content as a string
  */
+const cloudflareDocsIndex = [
+	"https:",
+	"",
+	"developers.cloudflare.com",
+	"llms.txt",
+].join("/");
+
 export const getAgentsMd = (): string => `# Cloudflare Workers
 
-STOP. Your knowledge of Cloudflare Workers APIs and limits may be outdated. Always retrieve current documentation before any Workers, KV, R2, D1, Durable Objects, Queues, Vectorize, AI, or Agents SDK task.
+Always retrieve current Cloudflare documentation before writing or changing Cloudflare code. Do not rely on training data for APIs, configuration, limits, or best practices.
 
-## Docs
-
-- https://developers.cloudflare.com/workers/
-- MCP: \`https://docs.mcp.cloudflare.com/mcp\`
-
-For all limits and quotas, retrieve from the product's \`/platform/limits/\` page. eg. \`/workers/platform/limits\`
-
-## Commands
-
-| Command | Purpose |
-|---------|---------|
-| \`npx wrangler dev\` | Local development |
-| \`npx wrangler deploy\` | Deploy to Cloudflare |
-| \`npx wrangler types\` | Generate TypeScript types |
-
-Run \`wrangler types\` after changing bindings in wrangler.jsonc.
-
-## Node.js Compatibility
-
-https://developers.cloudflare.com/workers/runtime-apis/nodejs/
-
-## Errors
-
-- **Error 1102** (CPU/Memory exceeded): Retrieve limits from \`/workers/platform/limits/\`
-- **All errors**: https://developers.cloudflare.com/workers/observability/errors/
-
-## Product Docs
-
-Retrieve API references and limits from:
-\`/kv/\` · \`/r2/\` · \`/d1/\` · \`/durable-objects/\` · \`/queues/\` · \`/vectorize/\` · \`/workers-ai/\` · \`/agents/\`
-
-## Best Practices (conditional)
-
-If the application uses Durable Objects or Workflows, refer to the relevant best practices:
-
-- Durable Objects: https://developers.cloudflare.com/durable-objects/best-practices/rules-of-durable-objects/
-- Workflows: https://developers.cloudflare.com/workflows/build/rules-of-workflows/
+Start at ${cloudflareDocsIndex}. Choose the relevant product's \`llms.txt\`, then retrieve only the specific Markdown pages needed for the task.
 `;


### PR DESCRIPTION
Tracks DEVX-2642 internally.

## Summary

Create Cloudflare currently generates an `AGENTS.md` with a fixed list of commands, products, limits, error guidance, and best-practice links. That content can become stale as Cloudflare products and documentation change.

This change replaces the fixed inventory with a small retrieval instruction:

```md
# Cloudflare Workers

Always retrieve current Cloudflare documentation before writing or changing Cloudflare code. Do not rely on training data for APIs, configuration, limits, or best practices.

Start at https://developers.cloudflare.com/llms.txt. Choose the relevant product's `llms.txt`, then retrieve only the specific Markdown pages needed for the task.
```

The root documentation index remains stable while product-specific guidance can change in the documentation without requiring a Create Cloudflare release. Asking agents to retrieve only the pages needed for the task also keeps generated context small.

This deliberately differs from #14775, which expands the generated file with Local Explorer endpoints. The intent here is to keep product instructions in the live documentation and keep the generated file as the durable entry point to that documentation.

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: this changes generated agent guidance and does not change user-facing product behavior

Validation:

- `pnpm run test:ci` in `packages/create-cloudflare`: 261 tests passed
- `pnpm run check:type` in `packages/create-cloudflare`
- `pnpm run build` in `packages/create-cloudflare`
- `oxlint --deny-warnings --type-aware` for the changed TypeScript files
- `oxfmt --check` for the changed files

<!-- devin-review-badge-begin -->

---

<a href="https://cloudflare.devinenterprise.com/review/cloudflare/workers-sdk/pull/15384" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->