### PR TITLE
fix(wrangler): tolerate missing KV access when deleting Workers

### DIFF
--- a/.changeset/fuzzy-waves-delete.md
+++ b/.changeset/fuzzy-waves-delete.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Allow `wrangler delete` to succeed without Workers KV permissions
+
+Deleting a Worker no longer reports a failure when the API token cannot perform optional cleanup of legacy Workers Sites KV namespaces. Wrangler instead warns that the legacy asset namespaces were not removed.

--- a/packages/wrangler/src/__tests__/delete.test.ts
+++ b/packages/wrangler/src/__tests__/delete.test.ts
@@ -224,6 +224,35 @@ describe("delete", () => {
 		`);
 	});
 
+	it("should succeed when the API token cannot clean up legacy Workers Sites namespaces", async ({
+		expect,
+	}) => {
+		msw.use(
+			http.get(
+				"*/accounts/:accountId/storage/kv/namespaces",
+				() =>
+					HttpResponse.json(
+						{
+							success: false,
+							errors: [{ code: 10000, message: "Authentication error" }],
+							messages: [],
+							result: null,
+						},
+						{ status: 403 }
+					),
+				{ once: true }
+			)
+		);
+		mockDeleteWorkerRequest(expect, { name: "my-script", force: true });
+
+		await runWrangler("delete --name my-script --force");
+
+		expect(std.out).toContain("Successfully deleted my-script");
+		expect(std.warn).toContain(
+			"The Worker was deleted, but Wrangler could not clean up legacy Workers Sites asset namespaces because the API token does not have Workers KV permissions."
+		);
+	});
+
 	it("should delete a site namespace associated with a worker, including it's preview namespace", async ({
 		expect,
 	}) => {

--- a/packages/wrangler/src/delete.ts
+++ b/packages/wrangler/src/delete.ts
@@ -2,6 +2,7 @@ import assert from "node:assert";
 import { configFileName, UserError } from "@cloudflare/workers-utils";
 import { fetchResult } from "./cfetch";
 import { createCommand } from "./core/create-command";
+import { isAuthenticationError } from "./core/handle-errors";
 import { confirm } from "./dialogs";
 import { deleteKVNamespace, listKVNamespaces } from "./kv/helpers";
 import { logger } from "./logger";
@@ -154,7 +155,16 @@ export const deleteCommand = createCommand({
 				new URLSearchParams({ force: needsForceDelete.toString() })
 			);
 
-			await deleteSiteNamespaceIfExisting(config, scriptName, accountId);
+			try {
+				await deleteSiteNamespaceIfExisting(config, scriptName, accountId);
+			} catch (error) {
+				if (!isAuthenticationError(error)) {
+					throw error;
+				}
+				logger.warn(
+					"The Worker was deleted, but Wrangler could not clean up legacy Workers Sites asset namespaces because the API token does not have Workers KV permissions."
+				);
+			}
 
 			logger.log("Successfully deleted", scriptName);
 		}


### PR DESCRIPTION
## Summary

- allow Worker deletion to complete when optional legacy Workers Sites KV cleanup is unauthorized
- warn that legacy asset namespaces were not removed
- continue surfacing non-authentication cleanup failures

## Testing

- [x] Tests included/updated
- `pnpm vitest run src/__tests__/delete.test.ts` (15 tests)
- `pnpm --filter wrangler check:type`
- `pnpm exec oxfmt --check packages/wrangler/src/delete.ts packages/wrangler/src/__tests__/delete.test.ts .changeset/fuzzy-waves-delete.md`

## Documentation

- [x] Documentation not necessary because: this changes CLI error handling only and includes a release changeset.