### PR TITLE
[wrangler] Exit quietly when the output pipe is closed early

### DIFF
--- a/.changeset/lucky-pans-repeat.md
+++ b/.changeset/lucky-pans-repeat.md
@@ -1,0 +1,11 @@
+---
+"wrangler": patch
+---
+
+Exit quietly instead of crashing when Wrangler's output pipe is closed early
+
+Running a Wrangler command with both stdout and stderr going to a reader that stops early — `wrangler whoami 2>&1 | head`, or an agent/CI runner that captures combined output and times out — made Wrangler abort with a JavaScript heap out-of-memory error instead of exiting.
+
+Node ignores `SIGPIPE`, so the failed write arrives as an unhandled `EPIPE` error event. That became an uncaught exception, and Sentry's handler for those logs the error with `console.error` before deferring `process.exit` behind a transport flush of up to two seconds. The `console.error` went to the stream that had just failed, raising another `EPIPE` that re-entered the handler well before the process was allowed to exit. Each turn allocated another `Error` with a captured stack, so Wrangler exhausted the heap and aborted, leaving a multi-hundred-megabyte core dump containing account data on systems that record them.
+
+Wrangler now attaches an `error` listener to both stdio streams when run as a CLI, so a broken pipe stops output and exits cleanly instead of ever becoming an uncaught exception. Other stdio errors are still surfaced, and the programmatic API is unaffected.

--- a/packages/wrangler/bin/cf-wrangler.js
+++ b/packages/wrangler/bin/cf-wrangler.js
@@ -6,11 +6,17 @@
 // the parent uses to feature-detect support.
 const {
 	ArgParseError,
+	handleBrokenPipe,
 	parseCfWranglerBuildArgs,
 	parseCfWranglerArgs,
 	runCfWranglerBuild,
 	runCfWranglerDev,
 } = require("../wrangler-dist/cli.js");
+
+// This binary runs delegate verbs in-process rather than re-spawning, so the
+// guard installed by `cli.ts` for the `wrangler` binary does not apply here.
+// Install it before writing anything.
+handleBrokenPipe();
 
 const argv = process.argv.slice(2);
 const verb = argv[0];

--- a/packages/wrangler/src/__tests__/utils-handle-broken-pipe.test.ts
+++ b/packages/wrangler/src/__tests__/utils-handle-broken-pipe.test.ts
@@ -1,0 +1,60 @@
+import { EventEmitter } from "node:events";
+import { describe, it, vi } from "vitest";
+import { handleBrokenPipe } from "../utils/handle-broken-pipe";
+
+function errorWithCode(code: string) {
+	return Object.assign(new Error(`write ${code}`), {
+		code,
+		syscall: "write",
+	});
+}
+
+describe("handleBrokenPipe()", () => {
+	for (const code of ["EPIPE", "ERR_STREAM_DESTROYED"]) {
+		it(`exits quietly when the stream fails with ${code}`, ({ expect }) => {
+			const stream = new EventEmitter();
+			const onBrokenPipe = vi.fn();
+
+			handleBrokenPipe([stream], onBrokenPipe);
+			stream.emit("error", errorWithCode(code));
+
+			expect(onBrokenPipe).toHaveBeenCalledOnce();
+		});
+	}
+
+	it("installs a listener on every stream it is given", ({ expect }) => {
+		const stdout = new EventEmitter();
+		const stderr = new EventEmitter();
+		const onBrokenPipe = vi.fn();
+
+		handleBrokenPipe([stdout, stderr], onBrokenPipe);
+
+		expect(stdout.listenerCount("error")).toBe(1);
+		expect(stderr.listenerCount("error")).toBe(1);
+
+		stderr.emit("error", errorWithCode("EPIPE"));
+		expect(onBrokenPipe).toHaveBeenCalledOnce();
+	});
+
+	it("re-throws stdio errors that are not a broken pipe", ({ expect }) => {
+		const stream = new EventEmitter();
+		const onBrokenPipe = vi.fn();
+		const error = errorWithCode("ENOSPC");
+
+		handleBrokenPipe([stream], onBrokenPipe);
+
+		expect(() => stream.emit("error", error)).toThrow(error);
+		expect(onBrokenPipe).not.toHaveBeenCalled();
+	});
+
+	it("does not swallow an error with no code", ({ expect }) => {
+		const stream = new EventEmitter();
+		const onBrokenPipe = vi.fn();
+		const error = new Error("something else went wrong");
+
+		handleBrokenPipe([stream], onBrokenPipe);
+
+		expect(() => stream.emit("error", error)).toThrow(error);
+		expect(onBrokenPipe).not.toHaveBeenCalled();
+	});
+});

