### PR TITLE
[miniflare] Reduce embedded asset worker bundle size

### DIFF
--- a/.changeset/tiny-assets-rest.md
+++ b/.changeset/tiny-assets-rest.md
@@ -1,0 +1,7 @@
+---
+"miniflare": patch
+---
+
+Reduce the size of Miniflare's embedded asset and router Workers
+
+Miniflare does not configure Sentry credentials for its asset services, so their builds now replace the unused production Sentry setup with a no-op instead of bundling Toucan.

--- a/packages/miniflare/scripts/build.mjs
+++ b/packages/miniflare/scripts/build.mjs
@@ -97,6 +97,18 @@ const localExplorerWorkerPath = path.join(
 	"local-explorer",
 	"explorer.worker.ts"
 );
+const assetWorkerPaths = new Set([
+	path.join(workersRoot, "assets", "assets.worker.ts"),
+	path.join(workersRoot, "assets", "router.worker.ts"),
+]);
+const workersSharedSentryPath = path.join(
+	pkgRoot,
+	"..",
+	"workers-shared",
+	"utils",
+	"sentry.ts"
+);
+const noopSentryPath = path.join(workersRoot, "assets", "sentry-noop.ts");
 
 /**
  * Test fixtures that need to be transpiled by esbuild as part of the build.
@@ -123,6 +135,28 @@ const rewriteNodeToInternalPlugin = {
 		build.onResolve({ filter: /^node:(assert|buffer)$/ }, async (args) => {
 			const module = args.path.substring("node:".length);
 			return { path: `node-internal:internal_${module}`, external: true };
+		});
+	},
+};
+
+/**
+ * Replaces the production Sentry setup used by the asset and router Workers.
+ * Miniflare never binds the required Sentry credentials, so the production
+ * implementation always returns before initialising Toucan.
+ *
+ * @type {esbuild.Plugin}
+ */
+const noopSentryPlugin = {
+	name: "noop-sentry",
+	setup(build) {
+		build.onResolve({ filter: /sentry(?:\.ts)?$/ }, (args) => {
+			const importPath = path.resolve(args.resolveDir, args.path);
+			if (
+				importPath === workersSharedSentryPath ||
+				`${importPath}.ts` === workersSharedSentryPath
+			) {
+				return { path: noopSentryPath };
+			}
 		});
 	},
 };
@@ -199,11 +233,13 @@ const embedWorkersPlugin = {
 					outdir: build.initialOptions.outdir,
 					outbase: pkgRoot,
 					// Shared extension workers need node:* → node-internal:*
-					plugins:
-						args.path === miniflareSharedExtensionPath ||
+					plugins: [
+						...(args.path === miniflareSharedExtensionPath ||
 						args.path === miniflareZodExtensionPath
 							? [rewriteNodeToInternalPlugin]
-							: [],
+							: []),
+						...(assetWorkerPaths.has(args.path) ? [noopSentryPlugin] : []),
+					],
 					// Inject SPARROW_SOURCE_KEY for the local explorer telemetry
 					define:
 						args.path === localExplorerWorkerPath

--- a/packages/miniflare/src/workers/assets/sentry-noop.ts
+++ b/packages/miniflare/src/workers/assets/sentry-noop.ts
@@ -1,0 +1,9 @@
+/**
+ * Miniflare's asset services do not bind Sentry credentials, so this preserves
+ * the production setup's credential-free behaviour without bundling Toucan.
+ *
+ * @returns `undefined`, matching production when credentials are absent.
+ */
+export function setupSentry(): undefined {
+	return undefined;
+}

--- a/packages/miniflare/test/plugins/assets/index.spec.ts
+++ b/packages/miniflare/test/plugins/assets/index.spec.ts
@@ -32,6 +32,27 @@ function makeOptions(directory: string, rootPath?: string): MiniflareOptions {
 	};
 }
 
+test("omits Sentry from the embedded asset service Workers", async ({
+	expect,
+}) => {
+	for (const worker of ["assets", "router"]) {
+		for (const extension of ["js", "js.map"]) {
+			const artifact = await fs.readFile(
+				path.join(
+					"dist",
+					"src",
+					"workers",
+					"assets",
+					`${worker}.worker.${extension}`
+				),
+				"utf8"
+			);
+			expect(artifact).not.toContain("node_modules/toucan-js");
+			expect(artifact).not.toContain("node_modules/@sentry");
+		}
+	}
+});
+
 test("starts without error when assets directory does not exist", async ({
 	expect,
 }) => {


### PR DESCRIPTION
Miniflare's embedded asset and router Workers use the shared production Workers, which import Sentry/Toucan. Miniflare never binds the three credentials required by `setupSentry()`, so the client is unreachable but was still included in both bundles and their source maps.

This replaces the production Sentry module with a Miniflare-only no-op when building those two embedded Workers. The production Workers and Sentry integration are unchanged. A regression test verifies that neither shipped script nor source map contains the Sentry/Toucan dependency.

Package measurements from `pnpm --filter miniflare pack`:

| Published package | Before | After | Saving |
| --- | ---: | ---: | ---: |
| Unpacked | 29,027,292 B | 26,800,819 B | 2,226,473 B (7.67%) |
| Gzipped `.tgz` | 6,018,492 B | 5,498,204 B | 520,288 B (8.64%) |

The two affected Workers specifically shrink from 862,649 B to 115,845 B for code, and from 2,558,670 B to 332,197 B including source maps.

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: This only changes internal Miniflare bundle contents; its API and runtime behavior are unchanged.

Validation:

- `pnpm -w test:ci -F miniflare -- test/plugins/assets/index.spec.ts`
- `pnpm run check --filter miniflare`
- `pnpm --filter miniflare check:type`

A full Miniflare test run reached 1,197 passing tests. Six unrelated Hyperdrive TLS fixture tests fail locally because Node/OpenSSL rejects their weak CA (`ERR_SSL_CA_MD_TOO_WEAK`); a transient external-server test passed when rerun in isolation.
