### PR TITLE
[wrangler] Experimental: proxy commands to cf

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -72,6 +72,7 @@ Workflow changes should avoid unsuppressed `zizmor` findings. In particular:
   - Updates to PRs.
 - Actions
   - Creates an installable pre-release of any package containing `{ "workers-sdk": { "prerelease": true } }` in its `package.json` (e.g. Wrangler, C3, and Miniflare) on every PR.
+  - PRs with the `preview:wrangler` label build and publish only Wrangler. This supports experimental Wrangler changes that prevent downstream workspace packages from building with the changed CLI.
   - Adds a comment to the PR with links to the pre-releases.
 
 ## Housekeeping actions

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -38,6 +38,7 @@ jobs:
           disable-cache: "true"
 
       - name: Build
+        if: ${{ !contains(github.event.*.labels.*.name, 'preview:wrangler') }}
         run: pnpm build --filter="./packages/*"
         env:
           NODE_ENV: "production"
@@ -49,5 +50,22 @@ jobs:
           ALGOLIA_PUBLIC_KEY: ${{ secrets.ALGOLIA_PUBLIC_KEY }}
           WRANGLER_PRERELEASE_LABEL: ${{ github.head_ref || github.ref_name }}
 
+      - name: Build Wrangler preview
+        if: ${{ contains(github.event.*.labels.*.name, 'preview:wrangler') }}
+        run: pnpm build --filter=wrangler
+        env:
+          NODE_ENV: "production"
+          CI_OS: ${{ runner.os }}
+          SPARROW_SOURCE_KEY: "5adf183f94b3436ba78d67f506965998"
+          ALGOLIA_APP_ID: ${{ secrets.ALGOLIA_APP_ID }}
+          SENTRY_DSN: "https://9edbb8417b284aa2bbead9b4c318918b@sentry10.cfdata.org/583"
+          ALGOLIA_PUBLIC_KEY: ${{ secrets.ALGOLIA_PUBLIC_KEY }}
+          WRANGLER_PRERELEASE_LABEL: ${{ github.head_ref || github.ref_name }}
+
       - name: Upload packages
+        if: ${{ !contains(github.event.*.labels.*.name, 'preview:wrangler') }}
         run: node -r esbuild-register .github/prereleases/upload.mjs
+
+      - name: Upload Wrangler preview
+        if: ${{ contains(github.event.*.labels.*.name, 'preview:wrangler') }}
+        run: pnpm dlx pkg-pr-new publish --pnpm --compact --no-template packages/wrangler

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -2,6 +2,7 @@ name: Prerelease
 
 on:
   pull_request:
+    types: [opened, reopened, synchronize, labeled]
   push:
     branches:
       - main

--- a/packages/wrangler/bin/wrangler.js
+++ b/packages/wrangler/bin/wrangler.js
@@ -1,91 +1,24 @@
 #!/usr/bin/env node
-const { spawn } = require("child_process");
-const path = require("path");
+const { spawn } = require("node:child_process");
 
-const MIN_NODE_VERSION = "22.0.0";
-let wranglerProcess;
+let cfProcess;
 
 /**
- * Executes ../wrangler-dist/cli.js
+ * Executes `npx cf` with the arguments passed to Wrangler.
  */
