### PR TITLE
[workers-utils] Share named tunnel resolution

### DIFF
--- a/.changeset/tidy-tunnels-share.md
+++ b/.changeset/tidy-tunnels-share.md
@@ -1,0 +1,7 @@
+---
+"@cloudflare/workers-utils": minor
+---
+
+Move named tunnel resolution into workers-utils
+
+Wrangler continues to expose the same behavior while delegating the implementation to the shared utility.

--- a/packages/workers-utils/src/index.ts
+++ b/packages/workers-utils/src/index.ts
@@ -158,7 +158,7 @@ export { MetricsRegistry } from "./prometheus-metrics";
 export type { Counter } from "./prometheus-metrics";
 
 export type { Tunnel, TunnelOptions } from "./tunnel";
-export { startTunnel } from "./tunnel";
+export { resolveNamedTunnel, startTunnel } from "./tunnel";
 export { spawnCloudflared } from "./cloudflared";
 
 export * from "./cfetch";

--- a/packages/workers-utils/src/tunnel.ts
+++ b/packages/workers-utils/src/tunnel.ts
@@ -1,5 +1,8 @@
+import { fetchResultBase } from "./cfetch";
 import { spawnCloudflared } from "./cloudflared";
-import { UserError } from "./errors";
+import { FatalError, UserError } from "./errors";
+import type { ApiCredentials } from "./cfetch";
+import type { ComplianceConfig } from "./environment-variables/misc-variables";
 import type { Logger } from "./logger";
 import type { ChildProcess } from "node:child_process";
 
@@ -17,6 +20,28 @@ const DEFAULT_TUNNEL_REMINDER_INTERVAL_MS = 10 * 60 * 1_000;
  * cloudflared logs the quick tunnel URL to stderr.
  */
 const QUICK_TUNNEL_URL_REGEX = /https:\/\/[a-z0-9-]+\.trycloudflare\.com/;
