### PR TITLE
[wrangler/miniflare] Omit unused Zod locales

### DIFF
--- a/.changeset/calm-zebras-rest.md
+++ b/.changeset/calm-zebras-rest.md
@@ -1,0 +1,8 @@
+---
+"miniflare": patch
+"wrangler": patch
+---
+
+Reduce Wrangler and Miniflare bundle sizes by omitting unused Zod locales
+
+Wrangler and Miniflare retain Zod's default English validation messages while excluding the unused aggregate collection of additional locales from their production bundles.

--- a/.changeset/tidy-zebras-share.md
+++ b/.changeset/tidy-zebras-share.md
@@ -1,0 +1,7 @@
+---
+"miniflare": patch
+---
+
+Reduce Miniflare's bundle size by sharing Zod across embedded workers
+
+Workflows, Email Store, and Local Explorer now import Zod from Miniflare's existing workerd extension instead of each bundling a separate copy.

--- a/packages/miniflare/scripts/build.mjs
+++ b/packages/miniflare/scripts/build.mjs
@@ -147,6 +147,35 @@ const aliasZodToMiniflareExtensionPlugin = {
 };
 
 /**
+ * esbuild plugin that omits Zod's unused collection of locale modules.
+ *
+ * Zod configures its default English locale with a separate direct import, so
+ * replacing the aggregate locale index only makes the unused `locales`
+ * namespace empty without changing default validation messages.
+ *
+ * @type {esbuild.Plugin}
+ */
+const omitZodLocalesPlugin = {
+	name: "omit-zod-locales",
+	setup(build) {
+		const namespace = "empty-zod-locales";
+		build.onResolve({ filter: /^\.\.\/locales\/index\.js$/ }, (args) => {
+			if (
+				!/[\\/]zod[\\/]v4[\\/](?:(?:classic|mini)[\\/]external|core[\\/]index)\.js$/.test(
+					args.importer
+				)
+			) {
+				return;
+			}
+			return { namespace, path: "zod-locales" };
+		});
+		build.onLoad({ filter: /.*/, namespace }, () => ({
+			contents: "export {};",
+		}));
+	},
+};
+
+/**
  * Cache of esbuild build contexts for worker sub-builds. In watch mode,
  * these are reused across rebuilds for incremental compilation.
  * @type {Map<string, esbuild.BuildContext>}
@@ -218,6 +247,7 @@ const embedWorkersPlugin = {
 					outdir: build.initialOptions.outdir,
 					outbase: pkgRoot,
 					plugins: [
+						omitZodLocalesPlugin,
 						// Shared extension workers need node:* → node-internal:*
 						...(args.path === miniflareSharedExtensionPath ||
 						args.path === miniflareZodExtensionPath
@@ -401,7 +431,7 @@ async function buildPackage() {
 			// esbuild is used by test fixtures at runtime
 			"esbuild",
 		],
-		plugins: [embedWorkersPlugin],
+		plugins: [omitZodLocalesPlugin, embedWorkersPlugin],
 		logLevel: watch ? "info" : "warning",
 		outdir: outPath,
 		outbase: pkgRoot,

--- a/packages/miniflare/scripts/build.mjs
+++ b/packages/miniflare/scripts/build.mjs
@@ -128,6 +128,25 @@ const rewriteNodeToInternalPlugin = {
 };
 
 /**
+ * esbuild plugin that redirects Zod imports to the shared workerd extension.
+ *
+ * Without this, every embedded worker importing Zod gets its own copy of the
+ * library. Keeping the rewrite here also covers imports from generated code and
+ * workspace packages bundled into Miniflare's workers.
+ *
+ * @type {esbuild.Plugin}
+ */
+const aliasZodToMiniflareExtensionPlugin = {
+	name: "alias-zod-to-miniflare-extension",
+	setup(build) {
+		build.onResolve({ filter: /^zod$/ }, () => ({
+			external: true,
+			path: "miniflare:zod",
+		}));
+	},
+};
+
+/**
  * Cache of esbuild build contexts for worker sub-builds. In watch mode,
  * these are reused across rebuilds for incremental compilation.
  * @type {Map<string, esbuild.BuildContext>}
@@ -198,12 +217,18 @@ const embedWorkersPlugin = {
 					minifySyntax: true,
 					outdir: build.initialOptions.outdir,
 					outbase: pkgRoot,
-					// Shared extension workers need node:* → node-internal:*
-					plugins:
-						args.path === miniflareSharedExtensionPath ||
+					plugins: [
+						// Shared extension workers need node:* → node-internal:*
+						...(args.path === miniflareSharedExtensionPath ||
 						args.path === miniflareZodExtensionPath
 							? [rewriteNodeToInternalPlugin]
-							: [],
+							: []),
+						// The Zod extension must bundle the real package, while all other
+						// workers import that single shared copy.
+						...(args.path === miniflareZodExtensionPath
+							? []
+							: [aliasZodToMiniflareExtensionPlugin]),
+					],
 					// Inject SPARROW_SOURCE_KEY for the local explorer telemetry
 					define:
 						args.path === localExplorerWorkerPath

--- a/packages/miniflare/src/workers/email/contracts.ts
+++ b/packages/miniflare/src/workers/email/contracts.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "miniflare:zod";
 
 export type EmailHandlerEvent =
 	| {

--- a/packages/miniflare/src/workers/email/email-store.ts
+++ b/packages/miniflare/src/workers/email/email-store.ts
@@ -16,7 +16,7 @@
  * directory).
  */
 import { DurableObject } from "cloudflare:workers";
