### PR TITLE
[deploy-helpers] join route lists before printing them in deploy messages

### DIFF
--- a/.changeset/route-messages-join.md
+++ b/.changeset/route-messages-join.md
@@ -1,0 +1,7 @@
+---
+"@cloudflare/deploy-helpers": patch
+---
+
+Join route lists before printing them in deploy messages
+
+The "already assigned to routes" error and the "Previously deployed routes" warning interpolated an array of routes straight into a template literal, so with more than one route the output picked up the commas that `Array.prototype.toString` inserts between elements. Both sites now join the mapped lines before printing.

--- a/packages/deploy-helpers/src/triggers/deploy.ts
+++ b/packages/deploy-helpers/src/triggers/deploy.ts
@@ -161,9 +161,9 @@ export async function triggersDeploy(
 
 			for (const worker in routesWithOtherBindings) {
 				const assignedRoutes = routesWithOtherBindings[worker];
-				errorMessage += `"${worker}" is already assigned to routes:\n${assignedRoutes.map(
-					(r) => `  - ${chalk.underline(r)}\n`
-				)}`;
+				errorMessage += `"${worker}" is already assigned to routes:\n${assignedRoutes
+					.map((r) => `  - ${chalk.underline(r)}\n`)
+					.join("")}`;
 			}
 
 			const resolution =

--- a/packages/deploy-helpers/src/triggers/publish-routes.ts
+++ b/packages/deploy-helpers/src/triggers/publish-routes.ts
@@ -242,7 +242,9 @@ async function publishRoutesFallback(
 		logger.warn(
 			"Previously deployed routes:\n" +
 				"The following routes were already associated with this worker, and have not been deleted:\n" +
-				[...alreadyDeployedRoutes.values()].map((route) => ` - "${route}"\n`) +
+				[...alreadyDeployedRoutes.values()]
+					.map((route) => ` - "${route}"\n`)
+					.join("") +
 				"If these routes are not wanted then you can remove them in the dashboard."
 		);
 	}

--- a/packages/wrangler/src/__tests__/deploy/routes.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/routes.test.ts
@@ -439,6 +439,68 @@ describe("deploy", () => {
 			`);
 		});
 
+		it("should list every conflicting route when routes are assigned to another worker", async ({
+			expect,
+		}) => {
+			writeWranglerConfig({
+				routes: ["example.com/route-one/*", "example.com/route-two/*"],
+			});
+			writeWorkerSource();
+			mockUpdateWorkerSubdomain({ enabled: false });
+			mockUploadWorkerRequest({ expectedType: "esm" });
+			mockGetZones(expect, "example.com", [{ id: "example-com-id" }]);
+			mockGetZoneWorkerRoutes(expect, "example-com-id", [
+				// Simulate both routes already being assigned to another worker.
+				{ pattern: "example.com/route-one/*", script: "other-worker" },
+				{ pattern: "example.com/route-two/*", script: "other-worker" },
+			]);
+			await expect(runWrangler("deploy ./index")).rejects
+				.toThrowErrorMatchingInlineSnapshot(`
+				[Error: Can't deploy routes that are assigned to another worker.
+				"other-worker" is already assigned to routes:
+				  - example.com/route-one/*
+				  - example.com/route-two/*
+
+				Unassign other workers from the routes you want to deploy to, and then try again.
+				Visit https://dash.cloudflare.com/some-account-id/workers/overview to unassign a worker from a route.]
+			`);
+		});
+
+		it("should list every previously deployed route in the fallback warning", async ({
+			expect,
+		}) => {
+			writeWranglerConfig({
+				routes: ["example.com/some-route/*"],
+			});
+			writeWorkerSource();
+			mockUpdateWorkerSubdomain({ enabled: false });
+			mockUploadWorkerRequest({ expectedType: "esm" });
+			mockGetZones(expect, "example.com", [{ id: "example-com-id" }]);
+			mockGetZoneWorkerRoutes(expect, "example-com-id", [
+				// Simulate that the worker has already been deployed to two other routes.
+				{ pattern: "foo.example.com/other-route", script: "test-name" },
+				{ pattern: "bar.example.com/other-route", script: "test-name" },
+			]);
+			// Simulate the bulk-routes API failing with a not authorized error.
+			mockUnauthorizedPublishRoutesRequest();
+			mockPublishRoutesFallbackRequest({
+				pattern: "example.com/some-route/*",
+				script: "test-name",
+			});
+			await runWrangler("deploy ./index");
+
+			expect(std.warn).toMatchInlineSnapshot(`
+				"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mPreviously deployed routes:[0m
+
+				  The following routes were already associated with this worker, and have not been deleted:
+				   - "foo.example.com/other-route"
+				   - "bar.example.com/other-route"
+				  If these routes are not wanted then you can remove them in the dashboard.
+
+				"
+			`);
+		});
+
 		describe("custom domains", () => {
 			it("should deploy routes marked with 'custom_domain' as separate custom domains", async ({
 				expect,


### PR DESCRIPTION
Two deploy messages interpolate an array of routes directly into a string, so `Array.prototype.toString` inserts commas between the mapped lines. With more than one route the output is:

```
"other-worker" is already assigned to routes:
  - example.com/route-one/*
,  - example.com/route-two/*
```

Affected:

- `packages/deploy-helpers/src/triggers/deploy.ts`, the "Can't deploy routes that are assigned to another worker" error.
- `packages/deploy-helpers/src/triggers/publish-routes.ts`, the "Previously deployed routes" warning on the zone based fallback path.

The existing tests only ever used a single route in these lists, and a one element array stringifies without a separator, which is why this was not caught.

This change joins the mapped lines at both sites. With the sources reverted and `@cloudflare/deploy-helpers` rebuilt, the two new tests fail on the comma lines; with the change `routes.test.ts` passes in full (33 passed, 1 todo).

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: this only corrects the formatting of an existing CLI message. No documented behaviour, flag or config option changes.

> [!NOTE]
> This is a contribution from an AI agent: Claude Code, Claude Opus.
