### PR TITLE
[wrangler] Reduce Pipelines S3 bundle size

### DIFF
--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -130,6 +130,7 @@
 		"@vitest/ui": "catalog:default",
 		"@webcontainer/env": "^1.1.0",
 		"am-i-vibing": "^0.5.0",
+		"aws4fetch": "^1.0.20",
 		"capnweb": "catalog:default",
 		"chalk": "catalog:default",
 		"chokidar": "^4.0.1",

--- a/packages/wrangler/scripts/deps.ts
+++ b/packages/wrangler/scripts/deps.ts
@@ -55,11 +55,6 @@ export const IGNORED_DIST_IMPORTS = [
 	"react-dom",
 	"react-router",
 	"waku",
-
-	// @aws-sdk/client-s3 (bundled devDependency) optionally uses this native
-	// crypto implementation if installed; falls back to a JS implementation
-	// when missing.
-	"@aws-sdk/signature-v4-crt",
 ];
 
 const pathToPackageJson = path.resolve(__dirname, "..", "package.json");

--- a/packages/wrangler/src/__tests__/pipelines-r2-client.test.ts
+++ b/packages/wrangler/src/__tests__/pipelines-r2-client.test.ts
@@ -1,0 +1,99 @@
+import { http, HttpResponse } from "msw";
+import { afterEach, describe, it, vi } from "vitest";
+import { R2Client } from "../pipelines/r2-client";
+import { msw } from "./helpers/msw";
+
+const endpoint = "https://account.r2.cloudflarestorage.com";
+const accessKeyId = "AKIDEXAMPLE";
+const secretAccessKey = "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY";
+
+afterEach(() => {
+	vi.useRealTimers();
+	vi.restoreAllMocks();
+});
+
+describe("Pipelines R2 client", () => {
+	it("performs a signed, path-style HeadBucket request", async ({ expect }) => {
+		vi.useFakeTimers({
+			now: new Date("2025-01-01T00:00:00.000Z"),
+			toFake: ["Date"],
+		});
+		let authorization: string | null = null;
+		let payloadHash: string | null = null;
+
+		msw.use(
+			http.head(`${endpoint}/bucket%20name/`, ({ request }) => {
+				authorization = request.headers.get("authorization");
+				payloadHash = request.headers.get("x-amz-content-sha256");
+				return new HttpResponse(null, { status: 200 });
+			})
+		);
+
+		const client = new R2Client(endpoint, accessKeyId, secretAccessKey);
+		await client.headBucket("bucket name");
+
+		expect(payloadHash).toBe(
+			"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+		);
+		expect(authorization).toMatchInlineSnapshot(
+			`"AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20250101/auto/s3/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature=5e47f7a0f28b7e16525295b3eceb9b22cb70003789f986113c548c1313193cf2"`
+		);
+	});
+
+	it("performs ListObjectsV2 with MaxKeys set to one", async ({ expect }) => {
+		let requestUrl: string | undefined;
+
+		msw.use(
+			http.get(`${endpoint}/bucket/`, ({ request }) => {
+				requestUrl = request.url;
+				return HttpResponse.xml("<ListBucketResult />");
+			})
+		);
+
+		const client = new R2Client(endpoint, accessKeyId, secretAccessKey);
+		await client.listObjectsV2("bucket", 1);
+
+		expect(requestUrl).toBe(`${endpoint}/bucket/?list-type=2&max-keys=1`);
+	});
+
+	it("retries transient responses up to the S3 SDK default", async ({
+		expect,
+	}) => {
+		vi.spyOn(Math, "random").mockReturnValue(0);
+		let attempts = 0;
+
+		msw.use(
+			http.head(`${endpoint}/bucket/`, () => {
+				attempts++;
+				return new HttpResponse(null, {
+					status: attempts < 3 ? 503 : 200,
+				});
+			})
+		);
+
+		const client = new R2Client(endpoint, accessKeyId, secretAccessKey);
+		await client.headBucket("bucket");
+
+		expect(attempts).toBe(3);
+	});
+
+	it("fails non-retryable responses immediately", async ({ expect }) => {
+		let attempts = 0;
+
+		msw.use(
+			http.get(`${endpoint}/bucket/`, () => {
+				attempts++;
+				return HttpResponse.xml("<Error><Code>AccessDenied</Code></Error>", {
+					status: 403,
+				});
+			})
+		);
+
+		const client = new R2Client(endpoint, accessKeyId, secretAccessKey);
+		await expect(client.listObjectsV2("bucket", 1)).rejects.toMatchObject({
+			name: "R2RequestError",
+			status: 403,
+		});
+		expect(attempts).toBe(1);
+	});
+});

--- a/packages/wrangler/src/pipelines/index.ts
+++ b/packages/wrangler/src/pipelines/index.ts
@@ -1,10 +1,5 @@
 import { setTimeout } from "node:timers/promises";
 import {
-	HeadBucketCommand,
-	ListObjectsV2Command,
-	S3Client,
-} from "@aws-sdk/client-s3";
-import {
 	APIError,
 	FatalError,
 	getCloudflareApiEnvironmentFromEnv,
@@ -12,6 +7,7 @@ import {
 import { createNamespace } from "../core/create-command";
 import { logger } from "../logger";
 import { generateR2ServiceToken, getR2Bucket } from "./client";
+import { R2Client } from "./r2-client";
 import type { ComplianceConfig } from "@cloudflare/workers-utils";
 
 export const BYTES_PER_MB = 1000 * 1000;
@@ -21,20 +17,20 @@ let __testSkipDelaysFlag = false;
 let __testSkipCredentialValidationFlag = false;
 
 /**
- * Verify the credentials used by the S3Client can access a R2 bucket by performing the
+ * Verify the credentials used by the R2 client can access a R2 bucket by performing the
  * HeadBucket operation. It will retry up to 10 times over 10s to handle newly
  * created credentials that might not be active yet (can take a few seconds to propagate).
  *
  * @param r2
  * @param bucketName
  */
-async function verifyBucketAccess(r2: S3Client, bucketName: string) {
+async function verifyBucketAccess(r2: R2Client, bucketName: string) {
 	const MAX_ATTEMPTS = 10;
 	const DELAY_MS = 1000;
 
 	const checkCredentials = async () => {
 		logger.debug(`Checking if credentials are active`);
-		await r2.send(new HeadBucketCommand({ Bucket: bucketName }));
+		await r2.headBucket(bucketName);
 	};
 
 	for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
@@ -68,16 +64,9 @@ export async function verifyR2Credentials(
 	}
 
 	const endpoint = getAccountR2Endpoint(accountId);
-	const r2 = new S3Client({
-		region: "auto",
-		credentials: {
-			accessKeyId,
-			secretAccessKey,
-		},
-		endpoint,
-	});
+	const r2 = new R2Client(endpoint, accessKeyId, secretAccessKey);
 
-	await r2.send(new ListObjectsV2Command({ Bucket: bucketName, MaxKeys: 1 }));
+	await r2.listObjectsV2(bucketName, 1);
 }
 
 export async function authorizeR2Bucket(
@@ -119,14 +108,11 @@ export async function authorizeR2Bucket(
 
 	const endpoint = getAccountR2Endpoint(accountId);
 	logger.debug(`Using R2 Endpoint ${endpoint}`);
-	const r2 = new S3Client({
-		region: "auto",
-		credentials: {
-			accessKeyId: serviceToken.accessKeyId,
-			secretAccessKey: serviceToken.secretAccessKey,
-		},
+	const r2 = new R2Client(
 		endpoint,
-	});
+		serviceToken.accessKeyId,
+		serviceToken.secretAccessKey
+	);
 
 	// Wait for token to settle/propagate, retry up to 10 times, with 2s waits in-between errors
 	if (!quiet) {

--- a/packages/wrangler/src/pipelines/r2-client.ts
+++ b/packages/wrangler/src/pipelines/r2-client.ts
@@ -1,0 +1,117 @@
+import { setTimeout } from "node:timers/promises";
+import { AwsV4Signer } from "aws4fetch";
+import { fetch } from "undici";
+
+const EMPTY_PAYLOAD_SHA256 =
+	"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+const MAX_ATTEMPTS = 3;
+const INITIAL_RETRY_DELAY_MS = 100;
+const RETRYABLE_STATUS_CODES = new Set([429, 500, 502, 503, 504]);
+
+class R2RequestError extends Error {
+	readonly status: number;
+
+	constructor(status: number, statusText: string) {
+		const statusDescription = statusText ? ` ${statusText}` : "";
+		super(`R2 request failed with status ${status}${statusDescription}`);
+		this.name = "R2RequestError";
+		this.status = status;
+	}
+}
+
+/**
+ * A minimal client for the two S3 operations used to validate R2 credentials.
+ *
+ * @param endpoint - The account-level R2 S3 endpoint.
+ * @param accessKeyId - The explicitly supplied R2 access key ID.
+ * @param secretAccessKey - The explicitly supplied R2 secret access key.
+ */
+export class R2Client {
+	private readonly accessKeyId: string;
+	private readonly endpoint: string;
+	private readonly secretAccessKey: string;
+	private readonly signingKeyCache = new Map<string, ArrayBuffer>();
+
+	constructor(endpoint: string, accessKeyId: string, secretAccessKey: string) {
+		this.endpoint = endpoint;
+		this.accessKeyId = accessKeyId;
+		this.secretAccessKey = secretAccessKey;
+	}
+
+	/**
+	 * Check whether these credentials can access a bucket.
+	 *
+	 * @param bucketName - The R2 bucket to check.
+	 */
+	async headBucket(bucketName: string): Promise<void> {
+		await this.request("HEAD", this.getBucketUrl(bucketName));
+	}
+
+	/**
+	 * List a bounded number of objects to validate credentials without downloading
+	 * object data.
+	 *
+	 * @param bucketName - The R2 bucket to check.
+	 * @param maxKeys - The maximum number of object keys to return.
+	 */
+	async listObjectsV2(bucketName: string, maxKeys: number): Promise<void> {
+		const url = this.getBucketUrl(bucketName);
+		url.searchParams.set("list-type", "2");
+		url.searchParams.set("max-keys", maxKeys.toString());
+		await this.request("GET", url);
+	}
+
+	private getBucketUrl(bucketName: string): URL {
+		const url = new URL(this.endpoint);
+		url.pathname = `/${encodeURIComponent(bucketName)}/`;
+		return url;
+	}
+
+	private async request(method: "GET" | "HEAD", url: URL): Promise<void> {
+		for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+			const signer = new AwsV4Signer({
+				method,
+				url: url.href,
+				headers: { "X-Amz-Content-Sha256": EMPTY_PAYLOAD_SHA256 },
+				accessKeyId: this.accessKeyId,
+				secretAccessKey: this.secretAccessKey,
+				service: "s3",
+				region: "auto",
+				cache: this.signingKeyCache,
+			});
+			const signedRequest = await signer.sign();
+
+			try {
+				const response = await fetch(signedRequest.url, {
+					method: signedRequest.method,
+					headers: Object.fromEntries(signedRequest.headers),
+					redirect: "manual",
+				});
+				await response.arrayBuffer();
+
+				if (response.ok) {
+					return;
+				}
+
+				const error = new R2RequestError(response.status, response.statusText);
+				if (
+					attempt === MAX_ATTEMPTS ||
+					!RETRYABLE_STATUS_CODES.has(response.status)
+				) {
+					throw error;
+				}
+			} catch (error) {
+				if (
+					attempt === MAX_ATTEMPTS ||
+					(error instanceof R2RequestError &&
+						!RETRYABLE_STATUS_CODES.has(error.status))
+				) {
+					throw error;
+				}
+			}
+
+			const maximumDelay = INITIAL_RETRY_DELAY_MS * 2 ** (attempt - 1);
+			await setTimeout(Math.random() * maximumDelay);
+		}
+	}
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4696,6 +4696,9 @@ importers:
       am-i-vibing:
         specifier: ^0.5.0
         version: 0.5.0
+      aws4fetch:
+        specifier: ^1.0.20
+        version: 1.0.20
       capnweb:
         specifier: catalog:default
         version: 0.5.0


### PR DESCRIPTION
Fixes no linked issue.

Wrangler's Pipelines credential validation only uses S3 `HeadBucket` and `ListObjectsV2` with `MaxKeys: 1`, but importing `S3Client` pulls 1,234,988 bytes of AWS and Smithy code into the published CLI bundle, including credential-provider paths that cannot be reached because Pipelines always supplies credentials and an endpoint explicitly.

This replaces that runtime client with a minimal R2 client built on `aws4fetch`'s low-level SigV4 signer and Wrangler's existing `undici` fetch. It preserves path-style bucket URLs, `auto/s3` signing scope, the empty-payload SHA-256 header, non-success failures, manual redirect handling, response-body disposal, and the SDK's default three attempts for network, throttling, and transient server failures. The existing outer propagation retry for newly created service tokens is unchanged.

### Bundle measurements

Measurements use equivalent source-map-disabled Wrangler builds from the same checkout.

| Size | Before | After | Saving |
| --- | ---: | ---: | ---: |
| Raw `cli.js` | 20,561,388 B | 19,153,577 B | 1,407,811 B / 6.85% |
| Gzip | 3,650,005 B | 3,457,556 B | 192,449 B / 5.27% |

The emitted metafile's AWS/Smithy contribution falls from 1,234,988 bytes across 751 inputs to zero. `aws4fetch` contributes 10,405 bytes.

### Validation

- `pnpm --dir packages/wrangler exec vitest run src/__tests__/pipelines-r2-client.test.ts src/__tests__/pipelines-setup.test.ts` — 27 passed
- `pnpm --dir packages/wrangler check:type`
- `pnpm --dir packages/wrangler type:tests`
- `SOURCEMAPS=false pnpm run build --filter wrangler --force`
- `pnpm run check --filter wrangler`

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: This is an internal dependency and credential-validation refactor with no user-facing API or behavior change.

> [!NOTE]
> This is a contribution from an AI agent: Codex.