-function runWrangler() {
-	if (semiver(process.versions.node, MIN_NODE_VERSION) < 0) {
-		// Note Volta and nvm are also recommended in the official docs:
-		// https://developers.cloudflare.com/workers/get-started/guide#2-install-the-workers-cli
-		console.error(
-			`Wrangler requires at least Node.js v${MIN_NODE_VERSION}. You are using v${process.versions.node}. Please update your version of Node.js.
-
-Consider using a Node.js version manager such as https://volta.sh/ or https://github.com/nvm-sh/nvm.`
-		);
-		process.exitCode = 1;
-		return;
-	}
-
-	return spawn(
-		process.execPath,
-		[
-			"--no-warnings",
-			...process.execArgv,
-			path.join(__dirname, "../wrangler-dist/cli.js"),
-			...process.argv.slice(2),
-		],
-		{
-			stdio: ["inherit", "inherit", "inherit", "ipc"],
-		}
-	)
-		.on("exit", (code) =>
-			process.exit(code === undefined || code === null ? 0 : code)
-		)
-		.on("message", (message) => {
-			if (process.send) {
-				process.send(message);
-			}
+function runCf() {
+	return spawn("npx", ["cf", ...process.argv.slice(2)], {
+		stdio: "inherit",
+	})
+		.on("error", (error) => {
+			process.stderr.write(`Failed to run npx cf: ${error.message}\n`);
+			process.exitCode = 1;
 		})
-		.on("disconnect", () => {
-			if (process.disconnect) {
-				process.disconnect();
-			}
-		});
+		.on("exit", (code) => process.exit(code ?? 0));
 }
-
-// semiver implementation via https://github.com/lukeed/semiver/blob/ae7eebe6053c96be63032b14fb0b68e2553fcac4/src/index.js
-
-/**
-MIT License
-
-Copyright (c) Luke Edwards <luke.edwards05@gmail.com> (lukeed.com)
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
- */
-
-var fn = new Intl.Collator(0, { numeric: 1 }).compare;
-
-function semiver(a, b, bool) {
-	a = a.split(".");
-	b = b.split(".");
-
-	return (
-		fn(a[0], b[0]) ||
-		fn(a[1], b[1]) ||
-		((b[2] = b.slice(2).join(".")),
-		(bool = /[.-]/.test((a[2] = a.slice(2).join(".")))),
-		bool == /[.-]/.test(b[2]) ? fn(a[2], b[2]) : bool ? -1 : 1)
-	);
-}
-
-// end semiver implementation
 
 if (module === require.main) {
-	wranglerProcess = runWrangler();
-	process.on("SIGINT", () => {
-		wranglerProcess && wranglerProcess.kill();
-	});
-	process.on("SIGTERM", () => {
-		wranglerProcess && wranglerProcess.kill();
-	});
+	cfProcess = runCf();
+	process.on("SIGINT", () => cfProcess.kill("SIGINT"));
+	process.on("SIGTERM", () => cfProcess.kill("SIGTERM"));
 }

--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "wrangler",
-	"version": "4.127.1",
+	"version": "5.0.0",
 	"description": "Command-line interface for all things Cloudflare Workers",
 	"keywords": [
 		"assembly",

--- a/packages/wrangler/src/__tests__/v5-cf-proxy.test.ts
+++ b/packages/wrangler/src/__tests__/v5-cf-proxy.test.ts
@@ -1,0 +1,79 @@
+import { spawnSync } from "node:child_process";
+import { chmodSync, mkdirSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
+
+const wranglerBin = path.resolve(import.meta.dirname, "../../bin/wrangler.js");
+
+describe("Wrangler v5 cf proxy", () => {
+	runInTempDir();
+
+	test("runs npx cf with all Wrangler arguments unchanged", ({ expect }) => {
+		const fakeBinDir = createFakeNpx();
+		const result = spawnSync(
+			process.execPath,
+			[
+				wranglerBin,
+				"deploy",
+				"--name",
+				"worker with spaces",
+				"--",
+				"literal-value",
+			],
+			{
+				encoding: "utf8",
+				env: withFakeNpx(fakeBinDir),
+			}
+		);
+
+		expect(result.status).toBe(0);
+		expect(JSON.parse(result.stdout)).toEqual([
+			"cf",
+			"deploy",
+			"--name",
+			"worker with spaces",
+			"--",
+			"literal-value",
+		]);
+	});
+
+	test("propagates the npx exit code", ({ expect }) => {
+		const fakeBinDir = createFakeNpx(23);
+		const result = spawnSync(process.execPath, [wranglerBin, "deploy"], {
+			env: withFakeNpx(fakeBinDir),
+		});
+
+		expect(result.status).toBe(23);
+	});
+});
+
+/**
+ * Creates an `npx` executable that reports the arguments it receives.
+ *
+ * @param exitCode The exit code returned by the executable.
+ * @returns The directory containing the fake executable.
+ */
+function createFakeNpx(exitCode = 0) {
+	const fakeBinDir = path.resolve("fake-bin");
+	const fakeNpxPath = path.join(fakeBinDir, "npx");
+	mkdirSync(fakeBinDir, { recursive: true });
+	writeFileSync(
+		fakeNpxPath,
+		`#!/usr/bin/env node\nprocess.stdout.write(JSON.stringify(process.argv.slice(2)));\nprocess.exit(${exitCode});\n`
+	);
+	chmodSync(fakeNpxPath, 0o755);
+	return fakeBinDir;
+}
+
+/**
+ * Prepends the fake executable directory to `PATH`.
+ *
+ * @param fakeBinDir The directory containing the fake `npx` executable.
+ * @returns An environment configured to resolve the fake executable first.
+ */
+function withFakeNpx(fakeBinDir: string) {
+	return {
+		...process.env,
+		PATH: `${fakeBinDir}${path.delimiter}${process.env.PATH ?? ""}`,
+	};
+}


### PR DESCRIPTION
This is an experimental-only change.

Wrangler v5 forwards CLI invocations to `npx cf`, preserving all user-provided arguments and returning the delegated exit code.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: this is an experimental-only change.

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

> [!NOTE]
> This is a contribution from an AI agent: Codex.
