### PR TITLE
[workers-utils] Extract reusable D1 migration helpers

### DIFF
--- a/.changeset/d1-migrations-utils.md
+++ b/.changeset/d1-migrations-utils.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/workers-utils": minor
+---
+
+Expose consumer-neutral D1 migration configuration, discovery and query helpers from `@cloudflare/workers-utils/d1-migrations`.

--- a/packages/workers-utils/AGENTS.md
+++ b/packages/workers-utils/AGENTS.md
@@ -11,6 +11,7 @@ Shared utility package used across wrangler, miniflare, and others. Two main are
   - `environment.ts` — Environment/config field definitions (many deprecated fields)
   - `config.ts` — Config types
 - `src/test-helpers/` — Shared test utilities used across packages
+- `src/d1-migrations.ts` — Reusable D1 migration discovery and query helpers
 - `src/types.ts` — Shared type definitions
 
 ## KEY EXPORTS
@@ -21,6 +22,8 @@ Shared utility package used across wrangler, miniflare, and others. Two main are
 - Used by wrangler for all config loading
 
 ### Shared runtime utilities
+
+- `@cloudflare/workers-utils/d1-migrations` — Consumer-neutral D1 migration configuration resolution, discovery, ordering, and SQL query generation. CLI-specific prompting, logging, error presentation, and query execution stay in consumers.
 
 - `createConfigCache(logger)` — file-backed JSON config cache (node_modules/.cache or `.wrangler/cache`). Generic mechanism; the consumer passes its logger (this package has no logger singleton). Both `wrangler` (`src/config-cache.ts`) and `@cloudflare/workers-auth` build their own instances.
 - `openInBrowser(url, logger)` — opens the `open` package with a graceful copy-paste fallback when no browser opener is available. Logger is a parameter, not imported.

--- a/packages/workers-utils/package.json
+++ b/packages/workers-utils/package.json
@@ -43,6 +43,10 @@
 			"import": "./dist/compatibility-date.mjs",
 			"types": "./dist/compatibility-date.d.mts"
 		},
