### PR TITLE
[workers-utils] Extract D1 migration creation

### DIFF
--- a/.changeset/d1-migration-creation-utils.md
+++ b/.changeset/d1-migration-creation-utils.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/workers-utils": minor
+---
+
+Expose reusable D1 migration creation helpers from `@cloudflare/workers-utils/d1-migrations`.

--- a/packages/workers-utils/AGENTS.md
+++ b/packages/workers-utils/AGENTS.md
@@ -23,7 +23,7 @@ Shared utility package used across wrangler, miniflare, and others. Two main are
 
 ### Shared runtime utilities
 
-- `@cloudflare/workers-utils/d1-migrations` — Consumer-neutral D1 migration configuration resolution, discovery, ordering, and SQL query generation. CLI-specific prompting, logging, error presentation, and query execution stay in consumers.
+- `@cloudflare/workers-utils/d1-migrations` — Consumer-neutral D1 migration configuration resolution, creation, discovery, ordering, and SQL query generation. CLI-specific prompting, logging, error presentation, and query execution stay in consumers.
 
 - `createConfigCache(logger)` — file-backed JSON config cache (node_modules/.cache or `.wrangler/cache`). Generic mechanism; the consumer passes its logger (this package has no logger singleton). Both `wrangler` (`src/config-cache.ts`) and `@cloudflare/workers-auth` build their own instances.
 - `openInBrowser(url, logger)` — opens the `open` package with a graceful copy-paste fallback when no browser opener is available. Logger is a parameter, not imported.

--- a/packages/workers-utils/src/d1-migrations.ts
+++ b/packages/workers-utils/src/d1-migrations.ts
@@ -13,6 +13,10 @@ export type MigrationsConfigErrorCode =
 	| "MIGRATIONS_PATTERN_REQUIRES_DIR"
 	| "MIGRATIONS_PATTERN_OUTSIDE_DIR";
 
