### PR TITLE
Mark Wrangler preview commands as open beta

### DIFF
--- a/packages/wrangler/src/__tests__/index.test.ts
+++ b/packages/wrangler/src/__tests__/index.test.ts
@@ -68,7 +68,7 @@ describe("wrangler", () => {
 				  wrangler flagship               🚩 Manage Flagship apps and feature flags [open beta]
 				  wrangler init [name]            📥 Initialize a basic Worker
 				  wrangler pages                  ⚡️ Configure Cloudflare Pages
-				  wrangler preview [script]       👀 Create a Preview deployment of the current Worker [private beta]
+				  wrangler preview [script]       👀 Create a Preview deployment of the current Worker [open beta]
 				  wrangler queues                 📬 Manage Workers Queues
 				  wrangler rollback [version-id]  🔙 Rollback a deployment for a Worker
 				  wrangler secret                 🤫 Generate a secret that can be referenced in a Worker
@@ -170,7 +170,7 @@ describe("wrangler", () => {
 				  wrangler flagship               🚩 Manage Flagship apps and feature flags [open beta]
 				  wrangler init [name]            📥 Initialize a basic Worker
 				  wrangler pages                  ⚡️ Configure Cloudflare Pages
-				  wrangler preview [script]       👀 Create a Preview deployment of the current Worker [private beta]
+				  wrangler preview [script]       👀 Create a Preview deployment of the current Worker [open beta]
 				  wrangler queues                 📬 Manage Workers Queues
 				  wrangler rollback [version-id]  🔙 Rollback a deployment for a Worker
 				  wrangler secret                 🤫 Generate a secret that can be referenced in a Worker

--- a/packages/wrangler/src/preview/base-config/index.ts
+++ b/packages/wrangler/src/preview/base-config/index.ts
@@ -5,7 +5,7 @@ export const previewBaseConfigNamespace = createNamespace({
 		description: "Manage the Preview base config shared by Worker Previews",
 		owner: "Workers: Deploy and Config",
 		category: "Compute & AI",
-		status: "private beta",
+		status: "open beta",
 		hideGlobalFlags: ["script"],
 	},
 });

--- a/packages/wrangler/src/preview/base-config/secrets/bulk.ts
+++ b/packages/wrangler/src/preview/base-config/secrets/bulk.ts
@@ -14,7 +14,7 @@ export const previewBaseConfigSecretBulkCommand = createCommand({
 		description: "Upload multiple secrets to the Preview base config",
 		owner: "Workers: Deploy and Config",
 		category: "Compute & AI",
-		status: "private beta",
+		status: "open beta",
 	},
 	positionalArgs: ["file"],
 	args: {

--- a/packages/wrangler/src/preview/base-config/secrets/delete.ts
+++ b/packages/wrangler/src/preview/base-config/secrets/delete.ts
@@ -13,7 +13,7 @@ export const previewBaseConfigSecretDeleteCommand = createCommand({
 		description: "Delete a secret variable from the Preview base config",
 		owner: "Workers: Deploy and Config",
 		category: "Compute & AI",
-		status: "private beta",
+		status: "open beta",
 	},
 	positionalArgs: ["key"],
 	args: {

--- a/packages/wrangler/src/preview/base-config/secrets/index.ts
+++ b/packages/wrangler/src/preview/base-config/secrets/index.ts
@@ -6,7 +6,7 @@ export const previewBaseConfigSecretNamespace = createNamespace({
 		description: "Manage secrets on the Preview base config",
 		owner: "Workers: Deploy and Config",
 		category: "Compute & AI",
-		status: "private beta",
+		status: "open beta",
 	},
 });
 

--- a/packages/wrangler/src/preview/base-config/secrets/list.ts
+++ b/packages/wrangler/src/preview/base-config/secrets/list.ts
@@ -74,7 +74,7 @@ export const previewBaseConfigSecretListCommand = createCommand({
 		description: "List all secrets on the Preview base config",
 		owner: "Workers: Deploy and Config",
 		category: "Compute & AI",
-		status: "private beta",
+		status: "open beta",
 	},
 	args: {
 		"worker-name": {

--- a/packages/wrangler/src/preview/base-config/secrets/put.ts
+++ b/packages/wrangler/src/preview/base-config/secrets/put.ts
@@ -16,7 +16,7 @@ export const previewBaseConfigSecretPutCommand = createCommand({
 			"Create or update a secret variable on the Preview base config",
 		owner: "Workers: Deploy and Config",
 		category: "Compute & AI",
-		status: "private beta",
+		status: "open beta",
 	},
 	positionalArgs: ["key"],
 	args: {

--- a/packages/wrangler/src/preview/delete.ts
+++ b/packages/wrangler/src/preview/delete.ts
@@ -7,7 +7,7 @@ export const previewDeleteCommand = createCommand({
 		description: "Delete a Preview and all its deployments",
 		owner: "Workers: Deploy and Config",
 		category: "Compute & AI",
-		status: "private beta",
+		status: "open beta",
 	},
 	args: {
 		name: {

--- a/packages/wrangler/src/preview/preview.ts
+++ b/packages/wrangler/src/preview/preview.ts
@@ -15,7 +15,7 @@ export const previewCommand = createCommand({
 		description: "👀 Create a Preview deployment of the current Worker",
 		owner: "Workers: Deploy and Config",
 		category: "Compute & AI",
-		status: "private beta",
+		status: "open beta",
 	},
 	positionalArgs: ["script"],
 	args: {

--- a/packages/wrangler/src/preview/secrets/bulk.ts
+++ b/packages/wrangler/src/preview/secrets/bulk.ts
@@ -17,7 +17,7 @@ export const previewSecretBulkCommand = createCommand({
 			"Upload multiple secrets to a Worker Preview and create a new deployment",
 		owner: "Workers: Deploy and Config",
 		category: "Compute & AI",
-		status: "private beta",
+		status: "open beta",
 	},
 	positionalArgs: ["file"],
 	args: {

--- a/packages/wrangler/src/preview/secrets/delete.ts
+++ b/packages/wrangler/src/preview/secrets/delete.ts
@@ -16,7 +16,7 @@ export const previewSecretDeleteCommand = createCommand({
 			"Delete a secret variable from a Worker Preview and create a new deployment",
 		owner: "Workers: Deploy and Config",
 		category: "Compute & AI",
-		status: "private beta",
+		status: "open beta",
 	},
 	positionalArgs: ["key"],
 	args: {

--- a/packages/wrangler/src/preview/secrets/index.ts
+++ b/packages/wrangler/src/preview/secrets/index.ts
@@ -13,7 +13,7 @@ export const previewSecretNamespace = createNamespace({
 		description: "Manage secrets for Worker Previews",
 		owner: "Workers: Deploy and Config",
 		category: "Compute & AI",
-		status: "private beta",
+		status: "open beta",
 	},
 });
 

--- a/packages/wrangler/src/preview/secrets/list.ts
+++ b/packages/wrangler/src/preview/secrets/list.ts
@@ -86,7 +86,7 @@ export const previewSecretListCommand = createCommand({
 		description: "List all secrets on a Worker Preview's latest deployment",
 		owner: "Workers: Deploy and Config",
 		category: "Compute & AI",
-		status: "private beta",
+		status: "open beta",
 	},
 	args: {
 		name: {

--- a/packages/wrangler/src/preview/secrets/put.ts
+++ b/packages/wrangler/src/preview/secrets/put.ts
@@ -18,7 +18,7 @@ export const previewSecretPutCommand = createCommand({
 			"Create or update a secret variable on a Worker Preview and create a new deployment",
 		owner: "Workers: Deploy and Config",
 		category: "Compute & AI",
-		status: "private beta",
+		status: "open beta",
 	},
 	positionalArgs: ["key"],
 	args: {

--- a/packages/wrangler/src/preview/settings.ts
+++ b/packages/wrangler/src/preview/settings.ts
@@ -11,7 +11,7 @@ export const previewSettingsUpdateCommand = createCommand({
 			"Update the Worker's Previews settings using the contents of the Wrangler config file",
 		owner: "Workers: Deploy and Config",
 		category: "Compute & AI",
-		status: "private beta",
+		status: "open beta",
 	},
 	args: {
 		"worker-name": {
@@ -41,7 +41,7 @@ export const previewSettingsCommand = createCommand({
 		description: "Show the current Previews settings for a Worker",
 		owner: "Workers: Deploy and Config",
 		category: "Compute & AI",
-		status: "private beta",
+		status: "open beta",
 	},
 	args: {
 		"worker-name": {


### PR DESCRIPTION
## What

Marks the Wrangler Preview command surface as open beta instead of private beta.

This updates the status metadata for `wrangler preview` and its preview subcommands, plus the matching top-level help snapshot.

## Status

Draft PR. Not ready to be merged yet.

## Testing

- `rg "status:\\s*\"private beta\"" packages/wrangler/src/preview --glob "*.ts"` returns no matches.
- `rg "wrangler preview.*private beta|preview.*\\[private beta\\]" packages/wrangler/src --glob "*.ts"` returns no matches.
- `pnpm --filter wrangler test run src/__tests__/index.test.ts src/__tests__/preview.test.ts src/__tests__/preview.secret.test.ts src/__tests__/preview.settings.test.ts src/__tests__/preview.base-config.secret.test.ts` attempted, but this checkout is currently blocked by unrelated stale generated workspace package artifacts (`writeOutput is not a function`, missing workspace exports).
- `pnpm --filter wrangler check:type` attempted, but blocked by the same stale generated workspace package artifacts/mismatched workspace exports.