### PR TITLE
[wrangler] Stop publishing build metafile

### DIFF
--- a/.changeset/quiet-pandas-pack.md
+++ b/.changeset/quiet-pandas-pack.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Reduce Wrangler's published package size
+
+Stop including the unused build metafile in the npm package, reducing its unpacked size by approximately 3.1 MiB.

--- a/packages/wrangler/tsup.config.ts
+++ b/packages/wrangler/tsup.config.ts
@@ -84,7 +84,6 @@ export default defineConfig((options) => [
 		},
 		outDir: "wrangler-dist",
 		tsconfig: "tsconfig.json",
-		metafile: true,
 		external: EXTERNAL_DEPENDENCIES,
 		sourcemap: process.env.SOURCEMAPS !== "false",
 		inject: [path.join(__dirname, "import_meta_url.js")],


### PR DESCRIPTION
Wrangler's tsup build generated `wrangler-dist/metafile-cjs.json`, even though no repository tooling consumes it. Because the entire `wrangler-dist` directory is published, this build-analysis artifact was included in every npm package.

Disable the unused metafile output so it is never generated in the publish directory.

Measured with `pnpm pack` before and after the change:

| Metric | Before | After | Saving |
| --- | ---: | ---: | ---: |
| Unpacked package | 64.214 MiB | 61.101 MiB | 3.113 MiB (4.85%) |
| npm tarball | 10.550 MiB | 10.404 MiB | 149.7 KiB (1.39%) |
| Published files | 48 | 47 | 1 file |

A patch changeset is included for the reduction in Wrangler's published package size.

---

- Tests
  - [ ] Tests included/updated
  - [x] Automated tests not possible - manual testing has been completed as follows:
    - Built Wrangler with `pnpm run build --filter wrangler`.
    - Packed Wrangler before and after with `pnpm pack --json` and inspected the tarball contents.
    - Ran `node packages/wrangler/bin/wrangler.js --version` as a smoke test.
    - Ran oxfmt and oxlint against `packages/wrangler/tsup.config.ts`.
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: this only removes an unused build-analysis artifact from the npm package.

*A picture of a cute animal (not mandatory, but encouraged)*
