### PR TITLE
[docs] Update linting and formatting tool references

### DIFF
--- a/.github/bonk_reviewer.md
+++ b/.github/bonk_reviewer.md
@@ -7,7 +7,7 @@ Do NOT:
 - Edit, write, create, or delete any files -- use file editing tools (Write, Edit) under no circumstances
 - Run `git commit`, `git push`, `git add`, `git checkout -b`, or any git write operation
 - Approve or request changes on the PR -- only post review comments
-- Flag formatting issues -- Prettier enforces style in this repo
+- Flag formatting issues -- Oxfmt enforces style in this repo
 
 If you want to suggest a code change, post a `suggestion` comment instead of editing the file.
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -29,7 +29,7 @@ Workflow changes should avoid unsuppressed `zizmor` findings. In particular:
 - Actions
   - Builds all the packages.
   - Runs formatting, linting and type checks.
-  - Runs fixture tests, Wrangler unit tests, C3 unit tests, Miniflare unit tests, and ESLint + Prettier checks.
+  - Runs fixture tests, Wrangler unit tests, C3 unit tests, Miniflare unit tests, and Oxlint + Oxfmt checks.
   - Adds the PR to a GitHub project
   - Makes sure that Wrangler's warning for old Node.js versions works.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -193,7 +193,7 @@ Remember that this change is specific to the current project and will not affect
 
 ### Linting
 
-The code is checked for linting errors by [ESLint](https://eslint.org/).
+The code is checked for linting errors by [Oxlint](https://oxc.rs/docs/guide/usage/linter.html).
 
 - Run the linting checks
 
@@ -201,11 +201,11 @@ The code is checked for linting errors by [ESLint](https://eslint.org/).
   pnpm run check:lint
   ```
 
-- The repository has a recommended VS Code plugin to run ESLint checks while editing source code, providing immediate feedback.
+- The repository recommends the [Oxc VS Code extension](https://marketplace.visualstudio.com/items?itemName=oxc.oxc-vscode) to run Oxlint checks while editing source code, providing immediate feedback.
 
 ### Formatting
 
-The code is checked for formatting errors by [Prettier](https://prettier.io/).
+The code is checked for formatting errors by [Oxfmt](https://oxc.rs/docs/guide/usage/formatter.html).
 
 - Run the formatting checks
 
@@ -213,8 +213,8 @@ The code is checked for formatting errors by [Prettier](https://prettier.io/).
   pnpm run check:format
   ```
 
-- The repository has a recommended VS Code plugin to run Prettier checks, and to automatically format using Prettier, while editing source code, providing immediate feedback
-- Use the following command to run prettier on the codebase
+- The Oxc VS Code extension can automatically format supported files with Oxfmt while editing source code.
+- Use the following command to format the codebase
 
   ```sh
   pnpm run prettify


### PR DESCRIPTION
No issue.

Updates contributor-facing repository documentation to match the current Oxlint/Oxfmt toolchain introduced in #12930. This replaces stale ESLint and Prettier references and points contributors to the repository-recommended Oxc VS Code extension.

---

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: This is a documentation-only change; `pnpm run check:format` passes across the repository.
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: This PR updates repository contributor and CI guidance without changing Cloudflare product behavior.

*A picture of a cute animal (not mandatory, but encouraged)*
<!-- devin-review-badge-begin -->

---

<a href="https://cloudflare.devinenterprise.com/review/cloudflare/workers-sdk/pull/15402" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->