### PR TITLE
[wrangler] Exclude non-runtime templates from package

### DIFF
--- a/.changeset/tidy-pandas-smile.md
+++ b/.changeset/tidy-pandas-smile.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Reduce the size of Wrangler's published package
+
+Exclude test-only, build-only, and obsolete template files from the npm package while retaining all runtime templates.

--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -45,6 +45,11 @@
 		"miniflare-dist",
 		"wrangler-dist",
 		"templates",
+		"!templates/__tests__",
+		"!templates/**/*.d.ts",
+		"!templates/new-worker*",
+		"!templates/startDevWorker",
+		"!templates/tsconfig*",
 		"kv-asset-handler.js",
 		"config-schema.json"
 	],


### PR DESCRIPTION
Exclude test-only, build-only, and obsolete files from the Wrangler npm package while retaining every runtime template.

The latest published package contains 14 unnecessary template files. A paired release-style `pnpm pack` comparison on this branch measured:

| | Before | After | Savings |
| --- | ---: | ---: | ---: |
| Packed size | 3,950,201 bytes | 3,936,711 bytes | 13,490 bytes (13.17 KiB) |
| Unpacked size | 24,607,784 bytes | 24,560,190 bytes | 47,594 bytes (46.48 KiB) |
| File count | 45 | 31 | 14 files |

The existing `wrangler-dist/metafile-cjs.json` is intentionally unchanged and remains in the package.

---

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: This only narrows the npm package file allowlist. I verified a release-style build, Wrangler and template type checks, an exact before/after tarball entry diff, formatting, and installation plus `wrangler --version` from the resulting tarball.
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: This is an internal npm packaging change with no CLI or configuration behavior change.

> [!NOTE]
> This is a contribution from an AI agent: Codex, GPT-5.
