### PR TITLE
tolerate missing permissions for pre-flight checks

### DIFF
--- a/.changeset/tolerate-delete-cleanup-permissions.md
+++ b/.changeset/tolerate-delete-cleanup-permissions.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Tolerate missing permissions during `wrangler delete` cleanup checks
+
+`wrangler delete` now warns and continues when it cannot inspect Worker dependencies or clean up legacy Workers Sites KV namespaces because of missing permissions. The Worker delete request itself still fails normally if the token cannot delete the Worker.

--- a/.changeset/tolerate-provisioning-permissions.md
+++ b/.changeset/tolerate-provisioning-permissions.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Tolerate missing resource permissions during resource provisioning
+
+When Wrangler cannot check whether a bound resource exists because the API returns a 403, it now skips automatic provisioning for that resource type and continues the deploy. The deploy may still fail later if the resource is missing.

--- a/.github/workflows/c3-e2e.yml
+++ b/.github/workflows/c3-e2e.yml
@@ -40,7 +40,7 @@ jobs:
         pm:
           - { name: pnpm, version: "10.33.0", label: "pnpm" }
           - { name: pnpm, version: "11.5.1", label: "pnpm@11.5.1" }
-          - { name: npm, version: "0.0.0", label: "npm" }
+          - { name: npm, version: "11.7.0", label: "npm" }
           # The yarn tests keep failing on Linux with out of space errors, with no clear reason why. Disabling for now.
           # - { name: yarn, version: "1.0.0", label: "yarn" }
         include:
@@ -135,6 +135,16 @@ jobs:
           echo "pnpm on PATH: $got (expected $want)"
           [ "$got" = "$want" ] || { echo "ERROR: PATH pnpm is $got, not $want — scaffolded installs would silently run the wrong version."; exit 1; }
 
+      - name: Install matrix npm version for scaffolded installs
+        if: matrix.pm.name == 'npm' && steps.changes.outputs.everything_but_markdown == 'true'
+        shell: bash
+        run: |
+          npm install --global npm@${{ matrix.pm.version }}
+          got="$(npm --version)"
+          want="${{ matrix.pm.version }}"
+          echo "npm on PATH: $got (expected $want)"
+          [ "$got" = "$want" ] || { echo "ERROR: PATH npm is $got, not $want."; exit 1; }
+
       - id: run-e2e
         if: steps.changes.outputs.everything_but_markdown == 'true'
         shell: bash
@@ -184,7 +194,7 @@ jobs:
         pm:
           - { name: pnpm, version: "10.33.0", label: "pnpm" }
           - { name: pnpm, version: "11.5.1", label: "pnpm@11.5.1" }
-          - { name: npm, version: "0.0.0", label: "npm" }
+          - { name: npm, version: "11.7.0", label: "npm" }
         include:
           # Experimental stays on the default pnpm to preserve historical
           # required-check names; pnpm 11 coverage comes from the base entry.
@@ -280,6 +290,16 @@ jobs:
           want="${{ matrix.pm.version }}"
           echo "pnpm on PATH: $got (expected $want)"
           [ "$got" = "$want" ] || { echo "ERROR: PATH pnpm is $got, not $want — scaffolded installs would silently run the wrong version."; exit 1; }
+
+      - name: Install matrix npm version for scaffolded installs
+        if: matrix.pm.name == 'npm' && steps.check-frameworks.outputs.run_frameworks == 'true' && steps.changes.outputs.everything_but_markdown == 'true'
+        shell: bash
+        run: |
+          npm install --global npm@${{ matrix.pm.version }}
+          got="$(npm --version)"
+          want="${{ matrix.pm.version }}"
+          echo "npm on PATH: $got (expected $want)"
+          [ "$got" = "$want" ] || { echo "ERROR: PATH npm is $got, not $want."; exit 1; }
 
       - id: run-e2e
         if: steps.check-frameworks.outputs.run_frameworks == 'true' && steps.changes.outputs.everything_but_markdown == 'true'

