### PR TITLE
Support partial manifests in build output

### DIFF
--- a/.changeset/resolve-partial-build-output-manifests.md
+++ b/.changeset/resolve-partial-build-output-manifests.md
@@ -1,0 +1,8 @@
+---
+"@cloudflare/build-output-utils": minor
+"@cloudflare/config": minor
+---
+
+Support partial manifests in the experimental Build Output Specification
+
+Build output producers now declare whether their module inventory is complete. `readBuildOutput()` resolves partial manifests by discovering `.js`, `.mjs`, and `.map` files while preserving explicit module type overrides.

--- a/packages/build-output-utils/src/__tests__/read.test.ts
+++ b/packages/build-output-utils/src/__tests__/read.test.ts
@@ -14,7 +14,8 @@ import { readBuildOutput } from "../read";
 import { writeSettingsConfig, writeWorkerConfig } from "../write";
 import type { ParsedOutputWorkerConfig } from "@cloudflare/config";
 
-const manifest: ParsedOutputWorkerConfig["manifest"] = {
+const completeManifest: ParsedOutputWorkerConfig["manifest"] = {
+	type: "complete",
 	mainModule: "index.js",
 	modules: { "index.js": { type: "esm" } },
 };
@@ -32,6 +33,18 @@ function inputWorkerConfig(name: string) {
 		compatibilityDate: "2026-06-01",
 		entrypoint: "index.js",
 	});
