### PR TITLE
fix(miniflare): disable per-browser SIGINT/SIGHUP to allow full multi-session teardown (Closes #15419)

### DIFF
--- a/.changeset/fix-browser-rendering-sigint.md
+++ b/.changeset/fix-browser-rendering-sigint.md
@@ -1,0 +1,5 @@
+---
+"miniflare": patch
+---
+
+fix: disable per-browser SIGINT and SIGHUP handlers in `@puppeteer/browsers` to allow centralized multi-browser teardown on SIGINT

--- a/packages/miniflare/src/index.ts
+++ b/packages/miniflare/src/index.ts
@@ -931,6 +931,14 @@ export class Miniflare {
 		this.#runtime = new Runtime();
 		this.#removeExitHook = exitHook(() => {
 			void this.#runtime?.dispose();
+			for (const { browserProcess } of this.#browserProcesses.values()) {
+				try {
+					browserProcess.kill();
+				} catch {
+					// Process might already be dead
+				}
+			}
+			this.#browserProcesses.clear();
 			// This exit hook is synchronous — the event loop will never run again
 			// after it returns, so any operation that schedules a microtask (like
 			// fs.promises.rm) will never even be executed, let alone completed.

--- a/packages/miniflare/src/plugins/browser-rendering/index.ts
+++ b/packages/miniflare/src/plugins/browser-rendering/index.ts
@@ -229,7 +229,9 @@ export async function launchBrowser({
 		const browserProcess = launch({
 			executablePath: installed.executablePath,
 			args: process.env.CI ? [...launchArgs, "--no-sandbox"] : launchArgs,
+			handleSIGINT: false,
 			handleSIGTERM: false,
+			handleSIGHUP: false,
 			dumpio: false,
 			pipe: false,
 			onExit: async () => {


### PR DESCRIPTION
Fixes #15419

### Summary
When a local Browser Rendering Worker has more than one active Chrome session, sending `SIGINT` directly to the Wrangler Node process terminates Wrangler and kills only the first Chrome process tree, leaving remaining Chrome process trees orphaned (reparented to PID 1).

### Solution
- Explicitly passed `handleSIGINT: false` and `handleSIGHUP: false` to `@puppeteer/browsers`'s `launch()` options in `packages/miniflare/src/plugins/browser-rendering/index.ts`.
- In Miniflare's `exitHook` in `packages/miniflare/src/index.ts`, synchronously terminate all tracked active browser processes in `#browserProcesses` before the process exits.
- Added patch changeset in `.changeset/fix-browser-rendering-sigint.md`.

---

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: Disables per-process signal handling in @puppeteer/browsers to allow Miniflare's centralized exitHook teardown to manage process lifecycle.
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: Internal process lifecycle and signal handling fix in Miniflare.