--- a/packages/deploy-helpers/src/deploy/deploy.ts
+++ b/packages/deploy-helpers/src/deploy/deploy.ts
@@ -466,11 +466,14 @@ async function deployWorker(
 		});
 	} else {
 		assert(accountId, "Missing accountId");
+		let provisionBindingsResult:
+			| Awaited<ReturnType<typeof provisionBindings>>
+			| undefined;
 
 		if (assetsOptions?.routerConfig.has_user_worker === false) {
 			logger.debug("skipping provisioning on assets-only project");
 		} else if (props.resourcesProvision) {
-			await provisionBindings(
+			provisionBindingsResult = await provisionBindings(
 				bindings ?? {},
 				accountId,
 				scriptName,
@@ -633,6 +636,7 @@ async function deployWorker(
 				containers: config.containers,
 				unsafeMetadata: config.unsafe?.metadata,
 			});
+			provisionBindingsResult?.warnOnSkippedProvisioning();
 
 			versionId = parseNonHyphenedUuid(result.deployment_id);
 

--- a/packages/deploy-helpers/src/deploy/helpers/provision-bindings.ts
+++ b/packages/deploy-helpers/src/deploy/helpers/provision-bindings.ts
@@ -962,6 +962,10 @@ type PendingResource = {
 		| FlagshipHandler;
 };
 
+export type ProvisionBindingsResult = {
+	warnOnSkippedProvisioning: () => void;
+};
+
 function isPermissionDeniedAPIError(error: unknown): error is APIError {
 	return error instanceof APIError && error.status === 403;
 }
@@ -1197,7 +1201,7 @@ export async function provisionBindings(
 	options: {
 		skipConfigWriteback?: boolean;
 	}
-): Promise<void> {
+): Promise<ProvisionBindingsResult> {
 	const configPath = config.userConfigPath ?? config.configPath;
 	const { pendingResources, skippedProvisioning } =
 		await collectPendingResources(config, accountId, scriptName, bindings);
@@ -1336,8 +1340,12 @@ export async function provisionBindings(
 		}
 
 		logger.log(`🎉 Resources provisioned, continuing with deployment...\n`);
-		warnSkippedProvisioning(skippedProvisioning);
 	}
+
+	return {
+		warnOnSkippedProvisioning: () =>
+			warnSkippedProvisioning(skippedProvisioning),
+	};
 }
 
 export function getSettings(

--- a/packages/deploy-helpers/src/deploy/helpers/provision-bindings.ts
+++ b/packages/deploy-helpers/src/deploy/helpers/provision-bindings.ts
@@ -957,6 +957,31 @@ type PendingResource = {
 		| FlagshipHandler;
 };
 
+function isPermissionDeniedAPIError(error: unknown): error is APIError {
+	return error instanceof APIError && error.status === 403;
+}
+
+function trackSkippedProvisioning(
+	skippedProvisioning: Map<keyof typeof HANDLERS, Set<string>>,
+	resourceType: keyof typeof HANDLERS,
+	bindingName: string
+): void {
+	const skippedBindingNames =
+		skippedProvisioning.get(resourceType) ?? new Set<string>();
+	skippedBindingNames.add(bindingName);
+	skippedProvisioning.set(resourceType, skippedBindingNames);
+}
+
+function warnSkippedProvisioning(
+	skippedProvisioning: Map<keyof typeof HANDLERS, Set<string>>
+): void {
+	for (const [resourceType, bindingNames] of skippedProvisioning) {
+		logger.warn(
+			`Skipping automatic provisioning for ${HANDLERS[resourceType].name} bindings (${Array.from(bindingNames).join(", ")}) because Wrangler does not have permission to check whether the resource exists. The deploy will continue, but may fail later if the resource does not exist.`
+		);
+	}
+}
+
 function isProvisionableBinding(
 	binding: Binding
 ): binding is ProvisionableBinding {
@@ -1059,7 +1084,10 @@ async function collectPendingResources(
 	accountId: string,
 	scriptName: string,
 	bindings: StartDevWorkerInput["bindings"]
-): Promise<PendingResource[]> {
+): Promise<{
+	pendingResources: PendingResource[];
+	skippedProvisioning: Map<keyof typeof HANDLERS, Set<string>>;
+}> {
 	let settings: Settings | undefined;
 
 	try {
@@ -1069,6 +1097,7 @@ async function collectPendingResources(
 	}
 
 	const pendingResources: PendingResource[] = [];
+	const skippedProvisioning = new Map<keyof typeof HANDLERS, Set<string>>();
 
 	for (const [bindingName, binding] of Object.entries(bindings ?? {})) {
 		if (!isProvisionableBinding(binding)) {
@@ -1082,7 +1111,20 @@ async function collectPendingResources(
 			accountId
 		);
 
-		if (await handler.shouldProvision(settings)) {
+		let shouldProvision;
+		try {
+			shouldProvision = await handler.shouldProvision(settings);
+		} catch (error) {
+			if (!isPermissionDeniedAPIError(error)) {
+				throw error;
+			}
+
+			handler.inherit();
+			trackSkippedProvisioning(skippedProvisioning, binding.type, bindingName);
+			continue;
+		}
+
+		if (shouldProvision) {
 			pendingResources.push({
 				binding: bindingName,
 				resourceType: binding.type,
@@ -1091,9 +1133,12 @@ async function collectPendingResources(
 		}
 	}
 
-	return pendingResources.sort(
-		(a, b) => HANDLERS[a.resourceType].sort - HANDLERS[b.resourceType].sort
-	);
+	return {
+		pendingResources: pendingResources.sort(
+			(a, b) => HANDLERS[a.resourceType].sort - HANDLERS[b.resourceType].sort
+		),
+		skippedProvisioning,
+	};
 }
 
 export async function provisionBindings(
@@ -1107,12 +1152,8 @@ export async function provisionBindings(
 	}
 ): Promise<void> {
 	const configPath = config.userConfigPath ?? config.configPath;
-	const pendingResources = await collectPendingResources(
-		config,
-		accountId,
-		scriptName,
-		bindings
-	);
+	const { pendingResources, skippedProvisioning } =
+		await collectPendingResources(config, accountId, scriptName, bindings);
 
 	if (pendingResources.length > 0) {
 		assert(
@@ -1142,9 +1183,23 @@ export async function provisionBindings(
 		const existingResources: Record<string, NormalisedResourceInfo[]> = {};
 
 		for (const resource of pendingResources) {
-			existingResources[resource.resourceType] ??= await HANDLERS[
-				resource.resourceType
-			].load(config, accountId);
+			try {
+				existingResources[resource.resourceType] ??= await HANDLERS[
+					resource.resourceType
+				].load(config, accountId);
+			} catch (error) {
+				if (!isPermissionDeniedAPIError(error)) {
+					throw error;
+				}
+
+				resource.handler.inherit();
+				trackSkippedProvisioning(
+					skippedProvisioning,
+					resource.resourceType,
+					resource.binding
+				);
+				continue;
+			}
 
 			await runProvisioningFlow(
 				resource,
@@ -1208,6 +1263,9 @@ export async function provisionBindings(
 			) {
 				continue;
 			}
+			if (skippedProvisioning.get(binding.type)?.has(bindingName)) {
+				continue;
+			}
 
 			const bindingToWrite = toConfigBinding(bindingName, binding);
 			addBindingToPatch(patch, binding.type, bindingToWrite);
@@ -1234,8 +1292,14 @@ export async function provisionBindings(
 			}
 		}
 
-		logger.log(`🎉 All resources provisioned, continuing with deployment...\n`);
+		logger.log(
+			skippedProvisioning.size === 0
+				? `🎉 All resources provisioned, continuing with deployment...\n`
+				: `🎉 Available resources provisioned, continuing with deployment...\n`
+		);
 	}
+
+	warnSkippedProvisioning(skippedProvisioning);
 }
 
 export function getSettings(

--- a/packages/deploy-helpers/src/deploy/helpers/provision-bindings.ts
+++ b/packages/deploy-helpers/src/deploy/helpers/provision-bindings.ts
@@ -1276,10 +1276,6 @@ export async function provisionBindings(
 			) {
 				continue;
 			}
-			if (skippedProvisioning.get(binding.type)?.has(bindingName)) {
-				continue;
-			}
-
 			const bindingToWrite = toConfigBinding(bindingName, binding);
 			addBindingToPatch(patch, binding.type, bindingToWrite);
 		}

--- a/packages/deploy-helpers/src/deploy/helpers/provision-bindings.ts
+++ b/packages/deploy-helpers/src/deploy/helpers/provision-bindings.ts
@@ -980,10 +980,44 @@ function trackSkippedProvisioning(
 function warnSkippedProvisioning(
 	skippedProvisioning: Map<keyof typeof HANDLERS, Set<string>>
 ): void {
-	for (const [resourceType, bindingNames] of skippedProvisioning) {
-		logger.warn(
-			`Skipping automatic provisioning for ${HANDLERS[resourceType].name} bindings (${Array.from(bindingNames).join(", ")}) because Wrangler does not have permission to check whether the resource exists. The deploy will continue, but may fail later if the resource does not exist.`
-		);
+	if (skippedProvisioning.size === 0) {
+		return;
+	}
+
+	const bindingsByResourceType = Array.from(
+		skippedProvisioning,
+		([type, names]) => {
+			return `${getSkippedProvisioningResourceName(type)} - ${Array.from(names).join(", ")}`;
+		}
+	).join("\n");
+
+	logger.warn(dedent`
+		Skipping automatic provisioning for the following bindings because Wrangler does not have permission to check whether the resource exists. The deploy will continue, but may fail later if the resource does not exist:
+
+		${bindingsByResourceType}
+	`);
+}
+
+function getSkippedProvisioningResourceName(
+	resourceType: keyof typeof HANDLERS
+): string {
+	switch (resourceType) {
+		case "kv_namespace":
+			return "KV";
+		case "d1":
+			return "D1";
+		case "r2_bucket":
+			return "R2";
+		case "ai_search_namespace":
+			return "AI Search";
+		case "agent_memory":
+			return "Agent Memory";
+		case "queue":
+			return "Queue";
+		case "dispatch_namespace":
+			return "Dispatch Namespace";
+		case "flagship":
+			return "Flagship";
 	}
 }
 
@@ -1301,14 +1335,9 @@ export async function provisionBindings(
 			}
 		}
 
-		logger.log(
-			skippedProvisioning.size === 0
-				? `🎉 All resources provisioned, continuing with deployment...\n`
-				: `🎉 Available resources provisioned, continuing with deployment...\n`
-		);
+		logger.log(`🎉 Resources provisioned, continuing with deployment...\n`);
+		warnSkippedProvisioning(skippedProvisioning);
 	}
-
-	warnSkippedProvisioning(skippedProvisioning);
 }
 
 export function getSettings(

--- a/packages/deploy-helpers/src/deploy/helpers/provision-bindings.ts
+++ b/packages/deploy-helpers/src/deploy/helpers/provision-bindings.ts
@@ -121,6 +121,11 @@ abstract class ProvisionResourceHandler<
 		this.binding[this.idField] = id;
 	}
 
+	hasConfiguredResourceIdentifier(): boolean {
+		const id = this.binding[this.idField];
+		return (typeof id === "string" && id.length > 0) || this.name !== undefined;
+	}
+
 	abstract create(name: string): Promise<string>;
 
 	abstract get name(): string | undefined;
@@ -982,6 +987,14 @@ function warnSkippedProvisioning(
 	}
 }
 
+function inheritIfNoConfiguredResourceIdentifier(
+	handler: PendingResource["handler"]
+): void {
+	if (!handler.hasConfiguredResourceIdentifier()) {
+		handler.inherit();
+	}
+}
+
 function isProvisionableBinding(
 	binding: Binding
 ): binding is ProvisionableBinding {
@@ -1119,7 +1132,7 @@ async function collectPendingResources(
 				throw error;
 			}
 
-			handler.inherit();
+			inheritIfNoConfiguredResourceIdentifier(handler);
 			trackSkippedProvisioning(skippedProvisioning, binding.type, bindingName);
 			continue;
 		}
@@ -1192,7 +1205,7 @@ export async function provisionBindings(
 					throw error;
 				}
 
-				resource.handler.inherit();
+				inheritIfNoConfiguredResourceIdentifier(resource.handler);
 				trackSkippedProvisioning(
 					skippedProvisioning,
 					resource.resourceType,

--- a/packages/deploy-helpers/src/deploy/versions-upload.ts
+++ b/packages/deploy-helpers/src/deploy/versions-upload.ts
@@ -261,10 +261,13 @@ async function uploadWorkerVersion(
 		});
 	} else {
 		assert(accountId, "Missing accountId");
+		let provisionBindingsResult:
+			| Awaited<ReturnType<typeof provisionBindings>>
+			| undefined;
 		if (assetsOptions?.routerConfig.has_user_worker === false) {
 			logger.debug("skipping provisioning on assets-only project");
 		} else if (props.resourcesProvision) {
-			await provisionBindings(
+			provisionBindingsResult = await provisionBindings(
 				bindings,
 				accountId,
 				scriptName,
@@ -314,6 +317,7 @@ async function uploadWorkerVersion(
 				streamingTailConsumers: config.streaming_tail_consumers,
 				unsafeMetadata: config.unsafe?.metadata,
 			});
+			provisionBindingsResult?.warnOnSkippedProvisioning();
 			versionId = result.id;
 			hasPreview = result.metadata.has_preview;
 		} catch (err) {

--- a/packages/wrangler/src/__tests__/delete.test.ts
+++ b/packages/wrangler/src/__tests__/delete.test.ts
@@ -311,6 +311,55 @@ describe("delete", () => {
 		`);
 	});
 
+	it("should skip Workers Sites namespace cleanup when listing KV namespaces is not permitted", async ({
+		expect,
+	}) => {
+		mockConfirm({
+			text: `Are you sure you want to delete my-script? This action cannot be undone.`,
+			result: true,
+		});
+		mockListReferencesRequest(expect, "my-script");
+		mockListTailsByConsumerRequest(expect, "my-script");
+		mockDeleteWorkerRequest(expect, { name: "my-script" });
+		mockListKVNamespacesPermissionDeniedRequest(expect);
+
+		await runWrangler("delete --name my-script");
+
+		expect(std.out).toContain("Successfully deleted my-script");
+		expect(std.warn).toContain(
+			'Skipping cleanup of legacy Workers Sites asset namespaces for "my-script" because Wrangler does not have permission to list KV namespaces.'
+		);
+		expect(std.err).toBe("");
+	});
+
+	it("should skip Workers Sites namespace cleanup when deleting a KV namespace is not permitted", async ({
+		expect,
+	}) => {
+		mockConfirm({
+			text: `Are you sure you want to delete my-script? This action cannot be undone.`,
+			result: true,
+		});
+		mockListReferencesRequest(expect, "my-script");
+		mockListTailsByConsumerRequest(expect, "my-script");
+		mockDeleteWorkerRequest(expect, { name: "my-script" });
+		mockListKVNamespacesRequest(expect, {
+			title: "__my-script-workers_sites_assets",
+			id: "id-for-my-script-site-ns",
+		});
+		mockDeleteKVNamespacePermissionDeniedRequest(
+			expect,
+			"id-for-my-script-site-ns"
+		);
+
+		await runWrangler("delete --name my-script");
+
+		expect(std.out).toContain("Successfully deleted my-script");
+		expect(std.warn).toContain(
+			'Skipping cleanup of legacy Workers Sites asset namespace "__my-script-workers_sites_assets" because Wrangler does not have permission to delete KV namespaces.'
+		);
+		expect(std.err).toBe("");
+	});
+
 	it("should error helpfully if pages_build_output_dir is set", async ({
 		expect,
 	}) => {
@@ -325,6 +374,49 @@ describe("delete", () => {
 		);
 	});
 	describe("force deletes", () => {
+		it("should skip dependency checks when listing Worker references is not permitted", async ({
+			expect,
+		}) => {
+			mockConfirm({
+				text: `Are you sure you want to delete test-name? This action cannot be undone.`,
+				result: true,
+			});
+			writeWranglerConfig();
+			mockListReferencesPermissionDeniedRequest(expect, "test-name");
+			mockDeleteWorkerRequest(expect);
+			mockListKVNamespacesRequest(expect);
+
+			await runWrangler("delete");
+
+			expect(std.out).toContain("Successfully deleted test-name");
+			expect(std.warn).toContain(
+				'Skipping dependency checks before deleting "test-name" because Wrangler does not have permission to inspect Worker dependencies. The delete will continue, but may fail later if this Worker is still in use.'
+			);
+			expect(std.err).toBe("");
+		});
+
+		it("should skip dependency checks when listing tail consumers is not permitted", async ({
+			expect,
+		}) => {
+			mockConfirm({
+				text: `Are you sure you want to delete test-name? This action cannot be undone.`,
+				result: true,
+			});
+			writeWranglerConfig();
+			mockListReferencesRequest(expect, "test-name");
+			mockListTailsByConsumerPermissionDeniedRequest(expect, "test-name");
+			mockDeleteWorkerRequest(expect);
+			mockListKVNamespacesRequest(expect);
+
+			await runWrangler("delete");
+
+			expect(std.out).toContain("Successfully deleted test-name");
+			expect(std.warn).toContain(
+				'Skipping dependency checks before deleting "test-name" because Wrangler does not have permission to inspect Worker dependencies. The delete will continue, but may fail later if this Worker is still in use.'
+			);
+			expect(std.err).toBe("");
+		});
+
 		it("should prompt for extra confirmation when service is depended on and use force", async ({
 			expect,
 		}) => {
@@ -653,6 +745,52 @@ function mockListKVNamespacesRequest(
 	);
 }
 
+function mockListKVNamespacesPermissionDeniedRequest(expect: ExpectStatic) {
+	msw.use(
+		http.get(
+			"*/accounts/:accountId/storage/kv/namespaces",
+			({ params }) => {
+				expect(params.accountId).toEqual("some-account-id");
+				return HttpResponse.json(
+					{
+						success: false,
+						errors: [{ code: 10000, message: "Authentication error" }],
+						messages: [],
+						result: null,
+					},
+					{ status: 403 }
+				);
+			},
+			{ once: true }
+		)
+	);
+}
+
+function mockDeleteKVNamespacePermissionDeniedRequest(
+	expect: ExpectStatic,
+	namespaceId: string
+) {
+	msw.use(
+		http.delete(
+			"*/accounts/:accountId/storage/kv/namespaces/:namespaceId",
+			({ params }) => {
+				expect(params.accountId).toEqual("some-account-id");
+				expect(params.namespaceId).toEqual(namespaceId);
+				return HttpResponse.json(
+					{
+						success: false,
+						errors: [{ code: 10000, message: "Authentication error" }],
+						messages: [],
+						result: null,
+					},
+					{ status: 403 }
+				);
+			},
+			{ once: true }
+		)
+	);
+}
+
 function mockListReferencesRequest(
 	expect: ExpectStatic,
 	forScript: string,
@@ -679,6 +817,31 @@ function mockListReferencesRequest(
 	);
 }
 
+function mockListReferencesPermissionDeniedRequest(
+	expect: ExpectStatic,
+	forScript: string
+) {
+	msw.use(
+		http.get(
+			"*/accounts/:accountId/workers/scripts/:scriptName/references",
+			({ params }) => {
+				expect(params.accountId).toEqual("some-account-id");
+				expect(params.scriptName).toEqual(forScript);
+				return HttpResponse.json(
+					{
+						success: false,
+						errors: [{ code: 10000, message: "Authentication error" }],
+						messages: [],
+						result: null,
+					},
+					{ status: 403 }
+				);
+			},
+			{ once: true }
+		)
+	);
+}
+
 function mockListTailsByConsumerRequest(
 	expect: ExpectStatic,
 	forScript: string,
@@ -698,6 +861,31 @@ function mockListTailsByConsumerRequest(
 						result: tails,
 					},
 					{ status: 200 }
+				);
+			},
+			{ once: true }
+		)
+	);
+}
+
+function mockListTailsByConsumerPermissionDeniedRequest(
+	expect: ExpectStatic,
+	forScript: string
+) {
+	msw.use(
+		http.get(
+			"*/accounts/:accountId/workers/tails/by-consumer/:scriptName",
+			({ params }) => {
+				expect(params.accountId).toEqual("some-account-id");
+				expect(params.scriptName).toEqual(forScript);
+				return HttpResponse.json(
+					{
+						success: false,
+						errors: [{ code: 10000, message: "Authentication error" }],
+						messages: [],
+						result: null,
+					},
+					{ status: 403 }
 				);
 			},
 			{ once: true }

--- a/packages/wrangler/src/__tests__/provision.test.ts
+++ b/packages/wrangler/src/__tests__/provision.test.ts
@@ -255,6 +255,80 @@ describe("resource provisioning", () => {
 		);
 	});
 
+	it("does not inherit from an existing D1 binding when a permission error prevents checking the configured database name", async ({
+		expect,
+	}) => {
+		writeWranglerConfig({
+			main: "index.js",
+			d1_databases: [{ binding: "D1", database_name: "new-d1-name" }],
+		});
+		mockGetSettings({
+			result: {
+				bindings: [{ type: "d1", name: "D1", id: "old-d1-id" }],
+			},
+		});
+		msw.use(
+			http.get(
+				"*/accounts/:accountId/d1/database/:databaseId",
+				({ params }) => {
+					expect(params.databaseId).toBe("old-d1-id");
+					return HttpResponse.json(
+						createFetchResult(null, false, [
+							{ code: 10000, message: "Authentication error" },
+						]),
+						{ status: 403 }
+					);
+				}
+			)
+		);
+
+		await expect(runWrangler("deploy")).rejects.toThrow(
+			'D1 bindings must have a "database_id" field'
+		);
+		expect(std.warn).toContain(
+			"Skipping automatic provisioning for D1 Database bindings (D1)"
+		);
+	});
+
+	it("preserves an explicitly configured resource name when the provisioning picker cannot load resources", async ({
+		expect,
+	}) => {
+		writeWranglerConfig({
+			main: "index.js",
+			r2_buckets: [{ binding: "R2", bucket_name: "existing-bucket" }],
+		});
+		mockGetSettings();
+		mockGetR2Bucket(expect, "existing-bucket", true);
+
+		let r2BucketCreated = false;
+		msw.use(
+			http.get("*/accounts/:accountId/r2/buckets", () =>
+				HttpResponse.json(
+					createFetchResult(null, false, [
+						{ code: 10000, message: "Authentication error" },
+					]),
+					{ status: 403 }
+				)
+			),
+			http.post("*/accounts/:accountId/r2/buckets", () => {
+				r2BucketCreated = true;
+				return HttpResponse.json(createFetchResult({}));
+			})
+		);
+		mockUploadWorkerRequest({
+			expectedBindings: [
+				{ name: "R2", type: "r2_bucket", bucket_name: "existing-bucket" },
+			],
+		});
+
+		await runWrangler("deploy");
+
+		expect(r2BucketCreated).toBe(false);
+		expect(std.warn).toContain(
+			"Skipping automatic provisioning for R2 Bucket bindings (R2)"
+		);
+	});
+
 	it("provisions a Queue used by both a producer and consumer", async ({
 		expect,
 	}) => {

--- a/packages/wrangler/src/__tests__/provision.test.ts
+++ b/packages/wrangler/src/__tests__/provision.test.ts
@@ -256,6 +256,42 @@ describe("resource provisioning", () => {
 		);
 	});
 
+	it("warns after a successful deploy when every provisionable binding skipped provisioning", async ({
+		expect,
+	}) => {
+		writeWranglerConfig({
+			main: "index.js",
+			r2_buckets: [{ binding: "R2", bucket_name: "existing-bucket" }],
+		});
+		mockGetSettings();
+		msw.use(
+			http.get("*/accounts/:accountId/r2/buckets/existing-bucket", () =>
+				HttpResponse.json(
+					createFetchResult(null, false, [
+						{ code: 10000, message: "Authentication error" },
+					]),
+					{ status: 403 }
+				)
+			)
+		);
+		mockUploadWorkerRequest({
+			expectedBindings: [
+				{ name: "R2", type: "r2_bucket", bucket_name: "existing-bucket" },
+			],
+		});
+
+		await runWrangler("deploy");
+
+		expect(std.out).toContain("Uploaded test-name");
+		expect(std.out).not.toContain(
+			"The following bindings need to be provisioned"
+		);
+		expect(std.warn).toContain(
+			"Skipping automatic provisioning for the following bindings"
+		);
+		expect(std.warn).toContain("R2 - R2");
+	});
+
 	it("does not inherit from an existing D1 binding when a permission error prevents checking the configured database name", async ({
 		expect,
 	}) => {

--- a/packages/wrangler/src/__tests__/provision.test.ts
+++ b/packages/wrangler/src/__tests__/provision.test.ts
@@ -184,6 +184,77 @@ describe("resource provisioning", () => {
 		expect(std.err).toBe("");
 	});
 
+	it("skips provisioning a resource type when Wrangler cannot check whether it exists", async ({
+		expect,
+	}) => {
+		writeWranglerConfig({
+			main: "index.js",
+			kv_namespaces: [{ binding: "KV" }],
+			r2_buckets: [{ binding: "R2" }],
+		});
+		mockGetSettings();
+		mockListKVNamespacesRequest(expect);
+		mockCreateKVNamespace(expect, {
+			resultId: "new-kv-id",
+			assertTitle: "test-name-kv",
+		});
+
+		let r2BucketCreated = false;
+		msw.use(
+			http.get("*/accounts/:accountId/r2/buckets", () =>
+				HttpResponse.json(
+					createFetchResult(null, false, [
+						{ code: 10000, message: "Authentication error" },
+					]),
+					{ status: 403 }
+				)
+			),
+			http.post("*/accounts/:accountId/r2/buckets", () => {
+				r2BucketCreated = true;
+				return HttpResponse.json(createFetchResult({}));
+			})
+		);
+		mockUploadWorkerRequest({
+			expectedBindings: [
+				{ name: "KV", type: "kv_namespace", namespace_id: "new-kv-id" },
+				{ name: "R2", type: "inherit" },
+			],
+		});
+
+		await runWrangler("deploy");
+
+		expect(r2BucketCreated).toBe(false);
+		expect(std.out).toContain("Uploaded test-name");
+		expect(std.warn).toContain(
+			"Skipping automatic provisioning for R2 Bucket bindings (R2)"
+		);
+		expect(std.err).toBe("");
+	});
+
+	it("fails provisioning when a resource check fails with a non-permission error", async ({
+		expect,
+	}) => {
+		writeWranglerConfig({
+			main: "index.js",
+			r2_buckets: [{ binding: "R2" }],
+		});
+		mockGetSettings();
+		msw.use(
+			http.get("*/accounts/:accountId/r2/buckets", () =>
+				HttpResponse.json(
+					createFetchResult(null, false, [
+						{ code: 10000, message: "Internal Server Error" },
+					]),
+					{ status: 500 }
+				)
+			)
+		);
+
+		await expect(runWrangler("deploy")).rejects.toThrow(
+			"A request to the Cloudflare API"
+		);
+	});
+
 	it("provisions a Queue used by both a producer and consumer", async ({
 		expect,
 	}) => {

--- a/packages/wrangler/src/__tests__/provision.test.ts
+++ b/packages/wrangler/src/__tests__/provision.test.ts
@@ -329,6 +329,74 @@ describe("resource provisioning", () => {
 		);
 	});
 
+	it("preserves skipped binding array positions when a later binding of the same type provisions successfully", async ({
+		expect,
+	}) => {
+		writeWranglerConfig({
+			main: "index.js",
+			r2_buckets: [
+				{ binding: "R2_ONE", bucket_name: "first-bucket" },
+				{ binding: "R2_TWO" },
+			],
+		});
+		mockGetSettings();
+
+		let firstBucketCreated = false;
+		msw.use(
+			http.get("*/accounts/:accountId/r2/buckets/first-bucket", () =>
+				HttpResponse.json(
+					createFetchResult(null, false, [
+						{ code: 10000, message: "Authentication error" },
+					]),
+					{ status: 403 }
+				)
+			),
+			http.get("*/accounts/:accountId/r2/buckets", () =>
+				HttpResponse.json(createFetchResult({ buckets: [] }))
+			),
+			http.post("*/accounts/:accountId/r2/buckets", async ({ request }) => {
+				const requestBody = await request.json();
+				if (
+					typeof requestBody === "object" &&
+					requestBody !== null &&
+					"name" in requestBody &&
+					requestBody.name === "first-bucket"
+				) {
+					firstBucketCreated = true;
+				}
+				expect(requestBody).toMatchObject({ name: "test-name-r2-two" });
+				return HttpResponse.json(createFetchResult({}));
+			})
+		);
+		mockUploadWorkerRequest({
+			expectedBindings: [
+				{ name: "R2_ONE", type: "r2_bucket", bucket_name: "first-bucket" },
+				{ name: "R2_TWO", type: "r2_bucket", bucket_name: "test-name-r2-two" },
+			],
+		});
+
+		await runWrangler("deploy");
+
+		expect(firstBucketCreated).toBe(false);
+		expect(await readFile("wrangler.toml", "utf-8")).toMatchInlineSnapshot(`
+			"compatibility_date = "2022-01-12"
+			name = "test-name"
+			main = "index.js"
+
+			[[r2_buckets]]
+			binding = "R2_ONE"
+			bucket_name = "first-bucket"
+
+			[[r2_buckets]]
+			binding = "R2_TWO"
+			bucket_name = "test-name-r2-two"
+			"
+		`);
+		expect(std.warn).toContain(
+			"Skipping automatic provisioning for R2 Bucket bindings (R2_ONE)"
+		);
+	});
+
 	it("provisions a Queue used by both a producer and consumer", async ({
 		expect,
 	}) => {

--- a/packages/wrangler/src/__tests__/provision.test.ts
+++ b/packages/wrangler/src/__tests__/provision.test.ts
@@ -226,8 +226,9 @@ describe("resource provisioning", () => {
 		expect(r2BucketCreated).toBe(false);
 		expect(std.out).toContain("Uploaded test-name");
 		expect(std.warn).toContain(
-			"Skipping automatic provisioning for R2 Bucket bindings (R2)"
+			"Skipping automatic provisioning for the following bindings"
 		);
+		expect(std.warn).toContain("R2 - R2");
 		expect(std.err).toBe("");
 	});
 
@@ -285,9 +286,7 @@ describe("resource provisioning", () => {
 		await expect(runWrangler("deploy")).rejects.toThrow(
 			'D1 bindings must have a "database_id" field'
 		);
-		expect(std.warn).toContain(
-			"Skipping automatic provisioning for D1 Database bindings (D1)"
-		);
+		expect(std.warn).toBe("");
 	});
 
 	it("preserves an explicitly configured resource name when the provisioning picker cannot load resources", async ({
@@ -325,8 +324,9 @@ describe("resource provisioning", () => {
 
 		expect(r2BucketCreated).toBe(false);
 		expect(std.warn).toContain(
-			"Skipping automatic provisioning for R2 Bucket bindings (R2)"
+			"Skipping automatic provisioning for the following bindings"
 		);
+		expect(std.warn).toContain("R2 - R2");
 	});
 
 	it("preserves skipped binding array positions when a later binding of the same type provisions successfully", async ({
@@ -393,8 +393,9 @@ describe("resource provisioning", () => {
 			"
 		`);
 		expect(std.warn).toContain(
-			"Skipping automatic provisioning for R2 Bucket bindings (R2_ONE)"
+			"Skipping automatic provisioning for the following bindings"
 		);
+		expect(std.warn).toContain("R2 - R2_ONE");
 	});
 
 	it("provisions a Queue used by both a producer and consumer", async ({
@@ -742,7 +743,7 @@ describe("resource provisioning", () => {
 				✨ R2 provisioned 🎉
 
 				Your Worker was deployed with provisioned resources. We've written the IDs of these resources to your config file, which you can choose to save or discard. Either way future deploys will continue to work.
-				🎉 All resources provisioned, continuing with deployment...
+				🎉 Resources provisioned, continuing with deployment...
 
 				Worker Startup Time: 100 ms
 				Your Worker has access to the following bindings:
@@ -865,7 +866,7 @@ describe("resource provisioning", () => {
 				✨ R2 provisioned 🎉
 
 				Your Worker was deployed with provisioned resources. We've written the IDs of these resources to your config file, which you can choose to save or discard. Either way future deploys will continue to work.
-				🎉 All resources provisioned, continuing with deployment...
+				🎉 Resources provisioned, continuing with deployment...
 
 				Worker Startup Time: 100 ms
 				Your Worker has access to the following bindings:
@@ -1001,7 +1002,7 @@ describe("resource provisioning", () => {
 				✨ R2 provisioned 🎉
 
 				Your Worker was deployed with provisioned resources. We've written the IDs of these resources to your config file, which you can choose to save or discard. Either way future deploys will continue to work.
-				🎉 All resources provisioned, continuing with deployment...
+				🎉 Resources provisioned, continuing with deployment...
 
 				Worker Startup Time: 100 ms
 				Your Worker has access to the following bindings:
@@ -1164,7 +1165,7 @@ describe("resource provisioning", () => {
 				✨ R2 provisioned 🎉
 
 				Your Worker was deployed with provisioned resources. We've written the IDs of these resources to your config file, which you can choose to save or discard. Either way future deploys will continue to work.
-				🎉 All resources provisioned, continuing with deployment...
+				🎉 Resources provisioned, continuing with deployment...
 
 				Worker Startup Time: 100 ms
 				Your Worker has access to the following bindings:
@@ -1319,7 +1320,7 @@ describe("resource provisioning", () => {
 				✨ R2 provisioned 🎉
 
 				Your Worker was deployed with provisioned resources. We've written the IDs of these resources to your config file, which you can choose to save or discard. Either way future deploys will continue to work.
-				🎉 All resources provisioned, continuing with deployment...
+				🎉 Resources provisioned, continuing with deployment...
 
 				Worker Startup Time: 100 ms
 				Your Worker has access to the following bindings:
@@ -1464,7 +1465,7 @@ describe("resource provisioning", () => {
 				✨ D1 provisioned 🎉
 
 				Your Worker was deployed with provisioned resources. We've written the IDs of these resources to your config file, which you can choose to save or discard. Either way future deploys will continue to work.
-				🎉 All resources provisioned, continuing with deployment...
+				🎉 Resources provisioned, continuing with deployment...
 
 				Worker Startup Time: 100 ms
 				Your Worker has access to the following bindings:
@@ -1597,7 +1598,7 @@ describe("resource provisioning", () => {
 				✨ D1 provisioned 🎉
 
 				Your Worker was deployed with provisioned resources. We've written the IDs of these resources to your config file, which you can choose to save or discard. Either way future deploys will continue to work.
-				🎉 All resources provisioned, continuing with deployment...
+				🎉 Resources provisioned, continuing with deployment...
 
 				Worker Startup Time: 100 ms
 				Your Worker has access to the following bindings:
@@ -1678,7 +1679,7 @@ describe("resource provisioning", () => {
 				✨ BUCKET provisioned 🎉
 
 				Your Worker was deployed with provisioned resources. We've written the IDs of these resources to your config file, which you can choose to save or discard. Either way future deploys will continue to work.
-				🎉 All resources provisioned, continuing with deployment...
+				🎉 Resources provisioned, continuing with deployment...
 
 				Worker Startup Time: 100 ms
 				Your Worker has access to the following bindings:
@@ -1878,7 +1879,7 @@ describe("resource provisioning", () => {
 				✨ BUCKET provisioned 🎉
 
 				Your Worker was deployed with provisioned resources. We've written the IDs of these resources to your config file, which you can choose to save or discard. Either way future deploys will continue to work.
-				🎉 All resources provisioned, continuing with deployment...
+				🎉 Resources provisioned, continuing with deployment...
 
 				Worker Startup Time: 100 ms
 				Your Worker has access to the following bindings:

--- a/packages/wrangler/src/delete.ts
+++ b/packages/wrangler/src/delete.ts
@@ -1,9 +1,13 @@
 import assert from "node:assert";
-import { configFileName, UserError } from "@cloudflare/workers-utils";
+import { APIError, configFileName, UserError } from "@cloudflare/workers-utils";
 import { fetchResult } from "./cfetch";
 import { createCommand } from "./core/create-command";
 import { confirm } from "./dialogs";
-import { deleteKVNamespace, listKVNamespaces } from "./kv/helpers";
+import {
+	deleteKVNamespace,
+	listKVNamespaces,
+	type KVNamespaceInfo,
+} from "./kv/helpers";
 import { logger } from "./logger";
 import * as metrics from "./metrics";
 import { requireAuth } from "./user";
@@ -168,14 +172,39 @@ async function deleteSiteNamespaceIfExisting(
 ): Promise<void> {
 	const title = `__${scriptName}-workers_sites_assets`;
 	const previewTitle = `__${scriptName}-workers_sites_assets_preview`;
-	const allNamespaces = await listKVNamespaces(complianceConfig, accountId);
+	let allNamespaces: KVNamespaceInfo[];
+	try {
+		allNamespaces = await listKVNamespaces(complianceConfig, accountId);
+	} catch (error) {
+		if (isPermissionDeniedAPIError(error)) {
+			logger.warn(
+				`Skipping cleanup of legacy Workers Sites asset namespaces for "${scriptName}" because Wrangler does not have permission to list KV namespaces.`
+			);
+			return;
+		}
+		throw error;
+	}
 	const namespacesToDelete = allNamespaces.filter(
 		(ns) => ns.title === title || ns.title === previewTitle
 	);
 	for (const ns of namespacesToDelete) {
-		await deleteKVNamespace(complianceConfig, accountId, ns.id);
+		try {
+			await deleteKVNamespace(complianceConfig, accountId, ns.id);
+		} catch (error) {
+			if (isPermissionDeniedAPIError(error)) {
+				logger.warn(
+					`Skipping cleanup of legacy Workers Sites asset namespace "${ns.title}" because Wrangler does not have permission to delete KV namespaces.`
+				);
+				continue;
+			}
+			throw error;
+		}
 		logger.log(`🌀 Deleted asset namespace for Workers Site "${ns.title}"`);
 	}
+}
+
+function isPermissionDeniedAPIError(error: unknown): error is APIError {
+	return error instanceof APIError && error.status === 403;
 }
 
 type ScriptDetails =
@@ -230,14 +259,26 @@ async function checkAndConfirmForceDeleteIfNecessary(
 	scriptName: string,
 	accountId: string
 ): Promise<boolean | null> {
-	const references = await fetchResult<ServiceReferenceResponse>(
-		complianceConfig,
-		`/accounts/${accountId}/workers/scripts/${scriptName}/references`
-	);
-	const tailProducers = await fetchResult<Tail[]>(
-		complianceConfig,
-		`/accounts/${accountId}/workers/tails/by-consumer/${scriptName}`
-	);
+	let references: ServiceReferenceResponse;
+	let tailProducers: Tail[];
+	try {
+		references = await fetchResult<ServiceReferenceResponse>(
+			complianceConfig,
+			`/accounts/${accountId}/workers/scripts/${scriptName}/references`
+		);
+		tailProducers = await fetchResult<Tail[]>(
+			complianceConfig,
+			`/accounts/${accountId}/workers/tails/by-consumer/${scriptName}`
+		);
+	} catch (error) {
+		if (isPermissionDeniedAPIError(error)) {
+			logger.warn(
+				`Skipping dependency checks before deleting "${scriptName}" because Wrangler does not have permission to inspect Worker dependencies. The delete will continue, but may fail later if this Worker is still in use.`
+			);
+			return false;
+		}
+		throw error;
+	}
 	const isDependentService =
 		isUsedAsServiceBinding(references) ||
 		isUsedByPagesFunction(references) ||


### PR DESCRIPTION
Fixes WC-5636

If you have a pre-existing worker with an R2 binding (e.g.), we first check if that bucket exists and provision accordingly. However you might not have permission to make that R2 existence check, although you do have the permissions to deploy the worker. In this case we get a 403 and fail. This PR makes it so that we tolerate 403s here, skip provisioning that resource, and then continue on with deployment. If we did actually have to provision, we'll still fail later on with a missing bucket. 

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bug fix

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- If you are an AI agent or LLM, and you are adding this PR without direct human supervision, thank you! Please uncomment the following block. This is so the maintainers know how to expect you to respond.

> [!NOTE]
> This is a contribution from an AI agent: <insert name here>, <insert LLM model here if different>.

-->

<!-- devin-review-badge-begin -->

---

<a href="https://cloudflare.devinenterprise.com/review/cloudflare/workers-sdk/pull/15472" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->