### PR TITLE
[vite-plugin-cloudflare] Surface export type fetch errors

### DIFF
--- a/.changeset/calm-rivers-report.md
+++ b/.changeset/calm-rivers-report.md
@@ -1,0 +1,7 @@
+---
+"@cloudflare/vite-plugin": patch
+---
+
+Surface Worker export type fetch errors during development
+
+The Vite plugin now reports the Worker name, HTTP status, and response body when fetching export types fails. This preserves the underlying error instead of replacing it with a JSON parsing error.

--- a/packages/vite-plugin-cloudflare/src/__tests__/cloudflare-environment.spec.ts
+++ b/packages/vite-plugin-cloudflare/src/__tests__/cloudflare-environment.spec.ts
@@ -1,0 +1,33 @@
+import { Response } from "miniflare";
+import { test } from "vitest";
+import { CloudflareDevEnvironment } from "../cloudflare-environment";
+import type { ResolvedWorkerConfig } from "../plugin-config";
+import type { Miniflare } from "miniflare";
+
+test("surfaces the response body when fetching Worker export types fails", async ({
+	expect,
+}) => {
+	const environment = {
+		fetchWorkerExportTypes:
+			CloudflareDevEnvironment.prototype.fetchWorkerExportTypes,
+	};
+	const miniflare = {
+		dispatchFetch() {
+			return Promise.resolve(
+				new Response("Error: Network connection lost.", {
+					status: 500,
+					statusText: "Internal Server Error",
+				})
+			);
+		},
+	} as Partial<Miniflare> as Miniflare;
+	const workerConfig = {
+		name: "auxiliary-worker",
+	} as Partial<ResolvedWorkerConfig> as ResolvedWorkerConfig;
+
+	await expect(
+		environment.fetchWorkerExportTypes(miniflare, workerConfig)
+	).rejects.toThrow(
+		'Failed to fetch export types for Worker "auxiliary-worker" (500 Internal Server Error): Error: Network connection lost.'
+	);
+});

--- a/packages/vite-plugin-cloudflare/src/__tests__/cloudflare-environment.spec.ts
+++ b/packages/vite-plugin-cloudflare/src/__tests__/cloudflare-environment.spec.ts
@@ -1,33 +1,66 @@
-import { Response } from "miniflare";
-import { test } from "vitest";
+import { CoreHeaders, Miniflare, Response } from "miniflare";
+import { resolveConfig } from "vite";
+import { onTestFinished, test, vi } from "vitest";
 import { CloudflareDevEnvironment } from "../cloudflare-environment";
+import { GET_EXPORT_TYPES_PATH, UNKNOWN_HOST } from "../shared";
 import type { ResolvedWorkerConfig } from "../plugin-config";
-import type { Miniflare } from "miniflare";
 
 test("surfaces the response body when fetching Worker export types fails", async ({
 	expect,
 }) => {
-	const environment = {
-		fetchWorkerExportTypes:
-			CloudflareDevEnvironment.prototype.fetchWorkerExportTypes,
-	};
-	const miniflare = {
-		dispatchFetch() {
-			return Promise.resolve(
-				new Response("Error: Network connection lost.", {
-					status: 500,
-					statusText: "Internal Server Error",
-				})
-			);
+	const config = await resolveConfig(
+		{
+			configFile: false,
+			environments: { auxiliary_worker: {} },
+			logLevel: "silent",
 		},
-	} as Partial<Miniflare> as Miniflare;
+		"serve"
+	);
+	const environment = new CloudflareDevEnvironment("auxiliary_worker", config);
+	const miniflare = new Miniflare({
+		workers: [
+			{
+				config: {
+					type: "worker",
+					name: "test-worker",
+					compatibilityDate: "2024-12-30",
+					manifest: {
+						mainModule: "index.mjs",
+						modules: {
+							"index.mjs": {
+								type: "esm",
+								contents: "export default {}",
+							},
+						},
+					},
+					env: {},
+					exports: {},
+				},
+			},
+		],
+	});
+
+	onTestFinished(async () => {
+		await miniflare.dispose();
+	});
+
+	const dispatchFetch = vi.spyOn(miniflare, "dispatchFetch").mockResolvedValue(
+		new Response("Error: Network connection lost.", {
+			status: 500,
+			statusText: "Internal Server Error",
+		})
+	);
 	const workerConfig = {
 		name: "auxiliary-worker",
-	} as Partial<ResolvedWorkerConfig> as ResolvedWorkerConfig;
+	} as ResolvedWorkerConfig;
 
 	await expect(
 		environment.fetchWorkerExportTypes(miniflare, workerConfig)
 	).rejects.toThrow(
 		'Failed to fetch export types for Worker "auxiliary-worker" (500 Internal Server Error): Error: Network connection lost.'
+	);
+	expect(dispatchFetch).toHaveBeenCalledWith(
+		new URL(GET_EXPORT_TYPES_PATH, UNKNOWN_HOST),
+		{ headers: { [CoreHeaders.ROUTE_OVERRIDE]: "auxiliary-worker" } }
 	);
 });

--- a/packages/vite-plugin-cloudflare/src/cloudflare-environment.ts
+++ b/packages/vite-plugin-cloudflare/src/cloudflare-environment.ts
@@ -156,6 +156,14 @@ export class CloudflareDevEnvironment extends vite.DevEnvironment {
 				},
 			}
 		);
+		if (!response.ok) {
+			const status = [response.status, response.statusText]
+				.filter(Boolean)
+				.join(" ");
+			throw new Error(
+				`Failed to fetch export types for Worker "${workerConfig.name}" (${status}): ${await response.text()}`
+			);
+		}
 		const json = await response.json();
 
 		return json as ExportTypes;


### PR DESCRIPTION
Fixes #15370.

When Miniflare returned a non-success response while the Vite plugin fetched Worker export types, the plugin attempted to parse the plain-text error body as JSON. This replaced the underlying failure with an unrelated SyntaxError.

This change checks the response status before JSON parsing and reports the Worker name, HTTP status, and original response body. Successful JSON responses keep their existing behavior.

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: this only improves an internal development error message and adds regression coverage.

Local verification:

- pnpm test (199 tests)
- pnpm check:type
- type-aware Oxlint on changed TypeScript files
- Oxfmt check on all changed files
- pnpm build
<!-- devin-review-badge-begin -->

---

<a href="https://cloudflare.devinenterprise.com/review/cloudflare/workers-sdk/pull/15407" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->