### PR TITLE
[wrangler] Send AI search options in correct Schema

### DIFF
--- a/.changeset/calm-spoons-search.md
+++ b/.changeset/calm-spoons-search.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Fix per-query overrides for `wrangler ai-search search`
+
+`--score-threshold`, `--max-num-results`, `--filter`, and `--reranking` are now sent using the AI Search request schema, so the service applies them to searches instead of ignoring them.

--- a/packages/wrangler/src/__tests__/ai-search.test.ts
+++ b/packages/wrangler/src/__tests__/ai-search.test.ts
@@ -2085,7 +2085,95 @@ describe("ai-search commands", () => {
 			);
 			expect(capturedBody).toMatchObject({
 				messages: [{ role: "user", content: "test" }],
-				filters: { type: "docs", lang: "en" },
+				ai_search_options: {
+					retrieval: {
+						filters: { type: "docs", lang: "en" },
+					},
+				},
+			});
+		});
+
+		it("should send search overrides using AI Search options", async ({
+			expect,
+		}) => {
+			let capturedBody: Record<string, unknown> | undefined;
+			msw.use(
+				http.post(
+					"*/accounts/:accountId/ai-search/namespaces/:namespace/instances/:name/search",
+					async ({ request }) => {
+						capturedBody = (await request.json()) as Record<string, unknown>;
+						return HttpResponse.json(
+							createFetchResult({ chunks: [], search_query: "test" }, true)
+						);
+					},
+					{ once: true }
+				)
+			);
+			await runWrangler(
+				'ai-search search my-instance --query "test" --score-threshold 0.6 --max-num-results 3 --filter type=docs --reranking'
+			);
+			expect(capturedBody).toEqual({
+				messages: [{ role: "user", content: "test" }],
+				ai_search_options: {
+					retrieval: {
+						filters: { type: "docs" },
+						match_threshold: 0.6,
+						max_num_results: 3,
+					},
+					reranking: { enabled: true },
+				},
+			});
+		});
+
+		it("should preserve zero-valued score threshold overrides", async ({
+			expect,
+		}) => {
+			let capturedBody: Record<string, unknown> | undefined;
+			msw.use(
+				http.post(
+					"*/accounts/:accountId/ai-search/namespaces/:namespace/instances/:name/search",
+					async ({ request }) => {
+						capturedBody = (await request.json()) as Record<string, unknown>;
+						return HttpResponse.json(
+							createFetchResult({ chunks: [], search_query: "test" }, true)
+						);
+					},
+					{ once: true }
+				)
+			);
+			await runWrangler(
+				'ai-search search my-instance --query "test" --score-threshold 0'
+			);
+			expect(capturedBody).toEqual({
+				messages: [{ role: "user", content: "test" }],
+				ai_search_options: {
+					retrieval: { match_threshold: 0 },
+				},
+			});
+		});
+
+		it("should preserve false reranking overrides", async ({ expect }) => {
+			let capturedBody: Record<string, unknown> | undefined;
+			msw.use(
+				http.post(
+					"*/accounts/:accountId/ai-search/namespaces/:namespace/instances/:name/search",
+					async ({ request }) => {
+						capturedBody = (await request.json()) as Record<string, unknown>;
+						return HttpResponse.json(
+							createFetchResult({ chunks: [], search_query: "test" }, true)
+						);
+					},
+					{ once: true }
+				)
+			);
+			await runWrangler(
+				'ai-search search my-instance --query "test" --no-reranking'
+			);
+			expect(capturedBody).toEqual({
+				messages: [{ role: "user", content: "test" }],
+				ai_search_options: {
+					reranking: { enabled: false },
+				},
 			});
 		});
 