-import { z } from "zod";
+import { z } from "miniflare:zod";
 import {
 	base64ToBytes,
 	bytesToBase64,

--- a/packages/miniflare/src/workers/shared/zod.worker.ts
+++ b/packages/miniflare/src/workers/shared/zod.worker.ts
@@ -13,4 +13,5 @@ export const Base64DataSchema = z
 	.regex(BASE64_REGEXP)
 	.transform((base64) => Buffer.from(base64, "base64"));
 
-export { z } from "zod";
+export { default } from "zod";
+export * from "zod";

--- a/packages/wrangler/tsup.config.ts
+++ b/packages/wrangler/tsup.config.ts
@@ -6,6 +6,32 @@ import type { Options } from "tsup";
 
 const TEMPLATES_DIR = path.join(__dirname, "templates");
 const workersContexts = new Map<string, esbuild.BuildContext>();
+
+/**
+ * Omits Zod's unused collection of locale modules from the Wrangler bundle.
+ * Zod's separately imported English locale remains available for default
+ * validation messages.
+ */
+const omitZodLocalesPlugin: Exclude<Options["esbuildPlugins"], undefined>[0] = {
+	name: "omit-zod-locales",
+	setup(build) {
+		const namespace = "empty-zod-locales";
+		build.onResolve({ filter: /^\.\.\/locales\/index\.js$/ }, (args) => {
+			if (
+				!/[\\/]zod[\\/]v4[\\/](?:(?:classic|mini)[\\/]external|core[\\/]index)\.js$/.test(
+					args.importer
+				)
+			) {
+				return;
+			}
+			return { namespace, path: "zod-locales" };
+		});
+		build.onLoad({ filter: /.*/, namespace }, () => ({
+			contents: "export {};",
+		}));
+	},
+};
+
 function embedWorkersPlugin({
 	isWatch,
 }: {
@@ -111,7 +137,10 @@ export default defineConfig((options) => [
 					}
 				: {}),
 		},
-		esbuildPlugins: [embedWorkersPlugin({ isWatch: !!options.watch })],
+		esbuildPlugins: [
+			omitZodLocalesPlugin,
+			embedWorkersPlugin({ isWatch: !!options.watch }),
+		],
 		esbuildOptions(esbuildOptions) {
 			esbuildOptions.logOverride = {
 				...esbuildOptions.logOverride,


### PR DESCRIPTION
## Stack

Depends on #15397. All before/after figures below compare against its exact head, `7a1494df50b6e728e438a0e0e6588f521ef0ee88`.

## Summary

- Replace Zod’s aggregate locale-index modules with an empty namespace at the Wrangler and Miniflare bundle boundaries.
- Preserve Zod’s separately imported English locale, so default validation messages are unchanged.
- Apply the optimization to the Miniflare host, its shared `miniflare:zod` extension, and the Wrangler CLI bundle.

Neither production bundle reads `z.locales` or `z.core.locales`. Direct locale imports are not intercepted.

## Bundle size relative to #15397

Raw emitted JavaScript, excluding source maps:

| Artifact | #15397 | This PR | Saved |
| --- | ---: | ---: | ---: |
| Wrangler CLI | 20,552,930 B | 20,235,294 B | 317,636 B |
| Miniflare host | 4,843,954 B | 4,563,639 B | 280,315 B |
| Shared Zod extension | 513,221 B | 250,106 B | 263,115 B |
| **Total** | **25,910,105 B** | **25,049,039 B** | **861,066 B** |

This layer saves an additional 0.861 MB / 0.821 MiB over #15397. Together, the two-PR stack saves 2,384,985 B (2.385 MB / 2.274 MiB) relative to `main` across the affected Wrangler and Miniflare JavaScript artifacts.

Metafiles show only the separately imported English locale remains: one locale module contributes 4,795 B in the Wrangler intermediate bundle and 3,716 B in the shared extension.

## Validation

- `pnpm run build --filter wrangler`
- `pnpm -w test:ci -F miniflare -- test/config/schema.spec.ts test/plugins/workflows/index.spec.ts test/plugins/email/index.spec.ts test/plugins/local-explorer/index.spec.ts test/plugins/local-explorer/email.spec.ts test/plugins/local-explorer/r2.spec.ts` — 166 tests passed
- `pnpm --filter miniflare check:type`
- `pnpm --filter wrangler check:type`
- Built Wrangler CLI `--version` smoke test
- Targeted oxlint and oxfmt checks

---

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: existing Miniflare host and embedded-service suites cover the affected Zod runtime paths, and emitted metafiles directly verify locale removal.
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: this is an internal production-bundle optimization with no public API or default-message change.
