### PR TITLE
Rebase absolute module specifiers under `preserve_file_names`

### DIFF
--- a/.changeset/silly-donkeys-smell.md
+++ b/.changeset/silly-donkeys-smell.md
@@ -1,0 +1,9 @@
+---
+"wrangler": patch
+---
+
+Rebase absolute non-JavaScript module specifiers when `preserve_file_names` is enabled
+
+With `preserve_file_names` set, a non-JS module imported by an absolute path kept that path as its module name. The build machine's filesystem layout ended up inside the deployed Worker, and the module was never written to `--outdir`. A local dry run reported success while the upload failed server-side with error code `10021`. Tooling that rewrites externals to absolute paths hits this, which is how it was found in `@opennextjs/cloudflare` with WASM imports.
+
+Absolute specifiers are now rebased to `./<basename>`, which is what the hashed branch of the same code already does minus the hash prefix. Relative specifiers keep the behaviour they had.

--- a/packages/wrangler/src/__tests__/deploy/formats.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/formats.test.ts
@@ -359,6 +359,46 @@ describe("deploy", () => {
 			expect(std.warn).toMatchInlineSnapshot(`""`);
 		});
 
+		it("should rebase absolute non-js imports to a relative preserved name (esm)", async ({
+			expect,
+		}) => {
+			writeWranglerConfig({
+				rules: [{ type: "Text", globs: ["**/*.txt"], fallthrough: true }],
+				preserve_file_names: true,
+			});
+			// Use forward-slash absolute paths so module-rule globs match on Windows too
+			// (glob-to-regexp does not treat `\` as a path separator).
+			const absoluteMessagePath = path
+				.resolve("./message.txt")
+				.split(path.sep)
+				.join("/");
+			fs.writeFileSync("./message.txt", "HELLO FROM ABSOLUTE IMPORT");
+			fs.writeFileSync(
+				"./index.js",
+				`import message from ${JSON.stringify(absoluteMessagePath)}; export default {};`
+			);
+			mockSubDomainRequest();
+			mockUploadWorkerRequest({
+				expectedType: "esm",
+				expectedBindings: [],
+				expectedModules: {
+					"./message.txt": "HELLO FROM ABSOLUTE IMPORT",
+				},
+				// Guard against the old bug of shipping the build-machine absolute path.
+				excludedModules: [absoluteMessagePath],
+			});
+			await runWrangler("deploy index.js --outdir some-dir");
+			expect(fs.existsSync("some-dir/message.txt")).toBe(true);
+			expect(fs.readFileSync("some-dir/index.js", "utf8")).toContain(
+				'from "./message.txt"'
+			);
+			expect(fs.readFileSync("some-dir/index.js", "utf8")).not.toContain(
+				absoluteMessagePath
+			);
+			expect(std.err).toMatchInlineSnapshot(`""`);
+			expect(std.warn).toMatchInlineSnapshot(`""`);
+		});
+
 		it("should strip query string suffixes from module names (esm)", async ({
 			expect,
 		}) => {

--- a/packages/wrangler/src/__tests__/deploy/formats.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/formats.test.ts
@@ -382,18 +382,70 @@ describe("deploy", () => {
 				expectedType: "esm",
 				expectedBindings: [],
 				expectedModules: {
-					"./message.txt": "HELLO FROM ABSOLUTE IMPORT",
+					"./a182964753994a9d8e94adcfa9e4faeff0bfd71a/message.txt":
+						"HELLO FROM ABSOLUTE IMPORT",
 				},
 				// Guard against the old bug of shipping the build-machine absolute path.
 				excludedModules: [absoluteMessagePath],
 			});
 			await runWrangler("deploy index.js --outdir some-dir");
-			expect(fs.existsSync("some-dir/message.txt")).toBe(true);
+			expect(
+				fs.existsSync(
+					"some-dir/a182964753994a9d8e94adcfa9e4faeff0bfd71a/message.txt"
+				)
+			).toBe(true);
 			expect(fs.readFileSync("some-dir/index.js", "utf8")).toContain(
-				'from "./message.txt"'
+				'from "./a182964753994a9d8e94adcfa9e4faeff0bfd71a/message.txt"'
 			);
 			expect(fs.readFileSync("some-dir/index.js", "utf8")).not.toContain(
 				absoluteMessagePath
+			);
+			expect(std.err).toMatchInlineSnapshot(`""`);
+			expect(std.warn).toMatchInlineSnapshot(`""`);
+		});
+
+		it("should keep absolute imports with matching basenames distinct (esm)", async ({
+			expect,
+		}) => {
+			writeWranglerConfig({
+				rules: [{ type: "Text", globs: ["**/*.txt"], fallthrough: true }],
+				preserve_file_names: true,
+			});
+			fs.mkdirSync("./first");
+			fs.mkdirSync("./second");
+			fs.writeFileSync("./first/message.txt", "FIRST ABSOLUTE MODULE");
+			fs.writeFileSync("./second/message.txt", "SECOND ABSOLUTE MODULE");
+			const firstPath = path
+				.resolve("./first/message.txt")
+				.split(path.sep)
+				.join("/");
+			const secondPath = path
+				.resolve("./second/message.txt")
+				.split(path.sep)
+				.join("/");
+			fs.writeFileSync(
+				"./index.js",
+				`import first from ${JSON.stringify(firstPath)}; import second from ${JSON.stringify(secondPath)}; export default {};`
+			);
+			mockSubDomainRequest();
+			mockUploadWorkerRequest({
+				expectedType: "esm",
+				expectedBindings: [],
+				expectedModules: {
+					"./600ae083223cb8c0e884f9b7db426d6f7cce2cd8/message.txt":
+						"FIRST ABSOLUTE MODULE",
+					"./54b3efcc8cb6313f13a918823b64453d43a70c14/message.txt":
+						"SECOND ABSOLUTE MODULE",
+				},
+				excludedModules: [firstPath, secondPath],
+			});
+			await runWrangler("deploy index.js --outdir some-dir");
+			const bundle = fs.readFileSync("some-dir/index.js", "utf8");
+			expect(bundle).toContain(
+				'from "./600ae083223cb8c0e884f9b7db426d6f7cce2cd8/message.txt"'
+			);
+			expect(bundle).toContain(
+				'from "./54b3efcc8cb6313f13a918823b64453d43a70c14/message.txt"'
 			);
 			expect(std.err).toMatchInlineSnapshot(`""`);
 			expect(std.warn).toMatchInlineSnapshot(`""`);

--- a/packages/wrangler/src/deployment-bundle/module-collection.ts
+++ b/packages/wrangler/src/deployment-bundle/module-collection.ts
@@ -52,6 +52,27 @@ function stripQueryString(modulePath: string): string {
 	return queryIndex !== -1 ? modulePath.slice(0, queryIndex) : modulePath;
 }
 
+/**
+ * Name used for a collected module in the bundle and the multipart upload.
+ * An absolute specifier is machine-local, so preserving it verbatim produces a
+ * bundle that only fails at upload. Under `preserve_file_names` we keep the
+ * basename and make it relative, matching how the hashed branch already
+ * flattens paths.
+ */
+function collectedModuleName(
+	cleanedPath: string,
+	fileHash: string,
+	preserveFileNames?: boolean
+): string {
+	if (!preserveFileNames) {
+		return `./${fileHash}-${path.basename(cleanedPath)}`;
+	}
+	if (path.isAbsolute(cleanedPath)) {
+		return `./${path.basename(cleanedPath)}`;
+	}
+	return cleanedPath;
+}
+
 // This is a combination of an esbuild plugin and a mutable array
 // that we use to collect module references from source code.
 // There will be modules that _shouldn't_ be inlined directly into
@@ -223,9 +244,11 @@ export function createModuleCollector(props: {
 								.createHash("sha1")
 								.update(fileContent)
 								.digest("hex");
-							const fileName = props.preserveFileNames
-								? cleanedPath
-								: `./${fileHash}-${path.basename(cleanedPath)}`;
+							const fileName = collectedModuleName(
+								cleanedPath,
+								fileHash,
+								props.preserveFileNames
+							);
 
 							const { rule } =
 								rulesMatchers.find(({ regex }) => regex.test(fileName)) || {};
@@ -326,9 +349,11 @@ export function createModuleCollector(props: {
 									.createHash("sha1")
 									.update(fileContent)
 									.digest("hex");
-								const fileName = props.preserveFileNames
-									? cleanedPath
-									: `./${fileHash}-${path.basename(cleanedPath)}`;
+								const fileName = collectedModuleName(
+									cleanedPath,
+									fileHash,
+									props.preserveFileNames
+								);
 
 								// add the module to the array
 								modules.push({

--- a/packages/wrangler/src/deployment-bundle/module-collection.ts
+++ b/packages/wrangler/src/deployment-bundle/module-collection.ts
@@ -56,8 +56,8 @@ function stripQueryString(modulePath: string): string {
  * Name used for a collected module in the bundle and the multipart upload.
  * An absolute specifier is machine-local, so preserving it verbatim produces a
  * bundle that only fails at upload. Under `preserve_file_names` we keep the
- * basename and make it relative, matching how the hashed branch already
- * flattens paths.
+ * basename and place it under a content hash, matching how the hashed branch
+ * already produces portable, unique names.
  */
 function collectedModuleName(
 	cleanedPath: string,
@@ -68,7 +68,7 @@ function collectedModuleName(
 		return `./${fileHash}-${path.basename(cleanedPath)}`;
 	}
 	if (path.isAbsolute(cleanedPath)) {
-		return `./${path.basename(cleanedPath)}`;
+		return `./${fileHash}/${path.basename(cleanedPath)}`;
 	}
 	return cleanedPath;
 }


### PR DESCRIPTION
Fixes #15292.

With `preserve_file_names`, absolute non-JavaScript imports kept their build-machine paths. Rebasing them to a bare basename fixed portability but made different absolute files with the same basename collapse into one module.

Absolute imports now use `./<content-hash>/<basename>`. This keeps each name portable and distinct while preserving the original basename. Relative imports and the public configuration surface are unchanged.

### Test Plan

- `pnpm --filter wrangler test run src/__tests__/deploy/formats.test.ts -t 'should (rebase absolute non-js imports|keep absolute imports with matching basenames distinct)'` (2 passed)
- `pnpm --filter wrangler check:type`
- `oxlint --deny-warnings --type-aware` on both changed files
- `oxfmt --check` on both changed files

- Tests
  - [x] Tests included/updated
- Public documentation
  - [x] Documentation not necessary because: this fixes module naming without changing configuration.