+}
+
+async function writeBundleFiles(
+	root: string,
+	files: Record<string, string>
+): Promise<void> {
+	const bundleDir = getWorkerBundleDir(root);
+	for (const [fileName, contents] of Object.entries(files)) {
+		const filePath = path.join(bundleDir, fileName);
+		await fsp.mkdir(path.dirname(filePath), { recursive: true });
+		await fsp.writeFile(filePath, contents);
+	}
 }
 
 /**
@@ -62,7 +75,7 @@ async function seedWorker(
 	await writeWorkerConfig({
 		root,
 		config: inputWorkerConfig(name),
-		manifest: hasBundle ? manifest : undefined,
+		manifest: hasBundle ? completeManifest : undefined,
 		workerDirectoryName,
 	});
 	if (bundleDir) {
@@ -95,7 +108,7 @@ describe("readBuildOutput", () => {
 		expect(output.workers.default.assetsDir).toBeUndefined();
 
 		expect(output.workers.default.config.name).toBe("my-worker");
-		expect(output.workers.default.config.manifest).toEqual(manifest);
+		expect(output.workers.default.config.manifest).toEqual(completeManifest);
 		expect(output.workers.default.config).not.toHaveProperty("entrypoint");
 	});
 
@@ -113,6 +126,103 @@ describe("readBuildOutput", () => {
 		expect(workers.additional?.config.name).toBe("additional-worker");
 		expect(workers.additional?.bundleDir).toBe(
 			getWorkerBundleDir(root, "additional")
+		);
+	});
+
+	it("resolves a partial manifest from bundle files and explicit overrides", async ({
+		expect,
+	}) => {
+		const root = process.cwd();
+		await seedWorker(root);
+		await writeWorkerConfig({
+			root,
+			config: inputWorkerConfig("my-worker"),
+			manifest: {
+				type: "partial",
+				mainModule: "index.js",
+				modules: {
+					"chunks/worker.mjs": { type: "cjs" },
+					"data.txt": { type: "text" },
+				},
+			},
+		});
+		await writeBundleFiles(root, {
+			"index.js": "module.exports = {};",
+			"chunks/worker.mjs": "export default {};",
+			"chunks/worker.mjs.map": "{}",
+			"data.txt": "data",
+			"ignored.json": "{}",
+		});
+
+		const { manifest: resolvedManifest } = (await readBuildOutput(root)).workers
+			.default.config;
+
+		expect(resolvedManifest).toEqual({
+			type: "complete",
+			mainModule: "index.js",
+			modules: {
+				"chunks/worker.mjs": { type: "cjs" },
+				"chunks/worker.mjs.map": { type: "sourcemap" },
+				"data.txt": { type: "text" },
+				"index.js": { type: "esm" },
+			},
+		});
+	});
+
+	it("does not scan bundle files for a complete manifest", async ({
+		expect,
+	}) => {
+		const root = process.cwd();
+		await seedWorker(root);
+		await writeBundleFiles(root, {
+			"index.js": "export default {};",
+			"unlisted.js": "export default {};",
+		});
+
+		const { manifest: resolvedManifest } = (await readBuildOutput(root)).workers
+			.default.config;
+
+		expect(resolvedManifest).toEqual(completeManifest);
+	});
+
+	it("throws when a partial manifest's main module cannot be resolved", async ({
+		expect,
+	}) => {
+		const root = process.cwd();
+		await seedWorker(root);
+		await writeWorkerConfig({
+			root,
+			config: inputWorkerConfig("my-worker"),
+			manifest: {
+				type: "partial",
+				mainModule: "missing.js",
+				modules: {},
+			},
+		});
+
+		await expect(readBuildOutput(root)).rejects.toThrow(
+			/partial manifest .* has main module "missing\.js", but it was not found as an ES module/
+		);
+	});
+
+	it("throws when a partial manifest's main module is a source map", async ({
+		expect,
+	}) => {
+		const root = process.cwd();
+		await seedWorker(root);
+		await writeWorkerConfig({
+			root,
+			config: inputWorkerConfig("my-worker"),
+			manifest: {
+				type: "partial",
+				mainModule: "index.js.map",
+				modules: {},
+			},
+		});
+		await writeBundleFiles(root, { "index.js.map": "{}" });
+
+		await expect(readBuildOutput(root)).rejects.toThrow(
+			/partial manifest .* has main module "index\.js\.map", but it was not found as an ES module/
 		);
 	});
 

--- a/packages/build-output-utils/src/__tests__/write.test.ts
+++ b/packages/build-output-utils/src/__tests__/write.test.ts
@@ -97,9 +97,10 @@ describe("writeWorkerConfig", () => {
 	}) => {
 		const root = process.cwd();
 		const manifest = {
+			type: "complete",
 			mainModule: "index.js",
-			modules: { "index.js": { type: "esm" as const } },
-		};
+			modules: { "index.js": { type: "esm" } },
+		} as const;
 
 		await writeWorkerConfig({ root, config: parsedWorkerConfig, manifest });
 

--- a/packages/build-output-utils/src/index.ts
+++ b/packages/build-output-utils/src/index.ts
@@ -22,4 +22,5 @@ export type {
 	BuildOutput,
 	BuildOutputWorker,
 	BuildOutputWorkers,
+	ResolvedOutputWorkerConfig,
 } from "./read";

--- a/packages/build-output-utils/src/read.ts
+++ b/packages/build-output-utils/src/read.ts
@@ -1,5 +1,6 @@
 import * as fs from "node:fs";
 import * as fsp from "node:fs/promises";
+import * as path from "node:path";
 import { OutputSettingsSchema, OutputWorkerSchema } from "@cloudflare/config";
 import { BuildOutputError } from "./errors";
 import {
@@ -12,15 +13,33 @@ import {
 	getWorkersDir,
 } from "./paths";
 import type {
+	ModuleType,
 	ParsedOutputSettingsConfig,
 	ParsedOutputWorkerConfig,
 } from "@cloudflare/config";
 
+type ManifestModules = NonNullable<
+	ParsedOutputWorkerConfig["manifest"]
+>["modules"];
+
+type CompleteManifest = Omit<
+	NonNullable<ParsedOutputWorkerConfig["manifest"]>,
+	"type"
+> & { type: "complete" };
+
+/** A schema-validated Worker config whose manifest has been fully resolved. */
+export type ResolvedOutputWorkerConfig = Omit<
+	ParsedOutputWorkerConfig,
+	"manifest"
+> & {
+	manifest?: CompleteManifest;
+};
+
 interface BuildOutputWorkerBase {
 	/** Absolute path to the Worker's `config.json`. */
 	configPath: string;
-	/** The parsed, schema-validated Worker config, including its `manifest`. */
-	config: ParsedOutputWorkerConfig;
+	/** The parsed Worker config, including its fully resolved `manifest`. */
+	config: ResolvedOutputWorkerConfig;
 }
 
 /**
@@ -81,7 +100,8 @@ export interface BuildOutput {
  *
  * Reads the optional top-level settings `config.json`, then reads and
  * schema-validates the Worker's `config.json` and resolves its
- * `bundle/` / `assets/` directories.
+ * `bundle/` / `assets/` directories. Partial manifests are resolved into
+ * complete manifests using the files in `bundle/`.
  *
  * @throws {BuildOutputError} if the top-level `config.json` is invalid, or if
  * the Worker config is missing, is not valid JSON, or fails schema validation.
@@ -155,18 +175,20 @@ async function readWorker(
 	}
 
 	if (hasBundleDir) {
+		const config = await resolveManifest(result.data, configPath, bundleDir);
 		return {
 			configPath,
-			config: result.data,
+			config,
 			bundleDir,
 			assetsDir: hasAssetsDir ? assetsDir : undefined,
 		};
 	}
 
 	if (hasAssetsDir) {
+		const { manifest: _manifest, ...config } = result.data;
 		return {
 			configPath,
-			config: result.data,
+			config,
 			bundleDir: undefined,
 			assetsDir,
 		};
@@ -175,6 +197,78 @@ async function readWorker(
 	throw new BuildOutputError(
 		`Worker config at ${configPath} has neither a bundle directory (${bundleDir}) nor an assets directory (${assetsDir}).`
 	);
+}
+
+/** Resolve the manifest against the bundle contents. */
+async function resolveManifest(
+	config: ParsedOutputWorkerConfig,
+	configPath: string,
+	bundleDir: string
+): Promise<ResolvedOutputWorkerConfig> {
+	const { manifest, ...workerConfig } = config;
+	if (manifest === undefined) {
+		return workerConfig;
+	}
+	if (manifest.type === "complete") {
+		return {
+			...workerConfig,
+			manifest: { ...manifest, type: "complete" },
+		};
+	}
+
+	const inferredModules = await scanModules(bundleDir);
+	if (inferredModules[manifest.mainModule]?.type !== "esm") {
+		throw new BuildOutputError(
+			`partial manifest at ${configPath} has main module "${manifest.mainModule}", but it was not found as an ES module in the bundle.`
+		);
+	}
+
+	const modules = {
+		...inferredModules,
+		...manifest.modules,
+	};
+
+	return {
+		...workerConfig,
+		manifest: {
+			type: "complete",
+			mainModule: manifest.mainModule,
+			modules,
+		},
+	};
+}
+
+/** Infer JavaScript modules and source maps from a bundle directory. */
+async function scanModules(bundleDir: string): Promise<ManifestModules> {
+	const modules: ManifestModules = {};
+	const entries = await fsp.readdir(bundleDir, {
+		recursive: true,
+		withFileTypes: true,
+	});
+
+	for (const entry of entries) {
+		const type = entry.isFile() ? inferModuleType(entry.name) : undefined;
+		if (type !== undefined) {
+			const modulePath = path
+				.relative(bundleDir, path.join(entry.parentPath, entry.name))
+				.split(path.sep)
+				.join("/");
+			modules[modulePath] = { type };
+		}
+	}
+
+	return modules;
+}
+
+/** Infer the module type for extensions supported by partial manifests. */
+function inferModuleType(modulePath: string): ModuleType | undefined {
+	switch (path.extname(modulePath)) {
+		case ".js":
+		case ".mjs":
+			return "esm";
+		case ".map":
+			return "sourcemap";
+	}
 }
 
 /**

--- a/packages/config/src/__tests__/schema.test.ts
+++ b/packages/config/src/__tests__/schema.test.ts
@@ -372,6 +372,7 @@ describe("InputWorkerSchema", () => {
 			const result = InputWorkerSchema.safeParse({
 				...baseConfig,
 				manifest: {
+					type: "complete",
 					mainModule: "index.js",
 					modules: { "index.js": { type: "esm" } },
 				},
@@ -680,10 +681,11 @@ describe("OutputWorkerSchema", () => {
 		}
 	});
 
-	it("accepts a config with a valid manifest", ({ expect }) => {
+	it("accepts a config with a valid complete manifest", ({ expect }) => {
 		const result = OutputWorkerSchema.safeParse({
 			...baseConfig,
 			manifest: {
+				type: "complete",
 				mainModule: "index.js",
 				modules: {
 					"index.js": { type: "esm" },
@@ -696,6 +698,36 @@ describe("OutputWorkerSchema", () => {
 		if (result.success) {
 			expect(result.data.manifest?.mainModule).toBe("index.js");
 		}
+	});
+
+	it("accepts a partial manifest that omits its main module from modules.manifest", ({
+		expect,
+	}) => {
+		const result = OutputWorkerSchema.safeParse({
+			...baseConfig,
+			manifest: {
+				type: "partial",
+				mainModule: "index.js",
+				modules: { "other.js": { type: "cjs" } },
+			},
+		});
+
+		expect(result.success).toBe(true);
+	});
+
+	it("rejects a partial manifest that includes its main module in modules.manifest", ({
+		expect,
+	}) => {
+		const result = OutputWorkerSchema.safeParse({
+			...baseConfig,
+			manifest: {
+				type: "partial",
+				mainModule: "index.js",
+				modules: { "index.js": { type: "esm" } },
+			},
+		});
+
+		expect(result.success).toBe(false);
 	});
 
 	it("rejects an entrypoint field (included in input schema only)", ({
@@ -713,6 +745,7 @@ describe("OutputWorkerSchema", () => {
 		const result = OutputWorkerSchema.safeParse({
 			...baseConfig,
 			manifest: {
+				type: "complete",
 				mainModule: "index.js",
 				modules: {
 					"index.js": { type: "bogus-type" },
@@ -727,7 +760,23 @@ describe("OutputWorkerSchema", () => {
 		const result = OutputWorkerSchema.safeParse({
 			...baseConfig,
 			manifest: {
+				type: "complete",
 				modules: { "index.js": { type: "esm" } },
+			},
+		});
+
+		expect(result.success).toBe(false);
+	});
+
+	it("rejects a complete manifest that does not include its main module", ({
+		expect,
+	}) => {
+		const result = OutputWorkerSchema.safeParse({
+			...baseConfig,
+			manifest: {
+				type: "complete",
+				mainModule: "index.js",
+				modules: {},
 			},
 		});
 
@@ -738,6 +787,7 @@ describe("OutputWorkerSchema", () => {
 		const result = OutputWorkerSchema.safeParse({
 			...baseConfig,
 			manifest: {
+				type: "complete",
 				mainModule: "index.js",
 				modules: {
 					"index.js": { type: "esm", extra: "field" },

--- a/packages/config/src/schema.ts
+++ b/packages/config/src/schema.ts
@@ -659,10 +659,34 @@ export const ModuleTypeSchema = z.enum([
 
 export type ModuleType = z.output<typeof ModuleTypeSchema>;
 
-const ManifestSchema = z.strictObject({
-	mainModule: z.string(),
-	modules: z.record(z.string(), z.strictObject({ type: ModuleTypeSchema })),
-});
+const ManifestModulesSchema = z.record(
+	z.string(),
+	z.strictObject({ type: ModuleTypeSchema })
+);
+
+const ManifestSchema = z
+	.strictObject({
+		type: z.enum(["partial", "complete"]),
+		mainModule: z.string(),
+		modules: ManifestModulesSchema,
+	})
+	.superRefine((manifest, ctx) => {
+		const mainModuleEntry = manifest.modules[manifest.mainModule];
+		if (manifest.type === "complete" && mainModuleEntry === undefined) {
+			ctx.addIssue({
+				code: "custom",
+				path: ["modules", manifest.mainModule],
+				message: "A complete manifest must include its main module.",
+			});
+		}
+		if (manifest.type === "partial" && mainModuleEntry !== undefined) {
+			ctx.addIssue({
+				code: "custom",
+				path: ["modules", manifest.mainModule],
+				message: "A partial manifest must not include its main module.",
+			});
+		}
+	});
 
 /**
  * Output Worker schema — the shape of the Worker's `config.json` in the

--- a/packages/vite-plugin-cloudflare/playground/experimental-build-output/__tests__/build-output.spec.ts
+++ b/packages/vite-plugin-cloudflare/playground/experimental-build-output/__tests__/build-output.spec.ts
@@ -63,6 +63,7 @@ describe.runIf(isBuild)("Build Output Specification files", () => {
 		expect(config).not.toHaveProperty("entrypoint");
 		expect(typeof config.manifest).toBe("object");
 		const manifest = config.manifest as Record<string, unknown>;
+		expect(manifest.type).toBe("complete");
 		expect(typeof manifest.mainModule).toBe("string");
 		expect(typeof manifest.modules).toBe("object");
 	});

--- a/packages/vite-plugin-cloudflare/src/plugins/build-output.ts
+++ b/packages/vite-plugin-cloudflare/src/plugins/build-output.ts
@@ -90,6 +90,7 @@ export const buildOutputPlugin = createPlugin("build-output", (ctx) => {
 				root: ctx.resolvedViteConfig.root,
 				config: workerNewConfig,
 				manifest: {
+					type: "complete",
 					mainModule: entryChunk.fileName,
 					modules,
 				},

--- a/packages/wrangler/src/__tests__/build-output.test.ts
+++ b/packages/wrangler/src/__tests__/build-output.test.ts
@@ -75,10 +75,12 @@ describe("wrangler build --experimental-cf-build-output", () => {
 		expect(config.compatibilityDate).toBe("2026-05-18");
 		expect(config.entrypoint).toBeUndefined();
 		const manifest = config.manifest as {
+			type: string;
 			mainModule: string;
 			modules: Record<string, { type: string }>;
 		};
 		expect(manifest).toBeDefined();
+		expect(manifest.type).toBe("complete");
 		expect(manifest.mainModule).toBe("index.js");
 		expect(manifest.modules["index.js"]).toEqual({ type: "esm" });
 
@@ -106,10 +108,12 @@ describe("wrangler build --experimental-cf-build-output", () => {
 
 		const config = readOutputConfig();
 		const manifest = config.manifest as {
+			type: string;
 			mainModule: string;
 			modules: Record<string, { type: string }>;
 		};
 		expect(manifest).toBeDefined();
+		expect(manifest.type).toBe("complete");
 		expect(manifest.mainModule).toBe("index.js");
 		expect(manifest.modules["index.js"]).toEqual({ type: "esm" });
 		expect(fs.existsSync(bundlePath("index.js"))).toBe(true);

--- a/packages/wrangler/src/deployment-bundle/build-output.ts
+++ b/packages/wrangler/src/deployment-bundle/build-output.ts
@@ -97,7 +97,7 @@ async function writeBundle({
 		modules[key] = { type: "sourcemap" };
 	}
 
-	return { mainModule: entryKey, modules };
+	return { type: "complete", mainModule: entryKey, modules };
 }
 
 async function writeAssets({


### PR DESCRIPTION
Support partial manifests in the experimental Build Output Specification

Build output producers now declare whether their module inventory is complete. `readBuildOutput()` resolves partial manifests by discovering `.js`, `.mjs`, and `.map` files while preserving explicit module type overrides.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: experimental feature

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- If you are an AI agent or LLM, and you are adding this PR without direct human supervision, thank you! Please uncomment the following block. This is so the maintainers know how to expect you to respond.

> [!NOTE]
> This is a contribution from an AI agent: <insert name here>, <insert LLM model here if different>.

-->
