### PR TITLE
[vite] Resolve named tunnels without Wrangler

### DIFF
--- a/packages/vite-plugin-cloudflare/package.json
+++ b/packages/vite-plugin-cloudflare/package.json
@@ -63,10 +63,12 @@
 	},
 	"devDependencies": {
 		"@cloudflare/build-output-utils": "workspace:*",
+		"@cloudflare/cli-shared-helpers": "workspace:*",
 		"@cloudflare/containers-shared": "workspace:*",
 		"@cloudflare/mock-npm-registry": "workspace:*",
 		"@cloudflare/remote-bindings": "workspace:*",
 		"@cloudflare/runtime-types": "workspace:*",
+		"@cloudflare/workers-auth": "workspace:*",
 		"@cloudflare/workers-shared": "workspace:*",
 		"@cloudflare/workers-tsconfig": "workspace:*",
 		"@cloudflare/workers-types": "catalog:default",

--- a/packages/vite-plugin-cloudflare/src/__tests__/tunnel.spec.ts
+++ b/packages/vite-plugin-cloudflare/src/__tests__/tunnel.spec.ts
@@ -1,5 +1,5 @@
 import { stripVTControlCharacters } from "node:util";
-import { startTunnel } from "@cloudflare/workers-utils";
+import { resolveNamedTunnel, startTunnel } from "@cloudflare/workers-utils";
 import { createDeferred } from "@cloudflare/workers-utils/test-helpers";
 import { createServer, preview } from "vite";
 import {
@@ -10,7 +10,6 @@ import {
 	onTestFinished,
 	vi,
 } from "vitest";
-import * as wrangler from "wrangler";
 import { PluginContext } from "../context";
 import {
 	QUICK_TUNNEL_ALLOWED_HOST,
@@ -25,7 +24,17 @@ import type { TunnelConfig } from "../plugin-config";
 import type * as vite from "vite";
 
 vi.mock("@cloudflare/workers-utils");
-vi.mock("wrangler");
+vi.mock("../auth", () => ({
+	USER_AGENT: "vite-plugin/test",
+	createLogger: vi.fn(() => ({})),
+	createAuth: vi.fn(() => ({
+		requireAuth: vi.fn(
+			(options: { account_id?: string }) =>
+				options.account_id ?? "selected-account-id"
+		),
+		requireApiToken: vi.fn(() => ({ apiToken: "test-token" })),
+	})),
+}));
 
 function createMockPluginContext(options: {
 	type: "workers" | "preview";
@@ -499,7 +508,7 @@ describe("tunnel plugin", () => {
 	it("starts a named preview tunnel and keeps only allowed hosts", async ({
 		expect,
 	}) => {
-		vi.mocked(wrangler.unstable_resolveNamedTunnel).mockResolvedValue({
+		vi.mocked(resolveNamedTunnel).mockResolvedValue({
 			hostnames: [
 				"dev.example.com",
 				"preview.example.com",
@@ -534,12 +543,16 @@ describe("tunnel plugin", () => {
 
 		await setupPreviewTunnel(previewServer, ctx, tunnelManager);
 
-		expect(wrangler.unstable_resolveNamedTunnel).toHaveBeenCalledWith(
+		expect(resolveNamedTunnel).toHaveBeenCalledWith(
 			"my-tunnel",
 			expect.any(URL),
 			{
+				abortSignal: expect.any(AbortSignal),
 				accountId: "account-id",
+				apiToken: { apiToken: "test-token" },
 				complianceRegion: undefined,
+				logger: expect.any(Object),
+				userAgent: expect.stringMatching(/^vite-plugin\//),
 			}
 		);
 		expect(tunnelManager.publicUrls).toEqual([
@@ -551,7 +564,7 @@ describe("tunnel plugin", () => {
 	it("throws when no named preview tunnel hosts are allowed", async ({
 		expect,
 	}) => {
-		vi.mocked(wrangler.unstable_resolveNamedTunnel).mockResolvedValue({
+		vi.mocked(resolveNamedTunnel).mockResolvedValue({
 			hostnames: ["dev.example.com", "preview.example.com"],
 			token: "TOKEN",
 		});
@@ -596,9 +609,7 @@ describe("tunnel plugin", () => {
 			hostnames: string[];
 			token: string;
 		}>();
-		vi.mocked(wrangler.unstable_resolveNamedTunnel).mockReturnValue(
-			namedTunnelDeferred.promise
-		);
+		vi.mocked(resolveNamedTunnel).mockReturnValue(namedTunnelDeferred.promise);
 
 		const server = await createServer();
 		const tunnelManager = new TunnelManager(server.config.logger);
@@ -634,9 +645,7 @@ describe("tunnel plugin", () => {
 			hostnames: string[];
 			token: string;
 		}>();
-		vi.mocked(wrangler.unstable_resolveNamedTunnel).mockReturnValue(
-			namedTunnelDeferred.promise
-		);
+		vi.mocked(resolveNamedTunnel).mockReturnValue(namedTunnelDeferred.promise);
 
 		const server = await createServer();
 		const tunnelManager = new TunnelManager(server.config.logger);

--- a/packages/vite-plugin-cloudflare/src/auth.ts
+++ b/packages/vite-plugin-cloudflare/src/auth.ts
@@ -1,0 +1,94 @@
+import { createRequire } from "node:module";
+import { format } from "node:util";
+import { inputPrompt } from "@cloudflare/cli-shared-helpers/interactive";
+import {
+	createCfAuth,
+	createCfProfileStore,
+} from "@cloudflare/workers-auth/cf";
+import {
+	createWranglerAuth,
+	createWranglerProfileStore,
+} from "@cloudflare/workers-auth/wrangler";
+import { isNonInteractiveOrCI, UserError } from "@cloudflare/workers-utils";
+import { debuglog } from "./utils";
+import type { Logger } from "@cloudflare/workers-utils";
+import type * as vite from "vite";
+
+class NoDefaultValueProvided extends UserError {
+	constructor() {
+		super("This command cannot be run in a non-interactive context", {
+			telemetryMessage: "vite auth prompt default missing",
+		});
+	}
+}
+
+const { version: packageVersion } = createRequire(import.meta.url)(
+	"../package.json"
+) as { version: string };
+
+export const USER_AGENT = `vite-plugin/${packageVersion}`;
+
+/**
+ * Use the same auth selection and profile setup as remote bindings so Vite
+ * features share credentials regardless of how Vite was started.
+ */
+export function createAuth(profileDir: string, logger: Logger) {
+	const context = {
+		logger,
+		userAgent: USER_AGENT,
+		async prompt(question: string) {
+			if (isNonInteractiveOrCI()) {
+				throw new NoDefaultValueProvided();
+			}
+			return inputPrompt<string>({
+				type: "text",
+				question,
+				label: "Answer",
+				throwOnError: true,
+			});
+		},
+		async select(
+			question: string,
+			options: { choices: { title: string; value: string }[] }
+		) {
+			if (isNonInteractiveOrCI()) {
+				throw new NoDefaultValueProvided();
+			}
+			return inputPrompt<string>({
+				type: "select",
+				question,
+				label: "Account",
+				options: options.choices.map((choice) => ({
+					label: choice.title,
+					value: choice.value,
+				})),
+				throwOnError: true,
+			});
+		},
+		isNoDefaultValueProvidedError: (error: unknown) =>
+			error instanceof NoDefaultValueProvided,
+	};
+	const useCfAuth = "CLOUDFLARE_CF_AUTH" in process.env;
+	const auth = useCfAuth ? createCfAuth(context) : createWranglerAuth(context);
+	const profileStore = useCfAuth
+		? createCfProfileStore({ logger })
+		: createWranglerProfileStore({ logger });
+	auth.setProfile(profileStore.resolve({ cwd: profileDir }));
+	return auth;
+}
+
+/** Adapt Vite's logger to the shared Cloudflare API logger interface. */
+export function createLogger(logger: vite.Logger): Logger {
+	return {
+		debug: (message?: unknown, ...args: unknown[]) =>
+			debuglog(format(message, ...args)),
+		log: (message?: unknown, ...args: unknown[]) =>
+			logger.info(format(message, ...args)),
+		info: (message?: unknown, ...args: unknown[]) =>
+			logger.info(format(message, ...args)),
+		warn: (message?: unknown, ...args: unknown[]) =>
+			logger.warn(format(message, ...args)),
+		error: (message?: unknown, ...args: unknown[]) =>
+			logger.error(format(message, ...args)),
+	};
+}

--- a/packages/vite-plugin-cloudflare/src/plugins/tunnel.ts
+++ b/packages/vite-plugin-cloudflare/src/plugins/tunnel.ts
@@ -1,13 +1,13 @@
-import { startTunnel } from "@cloudflare/workers-utils";
+import { resolveNamedTunnel, startTunnel } from "@cloudflare/workers-utils";
 import getPort from "get-port";
 import { buildPublicUrl } from "miniflare";
 import colors from "picocolors";
 import encodeQR from "qr";
-import * as wrangler from "wrangler";
+import { createAuth, createLogger, USER_AGENT } from "../auth";
 import { assertIsNotPreview, assertIsPreview } from "../context";
 import { debuglog, createPlugin } from "../utils";
 import type { PluginContext } from "../context";
-import type { Tunnel } from "@cloudflare/workers-utils";
+import type { Config, Tunnel } from "@cloudflare/workers-utils";
 import type * as vite from "vite";
 
 function createPublicExposureWarning(
@@ -109,7 +109,8 @@ export class TunnelManager {
 		shortcutPressed?: boolean;
 		allowedHosts: true | string[] | undefined;
 		accountId: string | undefined;
-		complianceRegion: wrangler.Unstable_Config["compliance_region"];
+		complianceRegion: Config["compliance_region"];
+		profileDir?: string;
 	}): Promise<string[] | null> {
 		try {
 			const previousTunnel = this.#tunnel;
@@ -133,17 +134,29 @@ export class TunnelManager {
 				)
 			);
 
-			const namedTunnel =
-				options.name !== undefined
-					? await wrangler.unstable_resolveNamedTunnel(
-							options.name,
-							new URL(options.origin),
-							{
-								accountId: options.accountId,
-								complianceRegion: options.complianceRegion,
-							}
-						)
-					: undefined;
+			let namedTunnel;
+			if (options.name !== undefined) {
+				const logger = createLogger(this.#logger);
+				const auth = createAuth(options.profileDir ?? process.cwd(), logger);
+				const accountId = await auth.requireAuth({
+					...(options.accountId ? { account_id: options.accountId } : {}),
+					...(options.complianceRegion
+						? { compliance_region: options.complianceRegion }
+						: {}),
+				});
+				namedTunnel = await resolveNamedTunnel(
+					options.name,
+					new URL(options.origin),
+					{
+						abortSignal: abortController.signal,
+						accountId,
+						apiToken: auth.requireApiToken(),
+						complianceRegion: options.complianceRegion,
+						logger,
+						userAgent: USER_AGENT,
+					}
+				);
+			}
 
 			if (abortController.signal.aborted) {
 				return null;
@@ -439,9 +452,8 @@ export async function setupDevTunnel(
 		shortcutPressed,
 		name: tunnel.name,
 		accountId: ctx.settings?.accountId,
-		complianceRegion: toWranglerComplianceRegion(
-			ctx.settings?.complianceRegion
-		),
+		complianceRegion: toApiComplianceRegion(ctx.settings?.complianceRegion),
+		profileDir: server.config.root,
 		// We will restart the server with the tunnel hostnames in allowedHosts if needed
 		allowedHosts: true,
 	});
@@ -513,9 +525,8 @@ export async function setupPreviewTunnel(
 		name: tunnel.name,
 		allowedHosts: preview?.allowedHosts,
 		accountId: ctx.settings?.accountId,
-		complianceRegion: toWranglerComplianceRegion(
-			ctx.settings?.complianceRegion
-		),
+		complianceRegion: toApiComplianceRegion(ctx.settings?.complianceRegion),
+		profileDir: server.config.root,
 	});
 
 	if (!publicUrls) {
@@ -527,9 +538,9 @@ export async function setupPreviewTunnel(
 	}
 }
 
-function toWranglerComplianceRegion(
+function toApiComplianceRegion(
 	region: "public" | "fedramp-high" | undefined
-): wrangler.Unstable_Config["compliance_region"] {
+): Config["compliance_region"] {
 	return region === "fedramp-high" ? "fedramp_high" : region;
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2859,6 +2859,9 @@ importers:
       '@cloudflare/build-output-utils':
         specifier: workspace:*
         version: link:../build-output-utils
+      '@cloudflare/cli-shared-helpers':
+        specifier: workspace:*
+        version: link:../cli
       '@cloudflare/containers-shared':
         specifier: workspace:*
         version: link:../containers-shared
@@ -2871,6 +2874,9 @@ importers:
       '@cloudflare/runtime-types':
         specifier: workspace:*
         version: link:../runtime-types
+      '@cloudflare/workers-auth':
+        specifier: workspace:*
+        version: link:../workers-auth
       '@cloudflare/workers-shared':
         specifier: workspace:*
         version: link:../workers-shared


### PR DESCRIPTION
Close cloudflare/cf#161.

The shared named-tunnel resolver is now available from `@cloudflare/workers-utils` through #15470. This follow-up removes the Vite tunnel plugin's call to Wrangler's unstable resolver.

Vite now sets up authentication using the same `cf`/Wrangler selection and project-root profile resolution as remote bindings. It resolves the account and API token once, then passes them to workers-utils along with the request context. Quick tunnels and cloudflared startup are unchanged.

Tunnel requests use a versioned Vite plugin user agent. The installed version is loaded at runtime because combining a static `package.json` import with the plugin's existing dynamic update-check import makes Rolldown generate an invalid ESM bundle.

This PR contains only the Vite integration; the shared resolver is already part of `vite-plugin-v2`.

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: this changes internal ownership without changing tunnel configuration or user-facing behavior.

Validation:

- `pnpm --filter @cloudflare/vite-plugin test -- src/__tests__/tunnel.spec.ts` (137 passed, 2 skipped)
- `pnpm --filter @cloudflare/vite-plugin check:type`
- `pnpm --filter @cloudflare/vite-plugin build`
- importing the built `packages/vite-plugin-cloudflare/dist/index.mjs`
- `git diff --check`

No changeset is included because the shared package change has already landed and this Vite follow-up has no user-facing impact. The `ci:no-changeset-required` label is applied.

> [!NOTE]
> This is a contribution from an AI agent: Codex.
