### PR TITLE
[ci] Report package size changes on pull requests

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -51,6 +51,12 @@ Workflow changes should avoid unsuppressed `zizmor` findings. In particular:
   - Runs the E2E tests for the Vite plugin.
   - Cloudflare API credentials are only passed on Version Packages PRs (`changeset-release/main`), in the merge queue, or when the `ci:run-remote-tests` label is applied. Other PRs run the E2E suite without remote tests.
 
+### Package size reporting (package-size.yml + package-size-report.yml)
+
+- Triggers on non-markdown pull request updates.
+- Builds the exact synthetic pull request merge commit and its first parent, then reports deterministic raw and gzip sizes for selected published packages.
+- Uses a split security model: the package build has read-only permissions, while the privileged default-branch reporter size-limits and validates the data artifact against trusted workflow, pull request, and merge-parent metadata before updating one sticky comment.
+
 ## Deploy Pages Previews (deploy-pages-preview.yml)
 
 - Triggers

--- a/.github/workflows/package-size-report.yml
+++ b/.github/workflows/package-size-report.yml
@@ -1,0 +1,108 @@
+name: Package Size Report
+
+# This privileged companion runs from the default branch and never checks out or
+# executes pull request code. It accepts only one size-capped artifact, validates
+# its complete schema, and binds it to trusted workflow and GitHub API metadata
+# before allowing fixed-format Markdown to reach a write-capable action.
+on:
+  workflow_run: # zizmor: ignore[dangerous-triggers] artifact data is strictly validated and no PR code executes with the write token
+    workflows: ["Package Size"]
+    types: [completed]
+
+permissions: {}
+
+concurrency:
+  group: package-size-report-${{ github.event.workflow_run.head_repository.id }}-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: true
+
+jobs:
+  report:
+    name: Update package size comment
+    if: github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.pull_requests[0]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      actions: read
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Check out the trusted reporter
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Select the package size artifact
+        id: artifact
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPOSITORY: ${{ github.repository }}
+          WORKFLOW_RUN_ID: ${{ github.event.workflow_run.id }}
+        run: |
+          artifacts=$(gh api --paginate --slurp \
+            "repos/$REPOSITORY/actions/runs/$WORKFLOW_RUN_ID/artifacts?per_page=100")
+          count=$(jq '[.[].artifacts[] | select(.name == "package-size-report")] | length' <<< "$artifacts")
+          if [ "$count" -ne 1 ]; then
+            echo "Expected exactly one package-size-report artifact, found $count" >&2
+            exit 1
+          fi
+          artifact_id=$(jq -r '.[].artifacts[] | select(.name == "package-size-report") | .id' <<< "$artifacts")
+          artifact_size=$(jq -r '.[].artifacts[] | select(.name == "package-size-report") | .size_in_bytes' <<< "$artifacts")
+          if ! [[ "$artifact_id" =~ ^[1-9][0-9]*$ ]] || \
+             ! [[ "$artifact_size" =~ ^[0-9]+$ ]] || \
+             [ "$artifact_size" -gt 5000000 ]; then
+            echo "Package size artifact metadata is invalid or exceeds 5 MB" >&2
+            exit 1
+          fi
+          printf 'id=%s\n' "$artifact_id" >> "$GITHUB_OUTPUT"
+
+      - name: Download the package size artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          artifact-ids: ${{ steps.artifact.outputs.id }}
+          run-id: ${{ github.event.workflow_run.id }}
+          path: ${{ runner.temp }}/package-size-artifact
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          merge-multiple: true
+
+      - name: Validate the artifact file
+        run: |
+          report="$RUNNER_TEMP/package-size-artifact/package-size-report.json"
+          mapfile -d '' entries < <(find "$RUNNER_TEMP/package-size-artifact" -mindepth 1 -print0)
+          if [ "${#entries[@]}" -ne 1 ] || \
+             [ "${entries[0]}" != "$report" ] || \
+             [ ! -f "$report" ] || [ -L "$report" ]; then
+            echo "Artifact must contain only package-size-report.json" >&2
+            exit 1
+          fi
+          report_size=$(wc -c < "$report")
+          if [ "$report_size" -eq 0 ] || [ "$report_size" -gt 5000000 ]; then
+            echo "Uncompressed package size report is empty or exceeds 5 MB" >&2
+            exit 1
+          fi
+
+      - name: Fetch trusted pull request and commit metadata
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PULL_REQUEST: ${{ github.event.workflow_run.pull_requests[0].number }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          gh api "repos/$REPOSITORY/pulls/$PULL_REQUEST" > "$RUNNER_TEMP/package-size-pr.json"
+          CANDIDATE_SHA=$(jq -er '.merge_commit_sha | select(test("^[0-9a-f]{40}$"))' "$RUNNER_TEMP/package-size-pr.json")
+          gh api "repos/$REPOSITORY/commits/$CANDIDATE_SHA" > "$RUNNER_TEMP/package-size-commit.json"
+
+      - name: Bind report to the workflow run and render it
+        run: |
+          node tools/package-size/index.mjs report \
+            --input "$RUNNER_TEMP/package-size-artifact/package-size-report.json" \
+            --event "$GITHUB_EVENT_PATH" \
+            --pull-request-json "$RUNNER_TEMP/package-size-pr.json" \
+            --candidate-commit-json "$RUNNER_TEMP/package-size-commit.json" \
+            --output "$RUNNER_TEMP/package-size-comment.md"
+          cat "$RUNNER_TEMP/package-size-comment.md" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Update the package size comment
+        uses: marocchino/sticky-pull-request-comment@d4d6b0936434b21bc8345ad45a440c5f7d2c40ff # v3.0.3
+        with:
+          number: ${{ github.event.workflow_run.pull_requests[0].number }}
+          header: package-size-report
+          path: ${{ runner.temp }}/package-size-comment.md

--- a/.github/workflows/package-size.yml
+++ b/.github/workflows/package-size.yml
@@ -1,0 +1,108 @@
+name: Package Size
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+    # Intentionally skip markdown-only changes as this is an informational signal.
+    paths-ignore:
+      - "**/*.md"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: package-size-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  measure:
+    name: Measure published packages
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    env:
+      SOURCEMAPS: "false"
+    steps:
+      - name: Check out the exact PR merge commit
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 2
+          persist-credentials: false
+
+      - name: Validate merge commit and record revisions
+        id: revisions
+        env:
+          EXPECTED_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          EXPECTED_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          EXPECTED_MERGE_SHA: ${{ github.sha }}
+        run: |
+          read -ra parents <<< "$(git rev-list --parents -n 1 HEAD)"
+          if [ "${#parents[@]}" -ne 3 ]; then
+            echo "Expected GitHub's synthetic two-parent PR merge commit" >&2
+            exit 1
+          fi
+          if [ "${parents[0]}" != "$EXPECTED_MERGE_SHA" ] || \
+             [ "${parents[1]}" != "$EXPECTED_BASE_SHA" ] || \
+             [ "${parents[2]}" != "$EXPECTED_HEAD_SHA" ]; then
+            echo "The checked-out merge commit does not match the PR event" >&2
+            exit 1
+          fi
+          printf 'candidate=%s\nbaseline=%s\n' "${parents[0]}" "${parents[1]}" >> "$GITHUB_OUTPUT"
+
+      - name: Install candidate dependencies
+        uses: ./.github/actions/install-dependencies
+
+      # Some generated files contain their absolute build path. Reusing one path
+      # for both revisions prevents checkout location from becoming a size delta.
+      - name: Build and measure the baseline
+        env:
+          BASELINE_SHA: ${{ steps.revisions.outputs.baseline }}
+          CI_OS: ${{ runner.os }}
+          NODE_ENV: production
+        run: |
+          git worktree add --detach "$RUNNER_TEMP/package-size-build" "$BASELINE_SHA"
+          pnpm --dir "$RUNNER_TEMP/package-size-build" install --frozen-lockfile
+          node tools/package-size/index.mjs build \
+            --workspace "$RUNNER_TEMP/package-size-build" \
+            --cache-dir "$RUNNER_TEMP/package-size-turbo-cache"
+          node tools/package-size/index.mjs measure \
+            --workspace "$RUNNER_TEMP/package-size-build" \
+            --output "$RUNNER_TEMP/package-size-baseline.json"
+
+      - name: Build and measure the candidate
+        env:
+          CANDIDATE_SHA: ${{ steps.revisions.outputs.candidate }}
+          CI_OS: ${{ runner.os }}
+          NODE_ENV: production
+        run: |
+          git worktree remove "$RUNNER_TEMP/package-size-build"
+          git worktree add --detach "$RUNNER_TEMP/package-size-build" "$CANDIDATE_SHA"
+          pnpm --dir "$RUNNER_TEMP/package-size-build" install --frozen-lockfile
+          node tools/package-size/index.mjs build \
+            --workspace "$RUNNER_TEMP/package-size-build" \
+            --cache-dir "$RUNNER_TEMP/package-size-turbo-cache"
+          node tools/package-size/index.mjs measure \
+            --workspace "$RUNNER_TEMP/package-size-build" \
+            --output "$RUNNER_TEMP/package-size-candidate.json"
+
+      - name: Create package size report
+        env:
+          BASELINE_SHA: ${{ steps.revisions.outputs.baseline }}
+          CANDIDATE_SHA: ${{ steps.revisions.outputs.candidate }}
+        run: |
+          node tools/package-size/index.mjs combine \
+            --baseline "$RUNNER_TEMP/package-size-baseline.json" \
+            --candidate "$RUNNER_TEMP/package-size-candidate.json" \
+            --candidate-sha "$CANDIDATE_SHA" \
+            --baseline-sha "$BASELINE_SHA" \
+            --output package-size-report.json
+          node tools/package-size/index.mjs summary \
+            --input package-size-report.json >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload package size report
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: package-size-report
+          path: package-size-report.json
+          if-no-files-found: error
+          retention-days: 14

--- a/tools/package-size/__tests__/index.test.ts
+++ b/tools/package-size/__tests__/index.test.ts
@@ -1,0 +1,78 @@
+import { describe, test } from "vitest";
+import config from "../config.json";
+import { bindReport, fileSize, render, validate } from "../index.mjs";
+
+function makeReport() {
+	const packages = config.packages.map(({ name }) => ({
+		name,
+		baseline: { name, raw: 3, gzip: 23 },
+		candidate: { name, raw: 4, gzip: 24 },
+	}));
+	return {
+		schemaVersion: 1,
+		candidateSha: "a".repeat(40),
+		baselineSha: "b".repeat(40),
+		packages,
+	};
+}
+
+type Report = ReturnType<typeof makeReport>;
+
+function event() {
+	return {
+		repository: { full_name: "cloudflare/workers-sdk" },
+		workflow_run: {
+			head_sha: "c".repeat(40),
+			head_branch: "sizes",
+			head_repository: { full_name: "contributor/workers-sdk" },
+			pull_requests: [{ number: 99 }],
+		},
+	};
+}
+
+function pullRequest(report: Report) {
+	return {
+		number: 99,
+		merge_commit_sha: report.candidateSha,
+		head: {
+			sha: "c".repeat(40),
+			ref: "sizes",
+			repo: { full_name: "contributor/workers-sdk" },
+		},
+		base: { repo: { full_name: "cloudflare/workers-sdk" } },
+	};
+}
+
+function candidateCommit(report: Report) {
+	return {
+		sha: report.candidateSha,
+		parents: [{ sha: report.baselineSha }, { sha: "c".repeat(40) }],
+	};
+}
+
+describe("package size report", () => {
+	test("normalizes manifest key order", ({ expect }) => {
+		expect(fileSize("package.json", Buffer.from('{"a":1,"b":2}'))).toEqual(
+			fileSize("package.json", Buffer.from('{"b":2,"a":1}'))
+		);
+	});
+
+	test("validates and renders deltas", ({ expect }) => {
+		expect(render(validate(makeReport()))).toContain(
+			"| wrangler | Raw | 3 B | 4 B | +1 B (+33.3%) |\n" +
+				"|  | Gzip | 23 B | 24 B | +1 B (+4.3%) |"
+		);
+	});
+
+	test("binds the artifact to the run, PR, and merge parents", ({ expect }) => {
+		const report = validate(makeReport());
+		expect(() =>
+			bindReport(report, event(), pullRequest(report), candidateCommit(report))
+		).not.toThrow();
+		const bad = pullRequest(report);
+		bad.number = 100;
+		expect(() =>
+			bindReport(report, event(), bad, candidateCommit(report))
+		).toThrow("merge ref");
+	});
+});

--- a/tools/package-size/config.json
+++ b/tools/package-size/config.json
@@ -1,0 +1,16 @@
+{
+	"packages": [
+		{
+			"name": "wrangler",
+			"directory": "packages/wrangler"
+		},
+		{
+			"name": "miniflare",
+			"directory": "packages/miniflare"
+		},
+		{
+			"name": "@cloudflare/vite-plugin",
+			"directory": "packages/vite-plugin-cloudflare"
+		}
+	]
+}

--- a/tools/package-size/index.mjs
+++ b/tools/package-size/index.mjs
@@ -1,0 +1,329 @@
+import { execFileSync } from "node:child_process";
+import {
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	statSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { gzipSync } from "node:zlib";
+
+const PACKAGES = JSON.parse(
+	readFileSync(resolve(dirname(fileURLToPath(import.meta.url)), "config.json"))
+).packages;
+const SHA = /^[0-9a-f]{40}$/;
+
+/** Measures the publishable bytes selected by `pnpm pack`. */
+export function measure(workspace) {
+	return PACKAGES.map((pkg) => {
+		const temporaryDirectory = mkdtempSync(resolve(tmpdir(), "package-size-"));
+		try {
+			const packed = JSON.parse(
+				execFileSync(
+					"pnpm",
+					["pack", "--json", "--pack-destination", temporaryDirectory],
+					{
+						cwd: resolve(workspace, pkg.directory),
+						encoding: "utf8",
+						stdio: ["ignore", "pipe", "inherit"],
+					}
+				)
+			);
+			if (
+				packed.name !== pkg.name ||
+				typeof packed.filename !== "string" ||
+				!Array.isArray(packed.files) ||
+				packed.files.length === 0 ||
+				packed.files.length > 20_000
+			) {
+				throw new Error(`Invalid pnpm pack output for ${pkg.name}`);
+			}
+			const tarball = resolve(packed.filename);
+			if (
+				dirname(tarball) !== temporaryDirectory ||
+				!statSync(tarball).isFile()
+			) {
+				throw new Error("pnpm pack wrote outside its temporary directory");
+			}
+			const extractionDirectory = resolve(temporaryDirectory, "extracted");
+			mkdirSync(extractionDirectory);
+			// This extraction runs only in the read-only pull request job.
+			execFileSync(
+				"tar",
+				[
+					"-xzf",
+					tarball,
+					"-C",
+					extractionDirectory,
+					"--no-same-owner",
+					"--no-same-permissions",
+				],
+				{ stdio: "inherit" }
+			);
+			const packageRoot = resolve(extractionDirectory, "package");
+			let raw = 0;
+			let gzip = 0;
+			for (const entry of packed.files) {
+				const path = assertObject(entry, "Packed file").path;
+				if (
+					typeof path !== "string" ||
+					path.startsWith("/") ||
+					path.split("/").includes("..") ||
+					path.includes("\\")
+				) {
+					throw new Error("Invalid packed file path");
+				}
+				const content = readFileSync(resolve(packageRoot, path));
+				const size = fileSize(path, content);
+				raw += size.raw;
+				gzip += size.gzip;
+			}
+			return { name: pkg.name, raw, gzip };
+		} finally {
+			// eslint-disable-next-line workers-sdk/no-direct-recursive-rm -- standalone CI utility cannot import unbuilt workspace helpers
+			rmSync(temporaryDirectory, { recursive: true, force: true });
+		}
+	});
+}
+
+/** Makes package manifest sizes stable despite nondeterministic key ordering. */
+export function fileSize(path, content) {
+	const input =
+		path === "package.json"
+			? Buffer.from(
+					`${JSON.stringify(sortJson(JSON.parse(content.toString("utf8"))), undefined, 2)}\n`
+				)
+			: content;
+	return { raw: input.length, gzip: gzipSync(input, { level: 9 }).length };
+}
+
+function sortJson(value) {
+	if (Array.isArray(value)) return value.map(sortJson);
+	if (typeof value !== "object" || value === null) return value;
+	return Object.fromEntries(
+		Object.entries(value)
+			.sort(([a], [b]) => a.localeCompare(b, "en"))
+			.map(([key, child]) => [key, sortJson(child)])
+	);
+}
+
+/** Validates every artifact field consumed by the privileged reporter. */
+export function validate(input) {
+	const report = assertObject(input, "Report");
+	if (
+		report.schemaVersion !== 1 ||
+		typeof report.candidateSha !== "string" ||
+		!SHA.test(report.candidateSha) ||
+		typeof report.baselineSha !== "string" ||
+		!SHA.test(report.baselineSha) ||
+		!Array.isArray(report.packages) ||
+		report.packages.length !== PACKAGES.length
+	) {
+		throw new Error("Invalid report metadata");
+	}
+	return {
+		schemaVersion: 1,
+		candidateSha: report.candidateSha,
+		baselineSha: report.baselineSha,
+		packages: report.packages.map((inputPackage, index) => {
+			const comparison = assertObject(inputPackage, "Package comparison");
+			const name = PACKAGES[index]?.name;
+			if (name === undefined || comparison.name !== name) {
+				throw new Error("Unexpected package name or order");
+			}
+			return {
+				name,
+				baseline: measurement(comparison.baseline, name),
+				candidate: measurement(comparison.candidate, name),
+			};
+		}),
+	};
+}
+
+function measurement(input, name) {
+	const value = assertObject(input, "Measurement");
+	if (value.name !== name || !byteCount(value.raw) || !byteCount(value.gzip)) {
+		throw new Error(`Invalid ${name} measurement`);
+	}
+	return { name, raw: value.raw, gzip: value.gzip };
+}
+
+/** Binds untrusted artifact data to trusted workflow and GitHub API data. */
+export function bindReport(report, event, pullRequest, candidateCommit) {
+	const workflowEvent = assertObject(event, "Event");
+	const repository = assertObject(workflowEvent.repository, "Repository");
+	const run = assertObject(workflowEvent.workflow_run, "Workflow run");
+	if (!Array.isArray(run.pull_requests) || run.pull_requests.length === 0) {
+		throw new Error("Workflow run has no pull request");
+	}
+	const workflowPull = assertObject(run.pull_requests[0], "Workflow PR");
+	const pull = assertObject(pullRequest, "Pull request");
+	const head = assertObject(pull.head, "PR head");
+	const base = assertObject(pull.base, "PR base");
+	if (
+		pull.number !== workflowPull.number ||
+		head.sha !== run.head_sha ||
+		head.ref !== run.head_branch ||
+		assertObject(head.repo, "Head repo").full_name !==
+			assertObject(run.head_repository, "Run head repo").full_name ||
+		assertObject(base.repo, "Base repo").full_name !== repository.full_name ||
+		pull.merge_commit_sha !== report.candidateSha
+	) {
+		throw new Error("Report does not match the PR merge ref");
+	}
+	const commit = assertObject(candidateCommit, "Commit");
+	if (
+		commit.sha !== report.candidateSha ||
+		!Array.isArray(commit.parents) ||
+		commit.parents.length !== 2 ||
+		assertObject(commit.parents[0], "First parent").sha !==
+			report.baselineSha ||
+		assertObject(commit.parents[1], "Second parent").sha !== run.head_sha
+	) {
+		throw new Error("Candidate merge parents do not match");
+	}
+}
+
+/** Renders fixed Markdown from validated fields. */
+export function render(report) {
+	const lines = [
+		"## Package size report",
+		"",
+		`Candidate: \`${report.candidateSha}\``,
+		`Baseline: \`${report.baselineSha}\` (first merge parent)`,
+		"",
+		"| Package | Metric | Base | Merge | Delta |",
+		"| --- | --- | ---: | ---: | ---: |",
+	];
+	for (const pkg of report.packages) {
+		lines.push(
+			`| ${pkg.name} | Raw | ${bytes(pkg.baseline.raw)} | ${bytes(pkg.candidate.raw)} | ${delta(pkg.baseline.raw, pkg.candidate.raw)} |`,
+			`|  | Gzip | ${bytes(pkg.baseline.gzip)} | ${bytes(pkg.candidate.gzip)} | ${delta(pkg.baseline.gzip, pkg.candidate.gzip)} |`
+		);
+	}
+	lines.push(
+		"",
+		"Raw and level-9 gzip use packed bytes with manifest keys normalized."
+	);
+	return `${lines.join("\n")}\n`;
+}
+
+function assertObject(value, name) {
+	if (typeof value !== "object" || value === null || Array.isArray(value)) {
+		throw new Error(`${name} must be an object`);
+	}
+	return value;
+}
+
+function byteCount(value) {
+	return Number.isSafeInteger(value) && value >= 0;
+}
+
+function bytes(value) {
+	return `${value.toLocaleString("en-US")} B`;
+}
+
+function delta(baseline, candidate) {
+	const difference = candidate - baseline;
+	const sign = difference > 0 ? "+" : "";
+	const percent =
+		baseline === 0
+			? candidate === 0
+				? "0.0%"
+				: "new"
+			: `${sign}${((difference / baseline) * 100).toFixed(1)}%`;
+	return `${sign}${difference.toLocaleString("en-US")} B (${percent})`;
+}
+
+function argument(name) {
+	const index = process.argv.indexOf(name);
+	const value = process.argv[index + 1];
+	if (index === -1 || value === undefined) throw new Error(`Missing ${name}`);
+	return value;
+}
+
+function readJson(path) {
+	return JSON.parse(readFileSync(path, "utf8"));
+}
+
+function writeJson(path, value) {
+	writeFileSync(path, `${JSON.stringify(value)}\n`, { flag: "wx" });
+}
+
+function measurementFile(path) {
+	const values = readJson(path);
+	if (!Array.isArray(values) || values.length !== PACKAGES.length) {
+		throw new Error("Unexpected measurement package list");
+	}
+	return values.map((value, index) =>
+		measurement(value, PACKAGES[index]?.name ?? "")
+	);
+}
+
+function buildPackages(workspace, cacheDirectory) {
+	execFileSync(
+		"pnpm",
+		[
+			"--dir",
+			workspace,
+			"run",
+			"build",
+			...PACKAGES.flatMap(({ name }) => ["--filter", name]),
+			"--cache-dir",
+			cacheDirectory,
+		],
+		{ stdio: "inherit" }
+	);
+}
+
+function main() {
+	const command = process.argv[2];
+	if (command === "build") {
+		buildPackages(argument("--workspace"), argument("--cache-dir"));
+		return;
+	}
+	if (command === "measure") {
+		writeJson(argument("--output"), measure(argument("--workspace")));
+		return;
+	}
+	if (command === "combine") {
+		const baseline = measurementFile(argument("--baseline"));
+		const candidate = measurementFile(argument("--candidate"));
+		writeJson(
+			argument("--output"),
+			validate({
+				schemaVersion: 1,
+				candidateSha: argument("--candidate-sha"),
+				baselineSha: argument("--baseline-sha"),
+				packages: PACKAGES.map((pkg, index) => ({
+					name: pkg.name,
+					baseline: baseline[index],
+					candidate: candidate[index],
+				})),
+			})
+		);
+		return;
+	}
+	const report = validate(readJson(argument("--input")));
+	if (command === "summary") {
+		process.stdout.write(render(report));
+		return;
+	}
+	if (command === "report") {
+		bindReport(
+			report,
+			readJson(argument("--event")),
+			readJson(argument("--pull-request-json")),
+			readJson(argument("--candidate-commit-json"))
+		);
+		writeFileSync(argument("--output"), render(report), { flag: "wx" });
+		return;
+	}
+	throw new Error("Unknown package-size command");
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) main();


### PR DESCRIPTION
Fixes #15455.

Adds deterministic published-package raw/gzip reporting for Wrangler, Miniflare, and the Cloudflare Vite plugin. The measurement workflow builds GitHub’s exact synthetic merge commit and first parent sequentially at the same path, writes the report to the job summary, and uploads strict JSON.

The privileged reporter never executes PR code: it caps and uniquely selects the artifact, validates its complete schema and totals, binds it to the workflow run, current PR merge ref, head repository/branch, and both merge parents, then updates one fixed-format sticky comment.

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: this is internal CI tooling, documented in the repository workflow README.

> [!NOTE]
> This is a contribution from an AI agent: OpenAI Codex.