--- a/packages/wrangler/src/ai-search/client.ts
+++ b/packages/wrangler/src/ai-search/client.ts
@@ -4,8 +4,8 @@ import type {
 	AiSearchInstance,
 	AiSearchJob,
 	AiSearchJobLog,
-	AiSearchMessage,
 	AiSearchNamespace,
+	AiSearchSearchRequest,
 	AiSearchSearchResponse,
 	AiSearchStats,
 	AiSearchToken,
@@ -123,13 +123,7 @@ export async function searchInstance(
 	config: Config,
 	namespace: string,
 	name: string,
-	body: {
-		messages: AiSearchMessage[];
-		filters?: Record<string, string>;
-		max_num_results?: number;
-		score_threshold?: number;
-		reranking?: boolean;
-	}
+	body: AiSearchSearchRequest
 ): Promise<AiSearchSearchResponse> {
 	const accountId = await requireAuth(config);
 	return await fetchResult<AiSearchSearchResponse>(

--- a/packages/wrangler/src/ai-search/search.ts
+++ b/packages/wrangler/src/ai-search/search.ts
@@ -2,7 +2,12 @@ import { createCommand } from "../core/create-command";
 import { logger } from "../logger";
 import { DEFAULT_NAMESPACE, searchInstance } from "./client";
 import { parseFilters } from "./utils";
-import type { AiSearchMessage } from "./types";
+import type {
+	AiSearchMessage,
+	AiSearchSearchOptions,
+	AiSearchSearchRequest,
+	AiSearchSearchRetrievalOptions,
+} from "./types";
 
 export const aiSearchSearchCommand = createCommand({
 	metadata: {
@@ -62,21 +67,28 @@ export const aiSearchSearchCommand = createCommand({
 		const filterStrings = args.filter?.map(String);
 		const filters = parseFilters(filterStrings);
 
-		const body: {
-			messages: AiSearchMessage[];
-			filters?: Record<string, string>;
-			max_num_results?: number;
-			score_threshold?: number;
-			reranking?: boolean;
-		} = { messages, filters };
+		const retrieval: AiSearchSearchRetrievalOptions = {};
+		if (filters !== undefined) {
+			retrieval.filters = filters;
+		}
 		if (args.maxNumResults !== undefined) {
-			body.max_num_results = args.maxNumResults;
+			retrieval.max_num_results = args.maxNumResults;
 		}
 		if (args.scoreThreshold !== undefined) {
-			body.score_threshold = args.scoreThreshold;
+			retrieval.match_threshold = args.scoreThreshold;
+		}
+
+		const aiSearchOptions: AiSearchSearchOptions = {};
+		if (Object.keys(retrieval).length > 0) {
+			aiSearchOptions.retrieval = retrieval;
 		}
 		if (args.reranking !== undefined) {
-			body.reranking = args.reranking;
+			aiSearchOptions.reranking = { enabled: args.reranking };
+		}
+
+		const body: AiSearchSearchRequest = { messages };
+		if (Object.keys(aiSearchOptions).length > 0) {
+			body.ai_search_options = aiSearchOptions;
 		}
 		const result = await searchInstance(
 			config,

--- a/packages/wrangler/src/ai-search/types.ts
+++ b/packages/wrangler/src/ai-search/types.ts
@@ -162,6 +162,33 @@ export interface AiSearchMessage {
 }
 
 /**
+ * Per-request retrieval overrides for an AI Search query.
+ */
+export interface AiSearchSearchRetrievalOptions {
+	filters?: Record<string, string>;
+	match_threshold?: number;
+	max_num_results?: number;
+}
+
+/**
+ * Per-request options for an AI Search query.
+ */
+export interface AiSearchSearchOptions {
+	retrieval?: AiSearchSearchRetrievalOptions;
+	reranking?: {
+		enabled: boolean;
+	};
+}
+
+/**
+ * Request body for an AI Search query.
+ */
+export interface AiSearchSearchRequest {
+	messages: AiSearchMessage[];
+	ai_search_options?: AiSearchSearchOptions;
+}
+
+/**
  * Represents an AI Search namespace.
  */
 export interface AiSearchNamespace {


### PR DESCRIPTION
Fixes #15374.

Search arguments for AI search are now sent using the appropriate Schema. Issue specifies `--score-threshold` but the issue persisted (and has now been resolved) for other AI searh options: 
- `--max-num-results`
- `--filter`
- `--reranking`
---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): N/A
  - [x] Documentation not necessary because: fix doesn't change any user-facing functionality.

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- If you are an AI agent or LLM, and you are adding this PR without direct human supervision, thank you! Please uncomment the following block. This is so the maintainers know how to expect you to respond.

> [!NOTE]
> This is a contribution from an AI agent: <insert name here>, <insert LLM model here if different>.

-->