--- a/packages/wrangler/src/cli.ts
+++ b/packages/wrangler/src/cli.ts
@@ -24,6 +24,7 @@ import {
 	unstable_pages,
 	unstable_readConfig,
 } from "./api";
+import { handleBrokenPipe } from "./utils/handle-broken-pipe";
 import { main } from "./index";
 import type {
 	Binding,
@@ -52,6 +53,11 @@ import type { Request, Response } from "miniflare";
  * main only gets called when the script is run directly, not when it's imported as a module.
  */
 if (typeof vitest === "undefined" && require.main === module) {
+	// Exit quietly if whoever is reading our output goes away, rather than
+	// looping on EPIPE while trying to report the EPIPE. Must be installed
+	// before anything is written.
+	handleBrokenPipe();
+
 	main(hideBin(process.argv)).catch((e) => {
 		// The logging of any error that was thrown from `main()` is handled in the `yargs.fail()` handler.
 		// Here we just want to ensure that the process exits with a non-zero code.

--- a/packages/wrangler/src/cli.ts
+++ b/packages/wrangler/src/cli.ts
@@ -116,6 +116,9 @@ export {
 	parseBuildArgs as parseCfWranglerBuildArgs,
 	parseArgs as parseCfWranglerArgs,
 } from "./cf-wrangler/args";
+// `cf-wrangler` runs in-process, so `require.main === module` is false here and
+// it does not get the guard installed below. It installs this itself instead.
+export { handleBrokenPipe } from "./utils/handle-broken-pipe";
 
 // Export internal APIs required by the Vitest integration as `unstable_`
 export { splitSqlQuery as unstable_splitSqlQuery } from "./d1/splitter";

--- a/packages/wrangler/src/utils/handle-broken-pipe.ts
+++ b/packages/wrangler/src/utils/handle-broken-pipe.ts
@@ -1,0 +1,65 @@
+import process from "node:process";
+
+/**
+ * Error codes that mean "the thing we were writing to has gone away".
+ *
+ * `EPIPE` is the reader closing the pipe (`wrangler whoami | head`).
+ * `ERR_STREAM_DESTROYED` is the same situation observed a tick later, once
+ * Node has torn the stream down.
+ */
+const BROKEN_PIPE_CODES = new Set(["EPIPE", "ERR_STREAM_DESTROYED"]);
+
+/**
+ * Make Wrangler exit quietly when its output stream is closed early.
+ *
+ * Node ignores `SIGPIPE`, so writing to a closed stdout/stderr surfaces as an
+ * asynchronous `error` event rather than terminating the process the way a
+ * normal Unix CLI would. With no listener attached, that becomes an uncaught
+ * exception, and in released builds the uncaught-exception path is Sentry's
+ * `logAndExitProcess`, which does two things in this order:
+ *
+ * 1. `console.error(error)` — written to the stream that just failed, raising
+ *    another asynchronous `EPIPE`;
+ * 2. `client.close(timeout).then(() => process.exit(1))` — so the exit is
+ *    deferred behind a transport flush of up to 2 seconds.
+ *
+ * The second `EPIPE` therefore lands back in the handler long before the
+ * process is allowed to die, and the cycle repeats. Each turn allocates a fresh
+ * `Error` with a captured stack, so this is not a busy loop that eventually
+ * exits: it exhausts the V8 heap and aborts. `wrangler whoami 2>&1 | head`
+ * reliably produced a multi-gigabyte out-of-memory crash (and, on Linux, a
+ * core dump containing the user's account data and credentials).
+ *
+ * Note that this only reproduces against a build with `SENTRY_DSN` set, i.e.
+ * published releases — a plain `pnpm build` leaves Sentry uninitialised.
+ *
+ * Attaching an `error` listener to both stdio streams is enough to break the
+ * cycle: the first broken-pipe error stops output and exits, matching what
+ * users expect from `| head`, `| less` or a CI runner that stopped reading.
+ *
+ * Only called from `cli.ts` when Wrangler is run as a binary — the programmatic
+ * API (`unstable_dev` and friends) must not install process-wide exit handlers
+ * on its embedder's behalf.
+ *
+ * @param streams The streams to guard. Defaults to `process.stdout` and
+ * `process.stderr`; overridable for testing.
+ * @param onBrokenPipe Invoked on the first broken-pipe error. Defaults to
+ * exiting the process; overridable for testing.
+ */
+export function handleBrokenPipe(
+	streams: NodeJS.EventEmitter[] = [process.stdout, process.stderr],
+	onBrokenPipe: () => void = () => process.exit(0)
+): void {
+	for (const stream of streams) {
+		stream.on("error", (error: NodeJS.ErrnoException) => {
+			if (BROKEN_PIPE_CODES.has(error?.code ?? "")) {
+				onBrokenPipe();
+				return;
+			}
+			// Not a broken pipe, so this is a genuine stdio failure we have
+			// nothing useful to say about. Re-throw to preserve the previous
+			// behaviour of surfacing it as an uncaught exception.
+			throw error;
+		});
+	}
+}


### PR DESCRIPTION
Fixes #15415.

When a Wrangler command has **both** stdout and stderr connected to a reader that stops early, Wrangler aborts with a JavaScript heap out-of-memory error instead of exiting:

```sh
npx wrangler@4.127.1 whoami 2>&1 | head -c 50
```

On Linux with `systemd-coredump` enabled that leaves a ~300 MB core dump per occurrence, containing the account data and OAuth/API token material the process was holding. It mainly affects agent and CI runners, since they capture combined output and close the pipe on timeout; an interactive TTY never yields `EPIPE`.

### Cause

Node ignores `SIGPIPE`, so the failed write arrives as an asynchronous `EPIPE` error event. Nothing listens for it on the stdio streams, so it becomes an uncaught exception — and in released builds that path is Sentry's `logAndExitProcess`, which `console.error`s the error (writing to the stream that just failed, raising another `EPIPE`) and only then calls `process.exit`, deferred behind a transport flush of up to 2s. The second `EPIPE` re-enters the handler well before the process can die, and each turn allocates another `Error` with a captured stack, so the heap is exhausted rather than the loop terminating.

The core dump contains ~787,000 copies of the same `console.error` → `Socket._writeGeneric` → `afterWriteDispatched` stack and 1.57M occurrences of `EPIPE`.

### Fix

Attach an `error` listener to `process.stdout` and `process.stderr` so a broken pipe stops output and exits cleanly, and never becomes an uncaught exception in the first place.

Deliberate scoping:

- Installed from `src/cli.ts` only inside the `require.main === module` branch, so the programmatic API (`unstable_dev` and friends) does not get process-wide exit handlers installed on its embedder's behalf.
- Only `EPIPE` and `ERR_STREAM_DESTROYED` are treated as a broken pipe. Any other stdio error is re-thrown, preserving today's behaviour rather than silently swallowing it.

### Verification

Built from source with `SENTRY_DSN` set (a dead local address), since a plain `pnpm build` leaves Sentry uninitialised and does not reproduce:

| build | `wrangler whoami 2>&1 \| head -c 50` |
| --- | --- |
| before this change | `SIGABRT`, heap OOM, core dumped |
| after this change | exits cleanly, 3/3 runs, no core |

Unit tests added for the guard, and `sentry.test.ts`, `cli.test.ts` and `index.test.ts` pass. `oxlint`, `oxfmt --check` and `tsc --noEmit` are clean.

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: this fixes a crash; there is no user-facing API or documented behaviour change.

> [!NOTE]
> This is a contribution from an AI agent: Claude Code, Claude Opus 5.

<!-- devin-review-badge-begin -->

---

<a href="https://cloudflare.devinenterprise.com/review/cloudflare/workers-sdk/pull/15416" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->