+export type CreateMigrationErrorCode =
+	| "MIGRATION_NAME_CONTAINS_PATH_SEPARATOR"
+	| "MIGRATION_NAME_DOES_NOT_MATCH_PATTERN";
+
 /** A consumer-neutral migration configuration validation error. */
 export class MigrationsConfigError extends Error {
 	constructor(
@@ -26,6 +30,22 @@ export class MigrationsConfigError extends Error {
 	) {
 		super(message);
 		this.name = "MigrationsConfigError";
+	}
+}
+
+/** A consumer-neutral migration creation validation error. */
+export class CreateMigrationError extends Error {
+	constructor(
+		message: string,
+		readonly code: CreateMigrationErrorCode,
+		readonly details: {
+			migrationMessage: string;
+			migrationName?: string;
+			migrationPath?: string;
+		}
+	) {
+		super(message);
+		this.name = "CreateMigrationError";
 	}
 }
 
@@ -396,4 +416,77 @@ export function getNextMigrationNumber(
 		// Math.max.
 		.filter((n) => Number.isFinite(n));
 	return Math.max(...migrationNumbers, 0) + 1;
+}
+
+export type PreparedMigration = {
+	name: string;
+	path: string;
+	contents: string;
+};
+
+export type CreatedMigration = Pick<PreparedMigration, "name" | "path">;
+
+/** Validate and describe the next numbered, top-level migration file. */
+export function prepareMigration(
+	migrationsConfig: MigrationsConfig,
+	message: string,
+	timestamp = new Date()
+): PreparedMigration {
+	const migrationMessage = message.replaceAll(" ", "_");
+	if (/[\\/]/.test(migrationMessage)) {
+		throw new CreateMigrationError(
+			"Migration messages cannot contain path separators.",
+			"MIGRATION_NAME_CONTAINS_PATH_SEPARATOR",
+			{ migrationMessage: message }
+		);
+	}
+
+	const migrationNumber = getNextMigrationNumber(migrationsConfig)
+		.toString()
+		.padStart(4, "0");
+	const migrationName = `${migrationNumber}_${migrationMessage}.sql`;
+	const migrationPath = normalizeRelativePath(
+		`${migrationsConfig.migrationsDir}/${migrationName}`
+	);
+	const migrationsDirPattern = stripDirPrefix(
+		migrationsConfig.migrationsPattern,
+		migrationsConfig.migrationsDir
+	);
+
+	if (
+		!new Minimatch(migrationsDirPattern, { dot: false }).match(migrationName)
+	) {
+		throw new CreateMigrationError(
+			"The new migration does not match the configured migrations pattern.",
+			"MIGRATION_NAME_DOES_NOT_MATCH_PATTERN",
+			{ migrationMessage: message, migrationName, migrationPath }
+		);
+	}
+
+	return {
+		name: migrationName,
+		path: path.resolve(
+			migrationsConfig.projectPath,
+			migrationsConfig.migrationsDir,
+			migrationName
+		),
+		contents: `-- Migration number: ${migrationNumber} \t ${timestamp.toISOString()}\n`,
+	};
+}
+
+/** Write a prepared migration file. */
+export function writeMigration(migration: PreparedMigration): CreatedMigration {
+	fs.writeFileSync(migration.path, migration.contents);
+	return { name: migration.name, path: migration.path };
+}
+
+/** Create the next numbered, top-level migration file and its directory. */
+export function createMigration(
+	migrationsConfig: MigrationsConfig,
+	message: string,
+	timestamp = new Date()
+): CreatedMigration {
+	const migration = prepareMigration(migrationsConfig, message, timestamp);
+	fs.mkdirSync(path.dirname(migration.path), { recursive: true });
+	return writeMigration(migration);
 }

--- a/packages/workers-utils/tests/d1-migrations.test.ts
+++ b/packages/workers-utils/tests/d1-migrations.test.ts
@@ -4,11 +4,26 @@ import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
 import { describe, it } from "vitest";
 import {
 	buildMigrationQuery,
+	createMigration,
+	CreateMigrationError,
 	getCreateMigrationsTableQuery,
 	getListAppliedMigrationsQuery,
 	MigrationsConfigError,
 	resolveMigrationsConfig,
 } from "../src/d1-migrations";
+import type { MigrationsConfig } from "../src/d1-migrations";
+
+function migrationsConfig(
+	overrides: Partial<MigrationsConfig> = {}
+): MigrationsConfig {
+	return {
+		projectPath: ".",
+		migrationsDir: "migrations",
+		migrationsPattern: "migrations/*.sql",
+		migrationsTableName: "d1_migrations",
+		...overrides,
+	};
+}
 
 function writeMigration(filePath: string, contents = "SELECT 1;"): void {
 	fs.mkdirSync(path.dirname(filePath), { recursive: true });
@@ -50,6 +65,52 @@ describe("D1 migrations", () => {
 		expect((caught as MigrationsConfigError).code).toBe(
 			"MIGRATIONS_PATTERN_REQUIRES_DIR"
 		);
+	});
+
+	it("creates the next migration and its directory", ({ expect }) => {
+		const created = createMigration(
+			migrationsConfig(),
+			"add posts",
+			new Date("2026-08-27T12:00:00.000Z")
+		);
+		expect(created).toEqual({
+			name: "0001_add_posts.sql",
+			path: path.resolve("migrations/0001_add_posts.sql"),
+		});
+		expect(fs.readFileSync(created.path, "utf8")).toBe(
+			"-- Migration number: 0001 \t 2026-08-27T12:00:00.000Z\n"
+		);
+	});
+
+	it("reports invalid migration names without writing files", ({ expect }) => {
+		let caught: unknown;
+		try {
+			createMigration(migrationsConfig(), "nested/name");
+		} catch (error) {
+			caught = error;
+		}
+
+		expect(caught).toBeInstanceOf(CreateMigrationError);
+		expect((caught as CreateMigrationError).code).toBe(
+			"MIGRATION_NAME_CONTAINS_PATH_SEPARATOR"
+		);
+		expect(fs.existsSync("migrations")).toBe(false);
+	});
+
+	it("rejects a migration the configured pattern would miss", ({ expect }) => {
+		expect(() =>
+			createMigration(
+				migrationsConfig({
+					migrationsPattern: "migrations/*/migration.sql",
+				}),
+				"add posts"
+			)
+		).toThrow(
+			expect.objectContaining({
+				code: "MIGRATION_NAME_DOES_NOT_MATCH_PATTERN",
+			})
+		);
+		expect(fs.existsSync("migrations")).toBe(false);
 	});
 
 	it("builds escaped tracking-table queries", ({ expect }) => {

--- a/packages/wrangler/src/d1/migrations/create.ts
+++ b/packages/wrangler/src/d1/migrations/create.ts
@@ -1,15 +1,14 @@
-import fs from "node:fs";
 import { configFileName, UserError } from "@cloudflare/workers-utils";
-import { Minimatch } from "minimatch";
 import dedent from "ts-dedent";
 import { createCommand } from "../../core/create-command";
 import { logger } from "../../logger";
 import { getDatabaseInfoFromConfig } from "../utils";
 import {
+	CreateMigrationError,
 	getMigrationsPath,
-	getNextMigrationNumber,
-	normalizeRelativePath,
+	prepareMigration,
 	resolveMigrationsConfig,
+	writeMigration,
 } from "./wrangler-helpers";
 
 export const d1MigrationsCreateCommand = createCommand({
@@ -67,53 +66,25 @@ export const d1MigrationsCreateCommand = createCommand({
 			configPath: config.configPath,
 		});
 
-		const nextMigrationNumber = pad(
-			getNextMigrationNumber(migrationsConfig),
-			4
-		);
-		const migrationName = message.replaceAll(" ", "_");
-
-		// `wrangler d1 migrations create` writes a single file directly inside
-		// `migrations_dir`, so a name containing a path separator can't work —
-		// it would imply nested directories. Reject it up front with a clear
-		// message, rather than letting it fall through to the confusing "does
-		// not match migrations_pattern" error below (a name like `foo/bar`
-		// produces an extra path segment that the pattern can't match).
-		if (/[\\/]/.test(migrationName)) {
-			throw new UserError(
-				`The migration name ${JSON.stringify(message)} contains a path separator ("/" or "\\"). Please remove this and try again.`,
-				{
-					telemetryMessage: "d1 migrations create name contains path separator",
-				}
-			);
-		}
-
-		const newMigrationName = `${nextMigrationNumber}_${migrationName}.sql`;
-
-		// Make sure the migration we are about to create will actually be picked
-		// up by `wrangler d1 migrations apply` — i.e. it matches the configured
-		// `migrations_pattern`. The default `${migrations_dir}/*.sql` always
-		// matches top-level `.sql` files, so this only fires for a user-set
-		// pattern.
-		//
-		// This runs BEFORE `getMigrationsPath` so we don't prompt the user to
-		// create a `migrations_dir` we'll then refuse to write into.
-		const matcher = new Minimatch(migrationsConfig.migrationsPattern, {
-			dot: false,
-		});
-		// Normalize so the path is shaped like the entries
-		// `getMigrationNames` matches against `migrationsPattern` — both
-		// `migrationsDir` and `migrationsPattern` are normalized, so the
-		// proposed path must be too. In particular, for `migrations_dir: "."`
-		// this strips the leading `./` (which would otherwise split into a
-		// separate segment and never match the normalized pattern).
-		const proposedPath = normalizeRelativePath(
-			`${migrationsConfig.migrationsDir}/${newMigrationName}`
-		);
-		if (!matcher.match(proposedPath)) {
+		let migration: ReturnType<typeof prepareMigration>;
+		try {
+			migration = prepareMigration(migrationsConfig, message);
+		} catch (error) {
+			if (!(error instanceof CreateMigrationError)) {
+				throw error;
+			}
+			if (error.code === "MIGRATION_NAME_CONTAINS_PATH_SEPARATOR") {
+				throw new UserError(
+					`The migration name ${JSON.stringify(message)} contains a path separator ("/" or "\\"). Please remove this and try again.`,
+					{
+						telemetryMessage:
+							"d1 migrations create name contains path separator",
+					}
+				);
+			}
 			throw new UserError(
 				dedent`
-					Wrangler would like to make a new migration called \`${proposedPath}\` but it does not match the configured \`migrations_pattern: "${migrationsConfig.migrationsPattern}"\` in your ${migrationsConfig.configFile} file, so \`wrangler d1 migrations apply\` would not pick it up. \`wrangler d1 migrations create\` only writes top-level files inside \`migrations_dir\`.
+					Wrangler would like to make a new migration called \`${error.details.migrationPath}\` but it does not match the configured \`migrations_pattern: "${migrationsConfig.migrationsPattern}"\` in your ${migrationsConfig.configFile} file, so \`wrangler d1 migrations apply\` would not pick it up. \`wrangler d1 migrations create\` only writes top-level files inside \`migrations_dir\`.
 
 					If you are using an ORM like drizzle to manage migrations, use the ORM's command (e.g. \`drizzle-kit generate\`) instead of \`wrangler d1 migrations create\` — it will create files in the nested layout your \`migrations_pattern\` expects.
 
@@ -126,7 +97,7 @@ export const d1MigrationsCreateCommand = createCommand({
 			);
 		}
 
-		const migrationsPath = await getMigrationsPath({
+		await getMigrationsPath({
 			projectPath: migrationsConfig.projectPath,
 			migrationsDir: migrationsConfig.migrationsDir,
 			migrationsDirRaw: migrationsConfig.migrationsDirRaw,
@@ -134,21 +105,12 @@ export const d1MigrationsCreateCommand = createCommand({
 			configPath: config.configPath,
 		});
 
-		fs.writeFileSync(
-			`${migrationsPath}/${newMigrationName}`,
-			`-- Migration number: ${nextMigrationNumber} \t ${new Date().toISOString()}\n`
-		);
+		const createdMigration = writeMigration(migration);
 
-		logger.log(`✅ Successfully created Migration '${newMigrationName}'!\n`);
+		logger.log(
+			`✅ Successfully created Migration '${createdMigration.name}'!\n`
+		);
 		logger.log(`The migration is available for editing here`);
-		logger.log(`${migrationsPath}/${newMigrationName}`);
+		logger.log(createdMigration.path);
 	},
 });
-
-function pad(num: number, size: number): string {
-	let newNum = num.toString();
-	while (newNum.length < size) {
-		newNum = "0" + newNum;
-	}
-	return newNum;
-}

--- a/packages/wrangler/src/d1/migrations/wrangler-helpers.ts
+++ b/packages/wrangler/src/d1/migrations/wrangler-helpers.ts
@@ -25,11 +25,15 @@ import type { MigrationsConfig as SharedMigrationsConfig } from "@cloudflare/wor
 export {
 	buildMigrationQuery,
 	compareMigrationPaths,
+	createMigration,
+	CreateMigrationError,
 	getCreateMigrationsTableQuery,
 	getListAppliedMigrationsQuery,
 	getNextMigrationNumber,
 	getUnappliedMigrationNames,
 	normalizeRelativePath,
+	prepareMigration,
+	writeMigration,
 } from "@cloudflare/workers-utils/d1-migrations";
 
 export type MigrationsConfig = SharedMigrationsConfig & {


### PR DESCRIPTION
Stacked on #15389.

## What this does

- Adds consumer-neutral `prepareMigration()`, `writeMigration()` and `createMigration()` helpers to `@cloudflare/workers-utils/d1-migrations`.
- Keeps validation separate from writing so Wrangler can preserve its confirmation prompt, while `cf` can use the one-call `createMigration()` path.
- Updates `wrangler d1 migrations create` to use the shared implementation without changing its errors or output.

## Testing

- `pnpm --filter @cloudflare/workers-utils build`
- `pnpm --filter @cloudflare/workers-utils test:ci`
- `pnpm --filter @cloudflare/workers-utils check:type`
- `pnpm --filter @cloudflare/workers-utils type:tests`
- `pnpm --filter wrangler check:type`
- Focused Wrangler D1 migration tests
- `pnpm check:lint`

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: This exposes an internal package API without changing user-facing Wrangler behaviour.