+		"./d1-migrations": {
+			"import": "./dist/d1-migrations.mjs",
+			"types": "./dist/d1-migrations.d.mts"
+		},
 		"./docker-path": {
 			"import": "./dist/docker-path.mjs",
 			"types": "./dist/docker-path.d.mts"
@@ -83,6 +87,7 @@
 		"@cloudflare/workers-tsconfig": "workspace:*",
 		"@cloudflare/workflows-shared": "workspace:*",
 		"@types/command-exists": "^1.2.0",
+		"@types/minimatch": "^5.1.2",
 		"@types/node": "catalog:default",
 		"@vitest/ui": "catalog:default",
 		"ci-info": "catalog:default",
@@ -93,6 +98,7 @@
 		"empathic": "^2.0.0",
 		"jsonc-parser": "catalog:default",
 		"kleur": "^4.1.5",
+		"minimatch": "^5.1.0",
 		"open": "catalog:default",
 		"signal-exit": "catalog:default",
 		"smol-toml": "catalog:default",

--- a/packages/workers-utils/src/d1-migrations.ts
+++ b/packages/workers-utils/src/d1-migrations.ts
@@ -1,19 +1,45 @@
 import fs from "node:fs";
 import path from "node:path";
-import { configFileName, UserError } from "@cloudflare/workers-utils";
-import { isNonInteractiveOrCI } from "@cloudflare/workers-utils";
 import { Minimatch } from "minimatch";
-import { confirm } from "../../dialogs";
-import { logger } from "../../logger";
-import { DEFAULT_MIGRATION_PATH, DEFAULT_MIGRATION_TABLE } from "../constants";
-import { executeSql } from "../execute";
-import type { QueryResult } from "../execute";
-import type { Database, Migration } from "../types";
-import type { Config } from "@cloudflare/workers-utils";
+
+export const DEFAULT_MIGRATION_PATH = "./migrations";
+export const DEFAULT_MIGRATION_TABLE = "d1_migrations";
 
 function getDefaultMigrationsPattern(migrationsDir: string) {
 	return normalizeRelativePath(`${migrationsDir}/*.sql`);
 }
+
+export type MigrationsConfigErrorCode =
+	| "MIGRATIONS_PATTERN_REQUIRES_DIR"
+	| "MIGRATIONS_PATTERN_OUTSIDE_DIR";
+
+/** A consumer-neutral migration configuration validation error. */
+export class MigrationsConfigError extends Error {
+	constructor(
+		message: string,
+		readonly code: MigrationsConfigErrorCode,
+		readonly details: {
+			migrationsDir?: string;
+			migrationsPattern: string;
+			suggestedPattern?: string;
+		}
+	) {
+		super(message);
+		this.name = "MigrationsConfigError";
+	}
+}
+
+/** Options for resolving D1 migration configuration. */
+export type ResolveMigrationsConfigOptions = {
+	/** Directory relative migration paths are resolved from. */
+	projectPath: string;
+	/** The configured migrations directory. */
+	migrationsDir?: string;
+	/** The configured migrations glob. */
+	migrationsPattern?: string;
+	/** The configured migration tracking table name. */
+	migrationsTableName?: string;
+};
 
 /**
  * Fully-resolved view of the D1 migrations configuration for one binding.
@@ -27,99 +53,66 @@ function getDefaultMigrationsPattern(migrationsDir: string) {
  *    `migrationsDir` — i.e. {@link stripDirPrefix} can rewrite it relative
  *    to `migrationsDir` without throwing. (When `migrationsDir` is `"."` the
  *    pattern carries no prefix, since normalization strips any leading `./`.)
- *  - `projectPath` is the directory containing the user's Wrangler config —
- *    the base that `migrationsDir` and `migrationsPattern` resolve against.
- *  - `configFile` is the short display name (e.g. `"wrangler.jsonc"`) used
- *    in error messages.
+ *  - `projectPath` is the base that `migrationsDir` and `migrationsPattern`
+ *    resolve against.
  */
 export type MigrationsConfig = {
 	projectPath: string;
-	configFile: string;
 	migrationsDir: string;
 	migrationsPattern: string;
 	migrationsTableName: string;
-	migrationsDirRaw?: string;
 };
 
 /**
- * Resolve the migrations-related config for one D1 binding into a
- * `MigrationsConfig`, throwing a `UserError` if `migrations_pattern` is set
- * without `migrations_dir`, or doesn't start with `${migrations_dir}/`.
+ * Resolve migration-related configuration for one D1 binding.
  *
- * `databaseInfo` may be `null` — `apply --local` and `list --local` pass
- * `null` when the binding can't be found, and fall back to the defaults
- * so the commands surface "no migrations found" instead of crashing.
+ * @param options - The project root and optional migration settings.
+ * @returns Normalized migration configuration.
  */
 export function resolveMigrationsConfig({
-	databaseInfo,
-	configPath,
-}: {
-	databaseInfo: Database | null;
-	configPath: string;
-}): MigrationsConfig {
-	const configFile = configFileName(configPath);
-	const projectPath = path.dirname(configPath);
-
-	const rawDir = databaseInfo?.migrationsDirRaw;
-	const rawPattern = databaseInfo?.migrationsPattern;
-
+	projectPath,
+	migrationsDir: rawDir,
+	migrationsPattern: rawPattern,
+	migrationsTableName = DEFAULT_MIGRATION_TABLE,
+}: ResolveMigrationsConfigOptions): MigrationsConfig {
 	if (rawPattern !== undefined && rawDir === undefined) {
-		throw new UserError(
-			`You have set \`migrations_pattern: "${rawPattern}"\` in your ${configFile} file but have not set \`migrations_dir\` for this D1 binding.\n\n` +
-				`When \`migrations_pattern\` is set, \`migrations_dir\` must also be set, and \`migrations_pattern\` must start with \`\${migrations_dir}/\`. Add a \`migrations_dir\` entry to your ${configFile} file (for example, \`"migrations_dir": "migrations"\`).`,
-			{
-				telemetryMessage:
-					"d1 migrations migrations_pattern set without migrations_dir",
-			}
+		throw new MigrationsConfigError(
+			"migrationsPattern requires migrationsDir to be set.",
+			"MIGRATIONS_PATTERN_REQUIRES_DIR",
+			{ migrationsPattern: rawPattern }
 		);
 	}
 
-	const migrationsDir = normalizeRelativePath(
-		databaseInfo?.migrationsDirRaw ?? DEFAULT_MIGRATION_PATH
-	);
-
+	const migrationsDir = normalizeRelativePath(rawDir ?? DEFAULT_MIGRATION_PATH);
 	let migrationsPattern: string;
 	if (rawPattern === undefined) {
 		migrationsPattern = getDefaultMigrationsPattern(migrationsDir);
 	} else {
 		migrationsPattern = normalizeRelativePath(rawPattern);
 		try {
-			// Called for its throw-on-non-prefix side effect
 			stripDirPrefix(migrationsPattern, migrationsDir);
 		} catch {
 			const suggestedPattern = getDefaultMigrationsPattern(migrationsDir);
-			throw new UserError(
-				`The configured \`migrations_pattern: "${rawPattern}"\` in your ${configFile} file must start with \`${migrationsDir}/\` to match \`"migrations_dir": "${migrationsDir}"\`.\n\n` +
-					`Either change \`migrations_pattern\` so it starts with \`${migrationsDir}/\` (for example, \`"${suggestedPattern}"\`), or change \`migrations_dir\` to match the start of your pattern.`,
+			throw new MigrationsConfigError(
+				`migrationsPattern must start with ${JSON.stringify(`${migrationsDir}/`)}.`,
+				"MIGRATIONS_PATTERN_OUTSIDE_DIR",
 				{
-					telemetryMessage:
-						"d1 migrations migrations_pattern does not start with migrations_dir",
+					migrationsDir,
+					migrationsPattern: rawPattern,
+					suggestedPattern,
 				}
 			);
 		}
 	}
 
-	const migrationsTableName =
-		databaseInfo?.migrationsTableName ?? DEFAULT_MIGRATION_TABLE;
-
 	return {
 		projectPath,
-		configFile,
 		migrationsDir,
 		migrationsPattern,
 		migrationsTableName,
-		migrationsDirRaw: rawDir,
 	};
 }
 
-/**
- * Normalize a relative path or glob into a canonical form for string-prefix
- * comparisons:
- *
- *  - Backslashes flipped to forward slashes.
- *  - Leading `./` and `//` runs collapsed (via `path.posix.normalize`).
- *  - Trailing `/` stripped (`normalize("foo/")` keeps it; we don't want it).
- */
 /**
  * Rewrite `pattern` relative to `dir` by stripping the `${dir}/` prefix. Both
  * `pattern` and `dir` must already be normalized (see
@@ -140,6 +133,14 @@ function stripDirPrefix(pattern: string, dir: string): string {
 	return pattern.slice(prefix.length);
 }
 
+/**
+ * Normalize a relative path or glob into a canonical form for string-prefix
+ * comparisons:
+ *
+ *  - Backslashes flipped to forward slashes.
+ *  - Leading `./` and `//` runs collapsed (via `path.posix.normalize`).
+ *  - Trailing `/` stripped (`normalize("foo/")` keeps it; we don't want it).
+ */
 export function normalizeRelativePath(p: string): string {
 	const forwardSlashed = p.replace(/\\/g, "/");
 	const normalized = path.posix.normalize(forwardSlashed);
@@ -149,10 +150,12 @@ export function normalizeRelativePath(p: string): string {
 	return normalized;
 }
 
+/** Escape a SQLite identifier using double quotes. */
 export function escapeIdentifier(id: string): string {
 	return `"${id.replace(/"/g, '""')}"`;
 }
 
+/** Build the query that creates the D1 migrations tracking table. */
 export function getCreateMigrationsTableQuery(migrationsTableName: string) {
 	const escapedTableName = escapeIdentifier(migrationsTableName);
 	return `CREATE TABLE IF NOT EXISTS ${escapedTableName}(
@@ -162,6 +165,7 @@ export function getCreateMigrationsTableQuery(migrationsTableName: string) {
 );`;
 }
 
+/** Build the query that lists applied migrations in application order. */
 export function getListAppliedMigrationsQuery(migrationsTableName: string) {
 	const escapedTableName = escapeIdentifier(migrationsTableName);
 	return `SELECT *
@@ -169,82 +173,7 @@ export function getListAppliedMigrationsQuery(migrationsTableName: string) {
 		ORDER BY id`;
 }
 
-export async function getMigrationsPath({
-	projectPath,
-	migrationsDir,
-	migrationsDirRaw,
-	createIfMissing,
-	configPath,
-}: {
-	projectPath: string;
-	migrationsDir: string;
-	migrationsDirRaw: string | undefined;
-	createIfMissing: boolean;
-	configPath: string | undefined;
-}): Promise<string> {
-	const dir = path.resolve(projectPath, migrationsDir);
-	if (fs.existsSync(dir)) {
-		return dir;
-	}
-
-	const warning = `No migrations folder found.${
-		migrationsDirRaw === undefined
-			? ` Set \`migrations_dir\` in your ${configFileName(configPath)} file to choose a different path.`
-			: ""
-	}`;
-
-	if (createIfMissing && (await confirm(`${warning}\nOk to create ${dir}?`))) {
-		fs.mkdirSync(dir, { recursive: true });
-		return dir;
-	} else {
-		logger.warn(warning);
-	}
-
-	throw new UserError(`No migrations present at ${dir}.`, {
-		telemetryMessage: "d1 migrations missing migrations directory",
-	});
-}
-
-export async function getUnappliedMigrations({
-	migrationsConfig,
-	local,
-	remote,
-	config,
-	name,
-	persistTo,
-	preview,
-}: {
-	migrationsConfig: MigrationsConfig;
-	local: boolean | undefined;
-	remote: boolean | undefined;
-	config: Config;
-	name: string;
-	persistTo: string | undefined;
-	preview: boolean | undefined;
-}): Promise<Array<string>> {
-	const appliedMigrations = (
-		await listAppliedMigrations({
-			migrationsTableName: migrationsConfig.migrationsTableName,
-			local,
-			remote,
-			config,
-			name,
-			persistTo,
-			preview,
-		})
-	).map((migration) => {
-		return migration.name;
-	});
-
-	const migrations = getMigrationNames(migrationsConfig, { logHint: true });
-	const unappliedMigrations = getUnappliedMigrationNames(
-		migrations,
-		appliedMigrations
-	);
-
-	return unappliedMigrations;
-}
-
+/** Return migration names that have not already been applied. */
 export function getUnappliedMigrationNames(
 	migrations: string[],
 	appliedMigrations: string[]
@@ -259,45 +188,6 @@ export function getUnappliedMigrationNames(
 
 	return unappliedMigrations;
 }
-
-type ListAppliedMigrationsProps = {
-	migrationsTableName: string;
-	local: boolean | undefined;
-	remote: boolean | undefined;
-	config: Config;
-	name: string;
-	persistTo: string | undefined;
-	preview: boolean | undefined;
-};
-
-const listAppliedMigrations = async ({
-	migrationsTableName,
-	local,
-	remote,
-	config,
-	name,
-	persistTo,
-	preview,
-}: ListAppliedMigrationsProps): Promise<Migration[]> => {
-	const response: QueryResult[] | null = await executeSql({
-		local,
-		remote,
-		config,
-		name,
-		shouldPrompt: !isNonInteractiveOrCI(),
-		persistTo,
-		command: getListAppliedMigrationsQuery(migrationsTableName),
-		file: undefined,
-		json: true,
-		preview,
-	});
-
-	if (!response || response[0].results.length === 0) {
-		return [];
-	}
-
-	return response[0].results as Migration[];
-};
 
 /**
  * Recursively list regular files under `dir` whose `dir`-relative path
@@ -410,15 +300,9 @@ function leadingMigrationNumber(relativePath: string): number {
  * Walk root is `projectPath/migrationsDir`. Each file is matched against
  * `migrationsPattern` interpreted as a glob relative to `projectPath` (i.e.
  * against `${migrationsDir}/${relativePath}`).
- *
- * If no files match but `*\/migration.sql` (drizzle's layout) matches files
- * on disk, logs a hint to stderr suggesting that pattern.
  */
 export function getMigrationNames(
-	migrationsConfig: MigrationsConfig,
-	options: {
-		logHint?: boolean;
-	} = {}
+	migrationsConfig: MigrationsConfig
 ): Array<string> {
 	const walkRoot = path.resolve(
 		migrationsConfig.projectPath,
@@ -438,13 +322,13 @@ export function getMigrationNames(
 		new Minimatch(dirRelativePattern, { dot: false })
 	);
 
-	if (options.logHint && matches.length === 0) {
-		maybeLogHint(migrationsConfig);
-	}
-
 	return matches;
 }
 
+/**
+ * Build a query containing a migration and the tracking-table insert that
+ * records it as applied.
+ */
 export function buildMigrationQuery({
 	migrationsPath,
 	migrationName,
@@ -465,34 +349,27 @@ values ('${migrationName.replace(/'/g, "''")}');`;
 }
 
 /**
- * If the configured `migrations_pattern` found nothing but `*\/migration.sql`
- * (drizzle's layout) matches files under `migrations_dir`, point the user
- * at the right pattern. Runs its own narrow walk — only called in the
- * no-matches branch.
+ * Return a matching Drizzle-style pattern when the configured pattern misses
+ * that layout.
  */
-export function maybeLogHint({
+export function findDrizzleMigrationsPattern({
 	projectPath,
 	migrationsDir,
-	migrationsPattern,
-	configFile,
-}: Pick<
-	MigrationsConfig,
-	"projectPath" | "migrationsDir" | "migrationsPattern" | "configFile"
->) {
+}: Pick<MigrationsConfig, "projectPath" | "migrationsDir">):
+	| string
+	| undefined {
 	const walkRoot = path.resolve(projectPath, migrationsDir);
 	const drizzleFiles = listFilesRelative(
 		walkRoot,
 		new Minimatch("*/migration.sql", { dot: false })
 	);
 	if (drizzleFiles.length === 0) {
-		return;
+		return undefined;
 	}
 	const drizzlePattern = normalizeRelativePath(
 		`${migrationsDir}/*/migration.sql`
 	);
-	logger.warn(
-		`Could not find any migration files matching \`${migrationsPattern}\`. It looks like there are migration files matching \`${drizzlePattern}\` though. If you are using drizzle to manage your migrations, please set \`migrations_pattern\` to \`${drizzlePattern}\` in ${configFile}.`
-	);
+	return drizzlePattern;
 }
 
 /**
@@ -520,34 +397,3 @@ export function getNextMigrationNumber(
 		.filter((n) => Number.isFinite(n));
 	return Math.max(...migrationNumbers, 0) + 1;
 }
-
-export const initMigrationsTable = async ({
-	migrationsTableName,
-	local,
-	remote,
-	config,
-	name,
-	persistTo,
-	preview,
-}: {
-	migrationsTableName: string;
-	local: boolean | undefined;
-	remote: boolean | undefined;
-	config: Config;
-	name: string;
-	persistTo: string | undefined;
-	preview: boolean | undefined;
-}) => {
-	return executeSql({
-		local,
-		remote,
-		config,
-		name,
-		shouldPrompt: !isNonInteractiveOrCI(),
-		persistTo,
-		command: getCreateMigrationsTableQuery(migrationsTableName),
-		file: undefined,
-		json: true,
-		preview,
-	});
-};

--- a/packages/workers-utils/tests/d1-migrations.test.ts
+++ b/packages/workers-utils/tests/d1-migrations.test.ts
@@ -1,0 +1,73 @@
+import fs from "node:fs";
+import path from "node:path";
+import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
+import { describe, it } from "vitest";
+import {
+	buildMigrationQuery,
+	getCreateMigrationsTableQuery,
+	getListAppliedMigrationsQuery,
+	MigrationsConfigError,
+	resolveMigrationsConfig,
+} from "../src/d1-migrations";
+
+function writeMigration(filePath: string, contents = "SELECT 1;"): void {
+	fs.mkdirSync(path.dirname(filePath), { recursive: true });
+	fs.writeFileSync(filePath, contents);
+}
+
+describe("D1 migrations", () => {
+	runInTempDir();
+
+	it("resolves defaults independently of Wrangler's database type", ({
+		expect,
+	}) => {
+		expect(
+			resolveMigrationsConfig({
+				projectPath: "project",
+			})
+		).toEqual({
+			projectPath: "project",
+			migrationsDir: "migrations",
+			migrationsPattern: "migrations/*.sql",
+			migrationsTableName: "d1_migrations",
+		});
+	});
+
+	it("reports configuration errors without coupling them to a CLI", ({
+		expect,
+	}) => {
+		let caught: unknown;
+		try {
+			resolveMigrationsConfig({
+				projectPath: ".",
+				migrationsPattern: "migrations/*.sql",
+			});
+		} catch (error) {
+			caught = error;
+		}
+
+		expect(caught).toBeInstanceOf(MigrationsConfigError);
+		expect((caught as MigrationsConfigError).code).toBe(
+			"MIGRATIONS_PATTERN_REQUIRES_DIR"
+		);
+	});
+
+	it("builds escaped tracking-table queries", ({ expect }) => {
+		writeMigration("migrations/0001_user's.sql", "CREATE TABLE users;");
+		expect(getCreateMigrationsTableQuery('custom"migrations')).toContain(
+			'"custom""migrations"'
+		);
+		expect(getListAppliedMigrationsQuery('custom"migrations')).toContain(
+			'FROM "custom""migrations"'
+		);
+		expect(
+			buildMigrationQuery({
+				migrationsPath: "migrations",
+				migrationName: "0001_user's.sql",
+				migrationsTableName: 'custom"migrations',
+			})
+		).toBe(`CREATE TABLE users;
+INSERT INTO "custom""migrations" (name)
+values ('0001_user''s.sql');`);
+	});
+});

--- a/packages/workers-utils/tsup.config.ts
+++ b/packages/workers-utils/tsup.config.ts
@@ -14,6 +14,7 @@ export default defineConfig(() => [
 			// pulling in the broad package barrel and its transitive dependencies.
 			"src/compliance.ts",
 			"src/compatibility-date.ts",
+			"src/d1-migrations.ts",
 			"src/docker-path.ts",
 			"src/errors.ts",
 			"src/fs-helpers.ts",

--- a/packages/wrangler/src/__tests__/d1/migrations/helpers.test.ts
+++ b/packages/wrangler/src/__tests__/d1/migrations/helpers.test.ts
@@ -8,9 +8,9 @@ import {
 	getNextMigrationNumber,
 	maybeLogHint,
 	resolveMigrationsConfig,
-} from "../../../d1/migrations/helpers";
+} from "../../../d1/migrations/wrangler-helpers";
 import { mockConsoleMethods } from "../../helpers/mock-console";
-import type { MigrationsConfig } from "../../../d1/migrations/helpers";
+import type { MigrationsConfig } from "../../../d1/migrations/wrangler-helpers";
 import type { Database } from "../../../d1/types";
 
 /**

--- a/packages/wrangler/src/api/test-harness.ts
+++ b/packages/wrangler/src/api/test-harness.ts
@@ -21,7 +21,7 @@ import {
 	getMigrationNames,
 	getUnappliedMigrationNames,
 	resolveMigrationsConfig,
-} from "../d1/migrations/helpers";
+} from "../d1/migrations/wrangler-helpers";
 import { splitSqlQuery } from "../d1/splitter";
 import { getDatabaseInfoFromConfig } from "../d1/utils";
 import { validateNodeCompatMode } from "../deployment-bundle/node-compat";

--- a/packages/wrangler/src/d1/migrations/apply.ts
+++ b/packages/wrangler/src/d1/migrations/apply.ts
@@ -12,7 +12,7 @@ import {
 	getUnappliedMigrations,
 	initMigrationsTable,
 	resolveMigrationsConfig,
-} from "./helpers";
+} from "./wrangler-helpers";
 import type { ParseError } from "@cloudflare/workers-utils";
 
 export const d1MigrationsApplyCommand = createCommand({

--- a/packages/wrangler/src/d1/migrations/create.ts
+++ b/packages/wrangler/src/d1/migrations/create.ts
@@ -10,7 +10,7 @@ import {
 	getNextMigrationNumber,
 	normalizeRelativePath,
 	resolveMigrationsConfig,
-} from "./helpers";
+} from "./wrangler-helpers";
 
 export const d1MigrationsCreateCommand = createCommand({
 	metadata: {

--- a/packages/wrangler/src/d1/migrations/list.ts
+++ b/packages/wrangler/src/d1/migrations/list.ts
@@ -8,7 +8,7 @@ import {
 	getUnappliedMigrations,
 	initMigrationsTable,
 	resolveMigrationsConfig,
-} from "./helpers";
+} from "./wrangler-helpers";
 
 export const d1MigrationsListCommand = createCommand({
 	metadata: {

--- a/packages/wrangler/src/d1/migrations/wrangler-helpers.ts
+++ b/packages/wrangler/src/d1/migrations/wrangler-helpers.ts
@@ -1,0 +1,246 @@
+import fs from "node:fs";
+import path from "node:path";
+import {
+	configFileName,
+	isNonInteractiveOrCI,
+	UserError,
+} from "@cloudflare/workers-utils";
+import {
+	findDrizzleMigrationsPattern,
+	getCreateMigrationsTableQuery,
+	getListAppliedMigrationsQuery,
+	getMigrationNames as getMigrationNamesFromConfig,
+	getUnappliedMigrationNames,
+	MigrationsConfigError,
+	resolveMigrationsConfig as resolveMigrationsConfigFromOptions,
+} from "@cloudflare/workers-utils/d1-migrations";
+import { confirm } from "../../dialogs";
+import { logger } from "../../logger";
+import { executeSql } from "../execute";
+import type { QueryResult } from "../execute";
+import type { Database, Migration } from "../types";
+import type { Config } from "@cloudflare/workers-utils";
+import type { MigrationsConfig as SharedMigrationsConfig } from "@cloudflare/workers-utils/d1-migrations";
+
+export {
+	buildMigrationQuery,
+	compareMigrationPaths,
+	getCreateMigrationsTableQuery,
+	getListAppliedMigrationsQuery,
+	getNextMigrationNumber,
+	getUnappliedMigrationNames,
+	normalizeRelativePath,
+} from "@cloudflare/workers-utils/d1-migrations";
+
+export type MigrationsConfig = SharedMigrationsConfig & {
+	configFile: string;
+	migrationsDirRaw?: string;
+};
+
+export function resolveMigrationsConfig({
+	databaseInfo,
+	configPath,
+}: {
+	databaseInfo: Database | null;
+	configPath: string;
+}): MigrationsConfig {
+	const configFile = configFileName(configPath);
+	try {
+		return {
+			...resolveMigrationsConfigFromOptions({
+				projectPath: path.dirname(configPath),
+				migrationsDir: databaseInfo?.migrationsDirRaw,
+				migrationsPattern: databaseInfo?.migrationsPattern,
+				migrationsTableName: databaseInfo?.migrationsTableName,
+			}),
+			configFile,
+			migrationsDirRaw: databaseInfo?.migrationsDirRaw,
+		};
+	} catch (error) {
+		if (!(error instanceof MigrationsConfigError)) {
+			throw error;
+		}
+		if (error.code === "MIGRATIONS_PATTERN_REQUIRES_DIR") {
+			throw new UserError(
+				`You have set \`migrations_pattern: "${error.details.migrationsPattern}"\` in your ${configFile} file but have not set \`migrations_dir\` for this D1 binding.\n\n` +
+					`When \`migrations_pattern\` is set, \`migrations_dir\` must also be set, and \`migrations_pattern\` must start with \`\${migrations_dir}/\`. Add a \`migrations_dir\` entry to your ${configFile} file (for example, \`"migrations_dir": "migrations"\`).`,
+				{
+					telemetryMessage:
+						"d1 migrations migrations_pattern set without migrations_dir",
+				}
+			);
+		}
+
+		throw new UserError(
+			`The configured \`migrations_pattern: "${error.details.migrationsPattern}"\` in your ${configFile} file must start with \`${error.details.migrationsDir}/\` to match \`"migrations_dir": "${error.details.migrationsDir}"\`.\n\n` +
+				`Either change \`migrations_pattern\` so it starts with \`${error.details.migrationsDir}/\` (for example, \`"${error.details.suggestedPattern}"\`), or change \`migrations_dir\` to match the start of your pattern.`,
+			{
+				telemetryMessage:
+					"d1 migrations migrations_pattern does not start with migrations_dir",
+			}
+		);
+	}
+}
+
+export async function getMigrationsPath({
+	projectPath,
+	migrationsDir,
+	migrationsDirRaw,
+	createIfMissing,
+	configPath,
+}: {
+	projectPath: string;
+	migrationsDir: string;
+	migrationsDirRaw: string | undefined;
+	createIfMissing: boolean;
+	configPath: string | undefined;
+}): Promise<string> {
+	const dir = path.resolve(projectPath, migrationsDir);
+	if (fs.existsSync(dir)) {
+		return dir;
+	}
+
+	const warning = `No migrations folder found.${
+		migrationsDirRaw === undefined
+			? ` Set \`migrations_dir\` in your ${configFileName(configPath)} file to choose a different path.`
+			: ""
+	}`;
+
+	if (createIfMissing && (await confirm(`${warning}\nOk to create ${dir}?`))) {
+		fs.mkdirSync(dir, { recursive: true });
+		return dir;
+	}
+
+	logger.warn(warning);
+	throw new UserError(`No migrations present at ${dir}.`, {
+		telemetryMessage: "d1 migrations missing migrations directory",
+	});
+}
+
+export async function getUnappliedMigrations({
+	migrationsConfig,
+	local,
+	remote,
+	config,
+	name,
+	persistTo,
+	preview,
+}: {
+	migrationsConfig: MigrationsConfig;
+	local: boolean | undefined;
+	remote: boolean | undefined;
+	config: Config;
+	name: string;
+	persistTo: string | undefined;
+	preview: boolean | undefined;
+}): Promise<string[]> {
+	const appliedMigrations = (
+		await listAppliedMigrations({
+			migrationsTableName: migrationsConfig.migrationsTableName,
+			local,
+			remote,
+			config,
+			name,
+			persistTo,
+			preview,
+		})
+	).map((migration) => migration.name);
+	const migrations = getMigrationNames(migrationsConfig, {
+		logHint: true,
+	});
+	return getUnappliedMigrationNames(migrations, appliedMigrations);
+}
+
+type ListAppliedMigrationsProps = {
+	migrationsTableName: string;
+	local: boolean | undefined;
+	remote: boolean | undefined;
+	config: Config;
+	name: string;
+	persistTo: string | undefined;
+	preview: boolean | undefined;
+};
+
+async function listAppliedMigrations({
+	migrationsTableName,
+	local,
+	remote,
+	config,
+	name,
+	persistTo,
+	preview,
+}: ListAppliedMigrationsProps): Promise<Migration[]> {
+	const response: QueryResult[] | null = await executeSql({
+		local,
+		remote,
+		config,
+		name,
+		shouldPrompt: !isNonInteractiveOrCI(),
+		persistTo,
+		command: getListAppliedMigrationsQuery(migrationsTableName),
+		file: undefined,
+		json: true,
+		preview,
+	});
+
+	if (!response || response[0].results.length === 0) {
+		return [];
+	}
+	return response[0].results as Migration[];
+}
+
+export function getMigrationNames(
+	migrationsConfig: MigrationsConfig,
+	options: { logHint?: boolean } = {}
+): string[] {
+	const names = getMigrationNamesFromConfig(migrationsConfig);
+	if (options.logHint && names.length === 0) {
+		maybeLogHint(migrationsConfig);
+	}
+	return names;
+}
+
+export function maybeLogHint(
+	migrationsConfig: Pick<
+		MigrationsConfig,
+		"projectPath" | "migrationsDir" | "migrationsPattern" | "configFile"
+	>
+): void {
+	const drizzlePattern = findDrizzleMigrationsPattern(migrationsConfig);
+	if (drizzlePattern !== undefined) {
+		logger.warn(
+			`Could not find any migration files matching \`${migrationsConfig.migrationsPattern}\`. It looks like there are migration files matching \`${drizzlePattern}\` though. If you are using drizzle to manage your migrations, please set \`migrations_pattern\` to \`${drizzlePattern}\` in ${migrationsConfig.configFile}.`
+		);
+	}
+}
+
+export async function initMigrationsTable({
+	migrationsTableName,
+	local,
+	remote,
+	config,
+	name,
+	persistTo,
+	preview,
+}: {
+	migrationsTableName: string;
+	local: boolean | undefined;
+	remote: boolean | undefined;
+	config: Config;
+	name: string;
+	persistTo: string | undefined;
+	preview: boolean | undefined;
+}) {
+	return executeSql({
+		local,
+		remote,
+		config,
+		name,
+		shouldPrompt: !isNonInteractiveOrCI(),
+		persistTo,
+		command: getCreateMigrationsTableQuery(migrationsTableName),
+		file: undefined,
+		json: true,
+		preview,
+	});
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4451,6 +4451,9 @@ importers:
       '@types/command-exists':
         specifier: ^1.2.0
         version: 1.2.0
+      '@types/minimatch':
+        specifier: ^5.1.2
+        version: 5.1.2
       '@types/node':
         specifier: 22.15.17
         version: 22.15.17
@@ -4481,6 +4484,9 @@ importers:
       kleur:
         specifier: ^4.1.5
         version: 4.1.5
+      minimatch:
+        specifier: ^5.1.0
+        version: 5.1.6
       open:
         specifier: catalog:default
         version: 11.0.0


### PR DESCRIPTION
## What this does

- Adds a Node-only `@cloudflare/workers-utils/d1-migrations` entry point for migration configuration resolution, file discovery and ordering, and tracking-table query generation.
- Moves the existing consumer-neutral logic out of Wrangler without changing its behaviour — Wrangler-specific prompting, logging, error presentation and SQL execution stay in `wrangler-helpers.ts`.
- Preserves Wrangler's existing helper surface through the adapter, so each current consumer only changes its import path.

Migration creation is split into #15395. D1 query CRLF normalisation is deliberately out of scope for both PRs.

## Testing

- `pnpm --filter @cloudflare/workers-utils build`
- `pnpm --filter @cloudflare/workers-utils test:ci`
- `pnpm --filter @cloudflare/workers-utils check:type`
- `pnpm --filter @cloudflare/workers-utils type:tests`
- `pnpm --filter wrangler check:type`
- Focused Wrangler D1 migration and splitter tests
- `pnpm check:lint`

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: This exposes an internal package API without changing user-facing Wrangler behaviour.