+
+const LOCAL_TUNNEL_HOSTNAMES = new Set([
+	"localhost",
+	"127.0.0.1",
+	"::1",
+	"0.0.0.0",
+	"::",
+]);
+
+interface CloudflareTunnel {
+	id?: string;
+	name?: string;
+}
+
+interface TunnelIngress {
+	hostname?: string;
+	service: string;
+}
+
+interface TunnelConfiguration {
+	config?: { ingress?: TunnelIngress[] };
+}
 
 export interface QuickTunnelResult {
 	mode: "quick";
@@ -44,6 +69,172 @@ export interface TunnelOptions {
 	reminderIntervalMs?: number;
 	extendHint?: string;
 	logger?: Pick<Logger, "debug" | "log" | "warn">;
+}
+
+/**
+ * Resolves the named tunnel to hostnames whose ingress rules target the current
+ * local dev origin and the token needed to start `cloudflared tunnel run`.
+ */
+export async function resolveNamedTunnel(
+	name: string,
+	origin: URL,
+	options: {
+		accountId: string;
+		apiToken: ApiCredentials;
+		complianceRegion: ComplianceConfig["compliance_region"];
+		logger: Logger;
+		userAgent: string;
+		abortSignal?: AbortSignal;
+	}
+): Promise<{ hostnames: string[]; token: string }> {
+	const {
+		accountId,
+		apiToken,
+		complianceRegion,
+		logger,
+		userAgent,
+		abortSignal,
+	} = options;
+	const complianceConfig = { compliance_region: complianceRegion };
+	const resource = `/accounts/${accountId}/cfd_tunnel`;
+	const tunnels = await fetchResultBase<CloudflareTunnel[]>(
+		complianceConfig,
+		resource,
+		undefined,
+		userAgent,
+		logger,
+		new URLSearchParams({ name, is_deleted: "false" }),
+		abortSignal,
+		apiToken
+	);
+	const tunnel = tunnels.find((item) => item.name === name);
+
+	if (!tunnel) {
+		throw new UserError(
+			`No Cloudflare Tunnel named "${name}" was found in this account. Use "wrangler tunnel list" to see available tunnels.`,
+			{ telemetryMessage: "tunnel resolve named missing tunnel" }
+		);
+	}
+
+	const tunnelId = tunnel.id;
+	if (!tunnelId) {
+		throw new FatalError(
+			`Tunnel "${name}" was found but has no ID. This is unexpected.`,
+			{ telemetryMessage: "tunnel resolve named missing tunnel id" }
+		);
+	}
+
+	const configuration = await fetchResultBase<TunnelConfiguration>(
+		complianceConfig,
+		`${resource}/${tunnelId}/configurations`,
+		undefined,
+		userAgent,
+		logger,
+		undefined,
+		abortSignal,
+		apiToken
+	);
+	const ingress = configuration.config?.ingress ?? [];
+	const hostnames = getMatchingIngressHostnames(origin, ingress);
+
+	if (hostnames.length === 0) {
+		throw new UserError(
+			createMissingIngressMessage(
+				name,
+				origin,
+				`https://dash.cloudflare.com/${accountId}/tunnels/${tunnelId}`,
+				ingress
+			),
+			{ telemetryMessage: "tunnel resolve named ingress mismatch" }
+		);
+	}
+
+	const token = await fetchResultBase<string>(
+		complianceConfig,
+		`${resource}/${tunnelId}/token`,
+		undefined,
+		userAgent,
+		logger,
+		undefined,
+		abortSignal,
+		apiToken
+	);
+
+	return { hostnames, token: String(token) };
+}
+/** Return ingress hostnames whose configured service targets the local origin. */
+function getMatchingIngressHostnames(
+	origin: URL,
+	ingressConfig: TunnelIngress[]
+): string[] {
+	const hostnames = new Set<string>();
+	const originUrl = normalizeURL(origin);
+
+	for (const ingress of ingressConfig) {
+		try {
+			const serviceUrl = normalizeURL(ingress.service);
+
+			if (ingress.hostname && serviceUrl.toString() === originUrl.toString()) {
+				hostnames.add(ingress.hostname);
+			}
+		} catch {
+			// Ignore invalid service URLs in ingress rules.
+		}
+	}
+
+	return [...hostnames];
+}
+
+function normalizeURL(url: URL | string): URL {
+	const normalizedUrl = new URL(url);
+
+	if (LOCAL_TUNNEL_HOSTNAMES.has(normalizedUrl.hostname)) {
+		normalizedUrl.hostname = "localhost";
+	}
+
+	if (!normalizedUrl.port) {
+		switch (normalizedUrl.protocol) {
+			case "http:":
+				normalizedUrl.port = "80";
+				break;
+			case "https:":
+				normalizedUrl.port = "443";
+				break;
+		}
+	}
+
+	return normalizedUrl;
+}
+
+function createMissingIngressMessage(
+	name: string,
+	origin: URL,
+	dashboardUrl: string,
+	ingress: TunnelIngress[]
+): string {
+	if (ingress.length === 0) {
+		return [
+			`Tunnel "${name}" has no routes configured.`,
+			"",
+			`Add a route for ${origin} in the Cloudflare dashboard:`,
+			dashboardUrl,
+			"",
+		].join("\n");
+	}
+
+	return [
+		`Tunnel "${name}" has no route for ${origin}`,
+		"",
+		"Resolved routes:",
+		...ingress.map(
+			({ hostname, service }) =>
+				`  - ${hostname ?? "(no hostname)"} -> ${service}`
+		),
+		"",
+		"Update your local server settings or the tunnel routes in the Cloudflare dashboard:",
+		dashboardUrl,
+		"",
+	].join("\n");
 }
 
 /**

--- a/packages/workers-utils/src/tunnel.ts
+++ b/packages/workers-utils/src/tunnel.ts
@@ -10,6 +10,7 @@ import type { ChildProcess } from "node:child_process";
  * Quick tunnels typically start in 5-15s, but we allow up to 30s for slow networks.
  */
 const TUNNEL_STARTUP_TIMEOUT_MS = 30_000;
+const TUNNEL_API_TIMEOUT_MS = 60_000;
 const TUNNEL_FORCE_KILL_TIMEOUT_MS = 5_000;
 const DEFAULT_TUNNEL_EXPIRY_MS = 60 * 60 * 1_000;
 const DEFAULT_TUNNEL_EXTENSION_MS = 60 * 60 * 1_000;
@@ -104,7 +105,7 @@ export async function resolveNamedTunnel(
 		userAgent,
 		logger,
 		new URLSearchParams({ name, is_deleted: "false" }),
-		abortSignal,
+		createApiAbortSignal(TUNNEL_API_TIMEOUT_MS, abortSignal),
 		apiToken
 	);
 	const tunnel = tunnels.find((item) => item.name === name);
@@ -131,7 +132,7 @@ export async function resolveNamedTunnel(
 		userAgent,
 		logger,
 		undefined,
-		abortSignal,
+		createApiAbortSignal(TUNNEL_API_TIMEOUT_MS, abortSignal),
 		apiToken
 	);
 	const ingress = configuration.config?.ingress ?? [];
@@ -139,12 +140,10 @@ export async function resolveNamedTunnel(
 
 	if (hostnames.length === 0) {
 		throw new UserError(
-			createMissingIngressMessage(
-				name,
-				origin,
-				`https://dash.cloudflare.com/${accountId}/tunnels/${tunnelId}`,
-				ingress
-			),
+			createMissingIngressMessage(name, origin, {
+				dashboardUrl: `https://dash.cloudflare.com/${accountId}/tunnels/${tunnelId}`,
+				ingress,
+			}),
 			{ telemetryMessage: "tunnel resolve named ingress mismatch" }
 		);
 	}
@@ -156,7 +155,7 @@ export async function resolveNamedTunnel(
 		userAgent,
 		logger,
 		undefined,
-		abortSignal,
+		createApiAbortSignal(TUNNEL_API_TIMEOUT_MS, abortSignal),
 		apiToken
 	);
 
@@ -206,11 +205,26 @@ function normalizeURL(url: URL | string): URL {
 	return normalizedUrl;
 }
 
+function createApiAbortSignal(
+	timeoutMs: number,
+	abortSignal?: AbortSignal
+): AbortSignal {
+	const timeoutSignal = AbortSignal.timeout(timeoutMs);
+	return abortSignal
+		? AbortSignal.any([abortSignal, timeoutSignal])
+		: timeoutSignal;
+}
+
 function createMissingIngressMessage(
 	name: string,
 	origin: URL,
-	dashboardUrl: string,
-	ingress: TunnelIngress[]
+	{
+		dashboardUrl,
+		ingress,
+	}: {
+		dashboardUrl: string;
+		ingress: TunnelIngress[];
+	}
 ): string {
 	if (ingress.length === 0) {
 		return [

--- a/packages/workers-utils/tests/tunnel.test.ts
+++ b/packages/workers-utils/tests/tunnel.test.ts
@@ -7,15 +7,21 @@ import {
 	onTestFinished,
 	vi,
 } from "vitest";
+import { fetchResultBase } from "../src/cfetch";
 import { spawnCloudflared } from "../src/cloudflared";
 import { UserError } from "../src/errors";
-import { startTunnel } from "../src/tunnel";
+import { resolveNamedTunnel, startTunnel } from "../src/tunnel";
 
 vi.mock("../src/cloudflared", () => {
 	return {
 		spawnCloudflared: vi.fn(),
 	};
 });
+
+vi.mock("../src/cfetch", async (importOriginal) => ({
+	...(await importOriginal<typeof import("../src/cfetch")>()),
+	fetchResultBase: vi.fn(),
+}));
 
 function createMockProcess() {
 	const proc = new EventEmitter() as EventEmitter & {
@@ -486,5 +492,116 @@ describe("startTunnel", () => {
 		await vi.advanceTimersByTimeAsync(3 * 60 * 60 * 1_000);
 		expect(logger.log).toHaveBeenCalledWith("Tunnel expired. Closing tunnel.");
 		expect(killSpy).toHaveBeenCalledWith("SIGTERM");
+	});
+});
+
+describe("resolveNamedTunnel", () => {
+	it("resolves matching ingress hostnames and the tunnel token", async ({
+		expect,
+	}) => {
+		vi.mocked(fetchResultBase)
+			.mockResolvedValueOnce([
+				{
+					id: "11111111-1111-4111-8111-111111111111",
+					name: "my-tunnel",
+				},
+			])
+			.mockResolvedValueOnce({
+				config: {
+					ingress: [
+						{
+							hostname: "dev.example.com",
+							service: "http://127.0.0.1:8787",
+						},
+						{
+							hostname: "other.example.com",
+							service: "http://localhost:3000",
+						},
+					],
+				},
+			})
+			.mockResolvedValueOnce("TOKEN");
+		const abortSignal = new AbortController().signal;
+		await expect(
+			resolveNamedTunnel("my-tunnel", new URL("http://localhost:8787"), {
+				abortSignal,
+				accountId: "account",
+				apiToken: { apiToken: "test-token" },
+				complianceRegion: undefined,
+				logger: console,
+				userAgent: "test",
+			})
+		).resolves.toEqual({
+			hostnames: ["dev.example.com"],
+			token: "TOKEN",
+		});
+		expect(
+			vi.mocked(fetchResultBase).mock.calls.map((call) => call[6])
+		).toEqual([abortSignal, abortSignal, abortSignal]);
+	});
+
+	it("throws when a named tunnel has no ingress for the local port", async ({
+		expect,
+	}) => {
+		vi.mocked(fetchResultBase)
+			.mockResolvedValueOnce([{ id: "test-tunnel-id", name: "my-tunnel" }])
+			.mockResolvedValueOnce({
+				config: {
+					ingress: [
+						{
+							hostname: "dev.example.com",
+							service: "http://localhost:3000",
+						},
+						{
+							hostname: "admin.example.com",
+							service: "http://localhost:4000",
+						},
+					],
+				},
+			});
+
+		await expect(
+			resolveNamedTunnel("my-tunnel", new URL("http://localhost:8787"), {
+				accountId: "test-account-id",
+				apiToken: { apiToken: "test-token" },
+				complianceRegion: undefined,
+				logger: console,
+				userAgent: "test",
+			})
+		).rejects.toThrowErrorMatchingInlineSnapshot(`
+			[Error: Tunnel "my-tunnel" has no route for http://localhost:8787/
+
+			Resolved routes:
+			  - dev.example.com -> http://localhost:3000
+			  - admin.example.com -> http://localhost:4000
+
+			Update your local server settings or the tunnel routes in the Cloudflare dashboard:
+			https://dash.cloudflare.com/test-account-id/tunnels/test-tunnel-id
+			]
+		`);
+	});
+
+	it("shows compact setup guidance when a named tunnel has no ingress rules", async ({
+		expect,
+	}) => {
+		vi.mocked(fetchResultBase)
+			.mockResolvedValueOnce([{ id: "test-tunnel-id", name: "my-tunnel" }])
+			.mockResolvedValueOnce({ config: { ingress: [] } });
+
+		await expect(
+			resolveNamedTunnel("my-tunnel", new URL("http://localhost:8787"), {
+				accountId: "test-account-id",
+				apiToken: { apiToken: "test-token" },
+				complianceRegion: undefined,
+				logger: console,
+				userAgent: "test",
+			})
+		).rejects.toThrowErrorMatchingInlineSnapshot(`
+			[Error: Tunnel "my-tunnel" has no routes configured.
+
+			Add a route for http://localhost:8787/ in the Cloudflare dashboard:
+			https://dash.cloudflare.com/test-account-id/tunnels/test-tunnel-id
+			]
+		`);
 	});
 });

--- a/packages/workers-utils/tests/tunnel.test.ts
+++ b/packages/workers-utils/tests/tunnel.test.ts
@@ -499,6 +499,8 @@ describe("resolveNamedTunnel", () => {
 	it("resolves matching ingress hostnames and the tunnel token", async ({
 		expect,
 	}) => {
+		const timeoutSpy = vi.spyOn(AbortSignal, "timeout");
+		onTestFinished(() => timeoutSpy.mockRestore());
 		vi.mocked(fetchResultBase)
 			.mockResolvedValueOnce([
 				{
@@ -521,10 +523,10 @@ describe("resolveNamedTunnel", () => {
 				},
 			})
 			.mockResolvedValueOnce("TOKEN");
-		const abortSignal = new AbortController().signal;
+		const abortController = new AbortController();
 		await expect(
 			resolveNamedTunnel("my-tunnel", new URL("http://localhost:8787"), {
-				abortSignal,
+				abortSignal: abortController.signal,
 				accountId: "account",
 				apiToken: { apiToken: "test-token" },
 				complianceRegion: undefined,
@@ -535,9 +537,14 @@ describe("resolveNamedTunnel", () => {
 			hostnames: ["dev.example.com"],
 			token: "TOKEN",
 		});
-		expect(
-			vi.mocked(fetchResultBase).mock.calls.map((call) => call[6])
-		).toEqual([abortSignal, abortSignal, abortSignal]);
+		const abortSignals = vi
+			.mocked(fetchResultBase)
+			.mock.calls.map((call) => call[6]);
+		expect(timeoutSpy).toHaveBeenCalledTimes(3);
+		expect(timeoutSpy).toHaveBeenCalledWith(60_000);
+		abortController.abort();
+		expect(abortSignals).toHaveLength(3);
+		expect(abortSignals.every((signal) => signal?.aborted)).toBe(true);
 	});
 
 	it("throws when a named tunnel has no ingress for the local port", async ({

--- a/packages/wrangler/src/__tests__/tunnel/tunnel-resolve.test.ts
+++ b/packages/wrangler/src/__tests__/tunnel/tunnel-resolve.test.ts
@@ -1,11 +1,21 @@
+import {
+	APIError,
+	resolveNamedTunnel as resolveNamedTunnelWithCredentials,
+} from "@cloudflare/workers-utils";
 import { describe, it, vi } from "vitest";
-import { createCloudflareClient } from "../../cfetch/internal";
 import { resolveNamedTunnel, resolveTunnelId } from "../../tunnel/client";
+import * as user from "../../user";
+import { mockApiToken } from "../helpers/mock-account-id";
 import type Cloudflare from "cloudflare";
 
-vi.mock("../../cfetch/internal");
+vi.mock("@cloudflare/workers-utils", async (importOriginal) => ({
+	...(await importOriginal<typeof import("@cloudflare/workers-utils")>()),
+	resolveNamedTunnel: vi.fn(),
+}));
 
 describe("resolveTunnelId", () => {
+	mockApiToken();
+
 	it("returns UUID input without calling API", async ({ expect }) => {
 		const sdk = {
 			zeroTrust: {
@@ -51,50 +61,10 @@ describe("resolveTunnelId", () => {
 	it("resolves a named tunnel target from matching ingress rules", async ({
 		expect,
 	}) => {
-		vi.mocked(createCloudflareClient).mockReturnValue({
-			zeroTrust: {
-				tunnels: {
-					cloudflared: {
-						// @ts-expect-error -- partial mock
-						list({ name }: { name?: string }) {
-							expect(name).toBe("my-tunnel");
-							return [
-								{
-									id: "11111111-1111-4111-8111-111111111111",
-									name: "my-tunnel",
-								},
-							];
-						},
-						configurations: {
-							// @ts-expect-error -- partial mock
-							get(tunnelId: string) {
-								expect(tunnelId).toBe("11111111-1111-4111-8111-111111111111");
-								return Promise.resolve({
-									config: {
-										ingress: [
-											{
-												hostname: "dev.example.com",
-												service: "http://localhost:8787",
-											},
-											{
-												hostname: "other.example.com",
-												service: "http://localhost:3000",
-											},
-										],
-									},
-								});
-							},
-						},
-						token: {
-							// @ts-expect-error -- partial mock
-							get(tunnelId: string) {
-								expect(tunnelId).toBe("11111111-1111-4111-8111-111111111111");
-								return Promise.resolve("TOKEN");
-							},
-						},
-					},
-				},
-			},
+		const requireAuthSpy = vi.spyOn(user, "requireAuth");
+		vi.mocked(resolveNamedTunnelWithCredentials).mockResolvedValue({
+			hostnames: ["dev.example.com"],
+			token: "TOKEN",
 		});
 
 		await expect(
@@ -106,116 +76,43 @@ describe("resolveTunnelId", () => {
 			hostnames: ["dev.example.com"],
 			token: "TOKEN",
 		});
+		expect(requireAuthSpy).toHaveBeenCalledWith({
+			account_id: "account",
+			compliance_region: undefined,
+		});
+		expect(resolveNamedTunnelWithCredentials).toHaveBeenCalledWith(
+			"my-tunnel",
+			expect.any(URL),
+			{
+				accountId: "account",
+				apiToken: { apiToken: "some-api-token" },
+				complianceRegion: undefined,
+				logger: expect.any(Object),
+				userAgent: expect.stringMatching(/^wrangler\//),
+			}
+		);
 	});
 
-	it("throws when a named tunnel has no ingress for the local port", async ({
+	it("shows API token guidance for named tunnel permission errors", async ({
 		expect,
 	}) => {
-		vi.mocked(createCloudflareClient).mockReturnValue({
-			zeroTrust: {
-				tunnels: {
-					cloudflared: {
-						// @ts-expect-error -- partial mock
-						list() {
-							return [
-								{
-									id: "test-tunnel-id",
-									name: "my-tunnel",
-								},
-							];
-						},
-						configurations: {
-							// @ts-expect-error -- partial mock
-							get() {
-								return Promise.resolve({
-									config: {
-										ingress: [
-											{
-												hostname: "dev.example.com",
-												service: "http://localhost:3000",
-											},
-											{
-												hostname: "admin.example.com",
-												service: "http://localhost:4000",
-											},
-										],
-									},
-								});
-							},
-						},
-						// @ts-expect-error -- partial mock
-						token: {
-							get() {
-								throw new Error("should not be called");
-							},
-						},
-					},
-				},
-			},
-		});
+		for (const status of [401, 403]) {
+			vi.mocked(resolveNamedTunnelWithCredentials).mockRejectedValueOnce(
+				new APIError({
+					text: "A request to the Cloudflare API failed.",
+					telemetryMessage: "test tunnel api error",
+					status,
+				})
+			);
 
-		await expect(
-			resolveNamedTunnel("my-tunnel", new URL("http://localhost:8787"), {
-				accountId: "test-account-id",
-				complianceRegion: undefined,
-			})
-		).rejects.toThrowErrorMatchingInlineSnapshot(`
-			[Error: Tunnel "my-tunnel" has no route for http://localhost:8787/
-
-			Resolved routes:
-			  - dev.example.com -> http://localhost:3000
-			  - admin.example.com -> http://localhost:4000
-
-			Update your local server settings or the tunnel routes in the Cloudflare dashboard:
-			https://dash.cloudflare.com/test-account-id/tunnels/test-tunnel-id
-			]
-		`);
-	});
-
-	it("shows compact setup guidance when a named tunnel has no ingress rules", async ({
-		expect,
-	}) => {
-		vi.mocked(createCloudflareClient).mockReturnValue({
-			zeroTrust: {
-				tunnels: {
-					cloudflared: {
-						// @ts-expect-error -- partial mock
-						list() {
-							return [
-								{
-									id: "test-tunnel-id",
-									name: "my-tunnel",
-								},
-							];
-						},
-						configurations: {
-							// @ts-expect-error -- partial mock
-							get() {
-								return Promise.resolve({ config: { ingress: [] } });
-							},
-						},
-						// @ts-expect-error -- partial mock
-						token: {
-							get() {
-								throw new Error("should not be called");
-							},
-						},
-					},
-				},
-			},
-		});
-
-		await expect(
-			resolveNamedTunnel("my-tunnel", new URL("http://localhost:8787"), {
-				accountId: "test-account-id",
-				complianceRegion: undefined,
-			})
-		).rejects.toThrowErrorMatchingInlineSnapshot(`
-			[Error: Tunnel "my-tunnel" has no routes configured.
-
-			Add a route for http://localhost:8787/ in the Cloudflare dashboard:
-			https://dash.cloudflare.com/test-account-id/tunnels/test-tunnel-id
-			]
-		`);
+			await expect(
+				resolveNamedTunnel("my-tunnel", new URL("http://localhost:8787"), {
+					accountId: "account",
+					complianceRegion: undefined,
+				})
+			).rejects.toThrow(
+				"Cloudflare Tunnel commands require API token authentication with tunnel permissions."
+			);
+		}
 	});
 });

--- a/packages/wrangler/src/tunnel/client.ts
+++ b/packages/wrangler/src/tunnel/client.ts
@@ -1,22 +1,16 @@
-import { FatalError, UserError } from "@cloudflare/workers-utils";
+import {
+	APIError as WorkersAPIError,
+	resolveNamedTunnel as resolveNamedTunnelWithCredentials,
+	UserError,
+} from "@cloudflare/workers-utils";
 import { Cloudflare as CloudflareSDK } from "cloudflare";
-import { createCloudflareClient } from "../cfetch/internal";
-import { requireAuth } from "../user";
+import { version as wranglerVersion } from "../../package.json";
+import { logger } from "../logger";
+import { requireApiToken, requireAuth } from "../user";
 import type { Config } from "@cloudflare/workers-utils";
 import type Cloudflare from "cloudflare";
 import type { CloudflareTunnel } from "cloudflare/resources/shared";
-import type {
-	CloudflaredCreateResponse,
-	ConfigurationGetResponse,
-} from "cloudflare/resources/zero-trust/tunnels/cloudflared";
-
-const LOCAL_TUNNEL_HOSTNAMES = new Set([
-	"localhost",
-	"127.0.0.1",
-	"::1",
-	"0.0.0.0",
-	"::",
-]);
+import type { CloudflaredCreateResponse } from "cloudflare/resources/zero-trust/tunnels/cloudflared";
 
 /**
  * Error message for tunnel permission issues when using OAuth login.
@@ -43,7 +37,10 @@ Then run your tunnel command again.
  * Check if an error is a tunnel permission/authentication error
  */
 function isTunnelPermissionError(error: unknown): boolean {
-	if (error instanceof CloudflareSDK.APIError) {
+	if (
+		error instanceof CloudflareSDK.APIError ||
+		error instanceof WorkersAPIError
+	) {
 		// 403 Forbidden or 401 Unauthorized typically indicate permission issues
 		if (error.status === 403 || error.status === 401) {
 			return true;
@@ -69,7 +66,10 @@ async function withTunnelErrorHandling<T>(
 				telemetryMessage: "tunnel api permission error",
 			});
 		}
-		if (error instanceof CloudflareSDK.APIError) {
+		if (
+			error instanceof CloudflareSDK.APIError ||
+			error instanceof WorkersAPIError
+		) {
 			throw new UserError(error.message, {
 				cause: error,
 				telemetryMessage: "tunnel api error",
@@ -192,149 +192,20 @@ export async function resolveNamedTunnel(
 	hostnames: string[];
 	token: string;
 }> {
-	let accountId = options.accountId;
-
-	if (!accountId) {
-		// If no accountId is specified, prompt for login and to select an account
-		accountId = await requireAuth({
-			account_id: options.accountId,
-			compliance_region: options.complianceRegion,
-		});
-	}
-
-	const sdk = createCloudflareClient({
+	const accountId = await requireAuth({
+		account_id: options.accountId,
 		compliance_region: options.complianceRegion,
 	});
-	const tunnel = await withTunnelErrorHandling(async () => {
-		for await (const item of sdk.zeroTrust.tunnels.cloudflared.list({
-			account_id: accountId,
-			name,
-			is_deleted: false,
-		})) {
-			if (item.name === name) {
-				return normalizeTunnelResponse(item);
-			}
-		}
 
-		return null;
-	});
-
-	if (!tunnel) {
-		throw new UserError(
-			`No Cloudflare Tunnel named "${name}" was found in this account. Use "wrangler tunnel list" to see available tunnels.`,
-			{ telemetryMessage: "tunnel resolve named missing tunnel" }
-		);
-	}
-
-	const tunnelId = tunnel.id;
-	if (!tunnelId) {
-		throw new FatalError(
-			`Tunnel "${name}" was found but has no ID. This is unexpected.`,
-			{ telemetryMessage: "tunnel resolve named missing tunnel id" }
-		);
-	}
-
-	const configuration = await withTunnelErrorHandling(() =>
-		sdk.zeroTrust.tunnels.cloudflared.configurations.get(tunnelId, {
-			account_id: accountId,
+	return withTunnelErrorHandling(() =>
+		resolveNamedTunnelWithCredentials(name, origin, {
+			accountId,
+			apiToken: requireApiToken(),
+			complianceRegion: options.complianceRegion,
+			logger,
+			userAgent: `wrangler/${wranglerVersion}`,
 		})
 	);
-	const hostnames = getMatchingIngressHostnames(
-		origin,
-		configuration.config?.ingress ?? []
-	);
-	if (hostnames.length === 0) {
-		throw new UserError(
-			createMissingIngressMessage(
-				name,
-				origin,
-				`https://dash.cloudflare.com/${accountId}/tunnels/${tunnelId}`,
-				configuration.config?.ingress ?? []
-			),
-			{ telemetryMessage: "tunnel resolve named ingress mismatch" }
-		);
-	}
-
-	const token = await getTunnelToken(sdk, accountId, tunnelId);
-
-	return { hostnames, token };
-}
-
-/**
- * Return ingress hostnames whose configured service targets the current local dev origin.
- */
-function getMatchingIngressHostnames(
-	origin: URL,
-	ingressConfig: ConfigurationGetResponse.Config.Ingress[]
-): string[] {
-	const hostnames = new Set<string>();
-	const originUrl = normalizeURL(origin);
-
-	for (const ingress of ingressConfig) {
-		try {
-			const serviceUrl = normalizeURL(ingress.service);
-
-			if (ingress.hostname && serviceUrl.toString() === originUrl.toString()) {
-				hostnames.add(ingress.hostname);
-			}
-		} catch {
-			// Ignore invalid service URLs in ingress rules
-		}
-	}
-
-	return [...hostnames];
-}
-
-function normalizeURL(url: URL | string): URL {
-	const normalizedUrl = new URL(url);
-
-	if (LOCAL_TUNNEL_HOSTNAMES.has(normalizedUrl.hostname)) {
-		normalizedUrl.hostname = "localhost";
-	}
-
-	if (!normalizedUrl.port) {
-		switch (normalizedUrl.protocol) {
-			case "http:":
-				normalizedUrl.port = "80";
-				break;
-			case "https:":
-				normalizedUrl.port = "443";
-				break;
-		}
-	}
-
-	return normalizedUrl;
-}
-
-function createMissingIngressMessage(
-	name: string,
-	origin: URL,
-	dashboardUrl: string,
-	ingress: ConfigurationGetResponse.Config.Ingress[]
-): string {
-	if (ingress.length === 0) {
-		return [
-			`Tunnel "${name}" has no routes configured.`,
-			"",
-			`Add a route for ${origin} in the Cloudflare dashboard:`,
-			dashboardUrl,
-			"",
-		].join("\n");
-	}
-
-	return [
-		`Tunnel "${name}" has no route for ${origin}`,
-		"",
-		"Resolved routes:",
-		...ingress.map(
-			({ hostname, service }) =>
-				`  - ${hostname ?? "(no hostname)"} -> ${service}`
-		),
-		"",
-		"Update your local server settings or the tunnel routes in the Cloudflare dashboard:",
-		dashboardUrl,
-		"",
-	].join("\n");
 }
 
 /**

--- a/packages/wrangler/src/tunnel/client.ts
+++ b/packages/wrangler/src/tunnel/client.ts
@@ -66,10 +66,7 @@ async function withTunnelErrorHandling<T>(
 				telemetryMessage: "tunnel api permission error",
 			});
 		}
-		if (
-			error instanceof CloudflareSDK.APIError ||
-			error instanceof WorkersAPIError
-		) {
+		if (error instanceof CloudflareSDK.APIError) {
 			throw new UserError(error.message, {
 				cause: error,
 				telemetryMessage: "tunnel api error",


### PR DESCRIPTION
Related to https://github.com/cloudflare/cf/issues/161.

Move named tunnel resolution from Wrangler into `workers-utils`, keeping Wrangler as an authenticated caller. This gives other development tools a shared resolver without depending on Wrangler or inheriting its API client.

Callers continue to own login, profile selection, and token refresh. The shared resolver accepts resolved credentials and uses direct API requests, preserving the existing ingress matching and user guidance.

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: This is an internal refactor with no user-facing behavior change.

*A picture of a cute animal (not mandatory, but encouraged)*
