### PR TITLE
Add workflow event subscription to local workflow engine

### DIFF
--- a/.changeset/workflow-event-subscriptions.md
+++ b/.changeset/workflow-event-subscriptions.md
@@ -1,0 +1,8 @@
+---
+"@cloudflare/workflows-shared": minor
+"miniflare": minor
+---
+
+Add experimental Workflow event subscriptions to local development
+
+Local Workflow instances now implement `subscribe()`, returning a disposable RPC subscription that streams historical and live lifecycle events. Subscriptions support event cursors and type filters and include Workflow inputs, status transitions, step configuration, outputs, errors, retries, waits, and rollback activity where applicable.

--- a/packages/miniflare/src/workers/workflows/wrapped-binding.worker.ts
+++ b/packages/miniflare/src/workers/workflows/wrapped-binding.worker.ts
@@ -3,6 +3,10 @@ import type {
 	WorkflowInstanceRestartOptions,
 	WorkflowInstanceTerminateOptions,
 } from "@cloudflare/workflows-shared/src/binding";
+import type {
+	WorkflowSubscription,
+	WorkflowSubscriptionOptions,
+} from "@cloudflare/workflows-shared/src/subscription";
 import type { WorkflowIntrospectionOperation } from "@cloudflare/workflows-shared/src/types";
 
 class WorkflowImpl implements Workflow {
@@ -136,6 +140,14 @@ class InstanceImpl implements WorkflowInstance {
 		using instance = await this.getInstance();
 		using res = (await instance.status()) as InstanceStatus & Disposable;
 		return structuredClone(res);
+	}
+
+	public async subscribe(
+		options?: WorkflowSubscriptionOptions
+	): Promise<WorkflowSubscription> {
+		using instance = await this.getInstance();
+		// @ts-expect-error `subscribe` not yet included in workers-types.
+		return await instance.subscribe(options);
 	}
 
 	public async sendEvent(args: {

--- a/packages/miniflare/test/plugins/workflows/index.spec.ts
+++ b/packages/miniflare/test/plugins/workflows/index.spec.ts
@@ -62,6 +62,173 @@ test("starts Workflows with user-provided experimental compatibility flag", asyn
 	);
 });
 
+test("subscribes to Workflow instance events through an RPC target", async ({
+	expect,
+}) => {
+	const tmp = await useTmp();
+	const mf = new Miniflare({
+		resourcePersistencePath: tmp,
+		workers: [
+			{
+				config: {
+					type: "worker",
+					name: "workflow-subscription-worker",
+					compatibilityDate: "2026-08-28",
+					manifest: singleModuleManifest(`
+						import { WorkflowEntrypoint } from "cloudflare:workers";
+						export class SubscriptionWorkflow extends WorkflowEntrypoint {
+							async run(event, step) {
+								await step.do("subscription step", async () => "step output");
+								return "workflow output";
+							}
+						}
+						export default {
+							async fetch(request, env) {
+								const instance = await env.SUBSCRIPTION_WORKFLOW.create({
+									id: "subscription-test",
+									params: { input: true },
+								});
+								using subscription = await instance.subscribe();
+								const events = [];
+								while (true) {
+									const result = await subscription.next();
+									if (result.done) break;
+									events.push(result.value);
+								}
+								return Response.json(events);
+							},
+						};
+					`),
+					env: {
+						SUBSCRIPTION_WORKFLOW: {
+							type: "workflow",
+							name: "SUBSCRIPTION_WORKFLOW",
+							worker: "workflow-subscription-worker",
+							exportName: "SubscriptionWorkflow",
+						},
+					},
+				},
+			},
+		],
+	});
+	useDispose(mf);
+
+	const response = await mf.dispatchFetch("http://localhost");
+	const body = await response.text();
+	expect(response.status, body).toBe(200);
+	const events = JSON.parse(body) as Array<Record<string, unknown>>;
+	expect(events.map(({ type }) => type)).toEqual([
+		"workflow_queued",
+		"workflow_started",
+		"workflow_running",
+		"step_started",
+		"attempt_started",
+		"attempt_completed",
+		"step_completed",
+		"workflow_completed",
+	]);
+	expect(events[1]).toMatchObject({
+		instanceId: "subscription-test",
+		params: { input: true },
+	});
+	expect(events[2]).toMatchObject({
+		type: "workflow_running",
+	});
+	expect(events[3]).toMatchObject({
+		stepName: "subscription step-1",
+		config: {
+			retries: { limit: 5, delay: 1000, backoff: "exponential" },
+			timeout: "10 minutes",
+		},
+	});
+	expect(events[6]).toMatchObject({
+		stepName: "subscription step-1",
+		output: "step output",
+	});
+	expect(events[7]).toMatchObject({ output: "workflow output" });
+});
+
+test("subscribes to structured and streamed step outputs", async ({
+	expect,
+}) => {
+	const tmp = await useTmp();
+	const mf = new Miniflare({
+		resourcePersistencePath: tmp,
+		workers: [
+			{
+				config: {
+					type: "worker",
+					name: "workflow-step-output-subscription-worker",
+					compatibilityDate: "2026-08-28",
+					manifest: singleModuleManifest(`
+						import { WorkflowEntrypoint } from "cloudflare:workers";
+						export class SubscriptionWorkflow extends WorkflowEntrypoint {
+							async run(event, step) {
+								await step.do("structured output", async () => ({ total: 1n }));
+								const stream = await step.do("stream output", async () => {
+									return new ReadableStream({
+										start(controller) {
+											controller.enqueue(new TextEncoder().encode("stream output"));
+											controller.close();
+										},
+									});
+								});
+								await new Response(stream).arrayBuffer();
+								return "done";
+							}
+						}
+						export default {
+							async fetch(request, env) {
+								const instance = await env.SUBSCRIPTION_WORKFLOW.create({
+									id: "step-output-subscription-test",
+								});
+								using subscription = await instance.subscribe({
+									filter: ["step_completed", "workflow_completed"],
+								});
+								const outputs = [];
+								while (true) {
+									const result = await subscription.next();
+									if (result.done) break;
+									if (result.value.type !== "step_completed") continue;
+									if (result.value.output instanceof ReadableStream) {
+										outputs.push({
+											stepName: result.value.stepName,
+											output: await new Response(result.value.output).text(),
+										});
+									} else {
+										outputs.push({
+											stepName: result.value.stepName,
+											output: { total: result.value.output.total.toString() },
+										});
+									}
+								}
+								return Response.json(outputs);
+							},
+						};
+					`),
+					env: {
+						SUBSCRIPTION_WORKFLOW: {
+							type: "workflow",
+							name: "SUBSCRIPTION_WORKFLOW",
+							worker: "workflow-step-output-subscription-worker",
+							exportName: "SubscriptionWorkflow",
+						},
+					},
+				},
+			},
+		],
+	});
+	useDispose(mf);
+
+	const response = await mf.dispatchFetch("http://localhost");
+	const body = await response.text();
+	expect(response.status, body).toBe(200);
+	expect(JSON.parse(body)).toEqual([
+		{ stepName: "structured output-1", output: { total: "1" } },
+		{ stepName: "stream output-1", output: "stream output" },
+	]);
+});
+
 test("persists Workflow data on file-system between runs", async ({
 	expect,
 }) => {

--- a/packages/workflows-shared/src/binding.ts
+++ b/packages/workflows-shared/src/binding.ts
@@ -12,6 +12,7 @@ import {
 	isValidAddressableWorkflowInstanceId,
 	isValidWorkflowInstanceId,
 } from "./lib/validators";
+import { parseWorkflowSubscriptionOptions } from "./subscription";
 import type {
 	DatabaseInstance,
 	DatabaseVersion,
@@ -20,6 +21,10 @@ import type {
 	EngineLogs,
 } from "./engine";
 import type { InstanceStatus as EngineInstanceStatus } from "./instance";
+import type {
+	WorkflowSubscription,
+	WorkflowSubscriptionOptions,
+} from "./subscription";
 import type {
 	WorkflowInstanceModifier,
 	WorkflowIntrospectionOperation,
@@ -623,6 +628,13 @@ export class WorkflowHandle extends RpcTarget implements WorkflowInstance {
 			output: workflowOutput,
 			error: workflowError,
 		};
+	}
+
+	public async subscribe(
+		options?: WorkflowSubscriptionOptions
+	): Promise<WorkflowSubscription> {
+		const parsedOptions = parseWorkflowSubscriptionOptions(options);
+		return this.stub.subscribe(parsedOptions);
 	}
 
 	public async sendEvent(args: {

--- a/packages/workflows-shared/src/context.ts
+++ b/packages/workflows-shared/src/context.ts
@@ -26,6 +26,7 @@ import {
 	parseRollbackOptions,
 	ROLLBACK_CACHE_KEY_PREFIX,
 } from "./lib/rollback";
+import { normalizeForStorage } from "./lib/serialization";
 import {
 	cleanupPendingStreamOutput,
 	createReplayReadableStream,
@@ -141,103 +142,6 @@ const defaultConfig: ResolvedStepConfig = {
 	},
 	timeout: "10 minutes",
 };
-
-/**
- * Returns a copy of `value` that is safe to persist via Durable Object SQL
- * storage without dragging unrelated bytes along with typed-array views.
- *
- * Background: workerd's `v8::ValueSerializer` writes the entire backing
- * `ArrayBuffer` for typed-array views, not just `byteLength` bytes. A view
- * sliced from a much larger buffer (`crypto.getRandomValues`, `arr.slice(...)`,
- * fetch-stream copies) blows up the wire size by a factor of
- * (backing-size / view-size) and can hit `SQLITE_TOOBIG` at view sizes well
- * below the documented 1MiB step-output limit (see issue #14101). Copying the
- * view's bytes into a tight backing buffer before persistence brings local
- * `wrangler dev` behaviour in line with production.
- *
- * The walk is recursive (cycle-safe via a `WeakMap`) so views nested inside
- * objects, arrays, Maps, and Sets are also compacted. View types are preserved
- * (`Uint8Array` stays `Uint8Array`, `Int16Array` stays `Int16Array`, etc.) so
- * the persisted shape matches the live shape — cached replays observe the
- * same constructor type the step originally returned. Class instances and
- * host objects (`Date`, `RegExp`, raw `ArrayBuffer`, streams, `Blob`, …) are
- * passed through unchanged — recursing into them would either fail to
- * reconstruct the original type or trigger their own structured-clone path.
- */
-function normalizeForStorage(
-	value: unknown,
-	seen: WeakMap<object, unknown> = new WeakMap()
-): unknown {
-	// Primitives: nothing to do.
-	if (value === null || typeof value !== "object") {
-		return value;
-	}
-
-	// Already visited (cycle): return the previously-built copy so the result
-	// graph mirrors the original's cycle topology.
-	if (seen.has(value)) {
-		return seen.get(value);
-	}
-
-	// Typed-array views (TypedArray + DataView): copy bytes into a tight
-	// backing buffer, preserving the original view constructor.
-	if (ArrayBuffer.isView(value)) {
-		return buildCompactView(value);
-	}
-
-	if (Array.isArray(value)) {
-		const result: unknown[] = [];
-		seen.set(value, result);
-		for (const item of value) {
-			result.push(normalizeForStorage(item, seen));
-		}
-		return result;
-	}
-
-	if (value instanceof Map) {
-		const result = new Map();
-		seen.set(value, result);
-		for (const [k, v] of value) {
-			result.set(normalizeForStorage(k, seen), normalizeForStorage(v, seen));
-		}
-		return result;
-	}
-
-	if (value instanceof Set) {
-		const result = new Set();
-		seen.set(value, result);
-		for (const v of value) {
-			result.add(normalizeForStorage(v, seen));
-		}
-		return result;
-	}
-
-	// Plain objects (Object literals and null-prototype objects). Class
-	// instances and host objects fall through to the pass-through below.
-	const proto = Object.getPrototypeOf(value);
-	if (proto === Object.prototype || proto === null) {
-		const result: Record<string, unknown> = {};
-		seen.set(value, result);
-		for (const key of Object.keys(value)) {
-			result[key] = normalizeForStorage(
-				(value as Record<string, unknown>)[key],
-				seen
-			);
-		}
-		return result;
-	}
-
-	return value;
-}
-
-type ViewCtor = new (buffer: ArrayBufferLike) => ArrayBufferView;
-function buildCompactView(view: ArrayBufferView): ArrayBufferView {
-	const tightBuffer = view.buffer.slice(
-		view.byteOffset,
-		view.byteOffset + view.byteLength
-	);
-	return new (view.constructor as ViewCtor)(tightBuffer);
-}
 
 export interface UserErrorField {
 	isUserError?: boolean;

--- a/packages/workflows-shared/src/engine.ts
+++ b/packages/workflows-shared/src/engine.ts
@@ -1,5 +1,5 @@
 import { DurableObject } from "cloudflare:workers";
-import { Context } from "./context";
+import { Context, REDACTED_STEP_OUTPUT } from "./context";
 import {
 	INSTANCE_METADATA,
 	InstanceEvent,
@@ -36,14 +36,21 @@ import {
 	registerRollbackFn,
 	ROLLBACK_CACHE_KEY_PREFIX,
 } from "./lib/rollback";
+import { normalizeForStorage } from "./lib/serialization";
 import {
 	createReplayReadableStream,
 	getInvalidStoredStreamOutputError,
 	getStoredStreamOutputPreview,
+	getStreamOutputMetaKey,
 	StreamOutputState,
 } from "./lib/streams";
 import { TimePriorityQueue } from "./lib/timePriorityQueue";
 import { MODIFIER_KEYS, WorkflowInstanceModifier } from "./modifier";
+import {
+	isTerminalEvent,
+	parseResolvedStepConfig,
+	WorkflowSubscriptionTarget,
+} from "./subscription";
 import type {
 	RestartFromStep,
 	WorkflowInstanceTerminateOptions,
@@ -55,6 +62,11 @@ import type {
 	RollbackRegistryEntry,
 } from "./lib/rollback";
 import type { StreamOutputMeta } from "./lib/streams";
+import type {
+	WorkflowSubscriptionEvent,
+	WorkflowSubscriptionOptions,
+	WorkflowSubscriptionState,
+} from "./subscription";
 import type {
 	WorkflowEntrypoint,
 	WorkflowEvent,
@@ -115,6 +127,7 @@ export type EngineLogs = {
 };
 
 const ENGINE_STATUS_KEY = "ENGINE_STATUS";
+const WORKFLOW_OUTPUT_KEY = "WORKFLOW_OUTPUT";
 
 const EVENT_MAP_PREFIX = "EVENT_MAP";
 
@@ -133,6 +146,9 @@ export type RollbackPhase = "replay" | "rollback";
  * inside objects or arrays are also handled.
  */
 function binaryReplacer(_key: string, value: unknown): unknown {
+	if (typeof value === "bigint") {
+		return `[BigInt(${value})]`;
+	}
 	if (value instanceof ArrayBuffer) {
 		return `[ArrayBuffer(${value.byteLength} bytes)]`;
 	}
@@ -147,6 +163,271 @@ function isStepSuccessEvent(event: InstanceEvent): boolean {
 		event === InstanceEvent.STEP_SUCCESS ||
 		event === InstanceEvent.ROLLBACK_STEP_SUCCESS
 	);
+}
+
+type EngineWorkflowSubscriptionEvent =
+	| WorkflowSubscriptionEvent
+	| (Pick<WorkflowSubscriptionEvent, "instanceId" | "eventId" | "timestamp"> & {
+			type: "internal";
+	  });
+
+async function readStepConfig(
+	storage: DurableObjectStorage,
+	groupKey: string | null
+) {
+	if (groupKey === null) {
+		return undefined;
+	}
+	return parseResolvedStepConfig(await storage.get(`${groupKey}-config`));
+}
+
+async function readStepCompletedOutput(
+	storage: DurableObjectStorage,
+	groupKey: string | null
+) {
+	if (groupKey === null) {
+		return undefined;
+	}
+
+	const valueKey = `${groupKey}-value`;
+	const streamMetaKey = getStreamOutputMetaKey(groupKey);
+	const configKey = `${groupKey}-config`;
+	const stored = await storage.get([valueKey, streamMetaKey, configKey]);
+	const config = parseResolvedStepConfig(stored.get(configKey));
+	if (config === undefined) {
+		return undefined;
+	}
+	if (config.sensitive === "output") {
+		return REDACTED_STEP_OUTPUT;
+	}
+
+	const streamMeta = stored.get(streamMetaKey) as StreamOutputMeta | undefined;
+	if (streamMeta?.state === StreamOutputState.Complete) {
+		const integrityError = getInvalidStoredStreamOutputError(
+			storage,
+			groupKey,
+			streamMeta
+		);
+		if (integrityError !== undefined) {
+			throw createWorkflowError(
+				"Step has completed but its stored stream output is corrupt or incomplete",
+				"instance.step_output_corrupt"
+			);
+		}
+		return createReplayReadableStream({
+			storage,
+			cacheKey: groupKey,
+			meta: streamMeta,
+		});
+	}
+
+	return (stored.get(valueKey) as { value: unknown } | undefined)?.value;
+}
+
+async function buildWorkflowSubscriptionEvent(
+	storage: DurableObjectStorage,
+	log: RawInstanceLog,
+	instanceId: string,
+	params: unknown
+): Promise<EngineWorkflowSubscriptionEvent> {
+	const common = {
+		instanceId,
+		eventId: log.id,
+		timestamp: new Date(log.timestamp).valueOf(),
+	};
+	const parseMetadata = () =>
+		JSON.parse(log.metadata) as {
+			result?: unknown;
+			error: { name: string; message: string };
+			attempt: number;
+			retryDelayMs?: number;
+			durationMs: number;
+			event: string;
+		};
+	const stepEvent = (
+		createEvent: (
+			stepName: string
+		) => Extract<WorkflowSubscriptionEvent, { stepName: string }>
+	): EngineWorkflowSubscriptionEvent =>
+		log.target === null
+			? { ...common, type: "internal" }
+			: createEvent(log.target);
+
+	switch (log.event) {
+		case InstanceEvent.WORKFLOW_QUEUED:
+			return { ...common, type: "workflow_queued" };
+		case InstanceEvent.WORKFLOW_START:
+			return { ...common, type: "workflow_started", params };
+		case InstanceEvent.WORKFLOW_RUNNING:
+			return { ...common, type: "workflow_running" };
+		case InstanceEvent.WORKFLOW_PAUSED:
+			return { ...common, type: "workflow_paused" };
+		case InstanceEvent.WORKFLOW_WAITING_FOR_PAUSE:
+			return { ...common, type: "workflow_waiting_for_pause" };
+		case InstanceEvent.WORKFLOW_WAITING:
+			return { ...common, type: "workflow_waiting" };
+		case InstanceEvent.WORKFLOW_SUCCESS: {
+			const storedOutput = await storage.get<{ value: unknown }>(
+				WORKFLOW_OUTPUT_KEY
+			);
+			return {
+				...common,
+				type: "workflow_completed",
+				output:
+					storedOutput === undefined
+						? parseMetadata().result
+						: storedOutput.value,
+			};
+		}
+		case InstanceEvent.WORKFLOW_FAILURE:
+			return {
+				...common,
+				type: "workflow_errored",
+				error: parseMetadata().error,
+			};
+		case InstanceEvent.WORKFLOW_TERMINATED:
+			return { ...common, type: "workflow_terminated" };
+		case InstanceEvent.STEP_START: {
+			const config = await readStepConfig(storage, log.groupKey);
+			return stepEvent((stepName) => ({
+				...common,
+				type: "step_started",
+				stepName,
+				...(config === undefined ? {} : { config }),
+			}));
+		}
+		case InstanceEvent.STEP_SUCCESS: {
+			const output = await readStepCompletedOutput(storage, log.groupKey);
+			return stepEvent((stepName) => ({
+				...common,
+				type: "step_completed",
+				stepName,
+				...(output === undefined ? {} : { output }),
+			}));
+		}
+		case InstanceEvent.STEP_FAILURE:
+			return stepEvent((stepName) => ({
+				...common,
+				type: "step_errored",
+				stepName,
+			}));
+		case InstanceEvent.ATTEMPT_START:
+			return stepEvent((stepName) => ({
+				...common,
+				type: "attempt_started",
+				stepName,
+				attempt: parseMetadata().attempt,
+			}));
+		case InstanceEvent.ATTEMPT_SUCCESS:
+			return stepEvent((stepName) => ({
+				...common,
+				type: "attempt_completed",
+				stepName,
+				attempt: parseMetadata().attempt,
+			}));
+		case InstanceEvent.ATTEMPT_FAILURE: {
+			const metadata = parseMetadata();
+			return stepEvent((stepName) => ({
+				...common,
+				type: "attempt_errored",
+				stepName,
+				attempt: metadata.attempt,
+				error: metadata.error,
+				...(metadata.retryDelayMs === undefined
+					? {}
+					: { retryDelayMs: metadata.retryDelayMs }),
+			}));
+		}
+		case InstanceEvent.SLEEP_START:
+			return stepEvent((stepName) => ({
+				...common,
+				type: "sleep_started",
+				stepName,
+				durationMs: parseMetadata().durationMs,
+			}));
+		case InstanceEvent.SLEEP_COMPLETE:
+			return stepEvent((stepName) => ({
+				...common,
+				type: "sleep_completed",
+				stepName,
+			}));
+		case InstanceEvent.WAIT_START:
+			return stepEvent((stepName) => ({
+				...common,
+				type: "wait_started",
+				stepName,
+				eventType: parseMetadata().event,
+			}));
+		case InstanceEvent.WAIT_COMPLETE:
+			return stepEvent((stepName) => ({
+				...common,
+				type: "wait_completed",
+				stepName,
+			}));
+		case InstanceEvent.WAIT_TIMED_OUT:
+			return stepEvent((stepName) => ({
+				...common,
+				type: "wait_timed_out",
+				stepName,
+			}));
+		case InstanceEvent.ROLLBACK_START:
+			return { ...common, type: "rollback_started" };
+		case InstanceEvent.ROLLBACK_STEP_START: {
+			const config = await readStepConfig(storage, log.groupKey);
+			return stepEvent((stepName) => ({
+				...common,
+				type: "rollback_step_started",
+				stepName,
+				...(config === undefined ? {} : { config }),
+			}));
+		}
+		case InstanceEvent.ROLLBACK_STEP_SUCCESS:
+			return stepEvent((stepName) => ({
+				...common,
+				type: "rollback_step_completed",
+				stepName,
+			}));
+		case InstanceEvent.ROLLBACK_STEP_FAILURE:
+			return stepEvent((stepName) => ({
+				...common,
+				type: "rollback_step_errored",
+				stepName,
+				error: parseMetadata().error,
+			}));
+		case InstanceEvent.ROLLBACK_ATTEMPT_START:
+			return stepEvent((stepName) => ({
+				...common,
+				type: "rollback_attempt_started",
+				stepName,
+				attempt: parseMetadata().attempt,
+			}));
+		case InstanceEvent.ROLLBACK_ATTEMPT_SUCCESS:
+			return stepEvent((stepName) => ({
+				...common,
+				type: "rollback_attempt_completed",
+				stepName,
+				attempt: parseMetadata().attempt,
+			}));
+		case InstanceEvent.ROLLBACK_ATTEMPT_FAILURE: {
+			const metadata = parseMetadata();
+			return stepEvent((stepName) => ({
+				...common,
+				type: "rollback_attempt_errored",
+				stepName,
+				attempt: metadata.attempt,
+				error: metadata.error,
+				...(metadata.retryDelayMs === undefined
+					? {}
+					: { retryDelayMs: metadata.retryDelayMs }),
+			}));
+		}
+		case InstanceEvent.ROLLBACK_COMPLETE:
+			return { ...common, type: "rollback_completed" };
+		case InstanceEvent.ROLLBACK_FAILED:
+			return { ...common, type: "rollback_errored" };
+		case InstanceEvent.__INTERNAL_PROD:
+			return { ...common, type: "internal" };
+	}
 }
 
 export class Engine extends DurableObject<Env> {
@@ -174,6 +455,8 @@ export class Engine extends DurableObject<Env> {
 
 	// Not persisted: rollback fns are RPC stubs, dead across DO restarts.
 	rollbackRegistry: Map<string, RollbackRegistryEntry> = new Map();
+
+	subscribers = new Set<WorkflowSubscriptionState>();
 
 	constructor(state: DurableObjectState, env: Env) {
 		super(state, env);
@@ -238,6 +521,14 @@ export class Engine extends DurableObject<Env> {
 			target,
 			JSON.stringify(metadata, binaryReplacer)
 		);
+
+		for (const subscriber of this.subscribers) {
+			const waiter = subscriber.waiter;
+			if (waiter !== undefined) {
+				subscriber.waiter = undefined;
+				waiter.resolve();
+			}
+		}
 
 		// Wake any waiters if this is a terminal step event
 		if (group) {
@@ -346,6 +637,94 @@ export class Engine extends DurableObject<Env> {
 
 	readLogsFromStep(_cacheKey: string): RawInstanceLog[] {
 		return [];
+	}
+
+	async subscribe(
+		options?: WorkflowSubscriptionOptions
+	): Promise<WorkflowSubscriptionTarget> {
+		const { cursor, filter } = options ?? {};
+		const metadata =
+			await this.ctx.storage.get<InstanceMetadata>(INSTANCE_METADATA);
+		if (metadata === undefined) {
+			throw createWorkflowError(
+				"Instance does not exist",
+				"instance.not_found"
+			);
+		}
+
+		const state: WorkflowSubscriptionState = {
+			instanceId: metadata.instance.id,
+			params: metadata.event.payload,
+			lastEventId: cursor ?? -1,
+			filter: filter === undefined ? undefined : new Set(filter),
+			waiter: undefined,
+			closed: false,
+		};
+		const subscription = new WorkflowSubscriptionTarget(
+			() => this.nextWorkflowEvent(state),
+			() => {
+				state.closed = true;
+				this.subscribers.delete(state);
+				state.waiter?.resolve();
+				state.waiter = undefined;
+			}
+		);
+		this.subscribers.add(state);
+		return subscription;
+	}
+
+	private async nextWorkflowEvent(
+		state: WorkflowSubscriptionState
+	): Promise<IteratorResult<WorkflowSubscriptionEvent, undefined>> {
+		while (!state.closed) {
+			const row = this.ctx.storage.sql
+				.exec<RawInstanceLog>(
+					"SELECT id, timestamp, event, groupKey, target, metadata FROM states WHERE id > ? ORDER BY id ASC LIMIT 1",
+					state.lastEventId
+				)
+				.toArray()[0];
+
+			if (row === undefined) {
+				const hasTerminalEvent =
+					this.ctx.storage.sql
+						.exec<{ id: number }>(
+							"SELECT id FROM states WHERE id <= ? AND event IN (?, ?, ?) LIMIT 1",
+							state.lastEventId,
+							InstanceEvent.WORKFLOW_SUCCESS,
+							InstanceEvent.WORKFLOW_FAILURE,
+							InstanceEvent.WORKFLOW_TERMINATED
+						)
+						.toArray()[0] !== undefined;
+				if (hasTerminalEvent) {
+					state.closed = true;
+					return { done: true, value: undefined };
+				}
+
+				await new Promise<void>((resolve) => {
+					state.waiter = { resolve };
+				});
+				continue;
+			}
+
+			state.lastEventId = row.id;
+			const event = await buildWorkflowSubscriptionEvent(
+				this.ctx.storage,
+				row,
+				state.instanceId,
+				state.params
+			);
+			if (event.type === "internal") {
+				continue;
+			}
+			if (state.filter === undefined || state.filter.has(event.type)) {
+				return { done: false, value: event };
+			}
+			if (isTerminalEvent(event)) {
+				return { done: true, value: undefined };
+			}
+		}
+
+		return { done: true, value: undefined };
 	}
 
 	readLogs(): EngineLogs {
@@ -557,7 +936,45 @@ export class Engine extends DurableObject<Env> {
 		instanceId: string,
 		status: InstanceStatus
 	): Promise<void> {
+		const previousStatus =
+			await this.ctx.storage.get<InstanceStatus>(ENGINE_STATUS_KEY);
 		await this.ctx.storage.put(ENGINE_STATUS_KEY, status);
+
+		if (previousStatus !== status) {
+			switch (status) {
+				case InstanceStatus.Queued: {
+					// Creation writes WORKFLOW_QUEUED before the first status is stored.
+					const hasQueuedEvent =
+						this.ctx.storage.sql
+							.exec<{ id: number }>(
+								"SELECT id FROM states WHERE event = ? LIMIT 1",
+								InstanceEvent.WORKFLOW_QUEUED
+							)
+							.toArray()[0] !== undefined;
+					if (!(previousStatus === undefined && hasQueuedEvent)) {
+						this.writeLog(InstanceEvent.WORKFLOW_QUEUED, null, null, {});
+					}
+					break;
+				}
+				case InstanceStatus.Running:
+					this.writeLog(InstanceEvent.WORKFLOW_RUNNING, null, null, {});
+					break;
+				case InstanceStatus.Paused:
+					this.writeLog(InstanceEvent.WORKFLOW_PAUSED, null, null, {});
+					break;
+				case InstanceStatus.WaitingForPause:
+					this.writeLog(
+						InstanceEvent.WORKFLOW_WAITING_FOR_PAUSE,
+						null,
+						null,
+						{}
+					);
+					break;
+				case InstanceStatus.Waiting:
+					this.writeLog(InstanceEvent.WORKFLOW_WAITING, null, null, {});
+					break;
+			}
+		}
 
 		// check if anyone is waiting for this status
 		this.handleStatusWaiter(status);
@@ -1314,6 +1731,9 @@ export class Engine extends DurableObject<Env> {
 				event,
 				stubStep as unknown as WorkflowStep
 			);
+			await this.ctx.storage.put(WORKFLOW_OUTPUT_KEY, {
+				value: normalizeForStorage(result),
+			});
 			this.writeLog(InstanceEvent.WORKFLOW_SUCCESS, null, null, {
 				result,
 			});

--- a/packages/workflows-shared/src/instance.ts
+++ b/packages/workflows-shared/src/instance.ts
@@ -134,6 +134,11 @@ export const enum InstanceEvent {
 	ROLLBACK_STEP_FAILURE = 23,
 	ROLLBACK_COMPLETE = 24,
 	ROLLBACK_FAILED = 25,
+
+	WORKFLOW_RUNNING = 26,
+	WORKFLOW_PAUSED = 27,
+	WORKFLOW_WAITING_FOR_PAUSE = 28,
+	WORKFLOW_WAITING = 29,
 }
 
 export const enum InstanceTrigger {

--- a/packages/workflows-shared/src/lib/serialization.ts
+++ b/packages/workflows-shared/src/lib/serialization.ts
@@ -1,0 +1,96 @@
+type ViewConstructor = new (buffer: ArrayBufferLike) => ArrayBufferView;
+
+function buildCompactView(view: ArrayBufferView): ArrayBufferView {
+	const tightBuffer = view.buffer.slice(
+		view.byteOffset,
+		view.byteOffset + view.byteLength
+	);
+	return new (view.constructor as ViewConstructor)(tightBuffer);
+}
+
+/**
+ * Returns a copy of `value` that is safe to persist via Durable Object storage
+ * without dragging unrelated bytes along with typed-array views.
+ *
+ * Background: workerd's `v8::ValueSerializer` writes the entire backing
+ * `ArrayBuffer` for typed-array views, not just `byteLength` bytes. A view
+ * sliced from a much larger buffer (`crypto.getRandomValues`, `arr.slice(...)`,
+ * fetch-stream copies) blows up the wire size by a factor of
+ * (backing-size / view-size) and can hit `SQLITE_TOOBIG` at view sizes well
+ * below the documented 1MiB output limit (see issue #14101). Copying the
+ * view's bytes into a tight backing buffer before persistence brings local
+ * `wrangler dev` behaviour in line with production.
+ *
+ * The walk is recursive (cycle-safe via a `WeakMap`) so views nested inside
+ * objects, arrays, Maps, and Sets are also compacted. View types are preserved
+ * (`Uint8Array` stays `Uint8Array`, `Int16Array` stays `Int16Array`, etc.) so
+ * the persisted shape matches the live shape. Class instances and host objects
+ * (`Date`, `RegExp`, raw `ArrayBuffer`, streams, `Blob`, …) are passed through
+ * unchanged — recursing into them would either fail to reconstruct the
+ * original type or trigger their own structured-clone path.
+ *
+ * @param value The value to normalize for storage.
+ * @param seen Previously visited objects, used to preserve cycles.
+ * @returns A storage-safe copy of the value.
+ */
+export function normalizeForStorage(
+	value: unknown,
+	seen: WeakMap<object, unknown> = new WeakMap()
+): unknown {
+	if (value === null || typeof value !== "object") {
+		return value;
+	}
+
+	if (seen.has(value)) {
+		return seen.get(value);
+	}
+
+	if (ArrayBuffer.isView(value)) {
+		return buildCompactView(value);
+	}
+
+	if (Array.isArray(value)) {
+		const result: unknown[] = [];
+		seen.set(value, result);
+		for (const item of value) {
+			result.push(normalizeForStorage(item, seen));
+		}
+		return result;
+	}
+
+	if (value instanceof Map) {
+		const result = new Map<unknown, unknown>();
+		seen.set(value, result);
+		for (const [key, item] of value) {
+			result.set(
+				normalizeForStorage(key, seen),
+				normalizeForStorage(item, seen)
+			);
+		}
+		return result;
+	}
+
+	if (value instanceof Set) {
+		const result = new Set<unknown>();
+		seen.set(value, result);
+		for (const item of value) {
+			result.add(normalizeForStorage(item, seen));
+		}
+		return result;
+	}
+
+	const prototype = Object.getPrototypeOf(value);
+	if (prototype === Object.prototype || prototype === null) {
+		const result: Record<string, unknown> = {};
+		seen.set(value, result);
+		for (const key of Object.keys(value)) {
+			result[key] = normalizeForStorage(
+				(value as Record<string, unknown>)[key],
+				seen
+			);
+		}
+		return result;
+	}
+
+	return value;
+}

--- a/packages/workflows-shared/src/subscription.ts
+++ b/packages/workflows-shared/src/subscription.ts
@@ -1,0 +1,292 @@
+import { RpcTarget } from "cloudflare:workers";
+import { ms } from "itty-time";
+import { z } from "zod";
+import type { ResolvedStepConfig } from "./context";
+
+const WorkflowSubscriptionEventCommonSchema = z.object({
+	instanceId: z.string(),
+	eventId: z.number(),
+	timestamp: z.number(),
+});
+const StepDurationSchema = z.custom<ResolvedStepConfig["timeout"]>(
+	(value) =>
+		typeof value === "number" ||
+		(typeof value === "string" && !Number.isNaN(ms(value)))
+);
+const ResolvedStepDelaySchema = z.union([
+	StepDurationSchema,
+	z.literal("[dynamic]"),
+]);
+const ResolvedStepConfigSchema: z.ZodType<ResolvedStepConfig> = z.object({
+	retries: z.object({
+		limit: z.union([z.number(), z.literal(Infinity)]),
+		delay: ResolvedStepDelaySchema,
+		backoff: z.enum(["constant", "linear", "exponential"]).optional(),
+	}),
+	timeout: StepDurationSchema,
+	sensitive: z.literal("output").optional(),
+});
+
+/**
+ * Parses a resolved step config read from persisted local Workflow state.
+ *
+ * @param value Persisted value to parse.
+ * @returns The resolved config, or `undefined` when the value is invalid.
+ */
+export function parseResolvedStepConfig(value: unknown) {
+	const result = ResolvedStepConfigSchema.safeParse(value);
+	return result.success ? result.data : undefined;
+}
+const WorkflowSubscriptionEventSchema = z.discriminatedUnion("type", [
+	WorkflowSubscriptionEventCommonSchema.extend({
+		type: z.literal("workflow_queued"),
+	}),
+	WorkflowSubscriptionEventCommonSchema.extend({
+		type: z.literal("workflow_started"),
+		params: z.unknown().optional(),
+	}),
+	WorkflowSubscriptionEventCommonSchema.extend({
+		type: z.literal("workflow_running"),
+	}),
+	WorkflowSubscriptionEventCommonSchema.extend({
+		type: z.literal("workflow_paused"),
+	}),
+	WorkflowSubscriptionEventCommonSchema.extend({
+		type: z.literal("workflow_waiting_for_pause"),
+	}),
+	WorkflowSubscriptionEventCommonSchema.extend({
+		type: z.literal("workflow_waiting"),
+	}),
+	WorkflowSubscriptionEventCommonSchema.extend({
+		type: z.literal("workflow_completed"),
+		output: z.unknown().optional(),
+	}),
+	WorkflowSubscriptionEventCommonSchema.extend({
+		type: z.literal("workflow_errored"),
+		error: z.object({ name: z.string(), message: z.string() }),
+	}),
+	WorkflowSubscriptionEventCommonSchema.extend({
+		type: z.literal("workflow_terminated"),
+	}),
+	WorkflowSubscriptionEventCommonSchema.extend({
+		type: z.literal("step_started"),
+		stepName: z.string(),
+		config: ResolvedStepConfigSchema.optional(),
+	}),
+	WorkflowSubscriptionEventCommonSchema.extend({
+		type: z.literal("step_completed"),
+		stepName: z.string(),
+		output: z.unknown().optional(),
+	}),
+	WorkflowSubscriptionEventCommonSchema.extend({
+		type: z.literal("step_errored"),
+		stepName: z.string(),
+	}),
+	WorkflowSubscriptionEventCommonSchema.extend({
+		type: z.literal("attempt_started"),
+		stepName: z.string(),
+		attempt: z.number(),
+	}),
+	WorkflowSubscriptionEventCommonSchema.extend({
+		type: z.literal("attempt_completed"),
+		stepName: z.string(),
+		attempt: z.number(),
+	}),
+	WorkflowSubscriptionEventCommonSchema.extend({
+		type: z.literal("attempt_errored"),
+		stepName: z.string(),
+		attempt: z.number(),
+		retryDelayMs: z.number().optional(),
+		error: z.object({ name: z.string(), message: z.string() }),
+	}),
+	WorkflowSubscriptionEventCommonSchema.extend({
+		type: z.literal("sleep_started"),
+		stepName: z.string(),
+		durationMs: z.number(),
+	}),
+	WorkflowSubscriptionEventCommonSchema.extend({
+		type: z.literal("sleep_completed"),
+		stepName: z.string(),
+	}),
+	WorkflowSubscriptionEventCommonSchema.extend({
+		type: z.literal("wait_started"),
+		stepName: z.string(),
+		eventType: z.string(),
+	}),
+	WorkflowSubscriptionEventCommonSchema.extend({
+		type: z.literal("wait_completed"),
+		stepName: z.string(),
+	}),
+	WorkflowSubscriptionEventCommonSchema.extend({
+		type: z.literal("wait_timed_out"),
+		stepName: z.string(),
+	}),
+	WorkflowSubscriptionEventCommonSchema.extend({
+		type: z.literal("rollback_started"),
+	}),
+	WorkflowSubscriptionEventCommonSchema.extend({
+		type: z.literal("rollback_step_started"),
+		stepName: z.string(),
+		config: ResolvedStepConfigSchema.optional(),
+	}),
+	WorkflowSubscriptionEventCommonSchema.extend({
+		type: z.literal("rollback_step_completed"),
+		stepName: z.string(),
+	}),
+	WorkflowSubscriptionEventCommonSchema.extend({
+		type: z.literal("rollback_step_errored"),
+		stepName: z.string(),
+		error: z.object({ name: z.string(), message: z.string() }),
+	}),
+	WorkflowSubscriptionEventCommonSchema.extend({
+		type: z.literal("rollback_attempt_started"),
+		stepName: z.string(),
+		attempt: z.number(),
+	}),
+	WorkflowSubscriptionEventCommonSchema.extend({
+		type: z.literal("rollback_attempt_completed"),
+		stepName: z.string(),
+		attempt: z.number(),
+	}),
+	WorkflowSubscriptionEventCommonSchema.extend({
+		type: z.literal("rollback_attempt_errored"),
+		stepName: z.string(),
+		attempt: z.number(),
+		retryDelayMs: z.number().optional(),
+		error: z.object({ name: z.string(), message: z.string() }),
+	}),
+	WorkflowSubscriptionEventCommonSchema.extend({
+		type: z.literal("rollback_completed"),
+	}),
+	WorkflowSubscriptionEventCommonSchema.extend({
+		type: z.literal("rollback_errored"),
+	}),
+]);
+
+export type WorkflowSubscriptionEvent = z.infer<
+	typeof WorkflowSubscriptionEventSchema
+>;
+
+const workflowSubscriptionEventTypeNames = new Set(
+	WorkflowSubscriptionEventSchema.options.map(
+		(option) => option.shape.type.value
+	)
+);
+const WorkflowSubscriptionEventTypeSchema = z.custom<
+	WorkflowSubscriptionEvent["type"]
+>(
+	(value) =>
+		typeof value === "string" &&
+		workflowSubscriptionEventTypeNames.has(
+			value as WorkflowSubscriptionEvent["type"]
+		)
+);
+
+export type WorkflowSubscriptionOptions = {
+	cursor?: number;
+	filter?: WorkflowSubscriptionEvent["type"][];
+};
+
+const WORKFLOW_SUBSCRIPTION_OPTIONS_SCHEMA = z
+	.object({
+		cursor: z.number().int().nonnegative().optional(),
+		filter: z.array(WorkflowSubscriptionEventTypeSchema).optional(),
+	})
+	.strict();
+
+export function parseWorkflowSubscriptionOptions(options: unknown) {
+	if (options === undefined) {
+		return {} satisfies WorkflowSubscriptionOptions;
+	}
+
+	const parsed = WORKFLOW_SUBSCRIPTION_OPTIONS_SCHEMA.safeParse(options);
+	if (!parsed.success) {
+		throw new Error("Invalid Workflow subscription options");
+	}
+
+	return parsed.data satisfies WorkflowSubscriptionOptions;
+}
+
+export type WorkflowSubscriptionState = {
+	instanceId: string;
+	params: unknown;
+	lastEventId: number;
+	filter: ReadonlySet<WorkflowSubscriptionEvent["type"]> | undefined;
+	waiter: { resolve: () => void } | undefined;
+	closed: boolean;
+};
+
+export interface WorkflowSubscription extends Disposable {
+	next(): Promise<IteratorResult<WorkflowSubscriptionEvent, undefined>>;
+}
+
+export function isTerminalEvent(event: WorkflowSubscriptionEvent): boolean {
+	return (
+		event.type === "workflow_completed" ||
+		event.type === "workflow_errored" ||
+		event.type === "workflow_terminated"
+	);
+}
+
+export class WorkflowSubscriptionTarget
+	extends RpcTarget
+	implements WorkflowSubscription
+{
+	readonly #nextEvent: () => Promise<
+		IteratorResult<WorkflowSubscriptionEvent, undefined>
+	>;
+	readonly #onClose: () => void;
+	#nextRequest = Promise.resolve<unknown>(undefined);
+	#closed = false;
+
+	constructor(
+		nextEvent: () => Promise<
+			IteratorResult<WorkflowSubscriptionEvent, undefined>
+		>,
+		onClose: () => void
+	) {
+		super();
+		this.#nextEvent = nextEvent;
+		this.#onClose = onClose;
+	}
+
+	async next(): Promise<IteratorResult<WorkflowSubscriptionEvent, undefined>> {
+		if (this.#closed) {
+			return { done: true, value: undefined };
+		}
+
+		const request = this.#nextRequest.then(async () => {
+			if (this.#closed) {
+				return { done: true, value: undefined } as const;
+			}
+
+			try {
+				const result = await this.#nextEvent();
+				if (this.#closed) {
+					return { done: true, value: undefined } as const;
+				}
+				if (result.done || isTerminalEvent(result.value)) {
+					this.#finish();
+				}
+				return result;
+			} catch (error) {
+				this.#finish();
+				throw error;
+			}
+		});
+		this.#nextRequest = request;
+		return request;
+	}
+
+	[Symbol.dispose](): void {
+		this.#finish();
+	}
+
+	#finish(): void {
+		if (this.#closed) {
+			return;
+		}
+		this.#closed = true;
+		this.#onClose();
+	}
+}

--- a/packages/workflows-shared/tests/binding.test.ts
+++ b/packages/workflows-shared/tests/binding.test.ts
@@ -3,9 +3,14 @@ import { env } from "cloudflare:workers";
 import { describe, it, vi } from "vitest";
 import { InstanceEvent, InstanceStatus } from "../src";
 import { WorkflowBinding } from "../src/binding";
+import { WorkflowSubscriptionTarget } from "../src/subscription";
 import { setTestWorkflowCallback } from "./test-entry";
 import type { WorkflowHandle } from "../src/binding";
 import type { Engine, EngineLogs } from "../src/engine";
+import type {
+	WorkflowSubscription,
+	WorkflowSubscriptionEvent,
+} from "../src/subscription";
 import type { WorkflowEvent } from "cloudflare:workers";
 
 let instanceCounter = 0;
@@ -627,6 +632,715 @@ describe("WorkflowHandle", () => {
 			const status = await newInstance.status();
 
 			expect(status.status).toBe("terminated");
+		});
+	});
+
+	describe("subscribe()", () => {
+		it("finishes a pending next request when disposed", async ({ expect }) => {
+			const started = Promise.withResolvers<void>();
+			const pendingEvent =
+				Promise.withResolvers<
+					IteratorResult<WorkflowSubscriptionEvent, undefined>
+				>();
+			const onClose = vi.fn();
+			const subscription = new WorkflowSubscriptionTarget(async () => {
+				started.resolve();
+				return pendingEvent.promise;
+			}, onClose);
+
+			const result = subscription.next();
+			await started.promise;
+			subscription[Symbol.dispose]();
+			pendingEvent.resolve({
+				done: false,
+				value: {
+					type: "workflow_queued",
+					instanceId: "disposed-subscription",
+					eventId: 0,
+					timestamp: Date.now(),
+				},
+			});
+
+			expect(await result).toEqual({ done: true, value: undefined });
+			expect(onClose).toHaveBeenCalledOnce();
+		});
+
+		it("closes after returning a terminal event", async ({ expect }) => {
+			const onClose = vi.fn();
+			const terminalEvent = {
+				type: "workflow_completed",
+				instanceId: "completed-subscription",
+				eventId: 1,
+				timestamp: Date.now(),
+				output: "done",
+			} as const satisfies WorkflowSubscriptionEvent;
+			const subscription = new WorkflowSubscriptionTarget(
+				() =>
+					Promise.resolve({
+						done: false as const,
+						value: terminalEvent,
+					}),
+				onClose
+			);
+
+			expect(await subscription.next()).toEqual({
+				done: false,
+				value: terminalEvent,
+			});
+			expect(onClose).toHaveBeenCalledOnce();
+			expect(await subscription.next()).toEqual({
+				done: true,
+				value: undefined,
+			});
+		});
+
+		it("streams historical events in log order through a disposable RPC target", async ({
+			expect,
+		}) => {
+			const id = uniqueId();
+			const binding = createBinding();
+			const engineStub = env.ENGINE.get(env.ENGINE.idFromName(id));
+
+			setTestWorkflowCallback(async (_event, step) => {
+				await step.do(
+					"subscription step",
+					{
+						retries: {
+							limit: 3,
+							delay: () => "2 seconds",
+							backoff: "linear",
+						},
+						timeout: "30 seconds",
+					},
+					async () => "step output"
+				);
+				return "workflow output";
+			});
+
+			await binding.create({ id, params: { input: true } });
+			await waitUntilLogEvent(engineStub, InstanceEvent.WORKFLOW_SUCCESS);
+
+			const instance = (await binding.get(id)) as WorkflowHandle;
+			using subscription = await instance.subscribe();
+			const events: Array<{
+				eventId: number;
+				type: string;
+				[key: string]: unknown;
+			}> = [];
+			while (true) {
+				const result = await subscription.next();
+				if (result.done) {
+					break;
+				}
+				events.push(result.value);
+			}
+
+			expect(events.map(({ type }) => type)).toEqual([
+				"workflow_queued",
+				"workflow_started",
+				"workflow_running",
+				"step_started",
+				"attempt_started",
+				"attempt_completed",
+				"step_completed",
+				"workflow_completed",
+			]);
+			expect(events[2]).toMatchObject({
+				type: "workflow_running",
+			});
+			const firstEvent = events[0];
+			if (firstEvent === undefined) {
+				throw new Error("Expected subscription events");
+			}
+			expect(events.map(({ eventId }) => eventId)).toEqual(
+				Array.from(
+					{ length: events.length },
+					(_, index) => firstEvent.eventId + index
+				)
+			);
+			expect(events).toContainEqual(
+				expect.objectContaining({
+					type: "workflow_started",
+					params: { input: true },
+				})
+			);
+			expect(events).toContainEqual(
+				expect.objectContaining({
+					type: "step_started",
+					stepName: "subscription step-1",
+					config: {
+						retries: {
+							limit: 3,
+							delay: "[dynamic]",
+							backoff: "linear",
+						},
+						timeout: "30 seconds",
+					},
+				})
+			);
+			expect(events).toContainEqual(
+				expect.objectContaining({
+					type: "step_completed",
+					stepName: "subscription step-1",
+					output: "step output",
+				})
+			);
+			expect(events.at(-1)).toMatchObject({
+				type: "workflow_completed",
+				output: "workflow output",
+			});
+			expect(await subscription.next()).toEqual({
+				done: true,
+				value: undefined,
+			});
+		});
+
+		it("uses errored event names for Workflow and step failures", async ({
+			expect,
+		}) => {
+			const id = uniqueId();
+			const binding = createBinding();
+			const engineStub = env.ENGINE.get(env.ENGINE.idFromName(id));
+
+			setTestWorkflowCallback(async (_event, step) => {
+				await step.do(
+					"failing subscription step",
+					{ retries: { limit: 0, delay: 0 } },
+					async () => {
+						throw new Error("subscription failure");
+					}
+				);
+			});
+
+			await binding.create({ id });
+			await waitUntilLogEvent(engineStub, InstanceEvent.WORKFLOW_FAILURE);
+
+			const instance = (await binding.get(id)) as WorkflowHandle;
+			using subscription = await instance.subscribe();
+			const eventTypes: string[] = [];
+			while (true) {
+				const result = await subscription.next();
+				if (result.done) {
+					break;
+				}
+				eventTypes.push(result.value.type);
+			}
+
+			expect(eventTypes).toContain("attempt_errored");
+			expect(eventTypes).toContain("step_errored");
+			expect(eventTypes.at(-1)).toBe("workflow_errored");
+		});
+
+		it("includes the resolved rollback config in rollback step events", async ({
+			expect,
+		}) => {
+			const id = uniqueId();
+			const binding = createBinding();
+			const engineStub = env.ENGINE.get(env.ENGINE.idFromName(id));
+
+			setTestWorkflowCallback(async (_event, step) => {
+				// @ts-expect-error -- rollback options are not in workers-types yet
+				await step.do("rollback subscription step", async () => "step output", {
+					rollback: async () => {},
+					rollbackConfig: {
+						retries: {
+							limit: 0,
+							delay: "1 second",
+							backoff: "constant",
+						},
+						timeout: "30 seconds",
+					},
+				});
+				throw new Error("trigger rollback");
+			});
+
+			await binding.create({ id });
+			await waitUntilLogEvent(engineStub, InstanceEvent.ROLLBACK_COMPLETE);
+
+			const instance = (await binding.get(id)) as WorkflowHandle;
+			using subscription = await instance.subscribe({
+				filter: ["rollback_step_started", "workflow_errored"],
+			});
+			expect(await subscription.next()).toMatchObject({
+				done: false,
+				value: {
+					type: "rollback_step_started",
+					stepName: "rollback subscription step-1",
+					config: {
+						retries: {
+							limit: 0,
+							delay: "1 second",
+							backoff: "constant",
+						},
+						timeout: "30 seconds",
+					},
+				},
+			});
+		});
+
+		it("returns stored structured and streamed step outputs", async ({
+			expect,
+		}) => {
+			const id = uniqueId();
+			const binding = createBinding();
+			const engineStub = env.ENGINE.get(env.ENGINE.idFromName(id));
+
+			setTestWorkflowCallback(async (_event, step) => {
+				await step.do("structured output", async () => ({ total: 1n }));
+				const stream = await step.do("stream output", async () => {
+					return new ReadableStream<Uint8Array>({
+						start(controller) {
+							controller.enqueue(
+								new TextEncoder().encode("streamed step output")
+							);
+							controller.close();
+						},
+					});
+				});
+				await new Response(stream as ReadableStream<Uint8Array>).arrayBuffer();
+				await step.do(
+					"sensitive output",
+					{ sensitive: "output" },
+					async () => "secret"
+				);
+				await step.do("undefined output", async () => undefined);
+				await step.do("null output", async () => null);
+				return "done";
+			});
+
+			await binding.create({ id });
+			await waitUntilLogEvent(engineStub, InstanceEvent.WORKFLOW_SUCCESS);
+
+			const instance = (await binding.get(id)) as WorkflowHandle;
+			using subscription = await instance.subscribe({
+				filter: ["step_completed", "workflow_completed"],
+			});
+
+			const structuredResult = await subscription.next();
+			if (
+				structuredResult.done ||
+				structuredResult.value.type !== "step_completed"
+			) {
+				throw new Error("Expected a structured step output event");
+			}
+			const structuredEvent = structuredResult.value;
+			expect(structuredEvent).toMatchObject({
+				type: "step_completed",
+				stepName: "structured output-1",
+				output: { total: 1n },
+			});
+
+			const streamResult = await subscription.next();
+			if (streamResult.done || streamResult.value.type !== "step_completed") {
+				throw new Error("Expected a streamed step output event");
+			}
+			const streamEvent = streamResult.value;
+			expect(streamEvent).toMatchObject({
+				type: "step_completed",
+				stepName: "stream output-1",
+			});
+			expect(streamEvent.output).toBeInstanceOf(ReadableStream);
+			expect(
+				await new Response(
+					streamEvent.output as ReadableStream<Uint8Array>
+				).text()
+			).toBe("streamed step output");
+
+			expect(await subscription.next()).toMatchObject({
+				done: false,
+				value: {
+					type: "step_completed",
+					stepName: "sensitive output-1",
+					output: "[REDACTED]",
+				},
+			});
+			const undefinedResult = await subscription.next();
+			expect(undefinedResult).toMatchObject({
+				done: false,
+				value: {
+					type: "step_completed",
+					stepName: "undefined output-1",
+				},
+			});
+			if (!undefinedResult.done) {
+				expect("output" in undefinedResult.value).toBe(false);
+			}
+			expect(await subscription.next()).toMatchObject({
+				done: false,
+				value: {
+					type: "step_completed",
+					stepName: "null output-1",
+					output: null,
+				},
+			});
+			expect(await subscription.next()).toMatchObject({
+				done: false,
+				value: { type: "workflow_completed", output: "done" },
+			});
+		});
+
+		it("returns full structured workflow outputs while keeping logs JSON-safe", async ({
+			expect,
+		}) => {
+			const id = uniqueId();
+			const binding = createBinding();
+			const engineStub = env.ENGINE.get(env.ENGINE.idFromName(id));
+			const createWorkflowOutput = () => ({
+				count: 42n,
+				typedArray: new Uint16Array([1, 2]),
+				arrayBuffer: new Uint8Array([3, 4, 5]).buffer,
+				completedAt: new Date("2026-09-09T12:00:00.000Z"),
+				values: new Map([["nested", new Set([6n, 7n])]]),
+			});
+
+			setTestWorkflowCallback(async () => createWorkflowOutput());
+			await binding.create({ id });
+			await waitUntilLogEvent(engineStub, InstanceEvent.WORKFLOW_SUCCESS);
+
+			const instance = (await binding.get(id)) as WorkflowHandle;
+			using subscription = await instance.subscribe({
+				filter: ["workflow_completed"],
+			});
+			const result = await subscription.next();
+			if (result.done || result.value.type !== "workflow_completed") {
+				throw new Error("Expected a completed Workflow event");
+			}
+			expect(result.value.output).toEqual(createWorkflowOutput());
+
+			const logs = (await engineStub.readLogs()) as EngineLogs;
+			const completedLog = logs.logs.find(
+				(log) => log.event === InstanceEvent.WORKFLOW_SUCCESS
+			);
+			expect(completedLog?.metadata.result).toEqual({
+				count: "[BigInt(42)]",
+				typedArray: "[Uint16Array(4 bytes)]",
+				arrayBuffer: "[ArrayBuffer(3 bytes)]",
+				completedAt: "2026-09-09T12:00:00.000Z",
+				values: {},
+			});
+		});
+
+		it("rejects when a stored streamed step output is corrupt", async ({
+			expect,
+		}) => {
+			const id = uniqueId();
+			const binding = createBinding();
+			const engineStub = env.ENGINE.get(env.ENGINE.idFromName(id));
+
+			setTestWorkflowCallback(async (_event, step) => {
+				const stream = await step.do("stream output", async () => {
+					return new ReadableStream<Uint8Array>({
+						start(controller) {
+							controller.enqueue(new TextEncoder().encode("streamed output"));
+							controller.close();
+						},
+					});
+				});
+				await new Response(stream as ReadableStream<Uint8Array>).arrayBuffer();
+			});
+
+			await binding.create({ id });
+			await waitUntilLogEvent(engineStub, InstanceEvent.WORKFLOW_SUCCESS);
+			await runInDurableObject(engineStub, (_engine, state) => {
+				const step = state.storage.sql
+					.exec<{ groupKey: string }>(
+						"SELECT groupKey FROM states WHERE event = ? LIMIT 1",
+						InstanceEvent.STEP_SUCCESS
+					)
+					.one();
+				if (step === null) {
+					throw new Error("Expected a completed step");
+				}
+				state.storage.sql.exec(
+					"DELETE FROM streaming_step_chunks WHERE cache_key = ?",
+					step.groupKey
+				);
+			});
+
+			await runInDurableObject(engineStub, async (engine) => {
+				const subscription = await engine.subscribe({
+					filter: ["step_completed"],
+				});
+				await expect(subscription.next()).rejects.toThrow(
+					"Step has completed but its stored stream output is corrupt or incomplete"
+				);
+				expect(await subscription.next()).toEqual({
+					done: true,
+					value: undefined,
+				});
+			});
+		});
+
+		it("returns done when the cursor is at or after a terminal event", async ({
+			expect,
+		}) => {
+			const id = uniqueId();
+			const binding = createBinding();
+			const engineStub = env.ENGINE.get(env.ENGINE.idFromName(id));
+
+			setTestWorkflowCallback(async () => "done");
+			await binding.create({ id });
+			await waitUntilLogEvent(engineStub, InstanceEvent.WORKFLOW_SUCCESS);
+
+			const getEventId = async (event: InstanceEvent) => {
+				const logs = (await engineStub.readDetailedLogs()) as Array<{
+					id: number;
+					event: InstanceEvent;
+				}>;
+				const eventId = logs.find((log) => log.event === event)?.id;
+				if (eventId === undefined) {
+					throw new Error(`Expected Workflow event ${event}`);
+				}
+				return eventId;
+			};
+			const expectDoneAtCursor = async (cursor: number) => {
+				const instance = (await binding.get(id)) as WorkflowHandle;
+				using subscription = await instance.subscribe({ cursor });
+				const result = Promise.resolve(subscription.next());
+				await expect(
+					Promise.race([
+						result,
+						scheduler.wait(1000).then(() => "timed out" as const),
+					])
+				).resolves.toEqual({ done: true, value: undefined });
+			};
+
+			const terminalEventId = await getEventId(InstanceEvent.WORKFLOW_SUCCESS);
+			await expectDoneAtCursor(terminalEventId);
+
+			await runInDurableObject(engineStub, (engine) => {
+				engine.writeLog(InstanceEvent.__INTERNAL_PROD, null, null, {});
+			});
+			const laterInternalEventId = await getEventId(
+				InstanceEvent.__INTERNAL_PROD
+			);
+			await expectDoneAtCursor(laterInternalEventId);
+		});
+
+		it("waits for live events and applies cursor and filter options", async ({
+			expect,
+		}) => {
+			const id = uniqueId();
+			const binding = createBinding();
+			const engineStub = env.ENGINE.get(env.ENGINE.idFromName(id));
+
+			setTestWorkflowCallback(async (_event, step) => {
+				await step.waitForEvent("subscription wait", {
+					type: "continue",
+					timeout: "10 seconds",
+				});
+				return "done";
+			});
+
+			await binding.create({ id });
+			await waitUntilLogEvent(engineStub, InstanceEvent.WAIT_START);
+
+			const logs = (await engineStub.readDetailedLogs()) as Array<{
+				id: number;
+				event: InstanceEvent;
+			}>;
+			const startEventId = logs.find(
+				({ event }) => event === InstanceEvent.WORKFLOW_START
+			)?.id;
+			if (startEventId === undefined) {
+				throw new Error("Expected a workflow start event");
+			}
+
+			const instance = (await binding.get(id)) as WorkflowHandle;
+			using subscription = await instance.subscribe({
+				cursor: startEventId,
+				filter: ["workflow_queued", "wait_started", "workflow_completed"],
+			});
+			expect(await subscription.next()).toMatchObject({
+				done: false,
+				value: {
+					type: "wait_started",
+					stepName: "subscription wait-1",
+					eventType: "continue",
+				},
+			});
+
+			const terminalEvent = subscription.next();
+			await instance.sendEvent({ type: "continue", payload: null });
+			expect(await terminalEvent).toMatchObject({
+				done: false,
+				value: { type: "workflow_completed", output: "done" },
+			});
+			expect(await subscription.next()).toEqual({
+				done: true,
+				value: undefined,
+			});
+		});
+
+		it("streams explicit Workflow status events", async ({ expect }) => {
+			const id = uniqueId();
+			const binding = createBinding();
+			const engineStub = env.ENGINE.get(env.ENGINE.idFromName(id));
+
+			setTestWorkflowCallback(async (_event, step) => {
+				await step.waitForEvent("status subscription wait", {
+					type: "continue",
+					timeout: "10 seconds",
+				});
+				return "done";
+			});
+
+			await binding.create({ id });
+			await waitUntilLogEvent(engineStub, InstanceEvent.WAIT_START);
+
+			const instance = (await binding.get(id)) as WorkflowHandle;
+			using subscription = await instance.subscribe({
+				filter: [
+					"workflow_queued",
+					"workflow_running",
+					"workflow_waiting",
+					"workflow_waiting_for_pause",
+					"workflow_paused",
+					"workflow_completed",
+				],
+			});
+
+			expect(await subscription.next()).toMatchObject({
+				done: false,
+				value: { type: "workflow_queued" },
+			});
+			expect(await subscription.next()).toMatchObject({
+				done: false,
+				value: { type: "workflow_running" },
+			});
+
+			await engineStub.setStatus(0, id, InstanceStatus.Waiting);
+			expect(await subscription.next()).toMatchObject({
+				done: false,
+				value: { type: "workflow_waiting" },
+			});
+
+			await engineStub.setStatus(0, id, InstanceStatus.Queued);
+			expect(await subscription.next()).toMatchObject({
+				done: false,
+				value: { type: "workflow_queued" },
+			});
+			await engineStub.setStatus(0, id, InstanceStatus.Running);
+			expect(await subscription.next()).toMatchObject({
+				done: false,
+				value: { type: "workflow_running" },
+			});
+
+			await engineStub.setStatus(0, id, InstanceStatus.WaitingForPause);
+			expect(await subscription.next()).toMatchObject({
+				done: false,
+				value: { type: "workflow_waiting_for_pause" },
+			});
+			await engineStub.setStatus(0, id, InstanceStatus.Paused);
+			expect(await subscription.next()).toMatchObject({
+				done: false,
+				value: { type: "workflow_paused" },
+			});
+
+			await engineStub.setStatus(0, id, InstanceStatus.Running);
+			expect(await subscription.next()).toMatchObject({
+				done: false,
+				value: { type: "workflow_running" },
+			});
+			const terminalEvent = subscription.next();
+			await instance.sendEvent({ type: "continue", payload: null });
+			expect(await terminalEvent).toMatchObject({
+				done: false,
+				value: { type: "workflow_completed", output: "done" },
+			});
+			expect(await subscription.next()).toEqual({
+				done: true,
+				value: undefined,
+			});
+
+			const explicitStatusEventTypes = new Set<InstanceEvent>([
+				InstanceEvent.WORKFLOW_QUEUED,
+				InstanceEvent.WORKFLOW_RUNNING,
+				InstanceEvent.WORKFLOW_PAUSED,
+				InstanceEvent.WORKFLOW_WAITING_FOR_PAUSE,
+				InstanceEvent.WORKFLOW_WAITING,
+			]);
+			const statusEvents = (
+				(await engineStub.readDetailedLogs()) as Array<{
+					event: InstanceEvent;
+				}>
+			)
+				.filter(({ event }) => explicitStatusEventTypes.has(event))
+				.map(({ event }) => event);
+			expect(statusEvents).toEqual([
+				InstanceEvent.WORKFLOW_QUEUED,
+				InstanceEvent.WORKFLOW_RUNNING,
+				InstanceEvent.WORKFLOW_WAITING,
+				InstanceEvent.WORKFLOW_QUEUED,
+				InstanceEvent.WORKFLOW_RUNNING,
+				InstanceEvent.WORKFLOW_WAITING_FOR_PAUSE,
+				InstanceEvent.WORKFLOW_PAUSED,
+				InstanceEvent.WORKFLOW_RUNNING,
+			]);
+		});
+
+		it("rejects invalid subscription options", async ({ expect }) => {
+			const id = uniqueId();
+			const binding = createBinding();
+			const engineStub = env.ENGINE.get(env.ENGINE.idFromName(id));
+
+			setTestWorkflowCallback(async () => undefined);
+			await binding.create({ id });
+			await waitUntilLogEvent(engineStub, InstanceEvent.WORKFLOW_SUCCESS);
+
+			const instance = await binding.get(id);
+			const unsafeInstance = instance as unknown as {
+				subscribe(options: unknown): Promise<WorkflowSubscription>;
+			};
+			const invalidOptions: Array<[description: string, options: unknown]> = [
+				["null", null],
+				["an array", []],
+				["a negative cursor", { cursor: -1 }],
+				["a fractional cursor", { cursor: 1.5 }],
+				["an unsafe cursor", { cursor: Number.MAX_SAFE_INTEGER + 1 }],
+				["a non-array filter", { filter: "workflow_started" }],
+				["a non-string event filter", { filter: [42] }],
+				["an unknown event filter", { filter: ["does_not_exist"] }],
+				["the internal event filter", { filter: ["internal"] }],
+				["an unknown option", { unexpected: true }],
+			];
+
+			for (const [description, options] of invalidOptions) {
+				await expect(
+					unsafeInstance.subscribe(options),
+					description
+				).rejects.toThrow("Invalid Workflow subscription options");
+			}
+		});
+
+		it("streams a persisted termination event after the Engine aborts", async ({
+			expect,
+		}) => {
+			const id = uniqueId();
+			const binding = createBinding();
+			const engineStub = env.ENGINE.get(env.ENGINE.idFromName(id));
+
+			setTestWorkflowCallback(async (_event, step) => {
+				await step.waitForEvent("termination wait", {
+					type: "never",
+					timeout: "10 seconds",
+				});
+			});
+
+			await binding.create({ id });
+			await waitUntilLogEvent(engineStub, InstanceEvent.WAIT_START);
+			const instance = await binding.get(id);
+			await instance.terminate();
+
+			const terminatedInstance = (await binding.get(id)) as WorkflowHandle;
+			using subscription = await terminatedInstance.subscribe({
+				filter: ["workflow_terminated"],
+			});
+
+			expect(await subscription.next()).toMatchObject({
+				done: false,
+				value: { type: "workflow_terminated" },
+			});
 		});
 	});
 


### PR DESCRIPTION
This PR adds the new subscribe feature to the local development workflows engine.

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [x] Cloudflare docs PR(s): https://github.com/cloudflare/cloudflare-docs/pull/33361 <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [ ] Documentation not necessary because:

*A picture of a cute animal (not mandatory, but encouraged)*
<img width="384" height="512" alt="image" src="https://github.com/user-attachments/assets/e6ac0c3c-3c35-4168-bbc5-e46ea462e6f5" />
