### PR TITLE
[miniflare] Enforce curly lint rule

### DIFF
--- a/.oxlintrc.jsonc
+++ b/.oxlintrc.jsonc
@@ -133,7 +133,6 @@
 		{
 			"files": ["packages/miniflare/**"],
 			"rules": {
-				"curly": "off",
 				"@typescript-eslint/no-explicit-any": "off",
 				"@typescript-eslint/ban-ts-comment": "off",
 				"@typescript-eslint/no-floating-promises": "off",

--- a/packages/miniflare/AGENTS.md
+++ b/packages/miniflare/AGENTS.md
@@ -27,7 +27,7 @@ Local dev simulator for Cloudflare Workers, powered by workerd runtime. Main cla
 
 ## Lint Status (Transitional)
 
-- Many shared ESLint rules temporarily DISABLED: `curly`, `no-explicit-any`, `consistent-type-imports`, `no-shadow`, `no-floating-promises`, others
+- Many shared ESLint rules temporarily DISABLED: `no-explicit-any`, `consistent-type-imports`, `no-shadow`, `no-floating-promises`, others
 - Comment in config: "temporarily enabled while we transition Miniflare to use the standard workers-sdk eslint config"
 - `no-console: error` is on, except for `src/workers/` and `scripts/`
 

--- a/packages/miniflare/src/http/fetch.ts
+++ b/packages/miniflare/src/http/fetch.ts
@@ -193,7 +193,9 @@ export class DispatchFetchDispatcher extends undici.Dispatcher {
 		cfBlob?: IncomingRequestCfProperties
 	) {
 		super();
-		if (cfBlob !== undefined) this.cfBlobJson = JSON.stringify(cfBlob);
+		if (cfBlob !== undefined) {
+			this.cfBlobJson = JSON.stringify(cfBlob);
+		}
 	}
 
 	addHeaders(
@@ -216,7 +218,9 @@ export class DispatchFetchDispatcher extends undici.Dispatcher {
 	): boolean {
 		let origin = String(options.origin);
 		// The first request in a redirect chain will always match the user origin
-		if (origin === this.userRuntimeOrigin) origin = this.actualRuntimeOrigin;
+		if (origin === this.userRuntimeOrigin) {
+			origin = this.actualRuntimeOrigin;
+		}
 		if (origin === this.actualRuntimeOrigin) {
 			// If this is now a request to the runtime, rewrite dispatching origin to
 			// the runtime's
@@ -273,8 +277,12 @@ export class DispatchFetchDispatcher extends undici.Dispatcher {
 		callback?: () => void
 	): Promise<void> {
 		let err: Error | null = null;
-		if (typeof errCallback === "function") callback = errCallback;
-		if (errCallback instanceof Error) err = errCallback;
+		if (typeof errCallback === "function") {
+			callback = errCallback;
+		}
+		if (errCallback instanceof Error) {
+			err = errCallback;
+		}
 
 		await Promise.all([
 			this.globalDispatcher.destroy(err),

--- a/packages/miniflare/src/http/request.ts
+++ b/packages/miniflare/src/http/request.ts
@@ -34,7 +34,9 @@ export class Request<
 		super(input, init);
 		this[kCf] = init?.cf;
 		// Prefer `cf` from `init`, but if it's set on `input`, use that
-		if (input instanceof Request) this[kCf] ??= input.cf;
+		if (input instanceof Request) {
+			this[kCf] ??= input.cf;
+		}
 	}
 
 	get cf() {

--- a/packages/miniflare/src/http/websocket.ts
+++ b/packages/miniflare/src/http/websocket.ts
@@ -110,11 +110,15 @@ export class WebSocket extends TypedEventTarget<WebSocketEventMap> {
 			);
 		}
 
-		if (this[kAccepted]) return; // Permit double `accept()`
+		if (this[kAccepted]) {
+			return;
+		} // Permit double `accept()`
 		this[kAccepted] = true;
 
 		if (this.#dispatchQueue !== undefined) {
-			for (const event of this.#dispatchQueue) this.dispatchEvent(event);
+			for (const event of this.#dispatchQueue) {
+				this.dispatchEvent(event);
+			}
 			this.#dispatchQueue = undefined;
 		}
 	}
@@ -149,7 +153,9 @@ export class WebSocket extends TypedEventTarget<WebSocketEventMap> {
 				code !== 1005 &&
 				code !== 1006 &&
 				code !== 1015;
-			if (!validCode) throw new TypeError("Invalid WebSocket close code.");
+			if (!validCode) {
+				throw new TypeError("Invalid WebSocket close code.");
+			}
 		}
 		if (reason !== undefined && code === undefined) {
 			throw new TypeError(
@@ -167,7 +173,9 @@ export class WebSocket extends TypedEventTarget<WebSocketEventMap> {
 	[kClose](code?: number, reason?: string): void {
 		// Split from close() so we can queue closes before accept() is called, and
 		// skip close code checks when forwarding close events from the client.
-		if (this[kClosedOutgoing]) throw new TypeError("WebSocket already closed");
+		if (this[kClosedOutgoing]) {
+			throw new TypeError("WebSocket already closed");
+		}
 
 		// Send close event to pair, it should then eventually call `close()` on
 		// itself which will dispatch a close event to us, completing the closing

--- a/packages/miniflare/src/index.ts
+++ b/packages/miniflare/src/index.ts
@@ -200,11 +200,15 @@ function resolveLocalhost(host: string) {
 function maybeGetLocallyAccessibleHost(
 	h: string
 ): "localhost" | "127.0.0.1" | "[::1]" | undefined {
-	if (h === "localhost") return "localhost";
+	if (h === "localhost") {
+		return "localhost";
+	}
 	if (h === "127.0.0.1" || h === "*" || h === "0.0.0.0" || h === "::") {
 		return "127.0.0.1";
 	}
-	if (h === "::1") return "[::1]";
+	if (h === "::1") {
+		return "[::1]";
+	}
 }
 
 /**
@@ -623,7 +627,9 @@ function getInternalDurableObjectProxyBindings(
 	plugin: string,
 	service: Service
 ): Worker_Binding[] | undefined {
-	if (!("worker" in service)) return;
+	if (!("worker" in service)) {
+		return;
+	}
 	assert(service.worker !== undefined);
 	const serviceName = service.name;
 	assert(serviceName !== undefined);
@@ -657,9 +663,13 @@ export function _transformsForContentEncodingAndContentType(
 	type: string | undefined | null
 ): Transform[] {
 	const encoders: Transform[] = [];
-	if (!encoding) return encoders;
+	if (!encoding) {
+		return encoders;
+	}
 	// if cloudflare's FL does not compress this mime-type, then don't compress locally either
-	if (!isCompressedByCloudflareFL(type)) return encoders;
+	if (!isCompressedByCloudflareFL(type)) {
+		return encoders;
+	}
 
 	// Reverse of https://github.com/nodejs/undici/blob/48d9578f431cbbd6e74f77455ba92184f57096cf/lib/fetch/index.js#L1660
 	const codings = encoding
@@ -1026,7 +1036,9 @@ export class Miniflare {
 	}
 
 	async #pushRegistryUpdate(retries = 3): Promise<void> {
-		if (this.#disposeController.signal.aborted) return;
+		if (this.#disposeController.signal.aborted) {
+			return;
+		}
 		if (!this.#devRegistryDispatcher) {
 			return;
 		}
@@ -1572,9 +1584,13 @@ export class Miniflare {
 			// These headers are unsupported in undici fetch requests, they're added
 			// automatically. For custom service bindings, we may pass this request
 			// straight through to another fetch so strip them now.
-			if (restrictedUndiciHeaders.includes(name)) continue;
+			if (restrictedUndiciHeaders.includes(name)) {
+				continue;
+			}
 			if (Array.isArray(values)) {
-				for (const value of values) headers.append(name, value);
+				for (const value of values) {
+					headers.append(name, value);
+				}
 			} else if (values !== undefined) {
 				headers.append(name, values);
 			}
@@ -1629,7 +1645,9 @@ export class Miniflare {
 				);
 				const logLevel = level as LogLevel;
 				let message = await request.text();
-				if (!colors$.enabled) message = stripAnsi(message);
+				if (!colors$.enabled) {
+					message = stripAnsi(message);
+				}
 				this.#log.logWithLevel(logLevel, message);
 				response = new Response(null, { status: 204 });
 			} else if (url.pathname === "/core/remote-bindings-access-warning") {
@@ -1872,7 +1890,9 @@ export class Miniflare {
 		if (response.body) {
 			try {
 				for await (const chunk of response.body) {
-					if (chunk) initialStream.write(chunk);
+					if (chunk) {
+						initialStream.write(chunk);
+					}
 				}
 			} catch (error) {
 				this.#log.debug(
@@ -1906,7 +1926,9 @@ export class Miniflare {
 	}
 
 	#startLoopbackServer(hostname: string): Promise<StoppableServer> {
-		if (hostname === "*") hostname = "::";
+		if (hostname === "*") {
+			hostname = "::";
+		}
 
 		return new Promise((resolve) => {
 			const server = stoppable(
@@ -2599,7 +2621,9 @@ export class Miniflare {
 					this.#disposeController.signal
 				)
 		);
-		if (this.#disposeController.signal.aborted) return;
+		if (this.#disposeController.signal.aborted) {
+			return;
+		}
 		if (maybeSocketPorts === undefined) {
 			throw new MiniflareCoreError(
 				"ERR_RUNTIME_FAILURE",
@@ -2765,7 +2789,9 @@ export class Miniflare {
 		// If we called `dispose()`, we may not have a `#runtimeEntryURL` if we
 		// `dispose()`d synchronously, immediately after constructing a `Miniflare`
 		// instance. In this case, return a discard URL which we'll ignore.
-		if (disposing) return new URL("http://[100::]/");
+		if (disposing) {
+			return new URL("http://[100::]/");
+		}
 		// if there is an inspector proxy let's wait for it to be ready
 		await this.#maybeInspectorProxyController?.ready;
 		// Make sure `dispose()` wasn't called in the time we've been waiting
@@ -3052,8 +3078,9 @@ export class Miniflare {
 		// Technically, at this point, this a malformed response so let's remove the header
 		// Retain it as MF-Content-Encoding so we can tell the body was actually compressed.
 		const contentEncoding = response.headers.get("Content-Encoding");
-		if (contentEncoding)
+		if (contentEncoding) {
 			response.headers.set("MF-Content-Encoding", contentEncoding);
+		}
 		response.headers.delete("Content-Encoding");
 
 		if (
@@ -3071,7 +3098,9 @@ export class Miniflare {
 			);
 			Error.stackTraceLimit = originalLimit;
 			setImmediate(() => {
-				if (!response.bodyUsed) throw error;
+				if (!response.bodyUsed) {
+					throw error;
+				}
 			});
 		}
 
@@ -3616,9 +3645,15 @@ export class Miniflare {
 		// existing behavior when an earlier cleanup operation fails.
 		maybeInstanceRegistry?.delete(this);
 
-		if (independentCleanupFailed) throw independentCleanupError;
-		if (!runtimeCleanupOutcome.ok) throw runtimeCleanupOutcome.error;
-		if (waitForReadyFailed) throw waitForReadyError;
+		if (independentCleanupFailed) {
+			throw independentCleanupError;
+		}
+		if (!runtimeCleanupOutcome.ok) {
+			throw runtimeCleanupOutcome.error;
+		}
+		if (waitForReadyFailed) {
+			throw waitForReadyError;
+		}
 	}
 }
 

--- a/packages/miniflare/src/plugins/browser-rendering/process.ts
+++ b/packages/miniflare/src/plugins/browser-rendering/process.ts
@@ -37,7 +37,9 @@ function waitForGracefulClose(
 		let finished = false;
 
 		function finish(closed: boolean) {
-			if (finished) return;
+			if (finished) {
+				return;
+			}
 			finished = true;
 			clearTimeout(timeout);
 			socket.terminate();
@@ -52,7 +54,9 @@ function waitForGracefulClose(
 			socket.send(
 				JSON.stringify({ id: 1, method: "Browser.close" }),
 				(error) => {
-					if (error) finish(false);
+					if (error) {
+						finish(false);
+					}
 				}
 			);
 		});
@@ -79,7 +83,9 @@ export async function closeBrowserProcess(
 	wsEndpoint: string,
 	timeoutMs = BROWSER_CLOSE_TIMEOUT
 ): Promise<void> {
-	if (await waitForGracefulClose(browserProcess, wsEndpoint, timeoutMs)) return;
+	if (await waitForGracefulClose(browserProcess, wsEndpoint, timeoutMs)) {
+		return;
+	}
 
 	// Process.kill() terminates the whole process tree with taskkill on Windows
 	// and SIGKILL on the detached process group on POSIX systems.

--- a/packages/miniflare/src/plugins/core/errors/callsite.ts
+++ b/packages/miniflare/src/plugins/core/errors/callsite.ts
@@ -53,7 +53,9 @@ function parseCallSite(line: string): CallSite | undefined {
 	if (lineMatch[1]) {
 		functionName = lineMatch[1];
 		let methodStart = functionName.lastIndexOf(".");
-		if (functionName[methodStart - 1] == ".") methodStart--;
+		if (functionName[methodStart - 1] == ".") {
+			methodStart--;
+		}
 		if (methodStart > 0) {
 			object = functionName.substring(0, methodStart);
 			method = functionName.substring(methodStart + 1);

--- a/packages/miniflare/src/plugins/core/errors/index.ts
+++ b/packages/miniflare/src/plugins/core/errors/index.ts
@@ -37,7 +37,9 @@ function maybeGetDiskFile(filePath: string): Required<SourceFile> | undefined {
 		return { path: filePath, contents };
 	} catch (e: any) {
 		// Ignore not-found errors, but throw everything else
-		if (e.code !== "ENOENT") throw e;
+		if (e.code !== "ENOENT") {
+			throw e;
+		}
 	}
 }
 
@@ -73,7 +75,9 @@ function maybeGetFile(
 			}
 
 			const manifest = config.manifest;
-			if (manifest === undefined) continue;
+			if (manifest === undefined) {
+				continue;
+			}
 			const modules = manifest.modules;
 			for (const [modulePath, module] of Object.entries(modules)) {
 				const resolvedModulePath = path.resolve(
@@ -136,13 +140,17 @@ function getSourceMappedStack(
 	// option from the "source-map-support" package.
 	function retrieveSourceMap(fileSpecifier: string): UrlAndMap | null {
 		const sourceFile = maybeGetFile(workerSrcOpts, fileSpecifier);
-		if (sourceFile?.path === undefined) return null;
+		if (sourceFile?.path === undefined) {
+			return null;
+		}
 
 		// Find the last source mapping URL if any
 		const sourceMapRegexp = /# sourceMappingURL=(.+)/g;
 		const matches = [...sourceFile.contents.matchAll(sourceMapRegexp)];
 		// If we couldn't find a source mapping URL, there's nothing we can do
-		if (matches.length === 0) return null;
+		if (matches.length === 0) {
+			return null;
+		}
 		const sourceMapMatch = matches[matches.length - 1];
 
 		// Get the source map. `maybeGetFile` first checks inline sources (e.g.
@@ -153,7 +161,9 @@ function getSourceMappedStack(
 			workerSrcOpts,
 			pathToFileURL(sourceMapPath).href
 		);
-		if (sourceMapFile?.path === undefined) return null;
+		if (sourceMapFile?.path === undefined) {
+			return null;
+		}
 
 		if (onSourceMap) {
 			try {
@@ -255,7 +265,9 @@ export function reviveError(
 	// construction, we override the stack trace to the one from the Worker in the
 	// JSON-serialised error.
 	const error = new ctor(jsonError.message, { cause });
-	if (jsonError.name !== undefined) error.name = jsonError.name;
+	if (jsonError.name !== undefined) {
+		error.name = jsonError.name;
+	}
 	error.stack = jsonError.stack;
 
 	// Try to apply source-mapping to the stack trace

--- a/packages/miniflare/src/plugins/core/errors/sourcemap.ts
+++ b/packages/miniflare/src/plugins/core/errors/sourcemap.ts
@@ -72,7 +72,9 @@ export type SourceMapper = (
 
 let sourceMapper: SourceMapper;
 export function getSourceMapper(): SourceMapper {
-	if (sourceMapper !== undefined) return sourceMapper;
+	if (sourceMapper !== undefined) {
+		return sourceMapper;
+	}
 
 	const support = getFreshSourceMapSupport();
 	const originalPrepareStackTrace = Error.prepareStackTrace;

--- a/packages/miniflare/src/plugins/core/index.ts
+++ b/packages/miniflare/src/plugins/core/index.ts
@@ -656,7 +656,9 @@ export const CORE_PLUGIN: Plugin = {
 				service,
 				dev
 			);
-			if (maybeService !== undefined) services.push(maybeService);
+			if (maybeService !== undefined) {
+				services.push(maybeService);
+			}
 		}
 
 		if (dev?.outboundService !== undefined) {
@@ -667,7 +669,9 @@ export const CORE_PLUGIN: Plugin = {
 				dev.outboundService,
 				dev
 			);
-			if (maybeService !== undefined) services.push(maybeService);
+			if (maybeService !== undefined) {
+				services.push(maybeService);
+			}
 		}
 
 		{

--- a/packages/miniflare/src/plugins/core/inspector-proxy/inspector-proxy-controller.ts
+++ b/packages/miniflare/src/plugins/core/inspector-proxy/inspector-proxy-controller.ts
@@ -139,7 +139,9 @@ export class InspectorProxyController {
 	#validateDevToolsWebSocketUpgradeRequest(req: IncomingMessage) {
 		// Validate `Host` header
 		const hostHeader = req.headers.host;
-		if (hostHeader == null) return { statusText: null, status: 400 };
+		if (hostHeader == null) {
+			return { statusText: null, status: 400 };
+		}
 		try {
 			const host = new URL(`http://${hostHeader}`);
 			// Allow the configured inspector host in addition to the default allowed hostnames
@@ -166,8 +168,11 @@ export class InspectorProxyController {
 		try {
 			const origin = new URL(originHeader);
 			const allowed = ALLOWED_ORIGIN_HOSTNAMES.some((rule) => {
-				if (typeof rule === "string") return origin.hostname === rule;
-				else return rule.test(origin.hostname);
+				if (typeof rule === "string") {
+					return origin.hostname === rule;
+				} else {
+					return rule.test(origin.hostname);
+				}
 			});
 			if (!allowed) {
 				return { statusText: "Disallowed `Origin` header", status: 401 };

--- a/packages/miniflare/src/plugins/core/modules.ts
+++ b/packages/miniflare/src/plugins/core/modules.ts
@@ -48,7 +48,9 @@ export function compileModuleRules(rules: V4ModuleRule[]) {
 export function withSourceURL(script: string, scriptPath: string): string {
 	// If we've already got a `//# sourceURL` comment, return `script` as is
 	// (searching from the end as that's where we'd expect it)
-	if (script.lastIndexOf("//# sourceURL=") !== -1) return script;
+	if (script.lastIndexOf("//# sourceURL=") !== -1) {
+		return script;
+	}
 
 	let scriptURL: URL | string = scriptPath;
 	if (maybeGetStringScriptPathIndex(scriptPath) === undefined) {

--- a/packages/miniflare/src/plugins/core/proxy/client.ts
+++ b/packages/miniflare/src/plugins/core/proxy/client.ts
@@ -80,8 +80,9 @@ const reducers: ReducersRevivers = {
 	...structuredSerializableReducers,
 	...createHTTPReducers(NODE_PLATFORM_IMPL),
 	Native(value) {
-		if (isNativeTarget(value))
+		if (isNativeTarget(value)) {
 			return [value[kAddress], value[kName], value[kIsFunction]];
+		}
 	},
 };
 const revivers: ReducersRevivers = {
@@ -197,10 +198,14 @@ class ProxyClientBridge {
 			// Sanity check: make sure the proxy hasn't been poisoned. We should
 			// unregister all proxies from the finalisation registry when poisoning,
 			// but it doesn't hurt to be careful.
-			if (held.version === this.#version) addresses.push(held.address);
+			if (held.version === this.#version) {
+				addresses.push(held.address);
+			}
 		}
 		// If there are no addresses to free, we don't need to send a request
-		if (addresses.length === 0) return;
+		if (addresses.length === 0) {
+			return;
+		}
 		try {
 			await this.dispatchFetch(this.url, {
 				method: "DELETE",
@@ -419,7 +424,9 @@ class ProxyStubHandler<T extends object>
 		assert(!isClientError(res.status));
 
 		const typeHeader = res.headers.get(CoreHeaders.OP_RESULT_TYPE);
-		if (typeHeader === "Promise, ReadableStream") return res.body;
+		if (typeHeader === "Promise, ReadableStream") {
+			return res.body;
+		}
 		assert(typeHeader === "Promise"); // Must be async
 
 		let stringifiedResult: string;
@@ -460,7 +467,9 @@ class ProxyStubHandler<T extends object>
 		assert(syncRes.body !== null);
 		// Unbuffered streams should only be sent as part of async responses
 		assert(syncRes.headers.get(CoreHeaders.OP_STRINGIFIED_SIZE) === null);
-		if (syncRes.body instanceof ReadableStream) return syncRes.body;
+		if (syncRes.body instanceof ReadableStream) {
+			return syncRes.body;
+		}
 
 		const stringifiedResult = DECODER.decode(syncRes.body);
 		const result = parseWithReadableStreams(
@@ -491,17 +500,27 @@ class ProxyStubHandler<T extends object>
 
 		// When `devalue` `stringify`ing `Proxy`, treat it as a `NativeTarget`
 		// (allows native proxies to be used as arguments, e.g. `DurableObjectId`s)
-		if (key === kAddress) return this.target[kAddress];
-		if (key === kName) return this.target[kName];
-		if (key === kIsFunction) return this.target[kIsFunction];
+		if (key === kAddress) {
+			return this.target[kAddress];
+		}
+		if (key === kName) {
+			return this.target[kName];
+		}
+		if (key === kIsFunction) {
+			return this.target[kIsFunction];
+		}
 		// Ignore all other symbol properties, or `then()`s. We should never return
 		// `Promise`s or thenables as native targets, and want to avoid the extra
 		// network call when `await`ing the proxy.
-		if (typeof key === "symbol" || key === "then") return undefined;
+		if (typeof key === "symbol" || key === "then") {
+			return undefined;
+		}
 
 		// See optimisation comments below for cases where this will be set
 		const maybeKnown = this.#knownValues.get(key);
-		if (maybeKnown !== undefined) return maybeKnown;
+		if (maybeKnown !== undefined) {
+			return maybeKnown;
+		}
 
 		// Always perform a synchronous GET, if this returns a `Promise`, we'll
 		// do an asynchronous GET in the reviver
@@ -548,12 +567,16 @@ class ProxyStubHandler<T extends object>
 	getOwnPropertyDescriptor(target: T, key: string | symbol) {
 		this.#assertSafe();
 
-		if (typeof key === "symbol") return undefined;
+		if (typeof key === "symbol") {
+			return undefined;
+		}
 
 		// Optimisation: assume constant prototypes of proxied objects, descriptors
 		// should never change after we've fetched them
 		const maybeKnown = this.#knownDescriptors.get(key);
-		if (maybeKnown !== undefined) return maybeKnown;
+		if (maybeKnown !== undefined) {
+			return maybeKnown;
+		}
 
 		const syncRes = this.bridge.sync.fetch(this.bridge.url, {
 			method: "POST",
@@ -578,7 +601,9 @@ class ProxyStubHandler<T extends object>
 
 		// Optimisation: assume constant prototypes of proxied objects, own keys
 		// should never change after we've fetched them
-		if (this.#knownOwnKeys !== undefined) return this.#knownOwnKeys;
+		if (this.#knownOwnKeys !== undefined) {
+			return this.#knownOwnKeys;
+		}
 
 		const syncRes = this.bridge.sync.fetch(this.bridge.url, {
 			method: "POST",
@@ -616,7 +641,9 @@ class ProxyStubHandler<T extends object>
 		const func = {
 			[key]: (...args: unknown[]) => {
 				const result = this.#call(key, knownAsync, args, func);
-				if (!knownAsync && result instanceof Promise) knownAsync = true;
+				if (!knownAsync && result instanceof Promise) {
+					knownAsync = true;
+				}
 				return result;
 			},
 		}[key];
@@ -632,7 +659,9 @@ class ProxyStubHandler<T extends object>
 
 		const targetName = this.target[kName];
 		// See `isFetcherFetch()` comment for why this is special
-		if (isFetcherFetch(targetName, key)) return this.#fetcherFetchCall(args);
+		if (isFetcherFetch(targetName, key)) {
+			return this.#fetcherFetchCall(args);
+		}
 
 		const stringified = stringifyWithStreams(
 			NODE_PLATFORM_IMPL,
@@ -663,7 +692,9 @@ class ProxyStubHandler<T extends object>
 				const arg = args[0];
 				assert(arg instanceof Headers);
 				assert(result instanceof Headers);
-				for (const [key, value] of result) arg.set(key, value);
+				for (const [key, value] of result) {
+					arg.set(key, value);
+				}
 				return; // void
 			}
 			return result;

--- a/packages/miniflare/src/plugins/core/proxy/fetch-sync.ts
+++ b/packages/miniflare/src/plugins/core/proxy/fetch-sync.ts
@@ -114,7 +114,9 @@ export class SynchronousFetcher {
 	}
 
 	#ensureWorker() {
-		if (this.#worker !== undefined) return;
+		if (this.#worker !== undefined) {
+			return;
+		}
 		this.#worker = new Worker(WORKER_SCRIPT, {
 			eval: true,
 			workerData: {

--- a/packages/miniflare/src/plugins/do/index.ts
+++ b/packages/miniflare/src/plugins/do/index.ts
@@ -58,12 +58,16 @@ export const DURABLE_OBJECTS_PLUGIN: Plugin = {
 				break;
 			}
 		}
-		if (!hasDurableObjects) return;
+		if (!hasDurableObjects) {
+			return;
+		}
 
 		// If this worker has enabled `unsafeEphemeralDurableObjects`, it won't need
 		// the Durable Object storage service. If all workers have this enabled, we
 		// don't need to create the storage service at all.
-		if (unsafeEphemeralDurableObjects) return;
+		if (unsafeEphemeralDurableObjects) {
+			return;
+		}
 
 		const storagePath = getPersistPath(
 			DURABLE_OBJECTS_PLUGIN_NAME,

--- a/packages/miniflare/src/plugins/hyperdrive/hyperdrive-proxy.ts
+++ b/packages/miniflare/src/plugins/hyperdrive/hyperdrive-proxy.ts
@@ -510,7 +510,9 @@ function mysqlSupportsSSL(payload: Buffer<ArrayBuffer>): boolean {
 	let offset = 1;
 
 	// Find end of server_version string (null terminator)
-	while (offset < payloadLength && payload[offset] != 0x00) offset++;
+	while (offset < payloadLength && payload[offset] != 0x00) {
+		offset++;
+	}
 
 	// Skip null terminator
 	offset++;
@@ -520,8 +522,9 @@ function mysqlSupportsSSL(payload: Buffer<ArrayBuffer>): boolean {
 	offset += MYSQL_AUTH_PLUGIN_DATA_PART_1_LENGTH;
 	offset += MYSQL_FILLER_LENGTH;
 	// Ensure there are enough bytes left for fixed fields
-	if (offset + MYSQL_CAPABILITY_FLAGS_LOWER_LENGTH > payloadLength)
+	if (offset + MYSQL_CAPABILITY_FLAGS_LOWER_LENGTH > payloadLength) {
 		return false;
+	}
 
 	// Read 2-byte little-endian capability_flags_lower
 	const caps = payload[offset] | (payload[offset + 1] << 8);

--- a/packages/miniflare/src/plugins/hyperdrive/index.ts
+++ b/packages/miniflare/src/plugins/hyperdrive/index.ts
@@ -26,9 +26,15 @@ function hasMysqlProtocol(url: URL) {
 }
 
 function getPort(url: URL) {
-	if (url.port !== "") return url.port;
-	if (hasPostgresProtocol(url)) return "5432";
-	if (hasMysqlProtocol(url)) return "3306";
+	if (url.port !== "") {
+		return url.port;
+	}
+	if (hasPostgresProtocol(url)) {
+		return "5432";
+	}
+	if (hasMysqlProtocol(url)) {
+		return "3306";
+	}
 	// Validated in `HyperdriveSchema`
 	assert.fail(`Expected known protocol, got ${url.protocol}`);
 }
@@ -37,7 +43,9 @@ function getPort(url: URL) {
 export const HyperdriveSchema = z
 	.union([z.url(), z.instanceof(URL)])
 	.transform((url, ctx) => {
-		if (typeof url === "string") url = new URL(url);
+		if (typeof url === "string") {
+			url = new URL(url);
+		}
 		if (url.protocol === "") {
 			ctx.addIssue({
 				code: "custom",

--- a/packages/miniflare/src/plugins/queues/index.ts
+++ b/packages/miniflare/src/plugins/queues/index.ts
@@ -59,7 +59,9 @@ export const QUEUES_PLUGIN: Plugin = {
 			(trigger) => trigger.name
 		);
 		const queueIds = new Set([...produced, ...consumed]);
-		if (queueIds.size === 0) return [];
+		if (queueIds.size === 0) {
+			return [];
+		}
 
 		const services = Array.from(queueIds).map<Service>((id) => ({
 			name: getQueueServiceName(id),

--- a/packages/miniflare/src/plugins/shared/index.ts
+++ b/packages/miniflare/src/plugins/shared/index.ts
@@ -175,7 +175,9 @@ export function namespaceEntries<
 }
 
 export function maybeParseURL(url: string | undefined): URL | undefined {
-	if (typeof url !== "string" || path.isAbsolute(url)) return;
+	if (typeof url !== "string" || path.isAbsolute(url)) {
+		return;
+	}
 	try {
 		return new URL(url);
 	} catch {}

--- a/packages/miniflare/src/plugins/shared/routing.ts
+++ b/packages/miniflare/src/plugins/shared/routing.ts
@@ -10,11 +10,15 @@ function routeSpecificity(url: URL) {
 	// Adapted from internal config service routing table implementation
 	const hostParts = url.host.split(".");
 	let hostScore = hostParts.length;
-	if (hostParts[0] === "*") hostScore -= 2;
+	if (hostParts[0] === "*") {
+		hostScore -= 2;
+	}
 
 	const pathParts = url.pathname.split("/");
 	let pathScore = pathParts.length;
-	if (pathParts[pathParts.length - 1] === "*") pathScore -= 2;
+	if (pathParts[pathParts.length - 1] === "*") {
+		pathScore -= 2;
+	}
 
 	return hostScore * 26 + pathScore;
 }
@@ -27,7 +31,9 @@ export function parseRoutes(allRoutes: Map<string, string[]>): WorkerRoute[] {
 
 			let urlInput = route;
 			// If route is missing a protocol, give it one so it parses
-			if (!hasProtocol) urlInput = `https://${urlInput}`;
+			if (!hasProtocol) {
+				urlInput = `https://${urlInput}`;
+			}
 			const url = new URL(urlInput);
 			const specificity = routeSpecificity(url);
 

--- a/packages/miniflare/src/runtime/index.ts
+++ b/packages/miniflare/src/runtime/index.ts
@@ -53,7 +53,9 @@ async function waitForPorts(
 	stream: Readable,
 	options: Abortable & Pick<RuntimeOptions, "requiredSockets">
 ): Promise<SocketPorts | undefined> {
-	if (options?.signal?.aborted) return;
+	if (options?.signal?.aborted) {
+		return;
+	}
 	const lines = rl.createInterface(stream);
 	// Calling `close()` will end the async iterator below and return undefined
 	const abortListener = () => lines.close();
@@ -65,18 +67,24 @@ async function waitForPorts(
 		for await (const line of lines) {
 			const message = ControlMessageSchema.safeParse(JSON.parse(line));
 			// If this was an unrecognised control message, ignore it
-			if (!message.success) continue;
+			if (!message.success) {
+				continue;
+			}
 			const data = message.data;
 			const socket: SocketIdentifier =
 				data.event === "listen-inspector" ? kInspectorSocket : data.socket;
 			const index = requiredSockets.indexOf(socket);
 			// If this wasn't a required socket, ignore it
-			if (index === -1) continue;
+			if (index === -1) {
+				continue;
+			}
 			// Record the port of this socket
 			socketPorts.set(socket, data.port);
 			// Satisfy the requirement, if there are no more, return the ports map
 			requiredSockets.splice(index, 1);
-			if (requiredSockets.length === 0) return socketPorts;
+			if (requiredSockets.length === 0) {
+				return socketPorts;
+			}
 		}
 	} finally {
 		options?.signal?.removeEventListener("abort", abortListener);

--- a/packages/miniflare/src/shared/mime-types.ts
+++ b/packages/miniflare/src/shared/mime-types.ts
@@ -52,7 +52,9 @@ export const compressedByCloudflareFL = new Set([
 export function isCompressedByCloudflareFL(
 	contentTypeHeader: string | undefined | null
 ) {
-	if (!contentTypeHeader) return true; // Content-Type inferred as text/plain
+	if (!contentTypeHeader) {
+		return true;
+	} // Content-Type inferred as text/plain
 
 	const [contentType] = contentTypeHeader.split(";");
 

--- a/packages/miniflare/src/shared/streams.ts
+++ b/packages/miniflare/src/shared/streams.ts
@@ -39,7 +39,9 @@ export async function readPrefix(
 		chunks.push(chunk);
 		chunksLength += chunk.byteLength;
 		// Once we've read enough bytes, stop
-		if (chunksLength >= prefixLength) break;
+		if (chunksLength >= prefixLength) {
+			break;
+		}
 	}
 	// If we read the entire stream without enough bytes for prefix, throw
 	if (chunksLength < prefixLength) {

--- a/packages/miniflare/src/shared/types.ts
+++ b/packages/miniflare/src/shared/types.ts
@@ -55,11 +55,17 @@ export const PathSchema = z.string().transform((p) => {
 
 /** @internal */
 export function _isCyclic(value: unknown, seen = new Set<unknown>()) {
-	if (typeof value !== "object" || value === null) return false;
+	if (typeof value !== "object" || value === null) {
+		return false;
+	}
 	for (const child of Object.values(value)) {
-		if (seen.has(child)) return true;
+		if (seen.has(child)) {
+			return true;
+		}
 		seen.add(child);
-		if (_isCyclic(child, seen)) return true;
+		if (_isCyclic(child, seen)) {
+			return true;
+		}
 		seen.delete(child);
 	}
 	return false;

--- a/packages/miniflare/src/workers/cache/cache.worker.ts
+++ b/packages/miniflare/src/workers/cache/cache.worker.ts
@@ -98,7 +98,9 @@ function getExpiration(timers: Timers, req: Request, res: Response) {
 // headers in KV once this has been determined.
 function normaliseHeaders(headers: Headers): Record<string, string> {
 	const result: Record<string, string> = {};
-	for (const [key, value] of headers) result[key.toLowerCase()] = value;
+	for (const [key, value] of headers) {
+		result[key.toLowerCase()] = value;
+	}
 	return result;
 }
 
@@ -174,7 +176,9 @@ function getMatchResponse(reqHeaders: Headers, res: CachedResponse): Response {
 		}
 	}
 
-	if (!(res.body instanceof ReadableStream)) res.body = res.body.body;
+	if (!(res.body instanceof ReadableStream)) {
+		res.body = res.body.body;
+	}
 	return new Response(res.body, { status: res.status, headers: res.headers });
 }
 
@@ -200,7 +204,9 @@ export async function parseHttpResponse(
 				buffer[index + 2] === CR &&
 				buffer[index + 3] === LF
 		);
-		if (blankLineIndex !== -1) break;
+		if (blankLineIndex !== -1) {
+			break;
+		}
 	}
 	assert(blankLineIndex !== -1, "Expected to find blank line in HTTP message");
 
@@ -274,7 +280,9 @@ export class CacheObject extends MiniflareDurableObject {
 		const cacheKey = getCacheKey(req);
 
 		// Never cache Workers Sites requests, so we always return on-disk files
-		if (isSitesRequest(req)) throw new CacheMiss();
+		if (isSitesRequest(req)) {
+			throw new CacheMiss();
+		}
 
 		let resHeaders: Headers | undefined;
 		let resRanges: InclusiveRange[] | undefined;
@@ -287,7 +295,9 @@ export class CacheObject extends MiniflareDurableObject {
 			const rangeHeader = req.headers.get("Range");
 			if (rangeHeader !== null) {
 				resRanges = parseRanges(rangeHeader, size);
-				if (resRanges === undefined) throw new RangeNotSatisfiable(size);
+				if (resRanges === undefined) {
+					throw new RangeNotSatisfiable(size);
+				}
 			}
 
 			return {
@@ -296,7 +306,9 @@ export class CacheObject extends MiniflareDurableObject {
 				contentType: contentType ?? undefined,
 			};
 		});
-		if (cached?.metadata === undefined) throw new CacheMiss();
+		if (cached?.metadata === undefined) {
+			throw new CacheMiss();
+		}
 
 		// Should've constructed headers when we extracted range options (the only
 		// time we don't do this is when the entry isn't found, or expired, in which
@@ -319,7 +331,9 @@ export class CacheObject extends MiniflareDurableObject {
 		const cacheKey = getCacheKey(req);
 
 		// Never cache Workers Sites requests, so we always return on-disk files
-		if (isSitesRequest(req)) throw new CacheMiss();
+		if (isSitesRequest(req)) {
+			throw new CacheMiss();
+		}
 
 		assert(req.body !== null);
 		const res = await parseHttpResponse(req.body);
@@ -373,7 +387,9 @@ export class CacheObject extends MiniflareDurableObject {
 
 		const deleted = await this.storage.delete(cacheKey);
 		// This is an extremely vague error, but it fits with what the cache API in workerd expects
-		if (!deleted) throw new PurgeFailure();
+		if (!deleted) {
+			throw new PurgeFailure();
+		}
 		return new Response(null);
 	};
 

--- a/packages/miniflare/src/workers/core/devalue.ts
+++ b/packages/miniflare/src/workers/core/devalue.ts
@@ -115,7 +115,9 @@ export const structuredSerializableRevivers: ReducersRevivers = {
 		] as (typeof ALLOWED_ARRAY_BUFFER_VIEW_CONSTRUCTORS)[number];
 		assert(ALLOWED_ARRAY_BUFFER_VIEW_CONSTRUCTORS.includes(ctor));
 		let length = byteLength;
-		if ("BYTES_PER_ELEMENT" in ctor) length /= ctor.BYTES_PER_ELEMENT;
+		if ("BYTES_PER_ELEMENT" in ctor) {
+			length /= ctor.BYTES_PER_ELEMENT;
+		}
 		return new ctor(buffer as ArrayBuffer, byteOffset, length);
 	},
 	RegExp(value) {
@@ -163,7 +165,9 @@ export function createHTTPReducers(
 ): ReducersRevivers {
 	return {
 		Headers(val) {
-			if (val instanceof impl.Headers) return [...val.entries()];
+			if (val instanceof impl.Headers) {
+				return [...val.entries()];
+			}
 		},
 		Request(val) {
 			if (val instanceof impl.Request) {
@@ -316,7 +320,9 @@ export class __MiniflareFunctionWrapper {
 	) {
 		return new Proxy(this, {
 			get: (_, key) => {
-				if (key === "__miniflareWrappedFunction") return fnWithProps;
+				if (key === "__miniflareWrappedFunction") {
+					return fnWithProps;
+				}
 				return fnWithProps[key];
 			},
 		});
@@ -345,7 +351,9 @@ export function parseWithReadableStreams<RS>(
 				assert(buffer instanceof ArrayBuffer);
 				assert(typeof type === "string");
 				const opts: WorkerBlobOptions = {};
-				if (type !== "") opts.type = type;
+				if (type !== "") {
+					opts.type = type;
+				}
 				return new impl.Blob([buffer], opts);
 			} else {
 				// File
@@ -356,7 +364,9 @@ export function parseWithReadableStreams<RS>(
 				assert(typeof name === "string");
 				assert(typeof lastModified === "number");
 				const opts: WorkerFileOptions = { lastModified };
-				if (type !== "") opts.type = type;
+				if (type !== "") {
+					opts.type = type;
+				}
 				return new impl.File([buffer], name, opts);
 			}
 		},

--- a/packages/miniflare/src/workers/core/entry.worker.ts
+++ b/packages/miniflare/src/workers/core/entry.worker.ts
@@ -93,7 +93,9 @@ function getUserRequest(
 		// If a custom `upstream` was specified, make sure the URL starts with it
 		let path = url.pathname + url.search;
 		// Remove leading slash, so we resolve relative to `upstream`'s path
-		if (path.startsWith("/")) path = `./${path.substring(1)}`;
+		if (path.startsWith("/")) {
+			path = `./${path.substring(1)}`;
+		}
 		url = new URL(path, upstreamUrl);
 		rewriteHeadersFromOriginalUrl = true;
 	}
@@ -172,7 +174,9 @@ function getTargetService(
 const LOCALHOST_HOSTNAMES = ["localhost", "127.0.0.1", "[::1]"];
 
 function isCdnCgiRequest(url: string | null): boolean {
-	if (url === null) return false;
+	if (url === null) {
+		return false;
+	}
 
 	try {
 		return new URL(url).pathname.startsWith("/cdn-cgi/");
@@ -320,7 +324,9 @@ function maybeParseAcceptEncodingElement(
 	element: string
 ): AcceptedEncoding | undefined {
 	const match = acceptEncodingElement.exec(element);
-	if (match?.groups == null) return;
+	if (match?.groups == null) {
+		return;
+	}
 	return {
 		coding: match.groups.coding,
 		weight:
@@ -331,7 +337,9 @@ function parseAcceptEncoding(header: string): AcceptedEncoding[] {
 	const encodings: AcceptedEncoding[] = [];
 	for (const element of header.split(",")) {
 		const maybeEncoding = maybeParseAcceptEncodingElement(element.trim());
-		if (maybeEncoding !== undefined) encodings.push(maybeEncoding);
+		if (maybeEncoding !== undefined) {
+			encodings.push(maybeEncoding);
+		}
 	}
 	// `Array#sort()` is stable, so original ordering preserved for same weights
 	return encodings.sort((a, b) => b.weight - a.weight);
@@ -343,9 +351,13 @@ function ensureAcceptableEncoding(
 	// https://www.rfc-editor.org/rfc/rfc9110#section-12.5.3
 
 	// If the client hasn't specified any acceptable encodings, assume anything is
-	if (clientAcceptEncoding === null) return response;
+	if (clientAcceptEncoding === null) {
+		return response;
+	}
 	const encodings = parseAcceptEncoding(clientAcceptEncoding);
-	if (encodings.length === 0) return response;
+	if (encodings.length === 0) {
+		return response;
+	}
 
 	const contentEncoding = response.headers.get("Content-Encoding");
 	const contentType = response.headers.get("Content-Type");
@@ -390,12 +402,16 @@ function ensureAcceptableEncoding(
 				headers: { "Accept-Encoding": "br, gzip" },
 			});
 		}
-		if (contentEncoding === null) return response;
+		if (contentEncoding === null) {
+			return response;
+		}
 		response = new Response(response.body, response); // Ensure mutable headers
 		response.headers.delete("Content-Encoding"); // Use identity
 		return response;
 	} else {
-		if (contentEncoding === desiredEncoding) return response;
+		if (contentEncoding === desiredEncoding) {
+			return response;
+		}
 		response = new Response(response.body, response); // Ensure mutable headers
 		response.headers.set("Content-Encoding", desiredEncoding); // Use desired
 		return response;
@@ -403,9 +419,15 @@ function ensureAcceptableEncoding(
 }
 
 function colourFromHTTPStatus(status: number): Colorize {
-	if (200 <= status && status < 300) return green;
-	if (400 <= status && status < 500) return yellow;
-	if (500 <= status) return red;
+	if (200 <= status && status < 300) {
+		return green;
+	}
+	if (400 <= status && status < 500) {
+		return yellow;
+	}
+	if (500 <= status) {
+		return red;
+	}
 	return blue;
 }
 
@@ -424,7 +446,9 @@ function maybeLogRequest(
 	);
 	res.headers.delete(ADDITIONAL_RESPONSE_LOG_HEADER_NAME);
 
-	if (env[CoreBindings.JSON_LOG_LEVEL] < LogLevel.INFO) return res;
+	if (env[CoreBindings.JSON_LOG_LEVEL] < LogLevel.INFO) {
+		return res;
+	}
 
 	const url = new URL(req.url);
 	const statusText = (res.statusText.trim() || STATUS_CODES[res.status]) ?? "";

--- a/packages/miniflare/src/workers/core/proxy.worker.ts
+++ b/packages/miniflare/src/workers/core/proxy.worker.ts
@@ -154,7 +154,9 @@ export class ProxyServer implements DurableObject {
 			// Rather than worrying about cleaning up `Promise`s some other way, we
 			// just remove them from the heap immediately, since we should never make
 			// a request to resolve them again.
-			if (heapValue instanceof Promise) this.heap.delete(address);
+			if (heapValue instanceof Promise) {
+				this.heap.delete(address);
+			}
 			return heapValue;
 		},
 	};
@@ -183,7 +185,9 @@ export class ProxyServer implements DurableObject {
 	async #fetch(request: Request) {
 		// Validate `Host` header
 		const hostHeader = request.headers.get("Host");
-		if (hostHeader == null) return new Response(null, { status: 400 });
+		if (hostHeader == null) {
+			return new Response(null, { status: 400 });
+		}
 		try {
 			const host = new URL(`http://${hostHeader}`);
 			if (!ALLOWED_HOSTNAMES.includes(host.hostname)) {
@@ -195,7 +199,9 @@ export class ProxyServer implements DurableObject {
 
 		// Validate secret header to prevent unauthorised access to proxy
 		const secretHex = request.headers.get(CoreHeaders.OP_SECRET);
-		if (secretHex == null) return new Response(null, { status: 401 });
+		if (secretHex == null) {
+			return new Response(null, { status: 401 });
+		}
 		const expectedSecret = this.env[CoreBindings.DATA_PROXY_SECRET];
 		const secretBuffer = Buffer.from(secretHex, "hex");
 		if (
@@ -213,7 +219,9 @@ export class ProxyServer implements DurableObject {
 		const contentLengthHeader = request.headers.get("Content-Length");
 
 		// Get target to perform operations on
-		if (targetHeader === null) return new Response(null, { status: 400 });
+		if (targetHeader === null) {
+			return new Response(null, { status: 400 });
+		}
 
 		// If this is a FREE operation, remove the target(s) from the heap
 		if (opHeader === ProxyOps.FREE) {
@@ -241,7 +249,9 @@ export class ProxyServer implements DurableObject {
 			result = keyHeader === null ? target : target[keyHeader];
 
 			// Immediately resolve all RpcProperties
-			if (result?.constructor.name === "RpcProperty") result = await result;
+			if (result?.constructor.name === "RpcProperty") {
+				result = await result;
+			}
 
 			if (typeof result === "function") {
 				// Calling functions-which-return-functions not yet supported
@@ -251,7 +261,9 @@ export class ProxyServer implements DurableObject {
 				});
 			}
 		} else if (opHeader === ProxyOps.GET_OWN_DESCRIPTOR) {
-			if (keyHeader === null) return new Response(null, { status: 400 });
+			if (keyHeader === null) {
+				return new Response(null, { status: 400 });
+			}
 			const descriptor = Object.getOwnPropertyDescriptor(target, keyHeader);
 			if (descriptor !== undefined) {
 				result = <PropertyDescriptor>{

--- a/packages/miniflare/src/workers/core/routing.ts
+++ b/packages/miniflare/src/workers/core/routing.ts
@@ -12,19 +12,29 @@ export interface WorkerRoute {
 
 export function matchRoutes(routes: WorkerRoute[], url: URL): string | null {
 	for (const route of routes) {
-		if (route.protocol && route.protocol !== url.protocol) continue;
+		if (route.protocol && route.protocol !== url.protocol) {
+			continue;
+		}
 
 		if (route.allowHostnamePrefix) {
-			if (!url.hostname.endsWith(route.hostname)) continue;
+			if (!url.hostname.endsWith(route.hostname)) {
+				continue;
+			}
 		} else {
-			if (url.hostname !== route.hostname) continue;
+			if (url.hostname !== route.hostname) {
+				continue;
+			}
 		}
 
 		const path = url.pathname + url.search;
 		if (route.allowPathSuffix) {
-			if (!path.startsWith(route.path)) continue;
+			if (!path.startsWith(route.path)) {
+				continue;
+			}
 		} else {
-			if (path !== route.path) continue;
+			if (path !== route.path) {
+				continue;
+			}
 		}
 
 		return route.target;

--- a/packages/miniflare/src/workers/d1/database.worker.ts
+++ b/packages/miniflare/src/workers/d1/database.worker.ts
@@ -154,8 +154,11 @@ export class D1DatabaseObject extends MiniflareDurableObject {
 		const rows = convertRows(Array.from(cursor.raw()));
 
 		let results = undefined;
-		if (format === "ROWS_AND_COLUMNS") results = { columns, rows };
-		else results = rowsToObjects(columns, rows);
+		if (format === "ROWS_AND_COLUMNS") {
+			results = { columns, rows };
+		} else {
+			results = rowsToObjects(columns, rows);
+		}
 		// Note that the "NONE" format behaviour here is inconsistent with workerd.
 		// See comment: https://github.com/cloudflare/workers-sdk/pull/5917#issuecomment-2133313156
 
@@ -210,7 +213,9 @@ export class D1DatabaseObject extends MiniflareDurableObject {
 	@POST("/execute")
 	queryExecute: RouteHandler = async (req) => {
 		let queries = D1QueriesSchema.parse(await req.json());
-		if (!Array.isArray(queries)) queries = [queries];
+		if (!Array.isArray(queries)) {
+			queries = [queries];
+		}
 
 		// Special local-mode-only handlers
 		if (this.#isExportPragma(queries)) {

--- a/packages/miniflare/src/workers/d1/dumpSql.ts
+++ b/packages/miniflare/src/workers/d1/dumpSql.ts
@@ -56,14 +56,20 @@ export function* dumpSql(
 	}
 
 	for (const { name: table, sql } of tables) {
-		if (filterTables.size > 0 && !filterTables.has(table)) continue;
+		if (filterTables.size > 0 && !filterTables.has(table)) {
+			continue;
+		}
 
 		if (table === "sqlite_sequence") {
-			if (!noSchema) yield `DELETE FROM sqlite_sequence;`;
+			if (!noSchema) {
+				yield `DELETE FROM sqlite_sequence;`;
+			}
 		} else if (table.match(/^sqlite_stat./)) {
 			// This feels like it should really appear _after_ the contents of sqlite_stat[1,4] but I'm choosing
 			// to match SQLite's dump output exactly so writing it immediately like they do.
-			if (!noSchema) yield `ANALYZE sqlite_schema;`;
+			if (!noSchema) {
+				yield `ANALYZE sqlite_schema;`;
+			}
 		} else if (sql.startsWith(`CREATE VIRTUAL TABLE`)) {
 			throw new Error(
 				`D1 Export error: cannot export databases with Virtual Tables (fts5)`
@@ -75,13 +81,19 @@ export function* dumpSql(
 			// quoted i.e. "Table", then in the dump it has `IF NOT EXISTS` injected. I don't understand
 			// why, but on the off chance there's a good reason to I am following suit.
 			if (sql.match(/CREATE TABLE ['"].*/)) {
-				if (!noSchema) yield `CREATE TABLE IF NOT EXISTS ${sql.substring(13)};`;
+				if (!noSchema) {
+					yield `CREATE TABLE IF NOT EXISTS ${sql.substring(13)};`;
+				}
 			} else {
-				if (!noSchema) yield `${sql};`;
+				if (!noSchema) {
+					yield `${sql};`;
+				}
 			}
 		}
 
-		if (noData) continue;
+		if (noData) {
+			continue;
+		}
 		// eslint-disable-next-line workers-sdk/no-unsafe-command-execution -- input is escaped via escapeId() so this PRAGMA call is safe
 		const columns_cursor = db.exec(`PRAGMA table_info=${escapeId(table)}`);
 
@@ -174,7 +186,9 @@ export function* dumpSql(
 			].join(" ")
 		);
 		for (const { name, sql } of rest_of_schema) {
-			if (filterTables.size > 0 && !filterTables.has(name as string)) continue;
+			if (filterTables.size > 0 && !filterTables.has(name as string)) {
+				continue;
+			}
 			yield `${sql};`;
 		}
 		if (stats) {
@@ -209,8 +223,12 @@ function outputQuotedEscapedString(cell: unknown) {
 		escapeQuotesDetectingNewlines
 	);
 	let output_string = `'${escaped_string}'`;
-	if (crs) output_string = `replace(${output_string},'\\r',char(13))`;
-	if (lfs) output_string = `replace(${output_string},'\\n',char(10))`;
+	if (crs) {
+		output_string = `replace(${output_string},'\\r',char(13))`;
+	}
+	if (lfs) {
+		output_string = `replace(${output_string},'\\n',char(10))`;
+	}
 	return output_string;
 }
 

--- a/packages/miniflare/src/workers/kv/constants.ts
+++ b/packages/miniflare/src/workers/kv/constants.ts
@@ -116,9 +116,13 @@ export function testSiteRegExps(
 	key: string
 ): boolean {
 	// Either include globs undefined, or name matches them
-	if (regExps.include !== undefined) return testRegExps(regExps.include, key);
+	if (regExps.include !== undefined) {
+		return testRegExps(regExps.include, key);
+	}
 	// Either exclude globs undefined, or name doesn't match them
-	if (regExps.exclude !== undefined) return !testRegExps(regExps.exclude, key);
+	if (regExps.exclude !== undefined) {
+		return !testRegExps(regExps.exclude, key);
+	}
 	return true;
 }
 

--- a/packages/miniflare/src/workers/kv/namespace.worker.ts
+++ b/packages/miniflare/src/workers/kv/namespace.worker.ts
@@ -180,7 +180,9 @@ export class KVNamespaceObject extends MiniflareDurableObject {
 		// Get value from storage
 		validateGetOptions(key, { cacheTtl });
 		const entry = await this.storage.get(key);
-		if (entry === null) throw new HttpError(404, "Not Found");
+		if (entry === null) {
+			throw new HttpError(404, "Not Found");
+		}
 
 		// Return value in runtime-friendly format
 		const headers = new Headers();
@@ -218,8 +220,11 @@ export class KVNamespaceObject extends MiniflareDurableObject {
 		let value = req.body;
 		const contentLength = parseInt(req.headers.get("Content-Length") ?? "NaN");
 		let valueLengthHint: number | undefined;
-		if (!Number.isNaN(contentLength)) valueLengthHint = contentLength;
-		else if (value === null) valueLengthHint = 0;
+		if (!Number.isNaN(contentLength)) {
+			valueLengthHint = contentLength;
+		} else if (value === null) {
+			valueLengthHint = 0;
+		}
 
 		// Empty values may be put with `null` bodies:
 		// https://github.com/cloudflare/miniflare/issues/703

--- a/packages/miniflare/src/workers/kv/sites.worker.ts
+++ b/packages/miniflare/src/workers/kv/sites.worker.ts
@@ -22,7 +22,9 @@ interface Env {
 const siteRegExpsCache = new WeakMap<Env, SiteMatcherRegExps>();
 function getSiteRegExps(env: Env): SiteMatcherRegExps {
 	let regExps = siteRegExpsCache.get(env);
-	if (regExps !== undefined) return regExps;
+	if (regExps !== undefined) {
+		return regExps;
+	}
 	regExps = deserialiseSiteRegExps(env[SiteBindings.JSON_SITE_FILTER]);
 	siteRegExpsCache.set(env, regExps);
 	return regExps;
@@ -77,8 +79,12 @@ function arrayCompare(
 	for (let i = 0; i < minLength; i++) {
 		const aElement = a[i];
 		const bElement = b[i];
-		if (aElement < bElement) return -1;
-		if (aElement > bElement) return 1;
+		if (aElement < bElement) {
+			return -1;
+		}
+		if (aElement > bElement) {
+			return 1;
+		}
 	}
 	return a.length - b.length;
 }
@@ -102,14 +108,20 @@ async function handleListRequest(
 	// (https://github.com/cloudflare/miniflare/issues/380).
 	let keys: { name: string; encodedName?: Uint8Array }[] = [];
 	for await (let name of walkDirectory(blobsService)) {
-		if (!testSiteRegExps(siteRegExps, name)) continue;
+		if (!testSiteRegExps(siteRegExps, name)) {
+			continue;
+		}
 		name = encodeSitesKey(name);
-		if (prefix !== undefined && !name.startsWith(prefix)) continue;
+		if (prefix !== undefined && !name.startsWith(prefix)) {
+			continue;
+		}
 		keys.push({ name, encodedName: encoder.encode(name) });
 	}
 	keys.sort((a, b) => arrayCompare(a.encodedName, b.encodedName));
 	// Remove `encodedName`s, so they don't get returned
-	for (const key of keys) delete key.encodedName;
+	for (const key of keys) {
+		delete key.encodedName;
+	}
 
 	// Apply cursor
 	const startAfter = cursor === undefined ? "" : base64Decode(cursor);
@@ -119,7 +131,9 @@ async function handleListRequest(
 		// is an incredibly unlikely operation, so doesn't need to be optimised
 		startIndex = keys.findIndex(({ name }) => name === startAfter);
 		// If we couldn't find where to start, return nothing
-		if (startIndex === -1) startIndex = keys.length;
+		if (startIndex === -1) {
+			startIndex = keys.length;
+		}
 		// Since we want to start AFTER this index, add 1 to it
 		startIndex++;
 	}

--- a/packages/miniflare/src/workers/kv/validator.worker.ts
+++ b/packages/miniflare/src/workers/kv/validator.worker.ts
@@ -3,7 +3,9 @@ import { HttpError } from "miniflare:shared";
 import { KVLimits, KVParams } from "./constants";
 
 export function decodeKey({ key }: { key: string }, query: URLSearchParams) {
-	if (query.get(KVParams.URL_ENCODED)?.toLowerCase() !== "true") return key;
+	if (query.get(KVParams.URL_ENCODED)?.toLowerCase() !== "true") {
+		return key;
+	}
 	try {
 		return decodeURIComponent(key);
 	} catch (e: any) {
@@ -148,5 +150,7 @@ export function validateListOptions(options: KVNamespaceListOptions): void {
 
 	// Validate key prefix
 	const prefix = options.prefix;
-	if (prefix != null) validateKeyLength(prefix);
+	if (prefix != null) {
+		validateKeyLength(prefix);
+	}
 }

--- a/packages/miniflare/src/workers/local-explorer/aggregation.ts
+++ b/packages/miniflare/src/workers/local-explorer/aggregation.ts
@@ -120,7 +120,9 @@ export async function aggregateListResults<T>(
 	const peerResults = await Promise.all(
 		peerUrls.map(async (url) => {
 			const response = await fetchFromPeer(url, apiPath);
-			if (!response?.ok) return [];
+			if (!response?.ok) {
+				return [];
+			}
 			try {
 				const data = (await response.json()) as {
 					result: T[] | { [key: string]: T[] };

--- a/packages/miniflare/src/workers/local-explorer/common.ts
+++ b/packages/miniflare/src/workers/local-explorer/common.ts
@@ -71,7 +71,9 @@ export function coerceValue(
 ): unknown {
 	// Unwrap optional/default to get inner type
 	if (schema instanceof z.ZodOptional || schema instanceof z.ZodDefault) {
-		if (value === undefined) return value;
+		if (value === undefined) {
+			return value;
+		}
 		return coerceValue(schema._zod.def.innerType as z.ZodType, value, path);
 	}
 
@@ -91,8 +93,12 @@ export function coerceValue(
 	}
 
 	if (schema instanceof z.ZodBoolean && typeof value === "string") {
-		if (value === "true") return true;
-		if (value === "false") return false;
+		if (value === "true") {
+			return true;
+		}
+		if (value === "false") {
+			return false;
+		}
 		throw new z.ZodError([
 			{
 				code: "invalid_type",

--- a/packages/miniflare/src/workers/local-explorer/explorer.worker.ts
+++ b/packages/miniflare/src/workers/local-explorer/explorer.worker.ts
@@ -454,7 +454,9 @@ app.get("/api/local/workers", async (c) => {
 		const peerResults = await Promise.all(
 			peerUrls.map(async (url) => {
 				const peerResponse = await fetchFromPeer(url, "/local/workers");
-				if (!peerResponse?.ok) return [];
+				if (!peerResponse?.ok) {
+					return [];
+				}
 				try {
 					const data = (await peerResponse.json()) as {
 						result?: LocalExplorerWorker[];

--- a/packages/miniflare/src/workers/local-explorer/resources/d1.ts
+++ b/packages/miniflare/src/workers/local-explorer/resources/d1.ts
@@ -74,12 +74,16 @@ async function findD1DatabaseOwner(
 	databaseId: string
 ): Promise<string | null> {
 	const peerUrls = await getPeerUrlsIfAggregating(c);
-	if (peerUrls.length === 0) return null;
+	if (peerUrls.length === 0) {
+		return null;
+	}
 
 	const responses = await Promise.all(
 		peerUrls.map(async (url) => {
 			const response = await fetchFromPeer(url, "/d1/database");
-			if (!response?.ok) return null;
+			if (!response?.ok) {
+				return null;
+			}
 			const data = (await response.json()) as {
 				result?: Array<{ uuid: string }>;
 			};
@@ -196,7 +200,9 @@ export async function rawD1Database(
 				body: JSON.stringify(body),
 			}
 		);
-		if (response) return response;
+		if (response) {
+			return response;
+		}
 	}
 
 	return errorResponse(

--- a/packages/miniflare/src/workers/local-explorer/resources/do.ts
+++ b/packages/miniflare/src/workers/local-explorer/resources/do.ts
@@ -50,7 +50,9 @@ function getDOBinding(
 	useSQLite: boolean;
 } | null {
 	const info = env.LOCAL_EXPLORER_BINDING_MAP.do[namespaceId];
-	if (!info) return null;
+	if (!info) {
+		return null;
+	}
 	return {
 		binding: env[
 			info.binding
@@ -78,7 +80,9 @@ async function findDONamespaceOwner(
 	namespaceId: string
 ): Promise<string | null> {
 	const peerUrls = await getPeerUrlsIfAggregating(c);
-	if (peerUrls.length === 0) return null;
+	if (peerUrls.length === 0) {
+		return null;
+	}
 
 	const responses = await Promise.all(
 		peerUrls.map(async (url) => {
@@ -86,7 +90,9 @@ async function findDONamespaceOwner(
 				url,
 				"/workers/durable_objects/namespaces"
 			);
-			if (!response?.ok) return null;
+			if (!response?.ok) {
+				return null;
+			}
 			const data = (await response.json()) as {
 				result?: Array<{ id: string }>;
 			};
@@ -158,15 +164,21 @@ export async function listDOObjects(
 	const ownerMiniflare = await findDONamespaceOwner(c, namespaceId);
 	if (ownerMiniflare) {
 		const params = new URLSearchParams();
-		if (cursor) params.set("cursor", cursor);
-		if (limit !== undefined) params.set("limit", String(limit));
+		if (cursor) {
+			params.set("cursor", cursor);
+		}
+		if (limit !== undefined) {
+			params.set("limit", String(limit));
+		}
 		const queryString = params.toString();
 		const path = `/workers/durable_objects/namespaces/${encodeURIComponent(
 			namespaceId
 		)}/objects${queryString ? `?${queryString}` : ""}`;
 
 		const response = await fetchFromPeer(ownerMiniflare, path);
-		if (response) return response;
+		if (response) {
+			return response;
+		}
 	}
 
 	return errorResponse(
@@ -327,7 +339,9 @@ export async function queryDOSqlite(
 				body: JSON.stringify(body),
 			}
 		);
-		if (response) return response;
+		if (response) {
+			return response;
+		}
 	}
 
 	return errorResponse(

--- a/packages/miniflare/src/workers/local-explorer/resources/kv.ts
+++ b/packages/miniflare/src/workers/local-explorer/resources/kv.ts
@@ -35,7 +35,9 @@ function getKVBinding(env: Env, namespace_id: string): KVNamespace | null {
 
 	// Find the binding name for this namespace ID
 	const bindingName = bindingMap[namespace_id];
-	if (!bindingName) return null;
+	if (!bindingName) {
+		return null;
+	}
 
 	return env[bindingName] as KVNamespace;
 }
@@ -45,12 +47,16 @@ async function findKVNamespaceOwner(
 	namespaceId: string
 ): Promise<string | null> {
 	const peerUrls = await getPeerUrlsIfAggregating(c);
-	if (peerUrls.length === 0) return null;
+	if (peerUrls.length === 0) {
+		return null;
+	}
 
 	const responses = await Promise.all(
 		peerUrls.map(async (url) => {
 			const response = await fetchFromPeer(url, "/storage/kv/namespaces");
-			if (!response?.ok) return null;
+			if (!response?.ok) {
+				return null;
+			}
 			const data = (await response.json()) as {
 				result?: Array<{ id: string }>;
 			};
@@ -163,16 +169,24 @@ export async function listKVKeys(c: AppContext, query: ListKeysQuery) {
 	const ownerMiniflare = await findKVNamespaceOwner(c, namespace_id);
 	if (ownerMiniflare) {
 		const params = new URLSearchParams();
-		if (cursor) params.set("cursor", cursor);
-		if (limit !== undefined) params.set("limit", String(limit));
-		if (prefix) params.set("prefix", prefix);
+		if (cursor) {
+			params.set("cursor", cursor);
+		}
+		if (limit !== undefined) {
+			params.set("limit", String(limit));
+		}
+		if (prefix) {
+			params.set("prefix", prefix);
+		}
 		const queryString = params.toString();
 		const path = `/storage/kv/namespaces/${encodeURIComponent(
 			namespace_id
 		)}/keys${queryString ? `?${queryString}` : ""}`;
 
 		const response = await fetchFromPeer(ownerMiniflare, path);
-		if (response) return response;
+		if (response) {
+			return response;
+		}
 	}
 
 	return errorResponse(
@@ -239,7 +253,9 @@ export async function getKVValue(
 				namespaceId
 			)}/values/${encodeURIComponent(keyName)}`
 		);
-		if (response) return response;
+		if (response) {
+			return response;
+		}
 	}
 
 	return errorResponse(
@@ -284,7 +300,9 @@ export async function putKVValue(
 				body,
 			}
 		);
-		if (response) return response;
+		if (response) {
+			return response;
+		}
 	}
 
 	return errorResponse(
@@ -344,7 +362,9 @@ async function executePutKVValue(
 	}
 
 	const options: KVNamespacePutOptions = {};
-	if (metadata) options.metadata = metadata;
+	if (metadata) {
+		options.metadata = metadata;
+	}
 
 	await kv.put(key_name, value, options);
 	return c.json(wrapResponse({}));
@@ -378,7 +398,9 @@ export async function deleteKVValue(
 			)}/values/${encodeURIComponent(keyName)}`,
 			{ method: "DELETE" }
 		);
-		if (response) return response;
+		if (response) {
+			return response;
+		}
 	}
 
 	return errorResponse(
@@ -431,7 +453,9 @@ export async function bulkGetKVValues(c: AppContext, body: BulkGetBody) {
 				body: JSON.stringify(body),
 			}
 		);
-		if (response) return response;
+		if (response) {
+			return response;
+		}
 	}
 
 	return errorResponse(

--- a/packages/miniflare/src/workers/local-explorer/resources/r2.ts
+++ b/packages/miniflare/src/workers/local-explorer/resources/r2.ts
@@ -39,7 +39,9 @@ function getR2Binding(env: Env, bucket_name: string): R2Bucket | null {
 
 	// Find the binding name for this bucket
 	const bindingName = bindingMap[bucket_name];
-	if (!bindingName) return null;
+	if (!bindingName) {
+		return null;
+	}
 
 	return env[bindingName] as R2Bucket;
 }
@@ -49,12 +51,16 @@ async function findR2BucketOwner(
 	bucketName: string
 ): Promise<string | null> {
 	const peerUrls = await getPeerUrlsIfAggregating(c);
-	if (peerUrls.length === 0) return null;
+	if (peerUrls.length === 0) {
+		return null;
+	}
 
 	const responses = await Promise.all(
 		peerUrls.map(async (url) => {
 			const response = await fetchFromPeer(url, "/r2/buckets");
-			if (!response?.ok) return null;
+			if (!response?.ok) {
+				return null;
+			}
 			const data = (await response.json()) as R2ListBucketsResponse;
 			const found = data.result?.buckets?.some((b) => b.name === bucketName);
 			return found ? url : null;
@@ -146,17 +152,27 @@ export async function listR2Objects(
 	const ownerMiniflare = await findR2BucketOwner(c, bucket_name);
 	if (ownerMiniflare) {
 		const params = new URLSearchParams();
-		if (prefix) params.set("prefix", prefix);
-		if (delimiter) params.set("delimiter", delimiter);
-		if (cursor) params.set("cursor", cursor);
-		if (limit !== undefined) params.set("per_page", String(limit));
+		if (prefix) {
+			params.set("prefix", prefix);
+		}
+		if (delimiter) {
+			params.set("delimiter", delimiter);
+		}
+		if (cursor) {
+			params.set("cursor", cursor);
+		}
+		if (limit !== undefined) {
+			params.set("per_page", String(limit));
+		}
 		const queryString = params.toString();
 		const path = `/r2/buckets/${encodeURIComponent(bucket_name)}/objects${
 			queryString ? `?${queryString}` : ""
 		}`;
 
 		const response = await fetchFromPeer(ownerMiniflare, path);
-		if (response) return response;
+		if (response) {
+			return response;
+		}
 	}
 
 	return errorResponse(
@@ -297,7 +313,9 @@ export async function getR2Object(
 		const response = await fetchFromPeer(ownerMiniflare, route, {
 			headers: metadataOnly ? { "cf-metadata-only": "true" } : undefined,
 		});
-		if (response) return response;
+		if (response) {
+			return response;
+		}
 	}
 
 	return errorResponse(
@@ -375,7 +393,9 @@ export async function putR2Object(
 			headers: fetchHeaders,
 			body,
 		});
-		if (response) return response;
+		if (response) {
+			return response;
+		}
 	}
 
 	return errorResponse(
@@ -423,7 +443,9 @@ export async function deleteR2Objects(
 			headers: { "Content-Type": "application/json" },
 			body: JSON.stringify(keys),
 		});
-		if (response) return response;
+		if (response) {
+			return response;
+		}
 	}
 
 	return errorResponse(

--- a/packages/miniflare/src/workers/observability/trace-store.ts
+++ b/packages/miniflare/src/workers/observability/trace-store.ts
@@ -96,7 +96,9 @@ export class TraceStore extends DurableObject {
 	constructor(ctx: DurableObjectState, env: unknown) {
 		super(ctx, env as never);
 		this.ctx.blockConcurrencyWhile(async () => {
-			for (const stmt of SCHEMA) this.sql.exec(stmt);
+			for (const stmt of SCHEMA) {
+				this.sql.exec(stmt);
+			}
 		});
 	}
 

--- a/packages/miniflare/src/workers/queues/broker.worker.ts
+++ b/packages/miniflare/src/workers/queues/broker.worker.ts
@@ -80,7 +80,9 @@ function validateContentType(headers: Headers): QueueContentType {
 
 function validateMessageDelay(headers: Headers): QueueMessageDelay {
 	const format = headers.get("X-Msg-Delay-Secs");
-	if (!format) return undefined;
+	if (!format) {
+		return undefined;
+	}
 	const result = QueueMessageDelaySchema.safeParse(Number(format));
 	if (!result.success) {
 		throw new HttpError(
@@ -199,12 +201,18 @@ function formatQueueResponse(
 	time?: number
 ) {
 	let colour: Colorize;
-	if (acked === total) colour = green;
-	else if (acked > 0) colour = yellow;
-	else colour = red;
+	if (acked === total) {
+		colour = green;
+	} else if (acked > 0) {
+		colour = yellow;
+	} else {
+		colour = red;
+	}
 
 	let message = `${bold("QUEUE")} ${queueName} ${colour(`${acked}/${total}`)}`;
-	if (time !== undefined) message += grey(` (${time}ms)`);
+	if (time !== undefined) {
+		message += grey(` (${time}ms)`);
+	}
 	return reset(message);
 }
 
@@ -236,12 +244,18 @@ export class QueueBrokerObject extends MiniflareDurableObject<QueueBrokerObjectE
 		super(state, env);
 
 		const maybeProducers = env[QueueBindings.MAYBE_JSON_QUEUE_PRODUCERS];
-		if (maybeProducers === undefined) this.#producers = {};
-		else this.#producers = QueueProducersSchema.parse(maybeProducers);
+		if (maybeProducers === undefined) {
+			this.#producers = {};
+		} else {
+			this.#producers = QueueProducersSchema.parse(maybeProducers);
+		}
 
 		const maybeConsumers = env[QueueBindings.MAYBE_JSON_QUEUE_CONSUMERS];
-		if (maybeConsumers === undefined) this.#consumers = {};
-		else this.#consumers = QueueConsumersSchema.parse(maybeConsumers);
+		if (maybeConsumers === undefined) {
+			this.#consumers = {};
+		} else {
+			this.#consumers = QueueConsumersSchema.parse(maybeConsumers);
+		}
 	}
 
 	get #maybeProducer() {
@@ -362,7 +376,9 @@ export class QueueBrokerObject extends MiniflareDurableObject<QueueBrokerObjectE
 
 		// Ensure we flush again if we still have messages.
 		this.#pendingFlush = undefined;
-		if (this.#messages.length > 0) this.#ensurePendingFlush();
+		if (this.#messages.length > 0) {
+			this.#ensurePendingFlush();
+		}
 
 		if (toDeadLetterQueue.length > 0) {
 			// If we have messages to move to a dead letter queue, do so
@@ -395,7 +411,9 @@ export class QueueBrokerObject extends MiniflareDurableObject<QueueBrokerObjectE
 		if (this.#pendingFlush !== undefined) {
 			// If we have a pending immediate flush, or a delayed flush we haven't
 			// filled the batch for yet, just wait for it
-			if (this.#pendingFlush.immediate || batchHasSpace) return;
+			if (this.#pendingFlush.immediate || batchHasSpace) {
+				return;
+			}
 			// Otherwise, the batch is full, so clear the existing timeout, and
 			// register an immediate flush
 			this.timers.clearTimeout(this.#pendingFlush.timeout);
@@ -447,7 +465,9 @@ export class QueueBrokerObject extends MiniflareDurableObject<QueueBrokerObjectE
 		req: Request<unknown, unknown>
 	): Promise<Response | null> {
 		const proxy = this.env[QueueBindings.MAYBE_SERVICE_QUEUE_PROXY];
-		if (proxy === undefined) return null;
+		if (proxy === undefined) {
+			return null;
+		}
 
 		const headers = new Headers(req.headers);
 		headers.set(HEADER_QUEUE_NAME, this.name);

--- a/packages/miniflare/src/workers/r2/bucket.worker.ts
+++ b/packages/miniflare/src/workers/r2/bucket.worker.ts
@@ -104,7 +104,9 @@ class DigestingStream<
 		});
 		super({
 			async transform(chunk, controller) {
-				for (const hash of hashes) await hash.writer.write(chunk);
+				for (const hash of hashes) {
+					await hash.writer.write(chunk);
+				}
 				controller.enqueue(chunk);
 			},
 			async flush() {
@@ -136,7 +138,9 @@ function generateId() {
 function generateMultipartEtag(md5Hexes: string[]) {
 	// https://stackoverflow.com/a/19896823
 	const hash = createHash("md5");
-	for (const md5Hex of md5Hexes) hash.update(md5Hex, "hex");
+	for (const md5Hex of md5Hexes) {
+		hash.update(md5Hex, "hex");
+	}
 	return `${hash.digest("hex")}-${md5Hexes.length}`;
 }
 
@@ -148,7 +152,9 @@ async function decodeMetadata(req: Request<unknown, unknown>) {
 	const metadataSize = parseInt(
 		req.headers.get(R2Headers.METADATA_SIZE) ?? "NaN"
 	);
-	if (Number.isNaN(metadataSize)) throw new InvalidMetadata();
+	if (Number.isNaN(metadataSize)) {
+		throw new InvalidMetadata();
+	}
 
 	assert(req.body !== null);
 	const body = req.body as ReadableStream<Uint8Array>;
@@ -162,7 +168,9 @@ async function decodeMetadata(req: Request<unknown, unknown>) {
 }
 function decodeHeaderMetadata(req: Request<unknown, unknown>) {
 	const header = req.headers.get(R2Headers.REQUEST);
-	if (header === null) throw new InvalidMetadata();
+	if (header === null) {
+		throw new InvalidMetadata();
+	}
 	return R2BindingRequestSchema.parse(JSON.parse(header));
 }
 
@@ -321,7 +329,9 @@ function sqlStmts(db: TypedSql) {
 		getByKey: stmtGetByKey,
 		getPartsByKey: db.txn((key: string) => {
 			const row = get(stmtGetByKey({ key }));
-			if (row === undefined) return;
+			if (row === undefined) {
+				return;
+			}
 			if (row.blob_id === null) {
 				// If this is a multipart object, also return the parts
 				const partsRows = all(stmtListPartsByKey({ object_key: key }));
@@ -334,7 +344,9 @@ function sqlStmts(db: TypedSql) {
 		put: db.txn((newRow: ObjectRow, onlyIf?: R2Conditional) => {
 			const key = newRow.key;
 			const row = get(stmtGetPreviousByKey({ key }));
-			if (onlyIf !== undefined) validate.condition(row, onlyIf);
+			if (onlyIf !== undefined) {
+				validate.condition(row, onlyIf);
+			}
 			stmtPut(newRow);
 			const maybeOldBlobId = row?.blob_id;
 			if (maybeOldBlobId === undefined) {
@@ -357,7 +369,9 @@ function sqlStmts(db: TypedSql) {
 					// If blob_id is null, this was a multipart object, so delete all
 					// multipart parts
 					const partRows = stmtDeletePartsByKey({ object_key: key });
-					for (const partRow of partRows) oldBlobIds.push(partRow.blob_id);
+					for (const partRow of partRows) {
+						oldBlobIds.push(partRow.blob_id);
+					}
 				} else if (maybeOldBlobId !== undefined) {
 					oldBlobIds.push(maybeOldBlobId);
 				}
@@ -454,7 +468,9 @@ function sqlStmts(db: TypedSql) {
 				// 2. Check all selected part numbers are unique
 				const partNumberSet = new Set<number>();
 				for (const { part } of selectedParts) {
-					if (partNumberSet.has(part)) throw new InternalError();
+					if (partNumberSet.has(part)) {
+						throw new InternalError();
+					}
 					partNumberSet.add(part);
 				}
 
@@ -517,7 +533,9 @@ function sqlStmts(db: TypedSql) {
 					// If blob_id is null, this was a multipart object, so delete all
 					// multipart parts
 					const partRows = stmtDeletePartsByKey({ object_key: key });
-					for (const partRow of partRows) oldBlobIds.push(partRow.blob_id);
+					for (const partRow of partRows) {
+						oldBlobIds.push(partRow.blob_id);
+					}
 				} else if (maybeOldBlobId !== undefined) {
 					oldBlobIds.push(maybeOldBlobId);
 				}
@@ -549,7 +567,9 @@ function sqlStmts(db: TypedSql) {
 
 				// 7. Delete unlinked, unused parts
 				const partRows = stmtDeleteUnlinkedPartsByUploadId({ upload_id });
-				for (const partRow of partRows) oldBlobIds.push(partRow.blob_id);
+				for (const partRow of partRows) {
+					oldBlobIds.push(partRow.blob_id);
+				}
 
 				// 8. Mark the upload as completed
 				stmtUpdateUploadState({
@@ -711,7 +731,9 @@ export class R2BucketObject extends MiniflareDurableObject {
 		validate.key(key);
 
 		const row = get(this.#stmts.getByKey({ key }));
-		if (row === undefined) throw new NoSuchKey();
+		if (row === undefined) {
+			throw new NoSuchKey();
+		}
 
 		const range: R2Range = { offset: 0, length: row.size };
 		return new InternalR2Object(row, range);
@@ -725,7 +747,9 @@ export class R2BucketObject extends MiniflareDurableObject {
 
 		// Try to get this key, including multipart parts if it's multipart
 		const result = this.#stmts.getPartsByKey(key);
-		if (result === undefined) throw new NoSuchKey();
+		if (result === undefined) {
+			throw new NoSuchKey();
+		}
 		const { row, parts } = result;
 
 		// Validate pre-condition
@@ -759,7 +783,9 @@ export class R2BucketObject extends MiniflareDurableObject {
 		} else {
 			// Otherwise, just return a single part value
 			value = await this.blob.get(row.blob_id, range);
-			if (value === null) throw new NoSuchKey();
+			if (value === null) {
+				throw new NoSuchKey();
+			}
 		}
 
 		return new InternalR2ObjectBody(row, value, r2Range);
@@ -776,7 +802,9 @@ export class R2BucketObject extends MiniflareDurableObject {
 		const algorithms: DigestAlgorithm[] = [];
 		for (const { name, field } of R2_HASH_ALGORITHMS) {
 			// Always compute MD5 digest
-			if (field === "md5" || opts[field] !== undefined) algorithms.push(name);
+			if (field === "md5" || opts[field] !== undefined) {
+				algorithms.push(name);
+			}
 		}
 		const digesting = new DigestingStream(algorithms);
 		const blobId = await this.blob.put(value.pipeThrough(digesting));
@@ -811,22 +839,36 @@ export class R2BucketObject extends MiniflareDurableObject {
 			throw e;
 		}
 		if (oldBlobIds !== undefined) {
-			for (const blobId of oldBlobIds) this.#backgroundDelete(blobId);
+			for (const blobId of oldBlobIds) {
+				this.#backgroundDelete(blobId);
+			}
 		}
 		return new InternalR2Object(row);
 	}
 
 	#delete(keys: string | string[]) {
-		if (!Array.isArray(keys)) keys = [keys];
-		for (const key of keys) validate.key(key);
+		if (!Array.isArray(keys)) {
+			keys = [keys];
+		}
+		for (const key of keys) {
+			validate.key(key);
+		}
 		const oldBlobIds = this.#stmts.deleteByKeys(keys);
-		for (const blobId of oldBlobIds) this.#backgroundDelete(blobId);
+		for (const blobId of oldBlobIds) {
+			this.#backgroundDelete(blobId);
+		}
 	}
 
 	#listWithoutDelimiterQuery(excludeHttp: boolean, excludeCustom: boolean) {
-		if (excludeHttp && excludeCustom) return this.#stmts.listWithoutDelimiter;
-		if (excludeHttp) return this.#stmts.listCustomMetadataWithoutDelimiter;
-		if (excludeCustom) return this.#stmts.listHttpMetadataWithoutDelimiter;
+		if (excludeHttp && excludeCustom) {
+			return this.#stmts.listWithoutDelimiter;
+		}
+		if (excludeHttp) {
+			return this.#stmts.listCustomMetadataWithoutDelimiter;
+		}
+		if (excludeCustom) {
+			return this.#stmts.listHttpMetadataWithoutDelimiter;
+		}
 		return this.#stmts.listHttpCustomMetadataWithoutDelimiter;
 	}
 
@@ -840,7 +882,9 @@ export class R2BucketObject extends MiniflareDurableObject {
 		// accommodate it. Simulate this by limiting the limit to 100.
 		// See https://developers.cloudflare.com/r2/api/workers/workers-api-reference/#r2listoptions.
 		const include = opts.include ?? [];
-		if (include.length > 0) limit = Math.min(limit, 100);
+		if (include.length > 0) {
+			limit = Math.min(limit, 100);
+		}
 		const excludeHttp = !include.includes("httpMetadata");
 		const excludeCustom = !include.includes("customMetadata");
 		const rowObject = (
@@ -869,7 +913,9 @@ export class R2BucketObject extends MiniflareDurableObject {
 		}
 
 		let delimiter = opts.delimiter;
-		if (delimiter === "") delimiter = undefined;
+		if (delimiter === "") {
+			delimiter = undefined;
+		}
 
 		// Run appropriate query depending on options
 		const params = {
@@ -901,7 +947,9 @@ export class R2BucketObject extends MiniflareDurableObject {
 				}
 			}
 
-			if (hasMoreRows) nextCursorStartAfter = rows[limit - 1].last_key;
+			if (hasMoreRows) {
+				nextCursorStartAfter = rows[limit - 1].last_key;
+			}
 		} else {
 			// If we don't have a delimiter, we can use a more efficient query
 			const query = this.#listWithoutDelimiterQuery(excludeHttp, excludeCustom);
@@ -913,7 +961,9 @@ export class R2BucketObject extends MiniflareDurableObject {
 
 			objects = rows.map(rowObject);
 
-			if (hasMoreRows) nextCursorStartAfter = rows[limit - 1].key;
+			if (hasMoreRows) {
+				nextCursorStartAfter = rows[limit - 1].key;
+			}
 		}
 
 		// The cursor encodes a key to start after rather than the key to start at
@@ -981,7 +1031,9 @@ export class R2BucketObject extends MiniflareDurableObject {
 			this.#backgroundDelete(blobId);
 			throw e;
 		}
-		if (maybeOldBlobId !== undefined) this.#backgroundDelete(maybeOldBlobId);
+		if (maybeOldBlobId !== undefined) {
+			this.#backgroundDelete(maybeOldBlobId);
+		}
 
 		return { etag };
 	}
@@ -1001,14 +1053,18 @@ export class R2BucketObject extends MiniflareDurableObject {
 			parts,
 			minPartSize
 		);
-		for (const blobId of oldBlobIds) this.#backgroundDelete(blobId);
+		for (const blobId of oldBlobIds) {
+			this.#backgroundDelete(blobId);
+		}
 		return new InternalR2Object(newRow);
 	}
 
 	async #abortMultipartUpload(key: string, uploadId: string): Promise<void> {
 		validate.key(key);
 		const oldBlobIds = this.#stmts.abortMultipartUpload(key, uploadId);
-		for (const blobId of oldBlobIds) this.#backgroundDelete(blobId);
+		for (const blobId of oldBlobIds) {
+			this.#backgroundDelete(blobId);
+		}
 	}
 
 	@GET("/")

--- a/packages/miniflare/src/workers/r2/validator.worker.ts
+++ b/packages/miniflare/src/workers/r2/validator.worker.ts
@@ -33,9 +33,13 @@ function includesEtag(
 ) {
 	// Adapted from internal R2 gateway implementation.
 	for (const condition of conditions) {
-		if (condition.type === "wildcard") return true;
+		if (condition.type === "wildcard") {
+			return true;
+		}
 		if (condition.value === etag) {
-			if (condition.type === "strong" || comparison === "weak") return true;
+			if (condition.type === "strong" || comparison === "weak") {
+				return true;
+			}
 		}
 	}
 	return false;
@@ -94,7 +98,9 @@ export type DigestAlgorithm = (typeof R2_HASH_ALGORITHMS)[number]["name"];
 function serialisedLength(x: string) {
 	//  Adapted from internal R2 gateway implementation
 	for (let i = 0; i < x.length; i++) {
-		if (x.charCodeAt(i) >= 256) return x.length * 2;
+		if (x.charCodeAt(i) >= 256) {
+			return x.length * 2;
+		}
 	}
 	return x.length;
 }
@@ -141,22 +147,36 @@ export class Validator {
 			// If the header contained a single range, use it. Otherwise, if the
 			// header was invalid, or contained multiple ranges, just return the full
 			// response (by returning undefined from this function).
-			if (ranges?.length === 1) return ranges[0];
+			if (ranges?.length === 1) {
+				return ranges[0];
+			}
 		} else if (options.range !== undefined) {
 			let { offset, length, suffix } = options.range;
 			// Eliminate suffix if specified
 			if (suffix !== undefined) {
-				if (suffix <= 0) throw new InvalidRange();
-				if (suffix > size) suffix = size;
+				if (suffix <= 0) {
+					throw new InvalidRange();
+				}
+				if (suffix > size) {
+					suffix = size;
+				}
 				offset = size - suffix;
 				length = suffix;
 			}
 			// Validate offset and length
-			if (offset === undefined) offset = 0;
-			if (length === undefined) length = size - offset;
-			if (offset < 0 || offset > size || length <= 0) throw new InvalidRange();
+			if (offset === undefined) {
+				offset = 0;
+			}
+			if (length === undefined) {
+				length = size - offset;
+			}
+			if (offset < 0 || offset > size || length <= 0) {
+				throw new InvalidRange();
+			}
 			// Clamp length to maximum
-			if (offset + length > size) length = size - offset;
+			if (offset + length > size) {
+				length = size - offset;
+			}
 			// Convert to inclusive range
 			return { start: offset, end: offset + length - 1 };
 		}
@@ -170,7 +190,9 @@ export class Validator {
 	}
 
 	metadataSize(customMetadata?: Record<string, string>): Validator {
-		if (customMetadata === undefined) return this;
+		if (customMetadata === undefined) {
+			return this;
+		}
 		let metadataLength = 0;
 		for (const [key, value] of Object.entries(customMetadata)) {
 			metadataLength += serialisedLength(key) + serialisedLength(value);

--- a/packages/miniflare/src/workers/shared/blob.worker.ts
+++ b/packages/miniflare/src/workers/shared/blob.worker.ts
@@ -42,7 +42,9 @@ async function fetchSingleRange(
 	const res = await fetcher.fetch(url, { headers });
 
 	// If we couldn't find the resource, return `null`
-	if (res.status === 404) return null;
+	if (res.status === 404) {
+		return null;
+	}
 
 	// Otherwise, make sure we have the expected response, and return the body
 	assert(res.ok && res.body !== null);
@@ -76,7 +78,9 @@ async function writeMultipleRanges(
 		const range = ranges[i];
 		const writer = writable.getWriter();
 		// If this isn't the first thing we've written, we'll need to prepend CRLF
-		if (i > 0) await writer.write(ENCODER.encode("\r\n"));
+		if (i > 0) {
+			await writer.write(ENCODER.encode("\r\n"));
+		}
 		// Write boundary and headers
 		await writer.write(ENCODER.encode(`--${boundary}\r\n`));
 		if (contentType !== undefined) {
@@ -98,12 +102,16 @@ async function writeMultipleRanges(
 		);
 		// If we specified a range, but received full content, make sure the range
 		// covered the full content
-		if (res.status !== 206) assertFullRangeRequest(range, contentLength);
+		if (res.status !== 206) {
+			assertFullRangeRequest(range, contentLength);
+		}
 		await res.body.pipeTo(writable, { preventClose: true });
 	}
 	// Finished writing all ranges, now write the trailer
 	const writer = writable.getWriter();
-	if (ranges.length > 0) await writer.write(ENCODER.encode("\r\n"));
+	if (ranges.length > 0) {
+		await writer.write(ENCODER.encode("\r\n"));
+	}
 	await writer.write(ENCODER.encode(`--${boundary}--`));
 	await writer.close();
 }
@@ -115,7 +123,9 @@ async function fetchMultipleRanges(
 ): Promise<MultipartReadableStream | null> {
 	// Check resource exists, and get content length
 	const res = await fetcher.fetch(url, { method: "HEAD" });
-	if (res.status === 404) return null;
+	if (res.status === 404) {
+		return null;
+	}
 	assert(res.ok);
 
 	const contentLength = parseInt(res.headers.get("Content-Length") ?? "NaN");
@@ -215,7 +225,9 @@ export class BlobStore {
 	): Promise<ReadableStream<Uint8Array> | MultipartReadableStream | null> {
 		// Get path for this ID, returning null if it's outside the root
 		const idURL = this.idURL(id);
-		if (idURL === null) return null;
+		if (idURL === null) {
+			return null;
+		}
 		// Get correct response for range, returning null if not found
 		return fetchRange(this.#fetcher, idURL, range, opts);
 	}
@@ -240,7 +252,9 @@ export class BlobStore {
 	async delete(id: BlobId): Promise<void> {
 		// Get path for this ID and delete, ignoring if outside root or not found
 		const idURL = this.idURL(id);
-		if (idURL === null) return;
+		if (idURL === null) {
+			return;
+		}
 		const res = await this.#fetcher.fetch(idURL, { method: "DELETE" });
 		assert(res.ok || res.status === 404);
 	}

--- a/packages/miniflare/src/workers/shared/keyvalue.worker.ts
+++ b/packages/miniflare/src/workers/shared/keyvalue.worker.ts
@@ -155,7 +155,9 @@ export class KeyValueStorage<Metadata = unknown> {
 	> {
 		// Try to get key from metadata store, returning null if not found
 		const row = get(this.#stmts.getByKey(key));
-		if (row === undefined) return null;
+		if (row === undefined) {
+			return null;
+		}
 
 		if (this.#hasExpired(row)) {
 			// If expired, delete from metadata and blob stores. Assuming a
@@ -179,12 +181,16 @@ export class KeyValueStorage<Metadata = unknown> {
 			// If no range was requested, or just a single one was, return a regular
 			// stream
 			const value = await this.#blob.get(row.blob_id, opts?.ranges?.[0]);
-			if (value === null) return null;
+			if (value === null) {
+				return null;
+			}
 			return { ...entry, value };
 		} else {
 			// Otherwise, if multiple ranges were requested, return a multipart stream
 			const value = await this.#blob.get(row.blob_id, opts.ranges, opts);
-			if (value === null) return null;
+			if (value === null) {
+				return null;
+			}
 			return { ...entry, value };
 		}
 	}
@@ -222,14 +228,18 @@ export class KeyValueStorage<Metadata = unknown> {
 					: JSON.stringify(await entry.metadata),
 		});
 		// Garbage collect previous entry's blob
-		if (maybeOldBlobId !== undefined) this.#backgroundDelete(maybeOldBlobId);
+		if (maybeOldBlobId !== undefined) {
+			this.#backgroundDelete(maybeOldBlobId);
+		}
 	}
 
 	async delete(key: string): Promise<boolean> {
 		// Try to delete key from metadata store, returning false if not found
 		const cursor = this.#stmts.deleteByKey({ key });
 		const row = get(cursor);
-		if (row === undefined) return false;
+		if (row === undefined) {
+			return false;
+		}
 		// Garbage collect deleted entry's blob
 		this.#backgroundDelete(row.blob_id);
 		// Return true iff this entry hasn't expired
@@ -274,7 +284,9 @@ export class KeyValueStorage<Metadata = unknown> {
 		// Garbage collect expired entries. As with `get()`, assuming a
 		// monotonically increasing clock, this doesn't need to be in a transaction.
 		const expiredRows = this.#stmts.deleteExpired({ now });
-		for (const row of expiredRows) this.#backgroundDelete(row.blob_id);
+		for (const row of expiredRows) {
+			this.#backgroundDelete(row.blob_id);
+		}
 
 		// If there are more results, we'll be returning a cursor
 		const hasMoreRows = rows.length === opts.limit + 1;

--- a/packages/miniflare/src/workers/shared/matcher.ts
+++ b/packages/miniflare/src/workers/shared/matcher.ts
@@ -7,7 +7,15 @@ export interface MatcherRegExps {
 }
 
 export function testRegExps(matcher: MatcherRegExps, value: string): boolean {
-	for (const exclude of matcher.exclude) if (exclude.test(value)) return false;
-	for (const include of matcher.include) if (include.test(value)) return true;
+	for (const exclude of matcher.exclude) {
+		if (exclude.test(value)) {
+			return false;
+		}
+	}
+	for (const include of matcher.include) {
+		if (include.test(value)) {
+			return true;
+		}
+	}
 	return false;
 }

--- a/packages/miniflare/src/workers/shared/object.worker.ts
+++ b/packages/miniflare/src/workers/shared/object.worker.ts
@@ -71,7 +71,9 @@ export abstract class MiniflareDurableObject<
 
 	#blob?: BlobStore;
 	get blob(): BlobStore {
-		if (this.#blob !== undefined) return this.#blob;
+		if (this.#blob !== undefined) {
+			return this.#blob;
+		}
 		const maybeBlobsService = this.env[SharedBindings.MAYBE_SERVICE_BLOBS];
 		assert(
 			maybeBlobsService !== undefined,
@@ -127,7 +129,9 @@ export abstract class MiniflareDurableObject<
 		// object. Used by tests to update fake time, and access internal storage.
 		if (this.env[SharedBindings.MAYBE_JSON_ENABLE_CONTROL_ENDPOINTS] === true) {
 			const controlOp = req?.cf?.miniflare?.controlOp;
-			if (controlOp !== undefined) return this.#handleControlOp(controlOp);
+			if (controlOp !== undefined) {
+				return this.#handleControlOp(controlOp);
+			}
 		}
 
 		// Each regular request to a `MiniflareDurableObject` includes the object

--- a/packages/miniflare/src/workers/shared/range.ts
+++ b/packages/miniflare/src/workers/shared/range.ts
@@ -31,34 +31,52 @@ export function parseRanges(
 
 	// Make sure unit is "bytes"
 	const prefixMatch = rangePrefixRegexp.exec(rangeHeader);
-	if (prefixMatch === null) return; // Invalid unit (Range Not Satisfiable)
+	if (prefixMatch === null) {
+		return;
+	} // Invalid unit (Range Not Satisfiable)
 
 	// Accept empty range header
 	rangeHeader = rangeHeader.substring(prefixMatch[0].length);
-	if (rangeHeader.trimStart() === "") return [];
+	if (rangeHeader.trimStart() === "") {
+		return [];
+	}
 
 	// Split ranges after prefix by ","
 	const ranges = rangeHeader.split(",");
 	const result: InclusiveRange[] = [];
 	for (const range of ranges) {
 		const match = rangeRegexp.exec(range);
-		if (match === null) return; // Invalid range format (Range Not Satisfiable)
+		if (match === null) {
+			return;
+		} // Invalid range format (Range Not Satisfiable)
 		const { start, end } = match.groups as RangeRegexpGroups;
 		if (start !== undefined && end !== undefined) {
 			const rangeStart = parseInt(start);
 			let rangeEnd = parseInt(end);
-			if (rangeStart > rangeEnd) return; // Start after end (Range Not Satisfiable)
-			if (rangeStart >= length) return; // Start after content (Range Not Satisfiable)
-			if (rangeEnd >= length) rangeEnd = length - 1;
+			if (rangeStart > rangeEnd) {
+				return;
+			} // Start after end (Range Not Satisfiable)
+			if (rangeStart >= length) {
+				return;
+			} // Start after content (Range Not Satisfiable)
+			if (rangeEnd >= length) {
+				rangeEnd = length - 1;
+			}
 			result.push({ start: rangeStart, end: rangeEnd });
 		} else if (start !== undefined && end === undefined) {
 			const rangeStart = parseInt(start);
-			if (rangeStart >= length) return; // Start after content (Range Not Satisfiable)
+			if (rangeStart >= length) {
+				return;
+			} // Start after content (Range Not Satisfiable)
 			result.push({ start: rangeStart, end: length - 1 });
 		} else if (start === undefined && end !== undefined) {
 			const suffix = parseInt(end);
-			if (suffix >= length) return []; // Entire Response
-			if (suffix === 0) continue; // Empty range
+			if (suffix >= length) {
+				return [];
+			} // Entire Response
+			if (suffix === 0) {
+				continue;
+			} // Empty range
 			result.push({ start: length - suffix, end: length - 1 });
 		} else {
 			return; // Invalid range format, missing both start & end (Range Not Satisfiable)

--- a/packages/miniflare/src/workers/shared/router.worker.ts
+++ b/packages/miniflare/src/workers/shared/router.worker.ts
@@ -37,12 +37,16 @@ export abstract class Router {
 	async fetch(req: Request<unknown, unknown>) {
 		const url = new URL(req.url);
 		const methodRoutes = this.#routes?.get(req.method);
-		if (methodRoutes === undefined) return new Response(null, { status: 405 });
+		if (methodRoutes === undefined) {
+			return new Response(null, { status: 405 });
+		}
 		const handlers = this as unknown as Record<PropertyKey, RouteHandler>;
 		try {
 			for (const [path, key] of methodRoutes) {
 				const match = path.exec(url.pathname);
-				if (match !== null) return await handlers[key](req, match.groups, url);
+				if (match !== null) {
+					return await handlers[key](req, match.groups, url);
+				}
 			}
 			return new Response(null, { status: 404 });
 		} catch (e) {
@@ -66,9 +70,13 @@ export type RouteHandler<Params = unknown, Cf = unknown> = (
 ) => Awaitable<Response>;
 
 function pathToRegexp(path?: string): RegExp {
-	if (path === undefined) return /^.*$/;
+	if (path === undefined) {
+		return /^.*$/;
+	}
 	// Optionally allow trailing slashes
-	if (!path.endsWith("/")) path += "/?";
+	if (!path.endsWith("/")) {
+		path += "/?";
+	}
 	// Escape forward slashes
 	path = path.replace(/\//g, "\\/");
 	// Replace `:key` with named capture groups
@@ -84,8 +92,11 @@ const createRouteDecorator =
 		const route = [pathToRegexp(path), key] as const;
 		const routes = (prototype[kRoutesTemplate] ??= new Map());
 		const methodRoutes = routes.get(method);
-		if (methodRoutes) methodRoutes.push(route);
-		else routes.set(method, [route]);
+		if (methodRoutes) {
+			methodRoutes.push(route);
+		} else {
+			routes.set(method, [route]);
+		}
 	};
 
 export const GET = createRouteDecorator("GET");

--- a/packages/miniflare/src/workers/shared/sql.worker.ts
+++ b/packages/miniflare/src/workers/shared/sql.worker.ts
@@ -112,7 +112,9 @@ export function get<R extends TypedResult>(
 	cursor: TypedSqlStorageCursor<R>
 ): R | undefined {
 	let result: R | undefined;
-	for (const row of cursor) result ??= row;
+	for (const row of cursor) {
+		result ??= row;
+	}
 	return result;
 }
 

--- a/packages/miniflare/src/workers/shared/sync.ts
+++ b/packages/miniflare/src/workers/shared/sync.ts
@@ -51,7 +51,9 @@ export class Mutex {
 		} else {
 			this.locked = false;
 			let resolve: (() => void) | undefined;
-			while ((resolve = this.drainQueue.shift()) !== undefined) resolve();
+			while ((resolve = this.drainQueue.shift()) !== undefined) {
+				resolve();
+			}
 		}
 	}
 
@@ -61,10 +63,14 @@ export class Mutex {
 
 	async runWith<T>(closure: () => Awaitable<T>): Promise<T> {
 		const acquireAwaitable = this.lock();
-		if (acquireAwaitable instanceof Promise) await acquireAwaitable;
+		if (acquireAwaitable instanceof Promise) {
+			await acquireAwaitable;
+		}
 		try {
 			const awaitable = closure();
-			if (awaitable instanceof Promise) return await awaitable;
+			if (awaitable instanceof Promise) {
+				return await awaitable;
+			}
 			return awaitable;
 		} finally {
 			this.unlock();
@@ -72,7 +78,9 @@ export class Mutex {
 	}
 
 	async drained(): Promise<void> {
-		if (this.resolveQueue.length === 0 && !this.locked) return;
+		if (this.resolveQueue.length === 0 && !this.locked) {
+			return;
+		}
 		return new Promise((resolve) => this.drainQueue.push(resolve));
 	}
 }
@@ -90,12 +98,16 @@ export class WaitGroup {
 		this.counter--;
 		if (this.counter === 0) {
 			let resolve: (() => void) | undefined;
-			while ((resolve = this.resolveQueue.shift()) !== undefined) resolve();
+			while ((resolve = this.resolveQueue.shift()) !== undefined) {
+				resolve();
+			}
 		}
 	}
 
 	wait(): Promise<void> {
-		if (this.counter === 0) return Promise.resolve();
+		if (this.counter === 0) {
+			return Promise.resolve();
+		}
 		return new Promise((resolve) => this.resolveQueue.push(resolve));
 	}
 }

--- a/packages/miniflare/src/workers/shared/timers.worker.ts
+++ b/packages/miniflare/src/workers/shared/timers.worker.ts
@@ -45,12 +45,17 @@ export class Timers {
 	}
 
 	clearTimeout(handle: TimerHandle): void {
-		if (typeof handle === "number") return clearTimeout(handle);
-		else this.#fakePendingTimeouts.delete(handle[kFakeTimerHandle]);
+		if (typeof handle === "number") {
+			return clearTimeout(handle);
+		} else {
+			this.#fakePendingTimeouts.delete(handle[kFakeTimerHandle]);
+		}
 	}
 
 	queueMicrotask(closure: () => Awaitable<unknown>): void {
-		if (this.#fakeTimestamp === undefined) return queueMicrotask(closure);
+		if (this.#fakeTimestamp === undefined) {
+			return queueMicrotask(closure);
+		}
 
 		const result = closure();
 		if (result instanceof Promise) {
@@ -62,7 +67,9 @@ export class Timers {
 	// Fake Timers Control API
 
 	#runPendingTimeouts() {
-		if (this.#fakeTimestamp === undefined) return;
+		if (this.#fakeTimestamp === undefined) {
+			return;
+		}
 		for (const [handle, timeout] of this.#fakePendingTimeouts) {
 			if (timeout.triggerTimestamp <= this.#fakeTimestamp) {
 				this.#fakePendingTimeouts.delete(handle);

--- a/packages/miniflare/src/workers/stream/object.worker.ts
+++ b/packages/miniflare/src/workers/stream/object.worker.ts
@@ -89,13 +89,17 @@ export class StreamObject extends DurableObject<Env> {
 		});
 
 		const row = get(this.#stmts.getVideo({ id }));
-		if (row === undefined) throw new NotFoundError(`Video not found: ${id}`);
+		if (row === undefined) {
+			throw new NotFoundError(`Video not found: ${id}`);
+		}
 		return row;
 	}
 
 	async getVideo(id: string): Promise<VideoRow> {
 		const row = get(this.#stmts.getVideo({ id }));
-		if (row === undefined) throw new NotFoundError(`Video not found: ${id}`);
+		if (row === undefined) {
+			throw new NotFoundError(`Video not found: ${id}`);
+		}
 		return row;
 	}
 
@@ -160,7 +164,9 @@ export class StreamObject extends DurableObject<Env> {
 
 	async generateToken(id: string): Promise<string> {
 		const row = get(this.#stmts.getVideo({ id }));
-		if (row === undefined) throw new NotFoundError(`Video not found: ${id}`);
+		if (row === undefined) {
+			throw new NotFoundError(`Video not found: ${id}`);
+		}
 
 		const payload = {
 			sub: id,
@@ -175,8 +181,9 @@ export class StreamObject extends DurableObject<Env> {
 		language: string
 	): Promise<CaptionRow> {
 		const video = get(this.#stmts.getVideo({ id: videoId }));
-		if (video === undefined)
+		if (video === undefined) {
 			throw new NotFoundError(`Video not found: ${videoId}`);
+		}
 
 		const label =
 			new Intl.DisplayNames(["en"], { type: "language" }).of(language) ??
@@ -200,8 +207,9 @@ export class StreamObject extends DurableObject<Env> {
 		});
 
 		const row = get(this.#stmts.getCaption({ video_id: videoId, language }));
-		if (row === undefined)
+		if (row === undefined) {
 			throw new NotFoundError(`Caption not found: ${videoId}/${language}`);
+		}
 		return row;
 	}
 
@@ -211,8 +219,9 @@ export class StreamObject extends DurableObject<Env> {
 		input: ReadableStream
 	): Promise<CaptionRow> {
 		const video = get(this.#stmts.getVideo({ id: videoId }));
-		if (video === undefined)
+		if (video === undefined) {
 			throw new NotFoundError(`Video not found: ${videoId}`);
+		}
 
 		const label =
 			new Intl.DisplayNames(["en"], { type: "language" }).of(language) ??
@@ -238,8 +247,9 @@ export class StreamObject extends DurableObject<Env> {
 		});
 
 		const row = get(this.#stmts.getCaption({ video_id: videoId, language }));
-		if (row === undefined)
+		if (row === undefined) {
 			throw new NotFoundError(`Caption not found: ${videoId}/${language}`);
+		}
 		return row;
 	}
 
@@ -248,8 +258,9 @@ export class StreamObject extends DurableObject<Env> {
 		language?: string
 	): Promise<CaptionRow[]> {
 		const video = get(this.#stmts.getVideo({ id: videoId }));
-		if (video === undefined)
+		if (video === undefined) {
 			throw new NotFoundError(`Video not found: ${videoId}`);
+		}
 
 		if (language !== undefined) {
 			const row = get(this.#stmts.getCaption({ video_id: videoId, language }));
@@ -315,15 +326,17 @@ export class StreamObject extends DurableObject<Env> {
 		});
 
 		const row = get(this.#stmts.getWatermark({ id }));
-		if (row === undefined)
+		if (row === undefined) {
 			throw new NotFoundError(`Watermark not found: ${id}`);
+		}
 		return row;
 	}
 
 	async getWatermark(id: string): Promise<WatermarkRow> {
 		const row = get(this.#stmts.getWatermark({ id }));
-		if (row === undefined)
+		if (row === undefined) {
 			throw new NotFoundError(`Watermark not found: ${id}`);
+		}
 		return row;
 	}
 
@@ -333,8 +346,9 @@ export class StreamObject extends DurableObject<Env> {
 
 	async deleteWatermark(id: string): Promise<void> {
 		const deleted = get(this.#stmts.deleteWatermark({ id }));
-		if (deleted === undefined)
+		if (deleted === undefined) {
 			throw new NotFoundError(`Watermark not found: ${id}`);
+		}
 		if (deleted.blob_id !== null) {
 			await this.#blob.delete(deleted.blob_id);
 		}
@@ -345,8 +359,9 @@ export class StreamObject extends DurableObject<Env> {
 		downloadType: StreamDownloadType = "default"
 	): Promise<DownloadRow[]> {
 		const video = get(this.#stmts.getVideo({ id: videoId }));
-		if (video === undefined)
+		if (video === undefined) {
 			throw new NotFoundError(`Video not found: ${videoId}`);
+		}
 
 		this.#stmts.upsertDownload({
 			video_id: videoId,
@@ -360,8 +375,9 @@ export class StreamObject extends DurableObject<Env> {
 
 	async listDownloads(videoId: string): Promise<DownloadRow[]> {
 		const video = get(this.#stmts.getVideo({ id: videoId }));
-		if (video === undefined)
+		if (video === undefined) {
 			throw new NotFoundError(`Video not found: ${videoId}`);
+		}
 		return all(this.#stmts.listDownloads({ video_id: videoId }));
 	}
 
@@ -609,19 +625,23 @@ function sqlStmts(db: TypedSql, now: () => string) {
 		stmtDeleteVideoDownloads({ id });
 
 		const videoRow = get(stmtDeleteVideo({ id }));
-		if (videoRow === undefined)
+		if (videoRow === undefined) {
 			throw new NotFoundError(`Video not found: ${id}`);
+		}
 
 		const blobIds = captionBlobs;
-		if (videoRow.blob_id !== null) blobIds.push(videoRow.blob_id);
+		if (videoRow.blob_id !== null) {
+			blobIds.push(videoRow.blob_id);
+		}
 		return blobIds;
 	});
 
 	const updateVideo = db.txn(
 		(id: string, params: StreamUpdateVideoParams): VideoRow => {
 			const current = get(stmtGetVideo({ id }));
-			if (current === undefined)
+			if (current === undefined) {
 				throw new NotFoundError(`Video not found: ${id}`);
+			}
 
 			const nowValue = now();
 			stmtUpdateVideo({
@@ -654,8 +674,9 @@ function sqlStmts(db: TypedSql, now: () => string) {
 			});
 
 			const updated = get(stmtGetVideo({ id }));
-			if (updated === undefined)
+			if (updated === undefined) {
 				throw new NotFoundError(`Video not found: ${id}`);
+			}
 			return updated;
 		}
 	);

--- a/packages/miniflare/test/http/fetch.spec.ts
+++ b/packages/miniflare/test/http/fetch.spec.ts
@@ -53,7 +53,9 @@ test("fetch: performs web socket upgrade", async ({ expect }) => {
 	const messages: MessageEvent["data"][] = [];
 	webSocket.addEventListener("message", (e) => {
 		messages.push(e.data);
-		if (e.data === "hello server") eventPromise.resolve();
+		if (e.data === "hello server") {
+			eventPromise.resolve();
+		}
 	});
 	webSocket.accept();
 	webSocket.send("hello server");
@@ -127,18 +129,24 @@ test(
 					}
 
 					clientCloses++;
-					if (clientCloses === 2) clientClosePromise.resolve();
+					if (clientCloses === 2) {
+						clientClosePromise.resolve();
+					}
 				});
 			} else if (req.url === "/server") {
 				ws.on("message", (data) => {
-					if (data.toString() === "close") ws.close(3003, "Server Close");
+					if (data.toString() === "close") {
+						ws.close(3003, "Server Close");
+					}
 				});
 				ws.on("close", (code, reason) => {
 					expect(code).toBe(3003);
 					expect(reason.toString()).toBe("Server Close");
 
 					serverCloses++;
-					if (serverCloses === 2) serverClosePromise.resolve();
+					if (serverCloses === 2) {
+						serverClosePromise.resolve();
+					}
 				});
 			}
 		});

--- a/packages/miniflare/test/index.spec.ts
+++ b/packages/miniflare/test/index.spec.ts
@@ -3019,7 +3019,9 @@ test("Miniflare: getBindings() returns all bindings", async ({
 	});
 	let disposed = false;
 	onTestFinished(() => {
-		if (!disposed) return mf.dispose();
+		if (!disposed) {
+			return mf.dispose();
+		}
 	});
 
 	interface Env {
@@ -3637,8 +3639,11 @@ unixSerialTest(
 		process.env.MINIFLARE_WORKERD_PATH = workerdPath;
 		onTestFinished(() => {
 			// Setting key/values pairs on `process.env` coerces values to strings
-			if (original === undefined) delete process.env.MINIFLARE_WORKERD_PATH;
-			else process.env.MINIFLARE_WORKERD_PATH = original;
+			if (original === undefined) {
+				delete process.env.MINIFLARE_WORKERD_PATH;
+			} else {
+				process.env.MINIFLARE_WORKERD_PATH = original;
+			}
 		});
 
 		const mf = new Miniflare({
@@ -4455,7 +4460,9 @@ test("Miniflare: can use module fallback service", async ({ expect }) => {
 			const specifier = url.searchParams.get("specifier");
 			assert(specifier !== null);
 			const maybeModule = modules[specifier];
-			if (maybeModule === undefined) return new Response(null, { status: 404 });
+			if (maybeModule === undefined) {
+				return new Response(null, { status: 404 });
+			}
 			const name = path.posix.relative(modulesRoot, specifier);
 			return new Response(JSON.stringify({ name, ...maybeModule }));
 		},

--- a/packages/miniflare/test/plugins/core/errors/index.spec.ts
+++ b/packages/miniflare/test/plugins/core/errors/index.spec.ts
@@ -306,7 +306,9 @@ function getSourceMapURL(
 	const ws = new NodeWebSocket(inspectorURL);
 
 	const finish = (error?: Error) => {
-		if (settled) return;
+		if (settled) {
+			return;
+		}
 		settled = true;
 		clearTimeout(timeout);
 		if (error) {
@@ -333,7 +335,9 @@ function getSourceMapURL(
 	}, 10_000);
 
 	ws.on("message", async (raw) => {
-		if (settled) return;
+		if (settled) {
+			return;
+		}
 		try {
 			const message = JSON.parse(raw.toString("utf8"));
 			if (message.method === "Debugger.scriptParsed") {

--- a/packages/miniflare/test/plugins/core/proxy/client.spec.ts
+++ b/packages/miniflare/test/plugins/core/proxy/client.spec.ts
@@ -200,7 +200,9 @@ describe("ProxyClient", () => {
 		});
 		let disposed = false;
 		onTestFinished(() => {
-			if (!disposed) return mf.dispose();
+			if (!disposed) {
+				return mf.dispose();
+			}
 		});
 		let caches = await mf.getCaches();
 		let defaultCache = caches.default;
@@ -420,7 +422,9 @@ describe("ProxyClient", () => {
 
 		async function readStream(objectKey: string, stream?: ReadableStream) {
 			logs.push(`[${objectKey}] stream start`);
-			if (!stream) return;
+			if (!stream) {
+				return;
+			}
 			await stream.pipeTo(
 				new WritableStream({
 					write(_chunk) {

--- a/packages/miniflare/test/plugins/kv/sites.spec.ts
+++ b/packages/miniflare/test/plugins/kv/sites.spec.ts
@@ -96,7 +96,9 @@ async function testGet(
 		const expected = opts.expectedRoutes.has(route as Route);
 		const text = (await res.text()).trim();
 		expect(res.status).toBe(expected ? 200 : 404);
-		if (expected) expect(text).toBe(expectedContents);
+		if (expected) {
+			expect(text).toBe(expectedContents);
+		}
 	}
 }
 

--- a/packages/miniflare/test/plugins/r2/index.spec.ts
+++ b/packages/miniflare/test/plugins/r2/index.spec.ts
@@ -651,8 +651,9 @@ async function testList(
 	const { r2, ns } = ctx;
 
 	// Seed bucket
-	for (let i = 0; i < opts.keys.length; i++)
+	for (let i = 0; i < opts.keys.length; i++) {
 		await r2.put(opts.keys[i], `value${i}`);
+	}
 
 	let lastCursor: string | undefined;
 	for (let pageIndex = 0; pageIndex < opts.pages.length; pageIndex++) {
@@ -929,7 +930,9 @@ test("list: returns correct delimitedPrefixes for delimiter and prefix", async (
 		file9: "value9",
 	};
 	const allKeys = Object.keys(values);
-	for (const [key, value] of Object.entries(values)) await r2.put(key, value);
+	for (const [key, value] of Object.entries(values)) {
+		await r2.put(key, value);
+	}
 
 	const keys = (result: Awaited<ReturnType<typeof r2.list>>) =>
 		result.objects.map(({ key }) => key.substring(ns.length));
@@ -1194,8 +1197,9 @@ test("abortMultipartUpload", async ({ expect }) => {
 	expect((await stmts.getPartsByUploadId(upload1.uploadId)).length).toBe(0);
 	// Check blobs deleted
 	await object.waitForFakeTasks();
-	for (const part of parts)
+	for (const part of parts) {
 		expect(await object.getBlob(part.blob_id)).toBe(null);
+	}
 
 	// Check cannot upload after abort
 	await expect(upload1.uploadPart(4, "value4")).rejects.toThrow(
@@ -1282,8 +1286,9 @@ test("completeMultipartUpload", async ({ expect }) => {
 	expect(object.etag).toBe("46d1741e8075da4ac72c71d8130fcb71-1");
 	// Check previous multipart uploads blobs deleted
 	await objectStub.waitForFakeTasks();
-	for (const part of parts)
+	for (const part of parts) {
 		expect(await objectStub.getBlob(part.blob_id)).toBe(null);
+	}
 
 	// Check completing multiple uploads overrides existing, deleting all parts
 	expect((await stmts.getPartsByUploadId(upload1.uploadId)).length).toBe(0);
@@ -1554,8 +1559,9 @@ test("put: is multipart aware", async ({ expect }) => {
 	expect((await stmts.getPartsByUploadId(upload.uploadId)).length).toBe(0);
 	// Check deletes all previous blobs
 	await objectStub.waitForFakeTasks();
-	for (const part of parts)
+	for (const part of parts) {
 		expect(await objectStub.getBlob(part.blob_id)).toBe(null);
+	}
 });
 test("delete: is multipart aware", async ({ expect }) => {
 	const { r2, object: objectStub } = ctx;
@@ -1577,8 +1583,9 @@ test("delete: is multipart aware", async ({ expect }) => {
 	expect((await stmts.getPartsByUploadId(upload.uploadId)).length).toBe(0);
 	// Check deletes all previous blobs
 	await objectStub.waitForFakeTasks();
-	for (const part of parts)
+	for (const part of parts) {
 		expect(await objectStub.getBlob(part.blob_id)).toBe(null);
+	}
 });
 test("delete: waits for in-progress multipart gets before deleting part blobs", async ({
 	expect,
@@ -1605,8 +1612,9 @@ test("delete: waits for in-progress multipart gets before deleting part blobs", 
 	);
 
 	await objectStub.waitForFakeTasks();
-	for (const part of parts)
+	for (const part of parts) {
 		expect(await objectStub.getBlob(part.blob_id)).toBe(null);
+	}
 });
 test("list: is multipart aware", async ({ expect }) => {
 	const { r2, ns } = ctx;

--- a/packages/miniflare/test/teardown-lifecycle.spec.ts
+++ b/packages/miniflare/test/teardown-lifecycle.spec.ts
@@ -146,7 +146,9 @@ test("Miniflare: dispose waits for workerd exit and continues cleanup before ret
 			"injected proxy cleanup failure"
 		);
 	} finally {
-		if (!runtimeExitReleased) releaseRuntimeExit();
+		if (!runtimeExitReleased) {
+			releaseRuntimeExit();
+		}
 		emit.mockRestore();
 		proxyDispose.mockRestore();
 		webSocketClose.mockRestore();

--- a/packages/miniflare/test/test-shared/miniflare.ts
+++ b/packages/miniflare/test/test-shared/miniflare.ts
@@ -120,12 +120,18 @@ export type Namespaced<T> = T & { ns: string };
 export function namespace<T>(ns: string, binding: T): Namespaced<T> {
 	return new Proxy(binding as Namespaced<T>, {
 		get(target, key, receiver) {
-			if (key === "ns") return ns;
+			if (key === "ns") {
+				return ns;
+			}
 			const value = Reflect.get(target, key, receiver);
 			if (typeof value === "function" && key !== "list") {
 				return (keys: unknown, ...args: unknown[]) => {
-					if (typeof keys === "string") keys = ns + keys;
-					if (Array.isArray(keys)) keys = keys.map((key) => ns + key);
+					if (typeof keys === "string") {
+						keys = ns + keys;
+					}
+					if (Array.isArray(keys)) {
+						keys = keys.map((key) => ns + key);
+					}
 					const result = (value as (...args: unknown[]) => unknown)(
 						keys,
 						...args

--- a/packages/miniflare/test/test-shared/storage.ts
+++ b/packages/miniflare/test/test-shared/storage.ts
@@ -78,8 +78,12 @@ export function createJunkStream(length: number): ReadableStream<Uint8Array> {
 			const byobRequest = unwrapBYOBRequest(controller);
 			const v = byobRequest.view;
 			const chunkLength = Math.min(v.byteLength, length - position);
-			for (let i = 0; i < chunkLength; i++) v[i] = 120; // 'x'
-			if (chunkLength === 0) controller.close();
+			for (let i = 0; i < chunkLength; i++) {
+				v[i] = 120;
+			} // 'x'
+			if (chunkLength === 0) {
+				controller.close();
+			}
 			position += chunkLength;
 			byobRequest.respond(chunkLength);
 		},


### PR DESCRIPTION
## What this PR does

- Enables the repo-wide `curly` lint rule for `packages/miniflare/**`.
- Adds braces to the existing single-line control flow statements — no behaviour changes.
- Updates the Miniflare agent guidance to remove `curly` from the transitional disabled-rule list.

No changeset — this is an internal lint-only refactor with no user-facing impact.

---

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: this is a mechanical lint-only refactor; the existing Miniflare test suite passes.
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: this only changes internal lint enforcement and code style.

*A picture of a cute animal (not mandatory, but encouraged)*
