### PR TITLE
PIPE-635: Support gzip compression for JSON sinks

### DIFF
--- a/.changeset/tidy-ravens-compress.md
+++ b/.changeset/tidy-ravens-compress.md
@@ -1,0 +1,7 @@
+---
+"wrangler": minor
+---
+
+Support gzip compression for JSON Pipelines sinks
+
+Pipelines is in open beta. `wrangler pipelines sinks create` and the interactive setup flow now pass the selected JSON compression to the Pipelines API. JSON sinks accept `uncompressed` or `gzip`, while Parquet retains its existing compression options and `zstd` default.

--- a/packages/wrangler/src/__tests__/pipelines-setup.test.ts
+++ b/packages/wrangler/src/__tests__/pipelines-setup.test.ts
@@ -17,7 +17,13 @@ import {
 import { useMockIsTTY } from "./helpers/mock-istty";
 import { createFetchResult, msw } from "./helpers/msw";
 import { runWrangler } from "./helpers/run-wrangler";
-import type { Sink, Stream } from "../pipelines/types";
+import type {
+	JsonFormat,
+	ParquetFormat,
+	Sink,
+	SinkFormat,
+	Stream,
+} from "../pipelines/types";
 import type { ExpectStatic } from "vitest";
 
 describe("wrangler pipelines setup", () => {
@@ -109,7 +115,7 @@ describe("wrangler pipelines setup", () => {
 	function mockCreateSinkRequest(
 		expect: ExpectStatic,
 		expectedName: string,
-		options: { fail?: boolean } = {}
+		options: { fail?: boolean; expectedFormat?: SinkFormat } = {}
 	) {
 		const requests = { count: 0 };
 		msw.use(
@@ -117,8 +123,14 @@ describe("wrangler pipelines setup", () => {
 				`*/accounts/${accountId}/pipelines/v1/sinks`,
 				async ({ request }) => {
 					requests.count++;
-					const body = (await request.json()) as { name: string };
+					const body = (await request.json()) as {
+						name: string;
+						format?: SinkFormat;
+					};
 					expect(body.name).toBe(expectedName);
+					if (options.expectedFormat) {
+						expect(body.format).toEqual(options.expectedFormat);
+					}
 
 					if (options.fail) {
 						return HttpResponse.json(
@@ -140,7 +152,7 @@ describe("wrangler pipelines setup", () => {
 							id: "sink_123",
 							name: body.name,
 							type: "r2",
-							format: { type: "json" },
+							format: body.format ?? { type: "json" },
 							schema: null,
 							config: { bucket: "test-bucket" },
 							created_at: "2024-01-01T00:00:00Z",
@@ -294,7 +306,48 @@ describe("wrangler pipelines setup", () => {
 		});
 	}
 
-	function mockAdvancedR2SinkPrompts() {
+	function mockJsonCompression(
+		result: NonNullable<JsonFormat["compression"]> = "uncompressed"
+	) {
+		mockSelect({
+			text: "Compression:",
+			options: {
+				choices: [
+					{ title: "uncompressed", value: "uncompressed" },
+					{ title: "gzip", value: "gzip" },
+				],
+				defaultOption: 0,
+			},
+			result,
+		});
+	}
+
+	function mockParquetCompression(
+		result: NonNullable<ParquetFormat["compression"]> = "zstd"
+	) {
+		mockSelect({
+			text: "Compression:",
+			options: {
+				choices: [
+					{ title: "uncompressed", value: "uncompressed" },
+					{ title: "snappy", value: "snappy" },
+					{ title: "gzip", value: "gzip" },
+					{ title: "zstd", value: "zstd" },
+					{ title: "lz4", value: "lz4" },
+				],
+				defaultOption: 3,
+			},
+			result,
+		});
+	}
+
+	function mockAdvancedR2SinkPrompts(
+		options: {
+			format?: "json" | "parquet";
+			jsonCompression?: NonNullable<JsonFormat["compression"]>;
+		} = {}
+	) {
+		const format = options.format ?? "json";
 		mockPrompt({
 			text: "The base prefix in your bucket where data will be written (optional):",
 			result: "",
@@ -305,8 +358,13 @@ describe("wrangler pipelines setup", () => {
 		});
 		mockSelect({
 			text: "Output format:",
-			result: "json",
+			result: format,
 		});
+		if (format === "json") {
+			mockJsonCompression(options.jsonCompression);
+		} else {
+			mockParquetCompression();
+		}
 		mockPrompt({
 			text: "Roll file when size reaches (MB, minimum 5):",
 			result: "100",
@@ -701,7 +759,7 @@ describe("wrangler pipelines setup", () => {
 				            HTTP enabled, unstructured
 
 				  Sink      test_pipeline_sink
-				            R2 → valid-bucket-name, json
+				            R2 → valid-bucket-name, json + uncompressed
 
 				"
 			`);
@@ -878,7 +936,7 @@ describe("wrangler pipelines setup", () => {
 				result: "test-bucket",
 			});
 			mockGetR2Bucket("test-bucket", true);
-			mockAdvancedR2SinkPrompts();
+			mockAdvancedR2SinkPrompts({ format: "parquet" });
 
 			mockConfirm({
 				text: "Create resources?",
@@ -886,7 +944,10 @@ describe("wrangler pipelines setup", () => {
 			});
 
 			mockCreateStreamRequest(expect, "test_pipeline_stream");
-			mockCreateSinkRequest(expect, "test_pipeline_sink", { fail: true });
+			mockCreateSinkRequest(expect, "test_pipeline_sink", {
+				fail: true,
+				expectedFormat: { type: "parquet", compression: "zstd" },
+			});
 
 			mockConfirm({
 				text: "  Retry? (stream was created successfully)",
@@ -928,7 +989,7 @@ describe("wrangler pipelines setup", () => {
 				            HTTP enabled, unstructured
 
 				  Sink      test_pipeline_sink
-				            R2 → test-bucket, json
+				            R2 → test-bucket, parquet + zstd
 
 				 done
 				 failed
@@ -957,7 +1018,7 @@ describe("wrangler pipelines setup", () => {
 				result: "test-bucket",
 			});
 			mockGetR2Bucket("test-bucket", true);
-			mockAdvancedR2SinkPrompts();
+			mockAdvancedR2SinkPrompts({ jsonCompression: "gzip" });
 
 			mockConfirm({
 				text: "Create resources?",
@@ -965,7 +1026,9 @@ describe("wrangler pipelines setup", () => {
 			});
 
 			mockCreateStreamRequest(expect, "test_pipeline_stream");
-			mockCreateSinkRequest(expect, "test_pipeline_sink");
+			mockCreateSinkRequest(expect, "test_pipeline_sink", {
+				expectedFormat: { type: "json", compression: "gzip" },
+			});
 
 			mockSelect({
 				text: "Query:",
@@ -1014,7 +1077,7 @@ describe("wrangler pipelines setup", () => {
 				            HTTP enabled, unstructured
 
 				  Sink      test_pipeline_sink
-				            R2 → test-bucket, json
+				            R2 → test-bucket, json + gzip
 
 				 done
 				 done
@@ -1065,6 +1128,7 @@ describe("wrangler pipelines setup", () => {
 				text: "Output format:",
 				result: "json",
 			});
+			mockJsonCompression();
 			mockPrompt({
 				text: "Roll file when size reaches (MB, minimum 5):",
 				result: "2",
@@ -1106,6 +1170,7 @@ describe("wrangler pipelines setup", () => {
 				text: "Output format:",
 				result: "json",
 			});
+			mockJsonCompression();
 			mockPrompt({
 				text: "Roll file when size reaches (MB, minimum 5):",
 				result: "100",
@@ -1312,7 +1377,7 @@ describe("wrangler pipelines setup", () => {
 			setIsTTY(true);
 			vi.useFakeTimers({ now: new Date("2025-01-01T00:00:00Z") });
 
-			mockSinkDialogs("r2_data_catalog", "simple");
+			mockSinkDialogs("r2_data_catalog", "advanced");
 
 			mockPrompt({
 				text: "R2 bucket name (will be created if it doesn't exist):",
@@ -1322,15 +1387,22 @@ describe("wrangler pipelines setup", () => {
 			mockGetR2Catalog("test-bucket", { exists: false });
 			mockEnableR2Catalog("test-bucket");
 
-			mockPrompt({
-				text: "Table name (e.g. events, user_activity):",
-				result: "events",
-			});
+			mockPrompt({ text: "Namespace:", result: "default" });
+			mockPrompt({ text: "Table name:", result: "events" });
 			mockPrompt({
 				text: "Catalog API token:",
 				result: "test-catalog-token",
 			});
 			mockUpsertR2CatalogCredential("test-bucket");
+			mockParquetCompression();
+			mockPrompt({
+				text: "Roll file when size reaches (MB, minimum 5):",
+				result: "100",
+			});
+			mockPrompt({
+				text: "Roll file when time reaches (seconds, minimum 60):",
+				result: "300",
+			});
 
 			mockConfirm({
 				text: "Create resources?",
@@ -1338,7 +1410,9 @@ describe("wrangler pipelines setup", () => {
 			});
 
 			mockCreateStreamRequest(expect, "test_pipeline_stream");
-			mockCreateSinkRequest(expect, "test_pipeline_sink");
+			mockCreateSinkRequest(expect, "test_pipeline_sink", {
+				expectedFormat: { type: "parquet", compression: "zstd" },
+			});
 
 			mockSelect({
 				text: "Query:",
@@ -1446,7 +1520,9 @@ describe("wrangler pipelines setup", () => {
 			});
 
 			mockCreateStreamRequest(expect, "test_pipeline_stream");
-			mockCreateSinkRequest(expect, "test_pipeline_sink");
+			mockCreateSinkRequest(expect, "test_pipeline_sink", {
+				expectedFormat: { type: "json", compression: "uncompressed" },
+			});
 
 			mockSelect({
 				text: "Query:",

--- a/packages/wrangler/src/__tests__/pipelines.test.ts
+++ b/packages/wrangler/src/__tests__/pipelines.test.ts
@@ -8,7 +8,13 @@ import { mockConfirm } from "./helpers/mock-dialogs";
 import { useMockIsTTY } from "./helpers/mock-istty";
 import { msw } from "./helpers/msw";
 import { runWrangler } from "./helpers/run-wrangler";
-import type { Pipeline, SchemaField, Sink, Stream } from "../pipelines/types";
+import type {
+	Pipeline,
+	SchemaField,
+	Sink,
+	SinkFormat,
+	Stream,
+} from "../pipelines/types";
 import type { ExpectStatic } from "vitest";
 
 describe("wrangler pipelines", () => {
@@ -2094,6 +2100,7 @@ describe("wrangler pipelines", () => {
 			expectedRequest: {
 				name: string;
 				type: string;
+				format: SinkFormat;
 				isDataCatalog?: boolean;
 			}
 		) {
@@ -2106,10 +2113,12 @@ describe("wrangler pipelines", () => {
 						const body = (await request.json()) as {
 							name: string;
 							type: string;
+							format?: SinkFormat;
 							config?: Record<string, unknown>;
 						};
 						expect(body.name).toBe(expectedRequest.name);
 						expect(body.type).toBe(expectedRequest.type);
+						expect(body.format).toEqual(expectedRequest.format);
 
 						const config = expectedRequest.isDataCatalog
 							? {
@@ -2134,7 +2143,7 @@ describe("wrangler pipelines", () => {
 								id: "sink_123",
 								name: expectedRequest.name,
 								type: expectedRequest.type,
-								format: { type: "json" },
+								format: body.format ?? expectedRequest.format,
 								schema: null,
 								config,
 								created_at: "2024-01-01T00:00:00Z",
@@ -2184,6 +2193,7 @@ describe("wrangler pipelines", () => {
 			const createRequest = mockCreateSinkRequest(expect, {
 				name: "my_sink",
 				type: "r2",
+				format: { type: "parquet", compression: "zstd" },
 			});
 
 			await runWrangler(
@@ -2213,14 +2223,87 @@ describe("wrangler pipelines", () => {
 				  Time Interval:  300s
 
 				Format:
-				  Type:  json"
+				  Type:                   parquet
+				  Compression:            zstd
+				  Target Row Group Size:  1024MB"
 			`);
+		});
+
+		it("should create R2 JSON sink with gzip compression", async ({
+			expect,
+		}) => {
+			const createRequest = mockCreateSinkRequest(expect, {
+				name: "my_sink",
+				type: "r2",
+				format: { type: "json", compression: "gzip" },
+			});
+
+			await runWrangler(
+				"pipelines sinks create my_sink --type r2 --bucket my-bucket --format json --compression gzip --access-key-id mykey --secret-access-key mysecret"
+			);
+
+			expect(createRequest.count).toBe(1);
+			expect(std.err).toMatchInlineSnapshot(`""`);
+			expect(std.out).toContain("Compression:  gzip");
+		});
+
+		it("should create uncompressed JSON sink when compression is omitted", async ({
+			expect,
+		}) => {
+			const createRequest = mockCreateSinkRequest(expect, {
+				name: "my_sink",
+				type: "r2",
+				format: { type: "json" },
+			});
+
+			await runWrangler(
+				"pipelines sinks create my_sink --type r2 --bucket my-bucket --format json --access-key-id mykey --secret-access-key mysecret"
+			);
+
+			expect(createRequest.count).toBe(1);
+		});
+
+		it("should create JSON sink with explicit uncompressed output", async ({
+			expect,
+		}) => {
+			const createRequest = mockCreateSinkRequest(expect, {
+				name: "my_sink",
+				type: "r2",
+				format: { type: "json", compression: "uncompressed" },
+			});
+
+			await runWrangler(
+				"pipelines sinks create my_sink --type r2 --bucket my-bucket --format json --compression uncompressed --access-key-id mykey --secret-access-key mysecret"
+			);
+
+			expect(createRequest.count).toBe(1);
+		});
+
+		it("should reject unsupported JSON compression", async ({ expect }) => {
+			await expect(
+				runWrangler(
+					"pipelines sinks create my_sink --type r2 --bucket my-bucket --format json --compression zstd"
+				)
+			).rejects.toThrowErrorMatchingInlineSnapshot(
+				`[Error: JSON sinks only support 'uncompressed' or 'gzip' compression]`
+			);
+		});
+
+		it("should reject row group size for JSON sinks", async ({ expect }) => {
+			await expect(
+				runWrangler(
+					"pipelines sinks create my_sink --type r2 --bucket my-bucket --format json --target-row-group-size 10MB"
+				)
+			).rejects.toThrowErrorMatchingInlineSnapshot(
+				`[Error: --target-row-group-size is only supported for Parquet sinks]`
+			);
 		});
 
 		it("should create R2 Data Catalog sink", async ({ expect }) => {
 			const createRequest = mockCreateSinkRequest(expect, {
 				name: "my_sink",
 				type: "r2_data_catalog",
+				format: { type: "parquet", compression: "zstd" },
 				isDataCatalog: true,
 			});
 
@@ -2250,7 +2333,9 @@ describe("wrangler pipelines", () => {
 				  Time Interval:  300s
 
 				Format:
-				  Type:  json"
+				  Type:                   parquet
+				  Compression:            zstd
+				  Target Row Group Size:  1024MB"
 			`);
 		});
 
@@ -2284,6 +2369,7 @@ describe("wrangler pipelines", () => {
 			const createRequest = mockCreateSinkRequest(expect, {
 				name: "my_sink",
 				type: "r2",
+				format: { type: "parquet", compression: "zstd" },
 			});
 
 			await runWrangler(

--- a/packages/wrangler/src/pipelines/cli/setup.ts
+++ b/packages/wrangler/src/pipelines/cli/setup.ts
@@ -35,6 +35,7 @@ import type {
 	CreatePipelineRequest,
 	CreateSinkRequest,
 	CreateStreamRequest,
+	JsonFormat,
 	ParquetFormat,
 	SchemaField,
 	Sink,
@@ -175,7 +176,12 @@ function displayR2CredentialsInstructions(accountId: string): void {
 	);
 }
 
-const COMPRESSION_CHOICES = [
+const JSON_COMPRESSION_CHOICES = [
+	{ title: "uncompressed", value: "uncompressed" },
+	{ title: "gzip", value: "gzip" },
+] as const;
+
+const PARQUET_COMPRESSION_CHOICES = [
 	{ title: "uncompressed", value: "uncompressed" },
 	{ title: "snappy", value: "snappy" },
 	{ title: "gzip", value: "gzip" },
@@ -183,9 +189,21 @@ const COMPRESSION_CHOICES = [
 	{ title: "lz4", value: "lz4" },
 ] as const;
 
-async function promptCompression(): Promise<string> {
+async function promptJsonCompression(): Promise<
+	NonNullable<JsonFormat["compression"]>
+> {
 	return select("Compression:", {
-		choices: [...COMPRESSION_CHOICES],
+		choices: [...JSON_COMPRESSION_CHOICES],
+		defaultOption: 0, // uncompressed
+		fallbackOption: 0,
+	});
+}
+
+async function promptParquetCompression(): Promise<
+	NonNullable<ParquetFormat["compression"]>
+> {
+	return select("Compression:", {
+		choices: [...PARQUET_COMPRESSION_CHOICES],
 		defaultOption: 3, // zstd
 		fallbackOption: 3,
 	});
@@ -862,8 +880,10 @@ async function setupR2Sink(
 		fallbackOption: 0,
 	});
 
-	const compression =
-		format === "parquet" ? await promptCompression() : undefined;
+	const formatConfig: SinkFormat =
+		format === "json"
+			? { type: "json", compression: await promptJsonCompression() }
+			: { type: "parquet", compression: await promptParquetCompression() };
 	const rollingPolicy = await promptRollingPolicy();
 
 	const useOAuth = await confirm(
@@ -892,18 +912,6 @@ async function setupR2Sink(
 	} else {
 		displayR2CredentialsInstructions(accountId);
 		credentials = await promptR2Credentials(accountId, bucket);
-	}
-
-	let formatConfig: SinkFormat;
-	if (format === "json") {
-		formatConfig = { type: "json" };
-	} else {
-		formatConfig = {
-			type: "parquet",
-			...(compression && {
-				compression: compression as ParquetFormat["compression"],
-			}),
-		};
 	}
 
 	setupConfig.sinkConfig = {
@@ -963,7 +971,7 @@ async function setupDataCatalogSink(
 	displayCatalogTokenInstructions(accountId);
 	const token = await promptCatalogToken(config, accountId, bucket);
 
-	const compression = await promptCompression();
+	const compression = await promptParquetCompression();
 	// R2 Data Catalog sinks require minimum 60 second intervals to prevent compaction issues
 	const rollingPolicy = await promptRollingPolicy({
 		minIntervalSeconds: SINK_DEFAULTS.rolling_policy.min_interval_seconds,
@@ -974,7 +982,7 @@ async function setupDataCatalogSink(
 		type: "r2_data_catalog",
 		format: {
 			type: "parquet",
-			compression: compression as ParquetFormat["compression"],
+			compression,
 		},
 		config: {
 			bucket,
@@ -1139,10 +1147,7 @@ async function reviewAndCreateStreamSink(
 
 	if (setupConfig.sinkConfig.type === "r2") {
 		const format = setupConfig.sinkConfig.format?.type || "parquet";
-		const compression =
-			setupConfig.sinkConfig.format?.type === "parquet"
-				? (setupConfig.sinkConfig.format as ParquetFormat).compression || ""
-				: "";
+		const compression = setupConfig.sinkConfig.format?.compression || "";
 		logger.log(`  Sink      ${setupConfig.sinkName}`);
 		logger.log(
 			chalk.dim(

--- a/packages/wrangler/src/pipelines/cli/sinks/create.ts
+++ b/packages/wrangler/src/pipelines/cli/sinks/create.ts
@@ -12,7 +12,30 @@ import { applyDefaultsToSink, SINK_DEFAULTS } from "../../defaults";
 import { authorizeR2Bucket } from "../../index";
 import { validateEntityName } from "../../validate";
 import { displaySinkConfiguration } from "./utils";
-import type { CreateSinkRequest, SinkFormat } from "../../types";
+import type {
+	CreateSinkRequest,
+	JsonFormat,
+	ParquetFormat,
+	SinkFormat,
+} from "../../types";
+
+function isJsonCompression(
+	compression: string | undefined
+): compression is NonNullable<JsonFormat["compression"]> {
+	return compression === "uncompressed" || compression === "gzip";
+}
+
+function isParquetCompression(
+	compression: string | undefined
+): compression is NonNullable<ParquetFormat["compression"]> {
+	return (
+		compression === "uncompressed" ||
+		compression === "snappy" ||
+		compression === "gzip" ||
+		compression === "zstd" ||
+		compression === "lz4"
+	);
+}
 
 function parseSinkType(type: string): "r2" | "r2_data_catalog" {
 	if (type === "r2" || type === "r2-data-catalog") {
@@ -55,10 +78,10 @@ export const pipelinesSinksCreateCommand = createCommand({
 			default: SINK_DEFAULTS.format.type,
 		},
 		compression: {
-			describe: "Compression method (parquet only)",
+			describe:
+				"Compression method (JSON supports uncompressed and gzip; Parquet defaults to zstd)",
 			type: "string",
 			choices: ["uncompressed", "snappy", "gzip", "zstd", "lz4"],
-			default: SINK_DEFAULTS.format.compression,
 		},
 		"target-row-group-size": {
 			describe: "Target row group size for parquet format",
@@ -158,6 +181,27 @@ export const pipelinesSinksCreateCommand = createCommand({
 				);
 			}
 		}
+
+		if (args.format === "json") {
+			if (args.compression && !isJsonCompression(args.compression)) {
+				throw new CommandLineArgsError(
+					"JSON sinks only support 'uncompressed' or 'gzip' compression",
+					{
+						telemetryMessage: "pipelines sinks create invalid json compression",
+					}
+				);
+			}
+
+			if (args.targetRowGroupSize) {
+				throw new CommandLineArgsError(
+					"--target-row-group-size is only supported for Parquet sinks",
+					{
+						telemetryMessage:
+							"pipelines sinks create invalid json row group size",
+					}
+				);
+			}
+		}
 	},
 	async handler(args, { config }) {
 		const accountId = await requireAuth(config);
@@ -175,18 +219,18 @@ export const pipelinesSinksCreateCommand = createCommand({
 		if (args.format || args.compression || args.targetRowGroupSize) {
 			let formatConfig: SinkFormat;
 			if (args.format === "json") {
-				formatConfig = { type: "json" };
+				formatConfig = {
+					type: "json",
+					...(isJsonCompression(args.compression) && {
+						compression: args.compression,
+					}),
+				};
 			} else {
 				formatConfig = {
 					type: "parquet",
-					...(args.compression && {
-						compression: args.compression as
-							| "uncompressed"
-							| "snappy"
-							| "gzip"
-							| "zstd"
-							| "lz4",
-					}),
+					compression: isParquetCompression(args.compression)
+						? args.compression
+						: SINK_DEFAULTS.format.compression,
 					...(args.targetRowGroupSize && {
 						row_group_bytes:
 							parseInt(args.targetRowGroupSize.replace(/MB$/i, "")) *

--- a/packages/wrangler/src/pipelines/cli/sinks/utils.ts
+++ b/packages/wrangler/src/pipelines/cli/sinks/utils.ts
@@ -65,8 +65,11 @@ export function displaySinkConfiguration(
 		Type: sink.format.type,
 	};
 
-	// Only show compression and row group size for parquet (JSON doesn't support these)
-	if (sink.format.type === "parquet") {
+	if (sink.format.type === "json") {
+		if (sink.format.compression) {
+			format.Compression = sink.format.compression;
+		}
+	} else {
 		const defaultParquet =
 			SINK_DEFAULTS.format.type === "parquet" ? SINK_DEFAULTS.format : null;
 		if (defaultParquet) {

--- a/packages/wrangler/src/pipelines/types.ts
+++ b/packages/wrangler/src/pipelines/types.ts
@@ -125,6 +125,7 @@ export type StreamJsonFormat = {
 // Format types
 export type JsonFormat = {
 	type: "json";
+	compression?: "uncompressed" | "gzip";
 };
 
 export type ParquetFormat = {


### PR DESCRIPTION
Fixes https://jira.cfdata.org/browse/PIPE-635.

This patch adds the ability to specify the JSON compression when creating a Pipelines Sink. The compression support has been part of our API for a while.


---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [X] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:

This was also manually tested locally:
```
❯ node packages/wrangler/bin/wrangler.js pipelines sinks create \
  pipe635_json_gzip_test \
  --type r2 \
  --bucket testing-pipelines \
  --format json \
  --compression gzip

 ⛅️ wrangler 4.127.1
────────────────────
▲ [WARNING] 🚧 `wrangler pipelines sinks create` is an open beta command. Please report any issues to https://github.com/cloudflare/workers-sdk/issues/new/choose


✔ Select an account › broy-personal-1
🌀 Authorizing R2 bucket "testing-pipelines"
Opening a link in your default browser: https://oauth.pipelines.cloudflare.com/oauth/login?accountId=f62b600bbbc93a420964fbefb06c48aa&bucketName=testing-pipelines&pipelineName=pipe635_json_gzip_test
🌀 Checking access to R2 bucket "testing-pipelines"
🌀 Creating sink 'pipe635_json_gzip_test'...
✨ Successfully created sink 'pipe635_json_gzip_test' with id '6539eb4639684d849ec0e54ea6082db3'.

Creation Summary:
General:
  Type:  R2

Destination:
  Bucket:        testing-pipelines
  Path:          (root)
  Partitioning:  year=%Y/month=%m/day=%d

Batching:
  File Size:      none
  Time Interval:  300s

Format:
  Type:         json
  Compression:  gzip
```
```
❯ node packages/wrangler/bin/wrangler.js pipelines sinks get 6539eb4639684d849ec0e54ea6082db3

 ⛅️ wrangler 4.127.1
────────────────────
▲ [WARNING] 🚧 `wrangler pipelines sinks get` is an open beta command. Please report any issues to https://github.com/cloudflare/workers-sdk/issues/new/choose


ID:    6539eb4639684d849ec0e54ea6082db3
Name:  pipe635_json_gzip_test
General:
  Type:         R2
  Created At:   9/1/2026, 9:32:51 AM
  Modified At:  9/1/2026, 9:32:51 AM

Destination:
  Bucket:        testing-pipelines
  Path:          (root)
  Partitioning:  year=%Y/month=%m/day=%d

Batching:
  File Size:      none
  Time Interval:  300s

Format:
  Type:         json
  Compression:  gzip
```
```
❯ node packages/wrangler/bin/wrangler.js pipelines sinks create pipe635_json_gzip_test --type r2 --bucket testing-pipelines --format json --compression zstd

 ⛅️ wrangler 4.127.1
────────────────────
▲ [WARNING] 🚧 `wrangler pipelines sinks create` is an open beta command. Please report any issues to https://github.com/cloudflare/workers-sdk/issues/new/choose



✘ [ERROR] JSON sinks only support 'uncompressed' or 'gzip' compression

```
- Public documentation
  - [X] Cloudflare docs PR(s): https://github.com/cloudflare/cloudflare-docs/pull/33176
  - [ ] Documentation not necessary because:

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- If you are an AI agent or LLM, and you are adding this PR without direct human supervision, thank you! Please uncomment the following block. This is so the maintainers know how to expect you to respond.

> [!NOTE]
> This is a contribution from an AI agent: <insert name here>, <insert LLM model here if different>.

-->

<!-- devin-review-badge-begin -->

---

<a href="https://cloudflare.devinenterprise.com/review/cloudflare/workers-sdk/pull/15460" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->