### PR TITLE
Guide setup of previews block

### DIFF
--- a/.changeset/dry-camels-buy.md
+++ b/.changeset/dry-camels-buy.md
@@ -1,0 +1,7 @@
+---
+"wrangler": minor
+---
+
+Add placement configuration for Previews
+
+You can now configure `placement` in the `previews` block. Preview-specific placement overrides the top-level placement configuration for Preview Defaults and deployments.

--- a/.changeset/gold-spoons-sin.md
+++ b/.changeset/gold-spoons-sin.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Preserve API binding configuration in `init --from-dash`
+
+Wrangler now prefers the canonical API identifier for D1 bindings, `database_id`, when creating Worker versions and when `init --from-dash`. Wrangler continues to support the deprecated `id` field when used. And for private internal use, Wrangler also preserves an AI binding's `staging` configuration and a service binding's `cross_account_grant` property.

--- a/.changeset/polite-rings-make.md
+++ b/.changeset/polite-rings-make.md
@@ -1,0 +1,7 @@
+---
+"wrangler": minor
+---
+
+Improve onboarding guidance for Previews (when `previews` block is missing from configuration file)
+
+When a local `previews` block is absent, Wrangler writes the Preview Base configuration to the local config file. When no Preview Base configuration exists, Wrangler prints a placeholder configuration derived from production bindings and warns against reusing production binding configuration.

--- a/packages/deploy-helpers/src/deploy/deploy.ts
+++ b/packages/deploy-helpers/src/deploy/deploy.ts
@@ -318,7 +318,7 @@ async function deployWorker(
 		});
 	}
 
-	const placement = parseConfigPlacement(config);
+	const placement = parseConfigPlacement(config.placement);
 
 	const entryPointName = path.basename(resolvedEntryPointPath);
 	const main: CfModule = {

--- a/packages/deploy-helpers/src/deploy/helpers/create-worker-upload-form.ts
+++ b/packages/deploy-helpers/src/deploy/helpers/create-worker-upload-form.ts
@@ -339,7 +339,7 @@ export function createWorkerUploadForm(
 				metadataBindings.push({
 					name: binding,
 					type: "d1",
-					id: database_id,
+					database_id,
 					internalEnv: database_internal_env,
 					raw,
 				});

--- a/packages/deploy-helpers/src/deploy/helpers/placement.ts
+++ b/packages/deploy-helpers/src/deploy/helpers/placement.ts
@@ -3,9 +3,11 @@ import type { CfPlacement, Config } from "@cloudflare/workers-utils";
 /**
  * Parse placement out of a Config
  */
-export function parseConfigPlacement(config: Config): CfPlacement | undefined {
-	if (config.placement) {
-		const configPlacement = config.placement;
+export function parseConfigPlacement(
+	placement: Config["placement"]
+): CfPlacement | undefined {
+	if (placement) {
+		const configPlacement = placement;
 		const hint = "hint" in configPlacement ? configPlacement.hint : undefined;
 
 		if (!hint && configPlacement.mode === "off") {

--- a/packages/deploy-helpers/src/deploy/helpers/provision-bindings.ts
+++ b/packages/deploy-helpers/src/deploy/helpers/provision-bindings.ts
@@ -653,10 +653,12 @@ class D1Handler extends ProvisionResourceHandler<
 
 			// ...and the user HAS specified a name in their config, so we need to check if the database_name they provided
 			// matches the database_name of the existing binding (which isn't present in settings, so we'll need to make an API call to check).
+			// oxlint-disable-next-line typescript/no-deprecated -- intentional support of deprecated binding style
+			const databaseId = maybeInherited.database_id ?? maybeInherited.id;
 			const dbFromId = await getDatabaseInfoFromIdOrName(
 				this.complianceConfig,
 				this.accountId,
-				maybeInherited.id
+				databaseId
 			);
 			if (this.binding.database_name === dbFromId.name) {
 				return true;

--- a/packages/deploy-helpers/src/deploy/versions-upload.ts
+++ b/packages/deploy-helpers/src/deploy/versions-upload.ts
@@ -195,7 +195,7 @@ async function uploadWorkerVersion(
 
 	addRequiredSecretsInheritBindings(config, bindings, { type: "upload" });
 
-	const placement = parseConfigPlacement(config);
+	const placement = parseConfigPlacement(config.placement);
 
 	const entryPointName = path.basename(resolvedEntryPointPath);
 	const main = {

--- a/packages/deploy-helpers/src/preview/api.ts
+++ b/packages/deploy-helpers/src/preview/api.ts
@@ -360,12 +360,12 @@ export async function getWorkerPreviewDefaults(
 	config: Config,
 	accountId: string,
 	workerName: string
-): Promise<PreviewDefaults> {
+): Promise<PreviewDefaults | undefined> {
 	const worker = await fetchResult<WorkerPreviewDefaultsResource>(
 		config,
 		`/accounts/${accountId}/workers/workers/${workerName}`
 	);
-	return worker.preview_defaults ?? {};
+	return worker.preview_defaults;
 }
 
 export async function editWorkerPreviewDefaults(
@@ -373,7 +373,7 @@ export async function editWorkerPreviewDefaults(
 	accountId: string,
 	workerName: string,
 	previewDefaults: PreviewDefaultsPatch
-): Promise<PreviewDefaults> {
+): Promise<PreviewDefaults | undefined> {
 	const worker = await fetchResult<WorkerPreviewDefaultsResource>(
 		config,
 		`/accounts/${accountId}/workers/workers/${workerName}`,
@@ -384,19 +384,19 @@ export async function editWorkerPreviewDefaults(
 		}
 	);
 
-	return worker.preview_defaults ?? {};
+	return worker.preview_defaults;
 }
 
 export async function getPreviewBaseConfig(
 	config: Config,
 	accountId: string,
 	workerName: string
-): Promise<PreviewBaseConfig> {
+): Promise<PreviewBaseConfig | undefined> {
 	const worker = await fetchResult<WorkerPreviewBaseConfigResource>(
 		config,
 		`/accounts/${accountId}/workers/workers/${workerName}`
 	);
-	return worker.previews_base_config ?? {};
+	return worker.previews_base_config;
 }
 
 export async function patchPreviewBaseConfig(
@@ -404,7 +404,7 @@ export async function patchPreviewBaseConfig(
 	accountId: string,
 	workerName: string,
 	previewBaseConfig: PreviewBaseConfigPatch
-): Promise<PreviewBaseConfig> {
+): Promise<PreviewBaseConfig | undefined> {
 	const worker = await fetchResult<WorkerPreviewBaseConfigResource>(
 		config,
 		`/accounts/${accountId}/workers/workers/${workerName}`,
@@ -415,5 +415,5 @@ export async function patchPreviewBaseConfig(
 		}
 	);
 
-	return worker.previews_base_config ?? {};
+	return worker.previews_base_config;
 }

--- a/packages/deploy-helpers/src/preview/api.ts
+++ b/packages/deploy-helpers/src/preview/api.ts
@@ -26,6 +26,7 @@ export interface Binding {
 	index_name?: string;
 	id?: string;
 	service?: string;
+	environment?: string;
 	dataset?: string;
 	namespace?: string;
 	outbound?: {
@@ -123,7 +124,7 @@ export type CreatePreviewDeploymentRequestParams = {
 	};
 	migrations?: CfWorkerInit["migrations"];
 	limits?: CfUserLimits;
-	placement?: CfPlacement;
+	placement?: CfPlacement | null;
 	cache?: CacheOptions;
 	env?: EnvBindings;
 	containers?: Array<{ class_name: string }>;

--- a/packages/deploy-helpers/src/preview/preview.ts
+++ b/packages/deploy-helpers/src/preview/preview.ts
@@ -840,7 +840,7 @@ export async function preview(
 			);
 			logMissingPreviewsBindingsWarning(
 				topLevelBindings,
-				previewDefaults.env,
+				previewDefaults?.env,
 				extractConfigBindings(config)
 			);
 		}

--- a/packages/deploy-helpers/src/preview/preview.ts
+++ b/packages/deploy-helpers/src/preview/preview.ts
@@ -507,8 +507,16 @@ async function assemblePreviewDeploymentSettings(
 	} else if (config.cache !== undefined) {
 		request.cache = config.cache;
 	}
-	if (config.placement) {
-		request.placement = parseConfigPlacement(config);
+	if (previews?.placement !== undefined) {
+		request.placement =
+			previews.placement.mode === "off"
+				? null
+				: parseConfigPlacement(previews.placement);
+	} else if (config.placement !== undefined) {
+		request.placement =
+			config.placement.mode === "off"
+				? null
+				: parseConfigPlacement(config.placement);
 	}
 
 	// Declare which DO classes are container-backed so the runtime populates

--- a/packages/deploy-helpers/src/preview/preview.ts
+++ b/packages/deploy-helpers/src/preview/preview.ts
@@ -507,16 +507,10 @@ async function assemblePreviewDeploymentSettings(
 	} else if (config.cache !== undefined) {
 		request.cache = config.cache;
 	}
-	if (previews?.placement !== undefined) {
+	const placement = previews?.placement ?? config.placement;
+	if (placement !== undefined) {
 		request.placement =
-			previews.placement.mode === "off"
-				? null
-				: parseConfigPlacement(previews.placement);
-	} else if (config.placement !== undefined) {
-		request.placement =
-			config.placement.mode === "off"
-				? null
-				: parseConfigPlacement(config.placement);
+			placement.mode === "off" ? null : parseConfigPlacement(placement);
 	}
 
 	// Declare which DO classes are container-backed so the runtime populates

--- a/packages/deploy-helpers/src/preview/settings.ts
+++ b/packages/deploy-helpers/src/preview/settings.ts
@@ -29,11 +29,8 @@ export async function previewSettingsGet(
 	config: Config
 ): Promise<void> {
 	const workerName = resolveWorkerName(args, config);
-	const previewDefaults = await getWorkerPreviewDefaults(
-		config,
-		accountId,
-		workerName
-	);
+	const previewDefaults =
+		(await getWorkerPreviewDefaults(config, accountId, workerName)) ?? {};
 
 	if (args.json) {
 		logger.log(JSON.stringify(previewDefaults, null, 2));
@@ -53,11 +50,8 @@ export async function previewSettingsUpdate(
 ): Promise<void> {
 	const workerName = resolveWorkerName(args, config);
 
-	const currentPreviewDefaults = await getWorkerPreviewDefaults(
-		config,
-		accountId,
-		workerName
-	);
+	const currentPreviewDefaults =
+		(await getWorkerPreviewDefaults(config, accountId, workerName)) ?? {};
 	const resolvedConfigFileSettings = assemblePreviewDefaults(config);
 	const requestPayloadPreviewDefaults = mergeDeep(
 		currentPreviewDefaults as Record<string, unknown>,
@@ -105,12 +99,13 @@ export async function previewSettingsUpdate(
 		}
 	}
 
-	const updatedPreviewDefaults = await editWorkerPreviewDefaults(
-		config,
-		accountId,
-		workerName,
-		requestPayloadPreviewDefaults
-	);
+	const updatedPreviewDefaults =
+		(await editWorkerPreviewDefaults(
+			config,
+			accountId,
+			workerName,
+			requestPayloadPreviewDefaults
+		)) ?? {};
 
 	logger.log(
 		`\n✨ Updated Previews settings for Worker ${chalk.bold.cyan(workerName)}.`

--- a/packages/deploy-helpers/src/preview/shared.ts
+++ b/packages/deploy-helpers/src/preview/shared.ts
@@ -780,8 +780,9 @@ export function assemblePreviewDefaults(config: Config): PreviewDefaults {
 		previewDefaults.cache = previews?.cache ?? config.cache;
 	}
 
-	if (config.placement) {
-		previewDefaults.placement = parseConfigPlacement(config);
+	const placement = previews?.placement ?? config.placement;
+	if (placement) {
+		previewDefaults.placement = parseConfigPlacement(placement);
 	}
 
 	return previewDefaults;

--- a/packages/deploy-helpers/src/preview/shared.ts
+++ b/packages/deploy-helpers/src/preview/shared.ts
@@ -463,6 +463,8 @@ export function extractConfigBindings(config: Config): EnvBindings {
 		env[service.binding] = {
 			type: "service",
 			service: service.service,
+			// oxlint-disable-next-line typescript/no-deprecated -- intentional support of deprecated service environments
+			environment: service.environment,
 			entrypoint: service.entrypoint,
 			...(crossAccountGrant !== undefined && {
 				cross_account_grant: crossAccountGrant,

--- a/packages/workers-utils/src/config/environment.ts
+++ b/packages/workers-utils/src/config/environment.ts
@@ -1968,7 +1968,7 @@ export type ContainerEngine =
  *
  * The `previews` block contains any intentionally divergent configuration intended solely for Previews, including:
  * - All non-inheritable properties (environment variables and bindings like KV, D1, R2, etc.)
- * - Select inheritable properties: `logpush`, `observability`, `limits`, `cache`
+ * - Select inheritable properties: `logpush`, `observability`, `limits`, `placement`, `cache`
  *
  * @inheritable
  */
@@ -1978,6 +1978,6 @@ export interface PreviewsConfig
 		Partial<
 			Pick<
 				EnvironmentInheritable,
-				"logpush" | "observability" | "limits" | "cache"
+				"logpush" | "observability" | "limits" | "placement" | "cache"
 			>
 		> {}

--- a/packages/workers-utils/src/config/environment.ts
+++ b/packages/workers-utils/src/config/environment.ts
@@ -1981,3 +1981,35 @@ export interface PreviewsConfig
 				"logpush" | "observability" | "limits" | "placement" | "cache"
 			>
 		> {}
+
+export const PREVIEW_BINDING_CONFIG_FIELDS = [
+	"vars",
+	"kv_namespaces",
+	"d1_databases",
+	"r2_buckets",
+	"services",
+	"durable_objects",
+	"workflows",
+	"send_email",
+	"queues",
+	"vectorize",
+	"hyperdrive",
+	"analytics_engine_datasets",
+	"dispatch_namespaces",
+	"mtls_certificates",
+	"pipelines",
+	"secrets_store_secrets",
+	"artifacts",
+	"flagship",
+	"ratelimits",
+	"worker_loaders",
+	"vpc_services",
+	"browser",
+	"ai",
+	"images",
+	"stream",
+	"media",
+	"version_metadata",
+	"unsafe",
+	"containers",
+] as const;

--- a/packages/workers-utils/src/config/patch-config.ts
+++ b/packages/workers-utils/src/config/patch-config.ts
@@ -73,6 +73,9 @@ const getJSONPath = (
 	for (const [k, v] of Object.entries(obj)) {
 		const currentPath = [...prevPath, k];
 		if (Array.isArray(v)) {
+			if (v.length === 0 && !isArrayInsertion) {
+				allPaths.push([...currentPath, v as unknown as JSONPath[number]]);
+			}
 			v.forEach((x, i) => {
 				if (isArrayInsertion) {
 					// makes sure we insert new array items at the end
@@ -84,7 +87,13 @@ const getJSONPath = (
 				}
 			});
 		} else if (typeof v === "object" && v !== null) {
-			getJSONPath(v, allPaths, isArrayInsertion, currentPath);
+			if (Object.keys(v).length === 0) {
+				if (!isArrayInsertion) {
+					allPaths.push([...currentPath, v]);
+				}
+			} else {
+				getJSONPath(v, allPaths, isArrayInsertion, currentPath);
+			}
 		} else {
 			allPaths.push([...currentPath, v]);
 		}

--- a/packages/workers-utils/src/config/validation.ts
+++ b/packages/workers-utils/src/config/validation.ts
@@ -10,7 +10,10 @@ import { isRedirectedRawConfig } from "./config-helpers";
 import { getContainerNameToClassNameMap } from "./containers";
 import { Diagnostics } from "./diagnostics";
 import { getDurableObjectExports } from "./durable-object-exports";
-import { ARTIFACTS_EVENT_TYPES } from "./environment";
+import {
+	ARTIFACTS_EVENT_TYPES,
+	PREVIEW_BINDING_CONFIG_FIELDS,
+} from "./environment";
 import {
 	all,
 	appendEnvName,
@@ -5966,39 +5969,11 @@ const validatePreviewsConfig =
 
 		isValid =
 			validateAdditionalProperties(diagnostics, field, Object.keys(previews), [
-				"vars",
+				...PREVIEW_BINDING_CONFIG_FIELDS,
 				"define",
-				"durable_objects",
-				"workflows",
-				"kv_namespaces",
-				"send_email",
-				"queues",
-				"d1_databases",
-				"r2_buckets",
-				"vectorize",
-				"hyperdrive",
-				"services",
-				"analytics_engine_datasets",
-				"dispatch_namespaces",
-				"mtls_certificates",
 				"tail_consumers",
 				"streaming_tail_consumers",
-				"unsafe",
-				"browser",
-				"ai",
-				"images",
-				"stream",
-				"media",
-				"pipelines",
-				"secrets_store_secrets",
-				"artifacts",
 				"unsafe_hello_world",
-				"flagship",
-				"worker_loaders",
-				"ratelimits",
-				"vpc_services",
-				"version_metadata",
-				"containers",
 				"logpush",
 				"observability",
 				"limits",

--- a/packages/workers-utils/src/config/validation.ts
+++ b/packages/workers-utils/src/config/validation.ts
@@ -1209,9 +1209,27 @@ function validateRoutes(
 function normalizeAndValidatePlacement(
 	diagnostics: Diagnostics,
 	topLevelEnv: Environment | undefined,
-	rawEnv: RawEnvironment
+	rawEnv: RawEnvironment,
+	diagnosticField = "placement"
 ): Config["placement"] {
-	if (rawEnv.placement) {
+	if (rawEnv.placement !== undefined) {
+		if (
+			typeof rawEnv.placement !== "object" ||
+			rawEnv.placement === null ||
+			Array.isArray(rawEnv.placement)
+		) {
+			diagnostics.errors.push(
+				`The field "${diagnosticField}" should be an object but got ${JSON.stringify(rawEnv.placement)}.`
+			);
+			return inheritable(
+				diagnostics,
+				topLevelEnv,
+				rawEnv,
+				"placement",
+				() => true,
+				undefined
+			);
+		}
 		const placement = rawEnv.placement as Record<string, unknown>;
 
 		// Detect which format is being used
@@ -1224,7 +1242,7 @@ function normalizeAndValidatePlacement(
 		// Validate that formats aren't mixed
 		if (hasHint && hasTargetedFields) {
 			diagnostics.errors.push(
-				`"placement" cannot have both "hint" (smart format) and "region"/"host"/"hostname" (targeted format) fields`
+				`"${diagnosticField}" cannot have both "hint" (smart format) and "region"/"host"/"hostname" (targeted format) fields`
 			);
 			return inheritable(
 				diagnostics,
@@ -1240,7 +1258,7 @@ function normalizeAndValidatePlacement(
 		if (hasHint) {
 			validateRequiredProperty(
 				diagnostics,
-				"placement",
+				diagnosticField,
 				"mode",
 				placement.mode,
 				"string",
@@ -1253,12 +1271,12 @@ function normalizeAndValidatePlacement(
 			// Hint must be a string (if provided)
 			if (hint !== undefined && typeof hint !== "string") {
 				diagnostics.errors.push(
-					`"placement.hint" must be a string when "placement.mode" is "${mode}"`
+					`"${diagnosticField}.hint" must be a string when "${diagnosticField}.mode" is "${mode}"`
 				);
 			}
 			if (hint && mode !== "smart") {
 				diagnostics.errors.push(
-					`"placement.hint" can only be set when "placement.mode" is "smart"`
+					`"${diagnosticField}.hint" can only be set when "${diagnosticField}.mode" is "smart"`
 				);
 			}
 		}
@@ -1267,7 +1285,7 @@ function normalizeAndValidatePlacement(
 			// Mode is optional for new format, but if present must be "off" or "targeted"
 			validateOptionalProperty(
 				diagnostics,
-				"placement",
+				diagnosticField,
 				"mode",
 				placement.mode,
 				"string",
@@ -1278,7 +1296,7 @@ function normalizeAndValidatePlacement(
 			if (hasRegion) {
 				validateOptionalProperty(
 					diagnostics,
-					"placement",
+					diagnosticField,
 					"region",
 					placement.region,
 					"string"
@@ -1287,7 +1305,7 @@ function normalizeAndValidatePlacement(
 			if (hasHost) {
 				validateOptionalProperty(
 					diagnostics,
-					"placement",
+					diagnosticField,
 					"host",
 					placement.host,
 					"string"
@@ -1296,7 +1314,7 @@ function normalizeAndValidatePlacement(
 			if (hasHostname) {
 				validateOptionalProperty(
 					diagnostics,
-					"placement",
+					diagnosticField,
 					"hostname",
 					placement.hostname,
 					"string"
@@ -1317,7 +1335,7 @@ function normalizeAndValidatePlacement(
 					presentFields.push("hostname");
 				}
 				diagnostics.errors.push(
-					`"placement" fields ${presentFields.map((f) => `"${f}"`).join(", ")} are mutually exclusive. Only one can be specified.`
+					`"${diagnosticField}" fields ${presentFields.map((f) => `"${f}"`).join(", ")} are mutually exclusive. Only one can be specified.`
 				);
 			}
 		}
@@ -1325,7 +1343,7 @@ function normalizeAndValidatePlacement(
 		else {
 			validateRequiredProperty(
 				diagnostics,
-				"placement",
+				diagnosticField,
 				"mode",
 				placement.mode,
 				"string",
@@ -5984,6 +6002,7 @@ const validatePreviewsConfig =
 				"logpush",
 				"observability",
 				"limits",
+				"placement",
 				"cache",
 			]) && isValid;
 
@@ -6002,6 +6021,13 @@ const validatePreviewsConfig =
 				previews.define,
 				undefined
 			) && isValid;
+
+		normalizeAndValidatePlacement(
+			diagnostics,
+			undefined,
+			previews,
+			`${field}.placement`
+		);
 
 		isValid =
 			validateBindingsProperty(envName, validateDurableObjectBinding)(

--- a/packages/workers-utils/src/map-worker-metadata-bindings.ts
+++ b/packages/workers-utils/src/map-worker-metadata-bindings.ts
@@ -63,11 +63,13 @@ export function mapWorkerMetadataBindings(
 						break;
 					case "d1":
 						{
+							// oxlint-disable-next-line typescript/no-deprecated -- intentional support of deprecated binding style
+							const databaseId = binding.database_id ?? binding.id;
 							configObj.d1_databases = [
 								...(configObj.d1_databases ?? []),
 								{
 									binding: binding.name,
-									database_id: binding.id,
+									database_id: databaseId,
 								},
 							];
 						}
@@ -83,6 +85,7 @@ export function mapWorkerMetadataBindings(
 						{
 							configObj.ai = {
 								binding: binding.name,
+								staging: binding.staging,
 							};
 						}
 						break;
@@ -171,6 +174,8 @@ export function mapWorkerMetadataBindings(
 									service: binding.service,
 									environment: binding.environment,
 									entrypoint: binding.entrypoint,
+									// @ts-expect-error - cross_account_grant is internal-only and not in the public config types
+									cross_account_grant: binding.cross_account_grant,
 								},
 							];
 						}

--- a/packages/workers-utils/src/types.ts
+++ b/packages/workers-utils/src/types.ts
@@ -130,7 +130,10 @@ export type WorkerMetadataBinding =
 	| {
 			type: "d1";
 			name: string;
-			id: string;
+			database_id: string;
+			database_name?: string;
+			/** @deprecated The API may return this for legacy D1 bindings. Use `database_id` instead. */
+			id?: string;
 			internalEnv?: string;
 			raw?: boolean;
 	  }

--- a/packages/workers-utils/tests/config/patch-config.test.ts
+++ b/packages/workers-utils/tests/config/patch-config.test.ts
@@ -480,6 +480,46 @@ const replacingOnlyTestCases: Omit<TestCase, "additivePatch">[] = [
 
 describe("experimental_patchConfig()", () => {
 	runInTempDir();
+	it("does not overwrite values with empty additive patches", ({ expect }) => {
+		writeWranglerConfig(
+			{
+				compatibility_flags: ["nodejs_compat"],
+				kv_namespaces: [{ binding: "KV", id: "namespace-id" }],
+				vars: { ENVIRONMENT: "production" },
+			},
+			"./wrangler.json"
+		);
+
+		const result = experimental_patchConfig("./wrangler.json", {
+			compatibility_flags: [],
+			kv_namespaces: [],
+			vars: {},
+		});
+
+		expect(JSON.parse(result)).toMatchObject({
+			compatibility_flags: ["nodejs_compat"],
+			kv_namespaces: [{ binding: "KV", id: "namespace-id" }],
+			vars: { ENVIRONMENT: "production" },
+		});
+	});
+
+	it.for(["json", "jsonc", "toml"])(
+		"creates an empty previews block in %s configuration",
+		(configType, { expect }) => {
+			const path = `./wrangler.${configType}`;
+			writeFileSync(
+				path,
+				configType === "toml"
+					? 'name = "test-name"\n'
+					: '{\n  "name": "test-name"\n}\n'
+			);
+
+			const result = experimental_patchConfig(path, { previews: {} }, false);
+			expect(result).toContain(
+				configType === "toml" ? "[previews]" : '"previews": {}'
+			);
+		}
+	);
 	describe.each([true, false])("isArrayInsertion = %o", (isArrayInsertion) => {
 		describe.each(testCases)(
 			`$name`,

--- a/packages/wrangler/src/__tests__/api/startDevWorker/utils.test.ts
+++ b/packages/wrangler/src/__tests__/api/startDevWorker/utils.test.ts
@@ -4,9 +4,32 @@ import {
 	convertStartDevOptionsToBindings,
 } from "../../../api/startDevWorker/binding-utils";
 import {
+	convertWorkerMetadataBindingsToFlatBindings,
 	isSameUserWorkerOrigin,
 	rewriteUrlInHeaderValue,
 } from "../../../api/startDevWorker/utils";
+
+describe("convertWorkerMetadataBindingsToFlatBindings", () => {
+	it("prefers canonical D1 IDs and supports legacy IDs", ({ expect }) => {
+		expect(
+			convertWorkerMetadataBindingsToFlatBindings([
+				{ type: "d1", name: "CANONICAL", database_id: "canonical-id" },
+				// Legacy API responses predate `database_id`.
+				{ type: "d1", name: "LEGACY", id: "legacy-id" } as never,
+				{
+					type: "d1",
+					name: "BOTH",
+					database_id: "canonical-id",
+					id: "legacy-id",
+				},
+			])
+		).toMatchObject({
+			CANONICAL: { type: "d1", database_id: "canonical-id" },
+			LEGACY: { type: "d1", database_id: "legacy-id" },
+			BOTH: { type: "d1", database_id: "canonical-id" },
+		});
+	});
+});
 
 describe("isSameUserWorkerOrigin", () => {
 	const userWorker = { protocol: "http:", hostname: "localhost", port: "8787" };

--- a/packages/wrangler/src/__tests__/init.test.ts
+++ b/packages/wrangler/src/__tests__/init.test.ts
@@ -1156,6 +1156,80 @@ describe("init", () => {
 			});
 		});
 
+		it("should map D1 database IDs from dashboard", async ({ expect }) => {
+			worker = makeWorker({
+				bindings: [
+					{
+						type: "d1",
+						name: "DATABASE_ID_ONLY",
+						database_id: "database-id-only",
+					},
+					{
+						type: "d1",
+						name: "ID_ONLY",
+						id: "id-only",
+					},
+					{
+						type: "d1",
+						name: "BOTH",
+						database_id: "database-id",
+						id: "legacy-id",
+					},
+				],
+			});
+
+			await runWrangler(
+				"init --from-dash isolinear-optical-chip --no-delegate-c3"
+			);
+
+			expect(
+				JSON.parse(
+					fs.readFileSync("./isolinear-optical-chip/wrangler.jsonc", "utf8")
+				)
+			).toMatchObject({
+				d1_databases: [
+					{ binding: "DATABASE_ID_ONLY", database_id: "database-id-only" },
+					{ binding: "ID_ONLY", database_id: "id-only" },
+					{ binding: "BOTH", database_id: "database-id" },
+				],
+			});
+		});
+
+		it("should preserve AI staging and service cross-account grants from dashboard", async ({
+			expect,
+		}) => {
+			worker = makeWorker({
+				bindings: [
+					{ type: "ai", name: "AI", staging: true },
+					{
+						type: "service",
+						name: "SERVICE",
+						service: "other-worker",
+						cross_account_grant: "grant-id",
+					},
+				],
+			});
+
+			await runWrangler(
+				"init --from-dash isolinear-optical-chip --no-delegate-c3"
+			);
+
+			expect(
+				JSON.parse(
+					fs.readFileSync("./isolinear-optical-chip/wrangler.jsonc", "utf8")
+				)
+			).toMatchObject({
+				ai: { binding: "AI", staging: true },
+				services: [
+					{
+						binding: "SERVICE",
+						service: "other-worker",
+						cross_account_grant: "grant-id",
+					},
+				],
+			});
+		});
+
 		it("should download source script from dashboard as plain JavaScript", async () => {
 			worker = makeWorker({ id: "isolinear-optical-chip" });
 

--- a/packages/wrangler/src/__tests__/preview.test.ts
+++ b/packages/wrangler/src/__tests__/preview.test.ts
@@ -1,5 +1,5 @@
 import * as childProcess from "node:child_process";
-import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { stripVTControlCharacters } from "node:util";
 import * as streams from "@cloudflare/cli-shared-helpers/streams";
 import {
@@ -16,10 +16,11 @@ import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
 import { afterAll, afterEach, beforeEach, describe, test, vi } from "vitest";
 import { clearOutputFilePath } from "../output";
+import { getPreviewConfigFromProductionBindings } from "../preview/preview";
 import * as user from "../user";
 import { mockAccountId, mockApiToken } from "./helpers/mock-account-id";
 import { mockConsoleMethods } from "./helpers/mock-console";
-import { mockConfirm } from "./helpers/mock-dialogs";
+import { clearDialogs, mockConfirm } from "./helpers/mock-dialogs";
 import { useMockIsTTY } from "./helpers/mock-istty";
 import { msw } from "./helpers/msw";
 import { runWrangler } from "./helpers/run-wrangler";
@@ -235,6 +236,7 @@ describe("wrangler preview", () => {
 	runInTempDir();
 	mockApiToken();
 	mockAccountId();
+	const { setIsTTY } = useMockIsTTY();
 	afterEach(() => {
 		clearOutputFilePath();
 		// Several container tests stub `getScopes` to grant `containers:write`.
@@ -242,6 +244,7 @@ describe("wrangler preview", () => {
 		// restore that stub would outlive its test and silently grant the scope
 		// to every later test in the file.
 		vi.restoreAllMocks();
+		clearDialogs();
 	});
 
 	describe("resolveWorkerName", () => {
@@ -808,6 +811,128 @@ describe("wrangler preview", () => {
 		});
 	});
 
+	describe("getPreviewConfigFromProductionBindings", () => {
+		test("replaces resource identifiers while preserving typed options", ({
+			expect,
+		}) => {
+			const config = {
+				...defaultWranglerConfig,
+				vars: { STRING_VALUE: "production", BOOLEAN_VALUE: true },
+				ai: { binding: "AI", staging: true },
+				queues: {
+					producers: [
+						{
+							binding: "QUEUE",
+							queue: "production-queue",
+							delivery_delay: 10,
+						},
+					],
+				},
+				services: [
+					{
+						binding: "SERVICE",
+						service: "production-service",
+						environment: "production",
+					},
+				],
+				send_email: [
+					{
+						name: "MAIL",
+						destination_address: "production@example.com",
+						allowed_destination_addresses: ["allowed@example.com"],
+						allowed_sender_addresses: ["sender@example.com"],
+					},
+				],
+				dispatch_namespaces: [
+					{
+						binding: "DISPATCH",
+						namespace: "production-namespace",
+						outbound: {
+							service: "production-worker",
+							environment: "production",
+						},
+					},
+					{
+						binding: "DEFAULT_DISPATCH",
+						namespace: "production-namespace",
+						outbound: { service: "production-worker" },
+					},
+				],
+				ratelimits: [
+					{
+						name: "RATE_LIMITER",
+						namespace_id: "production-namespace",
+						simple: { limit: 5, period: 60 },
+					},
+				],
+			} as Config;
+
+			const previews = getPreviewConfigFromProductionBindings(
+				config,
+				extractConfigBindings({
+					...config,
+					assets: undefined,
+					previews: config,
+				})
+			);
+
+			expect(previews).toEqual({
+				vars: { STRING_VALUE: "<REPLACE_ME>", BOOLEAN_VALUE: true },
+				ai: { binding: "AI", staging: true },
+				queues: {
+					producers: [
+						{
+							binding: "QUEUE",
+							queue: "<REPLACE_ME>",
+							delivery_delay: 10,
+						},
+					],
+				},
+				services: [
+					{
+						binding: "SERVICE",
+						service: "<REPLACE_ME>",
+						environment: "<REPLACE_ME>",
+					},
+				],
+				send_email: [
+					{
+						name: "MAIL",
+						destination_address: "<REPLACE_ME>",
+						allowed_destination_addresses: ["<REPLACE_ME>"],
+						allowed_sender_addresses: ["<REPLACE_ME>"],
+					},
+				],
+				dispatch_namespaces: [
+					{
+						binding: "DISPATCH",
+						namespace: "<REPLACE_ME>",
+						outbound: {
+							service: "<REPLACE_ME>",
+							environment: "<REPLACE_ME>",
+							parameters: [],
+						},
+					},
+					{
+						binding: "DEFAULT_DISPATCH",
+						namespace: "<REPLACE_ME>",
+						outbound: {
+							service: "<REPLACE_ME>",
+							parameters: [],
+						},
+					},
+				],
+				ratelimits: [
+					{
+						name: "RATE_LIMITER",
+						namespace_id: "<REPLACE_ME>",
+						simple: { limit: 5, period: 60 },
+					},
+				],
+			});
+		});
+	});
+
 	describe("preview command", () => {
 		beforeEach(() => {
 			vi.stubEnv("CI", undefined);
@@ -856,6 +981,539 @@ describe("wrangler preview", () => {
 						)
 				)
 			);
+		});
+
+		test("writes the Preview Base config when confirmed interactively", async ({
+			expect,
+		}) => {
+			writeFileSync(
+				"wrangler.json",
+				JSON.stringify({
+					name: "test-worker",
+					main: "src/index.ts",
+					compatibility_date: "2025-01-01",
+				})
+			);
+			setIsTTY(true);
+			mockConfirm({
+				text: "Would you like Wrangler to add the Preview Base configuration to your config file?",
+				options: { defaultValue: true },
+				result: true,
+			});
+			msw.use(
+				http.get(`*/accounts/:accountId/workers/workers/:workerId`, () =>
+					HttpResponse.json({
+						success: true,
+						result: {
+							previews_base_config: {
+								observability: { enabled: true, head_sampling_rate: 0.5 },
+								logpush: true,
+								limits: { cpu_ms: 10, subrequests: 100 },
+								placement: { mode: "smart" },
+								cache: { enabled: true },
+								tail_consumers: [{ name: "tail-worker" }],
+								env: {
+									ENVIRONMENT: { type: "plain_text", text: "preview" },
+									DB: {
+										type: "d1",
+										id: "preview-db-id",
+									},
+									DB_CANONICAL: {
+										type: "d1",
+										database_id: "preview-db-canonical-id",
+										id: "preview-db-legacy-id",
+									},
+									AI: {
+										type: "ai",
+									},
+									SERVICE: {
+										type: "service",
+										service: "service-worker",
+										environment: "staging",
+									},
+								},
+							},
+						},
+					})
+				),
+				http.get(
+					`*/accounts/:accountId/workers/workers/:workerId/previews/:previewId`,
+					() =>
+						HttpResponse.json({
+							success: true,
+							result: {
+								id: "preview-id",
+								name: "test-preview",
+								slug: "test-preview",
+								worker_name: "test-worker",
+								created_on: new Date().toISOString(),
+							},
+						})
+				),
+				http.patch(
+					`*/accounts/:accountId/workers/workers/:workerId/previews/:previewId`,
+					async ({ request }) => {
+						expect(await request.json()).toEqual({
+							observability: { enabled: true, head_sampling_rate: 0.5 },
+							logpush: true,
+							tail_consumers: [{ name: "tail-worker" }],
+						});
+
+						return HttpResponse.json({
+							success: true,
+							result: {
+								id: "preview-id",
+								name: "test-preview",
+								slug: "test-preview",
+								worker_name: "test-worker",
+								created_on: new Date().toISOString(),
+							},
+						});
+					}
+				),
+				http.post(
+					`*/accounts/:accountId/workers/workers/:workerId/previews/:previewId/deployments`,
+					async ({ request }) => {
+						expect(await request.json()).toMatchObject({
+							placement: { mode: "smart" },
+							limits: { cpu_ms: 10, subrequests: 100 },
+							cache: { enabled: true },
+							env: {
+								ENVIRONMENT: { type: "plain_text", text: "preview" },
+								DB: { type: "d1", database_id: "preview-db-id" },
+								DB_CANONICAL: {
+									type: "d1",
+									database_id: "preview-db-canonical-id",
+								},
+								AI: {
+									type: "ai",
+								},
+								SERVICE: {
+									type: "service",
+									service: "service-worker",
+									environment: "staging",
+								},
+							},
+						});
+
+						return HttpResponse.json({
+							success: true,
+							result: {
+								id: "deployment-id",
+								preview_id: "preview-id",
+								preview_name: "test-preview",
+								urls: [],
+								compatibility_date: "2025-01-01",
+								env: {
+									ENVIRONMENT: { type: "plain_text", text: "preview" },
+									DB: { type: "d1", id: "preview-db-id" },
+									DB_CANONICAL: {
+										type: "d1",
+										database_id: "preview-db-canonical-id",
+									},
+									AI: {
+										type: "ai",
+									},
+								},
+								created_on: new Date().toISOString(),
+							},
+						});
+					}
+				)
+			);
+
+			await runWrangler("preview --name test-preview");
+			expect(std.out).toContain("Deployment ID: deployment-id");
+
+			const config = JSON.parse(readFileSync("wrangler.json", "utf8"));
+			expect(config).toMatchObject({
+				previews: {
+					observability: { enabled: true, head_sampling_rate: 0.5 },
+					logpush: true,
+					limits: { cpu_ms: 10, subrequests: 100 },
+					placement: { mode: "smart" },
+					cache: { enabled: true },
+					tail_consumers: [{ service: "tail-worker" }],
+					vars: { ENVIRONMENT: "preview" },
+					d1_databases: [
+						{ binding: "DB", database_id: "preview-db-id" },
+						{
+							binding: "DB_CANONICAL",
+							database_id: "preview-db-canonical-id",
+						},
+					],
+					ai: { binding: "AI" },
+					services: [
+						{
+							binding: "SERVICE",
+							service: "service-worker",
+							environment: "staging",
+						},
+					],
+				},
+			});
+		});
+
+		test("does not fetch Preview Base configuration with --ignore-base-config", async ({
+			expect,
+		}) => {
+			writeFileSync(
+				"wrangler.json",
+				JSON.stringify({
+					name: "test-worker",
+					main: "src/index.ts",
+					compatibility_date: "2025-01-01",
+					kv_namespaces: [
+						{ binding: "MY_KV", id: "production-kv-namespace-id" },
+					],
+				})
+			);
+			let baseConfigRequested = false;
+			msw.use(
+				http.get(`*/accounts/:accountId/workers/workers/:workerId`, () => {
+					baseConfigRequested = true;
+					return HttpResponse.json({
+						success: true,
+						result: {
+							previews_base_config: {
+								env: { REMOTE: { type: "plain_text", text: "remote" } },
+							},
+						},
+					});
+				})
+			);
+
+			await expect(
+				runWrangler("preview --name test-preview --ignore-base-config")
+			).rejects.toThrow(/"id": "<REPLACE_ME>"/);
+
+			expect(baseConfigRequested).toBe(false);
+		});
+
+		test("prints the required production config when the parent Worker does not exist", async ({
+			expect,
+		}) => {
+			writeFileSync(
+				"wrangler.json",
+				JSON.stringify({
+					name: "test-worker",
+					main: "src/index.ts",
+					compatibility_date: "2025-01-01",
+					kv_namespaces: [
+						{ binding: "MY_KV", id: "production-kv-namespace-id" },
+					],
+				})
+			);
+			msw.use(
+				http.get(`*/accounts/:accountId/workers/workers/:workerId`, () =>
+					HttpResponse.json(
+						{
+							success: false,
+							result: null,
+							errors: [
+								{
+									code: 10007,
+									message: "This Worker does not exist on your account.",
+								},
+							],
+						},
+						{ status: 404 }
+					)
+				)
+			);
+
+			await expect(runWrangler("preview --name test-preview")).rejects.toThrow(
+				/"id": "<REPLACE_ME>"/
+			);
+		});
+
+		test("prints the Preview Base config when declined interactively", async ({
+			expect,
+		}) => {
+			writeFileSync(
+				"wrangler.json",
+				JSON.stringify({
+					name: "test-worker",
+					main: "src/index.ts",
+					compatibility_date: "2025-01-01",
+				})
+			);
+			setIsTTY(true);
+			mockConfirm({
+				text: "Would you like Wrangler to add the Preview Base configuration to your config file?",
+				options: { defaultValue: true },
+				result: false,
+			});
+			msw.use(
+				http.get(`*/accounts/:accountId/workers/workers/:workerId`, () =>
+					HttpResponse.json({
+						success: true,
+						result: {
+							previews_base_config: {
+								env: { ENVIRONMENT: { type: "plain_text", text: "preview" } },
+							},
+						},
+					})
+				)
+			);
+
+			await expect(runWrangler("preview --name test-preview")).rejects
+				.toThrowErrorMatchingInlineSnapshot(`
+				[Error: Your Wrangler configuration is missing a \`previews\` block. Add the following to your configuration file:
+
+				{
+				  "previews": {
+				    "vars": {
+				      "ENVIRONMENT": "preview"
+				    }
+				  }
+				}]
+			`);
+		});
+
+		test("prints the Preview Base config non-interactively", async ({
+			expect,
+		}) => {
+			writeFileSync(
+				"wrangler.json",
+				JSON.stringify({
+					name: "test-worker",
+					main: "src/index.ts",
+					compatibility_date: "2025-01-01",
+				})
+			);
+			setIsTTY(false);
+			msw.use(
+				http.get(`*/accounts/:accountId/workers/workers/:workerId`, () =>
+					HttpResponse.json({
+						success: true,
+						result: {
+							previews_base_config: {
+								env: { ENVIRONMENT: { type: "plain_text", text: "preview" } },
+							},
+						},
+					})
+				)
+			);
+
+			await expect(runWrangler("preview --name test-preview")).rejects
+				.toThrowErrorMatchingInlineSnapshot(`
+				[Error: Your Wrangler configuration is missing a \`previews\` block. Add the following to your configuration file:
+
+				{
+				  "previews": {
+				    "vars": {
+				      "ENVIRONMENT": "preview"
+				    }
+				  }
+				}]
+			`);
+		});
+
+		test("prints the Preview Base config when it cannot update the config file", async ({
+			expect,
+		}) => {
+			rmSync("wrangler.json");
+			writeFileSync(
+				"wrangler.toml",
+				`# Keep this comment.
+name = "test-worker"
+main = "src/index.ts"
+compatibility_date = "2025-01-01"
+`
+			);
+			setIsTTY(true);
+			mockConfirm({
+				text: "Would you like Wrangler to add the Preview Base configuration to your config file?",
+				options: { defaultValue: true },
+				result: true,
+			});
+			msw.use(
+				http.get(`*/accounts/:accountId/workers/workers/:workerId`, () =>
+					HttpResponse.json({
+						success: true,
+						result: {
+							previews_base_config: {
+								env: { ENVIRONMENT: { type: "plain_text", text: "preview" } },
+							},
+						},
+					})
+				)
+			);
+
+			await expect(runWrangler("preview --name test-preview")).rejects
+				.toThrowErrorMatchingInlineSnapshot(`
+				[Error: Your Wrangler configuration is missing a \`previews\` block. Add the following to your configuration file:
+
+				[previews.vars]
+				ENVIRONMENT = "preview"
+				]
+			`);
+		});
+
+		test.for([
+			{ worker: {}, scenario: "omitted" },
+			{ worker: { previews_base_config: {} }, scenario: "empty" },
+			{
+				worker: { previews_base_config: { env: {}, tail_consumers: [] } },
+				scenario: "only empty collections",
+			},
+		])(
+			"proceeds when previews_base_config is $scenario and no production config exists",
+			async ({ worker }, { expect }) => {
+				mkdirSync("public", { recursive: true });
+				writeFileSync("public/index.html", "<h1>Hello</h1>");
+				writeFileSync(
+					"wrangler.json",
+					JSON.stringify({
+						name: "test-worker",
+						main: "src/index.ts",
+						compatibility_date: "2025-01-01",
+						assets: { directory: "public", binding: "ASSETS" },
+						kv_namespaces: [],
+					})
+				);
+				setIsTTY(false);
+				msw.use(
+					http.get(`*/accounts/:accountId/workers/workers/:workerId`, () =>
+						HttpResponse.json({
+							success: true,
+							result: worker,
+						})
+					),
+					http.get(
+						`*/accounts/:accountId/workers/workers/:workerId/previews/:previewId`,
+						() =>
+							HttpResponse.json({
+								success: true,
+								result: {
+									id: "preview-id",
+									name: "test-preview",
+									slug: "test-preview",
+									worker_name: "test-worker",
+									created_on: new Date().toISOString(),
+								},
+							})
+					),
+					http.post(
+						`*/accounts/:accountId/workers/scripts/:workerId/assets-upload-session`,
+						() =>
+							HttpResponse.json({
+								success: true,
+								result: { buckets: [], jwt: "assets-jwt-from-session" },
+							})
+					),
+					http.post(
+						`*/accounts/:accountId/workers/workers/:workerId/previews/:previewId/deployments`,
+						async ({ request }) => {
+							expect(await request.json()).toMatchObject({
+								env: { ASSETS: { type: "assets" } },
+							});
+
+							return HttpResponse.json({
+								success: true,
+								result: {
+									id: "deployment-id",
+									preview_id: "preview-id",
+									preview_name: "test-preview",
+									urls: [],
+									compatibility_date: "2025-01-01",
+									env: { ASSETS: { type: "assets" } },
+									created_on: new Date().toISOString(),
+								},
+							});
+						}
+					)
+				);
+
+				await runWrangler("preview --name test-preview");
+				expect(std.out).toContain("Deployment ID: deployment-id");
+			}
+		);
+
+		test("prints the required production config when no Previews Base configuration exists and production bindings are configured", async ({
+			expect,
+		}) => {
+			writeFileSync(
+				"wrangler.json",
+				JSON.stringify({
+					name: "test-worker",
+					main: "src/index.ts",
+					compatibility_date: "2025-01-01",
+					vars: { ENVIRONMENT: "production" },
+					ai: { binding: "AI", staging: true },
+					kv_namespaces: [
+						{ binding: "MY_KV", id: "production-kv-namespace-id" },
+					],
+					queues: {
+						producers: [
+							{
+								binding: "QUEUE",
+								queue: "production-queue",
+								delivery_delay: 10,
+							},
+						],
+					},
+					ratelimits: [
+						{
+							name: "RATE_LIMITER",
+							namespace_id: "production-namespace",
+							simple: { limit: 5, period: 60 },
+						},
+					],
+					assets: { directory: "assets", binding: "ASSETS" },
+				})
+			);
+			setIsTTY(false);
+			msw.use(
+				http.get(`*/accounts/:accountId/workers/workers/:workerId`, () =>
+					HttpResponse.json({ success: true, result: { preview_defaults: {} } })
+				)
+			);
+
+			await expect(runWrangler("preview --name test-preview")).rejects
+				.toThrowErrorMatchingInlineSnapshot(`
+				[Error: Your Wrangler configuration is missing a \`previews\` block. Add the following to your configuration file:
+
+				{
+				  "previews": {
+				    "vars": {
+				      "ENVIRONMENT": "<REPLACE_ME>"
+				    },
+				    "kv_namespaces": [
+				      {
+				        "id": "<REPLACE_ME>",
+				        "binding": "MY_KV"
+				      }
+				    ],
+				    "queues": {
+				      "producers": [
+				        {
+				          "binding": "QUEUE",
+				          "queue": "<REPLACE_ME>",
+				          "delivery_delay": 10
+				        }
+				      ]
+				    },
+				    "ratelimits": [
+				      {
+				        "name": "RATE_LIMITER",
+				        "namespace_id": "<REPLACE_ME>",
+				        "simple": {
+				          "limit": 5,
+				          "period": 60
+				        }
+				      }
+				    ],
+				    "ai": {
+				      "binding": "AI",
+				      "staging": true
+				    }
+				  }
+				}
+
+				Do not reuse production binding configuration for Environment Variable, KV Namespace, Queue, Rate Limit, and AI unless you intentionally want Preview traffic to share production resources.]
+			`);
 		});
 
 		test("should create a new preview with defaults applied", async ({
@@ -1153,6 +1811,7 @@ describe("wrangler preview", () => {
 					name: "test-worker",
 					main: "src/index.ts",
 					compatibility_date: "2025-01-01",
+					previews: {},
 					kv_namespaces: [{ binding: "IMPORTANT_BINDING", id: "kv-id-123" }],
 				})
 			);
@@ -1704,6 +2363,7 @@ describe("wrangler preview", () => {
 					definedEnvironments: [],
 					compatibility_date: "2025-01-01",
 					compatibility_flags: ["nodejs_compat"],
+					previews: {},
 					rules: [{ type: "ESModule", globs: ["**/*.mjs"] }],
 					name: "entry-worker",
 					main: "entry.mjs",

--- a/packages/wrangler/src/__tests__/preview.test.ts
+++ b/packages/wrangler/src/__tests__/preview.test.ts
@@ -4978,7 +4978,7 @@ describe("wrangler preview", () => {
 			vi.unstubAllEnvs();
 		});
 
-		test("should inherit top-level previews config into an environment when env.previews is absent", async ({
+		test("should disable placement when previews placement is off", async ({
 			expect,
 		}) => {
 			writeFileSync(
@@ -4989,6 +4989,7 @@ describe("wrangler preview", () => {
 					compatibility_date: "2025-01-01",
 					placement: { mode: "smart" },
 					previews: {
+						placement: { mode: "off" },
 						observability: {
 							enabled: true,
 							redact_query_string: true,
@@ -5013,7 +5014,7 @@ describe("wrangler preview", () => {
 			let deploymentRequestBody:
 				| {
 						compatibility_date?: string;
-						placement?: { mode?: string };
+						placement?: { mode?: string } | null;
 						env?: Record<
 							string,
 							{ type: string; text?: string; namespace_id?: string }
@@ -5088,7 +5089,7 @@ describe("wrangler preview", () => {
 				redact_query_string: true,
 			});
 			expect(deploymentRequestBody?.compatibility_date).toBe("2025-01-01");
-			expect(deploymentRequestBody?.placement).toEqual({ mode: "smart" });
+			expect(deploymentRequestBody?.placement).toBeNull();
 			expect(deploymentRequestBody?.env).toMatchObject({
 				TOP_LEVEL_PREVIEW: { type: "plain_text", text: "top-value" },
 				TOP_KV: { type: "kv_namespace", namespace_id: "top-kv-id" },

--- a/packages/wrangler/src/api/pages/create-worker-bundle-contents.ts
+++ b/packages/wrangler/src/api/pages/create-worker-bundle-contents.ts
@@ -48,7 +48,7 @@ function createWorkerBundleFormData(
 	let placement: CfPlacement | undefined;
 
 	if (config !== undefined) {
-		placement = parseConfigPlacement(config);
+		placement = parseConfigPlacement(config.placement);
 	} else {
 		placement = undefined;
 	}

--- a/packages/wrangler/src/api/startDevWorker/utils.ts
+++ b/packages/wrangler/src/api/startDevWorker/utils.ts
@@ -143,7 +143,7 @@ export async function getBinaryFileContents(file: File<string | Uint8Array>) {
  *
  * WorkerMetadataBinding uses different field names than Binding:
  * - KV: namespace_id -> id
- * - D1: id -> database_id
+ * - D1: database_id (or legacy id) -> database_id
  * - plain_text/json: text/json -> value
  * - dispatch_namespace: outbound.worker.service -> outbound.service
  */
@@ -189,7 +189,8 @@ export function convertWorkerMetadataBindingsToFlatBindings(
 				const b = binding as Extract<WorkerMetadataBinding, { type: "d1" }>;
 				output[name] = {
 					type: "d1",
-					database_id: b.id,
+					// oxlint-disable-next-line typescript/no-deprecated -- intentional support of deprecated binding style
+					database_id: b.database_id ?? b.id,
 					database_internal_env: b.internalEnv,
 					raw: b.raw,
 				};

--- a/packages/wrangler/src/preview/base-config/secrets/list.ts
+++ b/packages/wrangler/src/preview/base-config/secrets/list.ts
@@ -103,13 +103,13 @@ export const previewBaseConfigSecretListCommand = createCommand({
 			accountId,
 			workerName
 		);
-		const secrets = extractSecretSummaries(baseConfig.env);
+		const secrets = extractSecretSummaries(baseConfig?.env);
 
 		if (args.json) {
 			logger.log(JSON.stringify(secrets, null, 2));
 			return;
 		}
 
-		logger.log(formatBaseConfigSecrets(workerName, baseConfig.env));
+		logger.log(formatBaseConfigSecrets(workerName, baseConfig?.env));
 	},
 });

--- a/packages/wrangler/src/preview/preview.ts
+++ b/packages/wrangler/src/preview/preview.ts
@@ -1,14 +1,323 @@
-import { preview } from "@cloudflare/deploy-helpers";
-import { getWranglerTmpDir } from "@cloudflare/workers-utils";
+import {
+	getPreviewBaseConfig,
+	extractConfigBindings,
+	isWorkerNotFoundError,
+	preview,
+	resolveWorkerName,
+} from "@cloudflare/deploy-helpers";
+import {
+	experimental_patchConfig,
+	formatConfigSnippet,
+	getBindingTypeFriendlyName,
+	getWranglerTmpDir,
+	isNonInteractiveOrCI,
+	PatchConfigError,
+	UserError,
+	mapWorkerMetadataBindings,
+	PREVIEW_BINDING_CONFIG_FIELDS,
+} from "@cloudflare/workers-utils";
 import { getAssetsOptions } from "../assets";
 import { getNormalizedContainerOptions } from "../containers/config";
 import { createCommand } from "../core/create-command";
 import { getEntry } from "../deployment-bundle/entry";
 import { buildWorker } from "../deployment-bundle/maybe-build-worker";
 import { cleanupDestination } from "../deployment-bundle/merge-config-args";
+import { confirm } from "../dialogs";
 import { writeOutput } from "../output";
 import { requireAuth } from "../user";
 import { deployPreviewContainers, verifyContainersScope } from "./containers";
+import type { PreviewBaseConfig } from "@cloudflare/deploy-helpers";
+import type {
+	Config,
+	PreviewsConfig,
+	WorkerMetadataBinding,
+} from "@cloudflare/workers-utils";
+
+function configFromPreviewBaseConfig({
+	env,
+	tail_consumers,
+	...baseConfig
+}: PreviewBaseConfig): PreviewsConfig {
+	const bindings = mapWorkerMetadataBindings(
+		Object.entries(env ?? {}).map(([name, binding]) => ({
+			name,
+			...binding,
+		})) as unknown as WorkerMetadataBinding[]
+	);
+
+	return {
+		...baseConfig,
+		...bindings,
+		...(tail_consumers && {
+			tail_consumers: tail_consumers.map(({ name }) => ({ service: name })),
+		}),
+	};
+}
+
+const REPLACE_ME = "<REPLACE_ME>";
+
+function isConfigured(value: unknown): boolean {
+	if (Array.isArray(value)) {
+		return value.length > 0;
+	}
+	if (value !== null && typeof value === "object") {
+		return Object.values(value).some(isConfigured);
+	}
+	return value !== undefined;
+}
+
+function formatList(items: string[]): string {
+	if (items.length <= 1) {
+		return items[0] ?? "";
+	}
+	if (items.length === 2) {
+		return items.join(" and ");
+	}
+	return `${items.slice(0, -1).join(", ")}, and ${items.at(-1)}`;
+}
+
+function getProductionBindings(config: Config) {
+	return extractConfigBindings({
+		...config,
+		assets: undefined,
+		previews: config,
+	});
+}
+
+function getProductionResourceWarning(
+	productionBindings: ReturnType<typeof getProductionBindings>
+): string {
+	const bindingTypes = [
+		...new Set(
+			Object.values(productionBindings).map(({ type }) =>
+				getBindingTypeFriendlyName(
+					type as Parameters<typeof getBindingTypeFriendlyName>[0]
+				)
+			)
+		),
+	];
+	if (bindingTypes.length === 0) {
+		return "";
+	}
+	return `\n\nDo not reuse production binding configuration for ${formatList(bindingTypes)} unless you intentionally want Preview traffic to share production resources.`;
+}
+
+function replaceProductionBindingValues(
+	binding: WorkerMetadataBinding
+): WorkerMetadataBinding {
+	switch (binding.type) {
+		case "plain_text":
+			return { ...binding, text: REPLACE_ME };
+		case "json":
+			return {
+				...binding,
+				json: typeof binding.json === "string" ? REPLACE_ME : binding.json,
+			};
+		case "kv_namespace":
+			return { ...binding, namespace_id: REPLACE_ME };
+		case "d1":
+			return { ...binding, database_id: REPLACE_ME };
+		case "r2_bucket":
+			return { ...binding, bucket_name: REPLACE_ME };
+		case "service":
+			return {
+				...binding,
+				service: REPLACE_ME,
+				...(binding.environment !== undefined && {
+					environment: REPLACE_ME,
+				}),
+			};
+		case "durable_object_namespace":
+			return {
+				...binding,
+				...(binding.script_name !== undefined && { script_name: REPLACE_ME }),
+			};
+		case "workflow":
+			return {
+				...binding,
+				workflow_name: REPLACE_ME,
+				...(binding.script_name !== undefined && { script_name: REPLACE_ME }),
+			};
+		case "queue":
+			return { ...binding, queue_name: REPLACE_ME };
+		case "vectorize":
+			return { ...binding, index_name: REPLACE_ME };
+		case "hyperdrive":
+			return { ...binding, id: REPLACE_ME };
+		case "analytics_engine":
+			return { ...binding, dataset: REPLACE_ME };
+		case "dispatch_namespace":
+			return {
+				...binding,
+				namespace: REPLACE_ME,
+				...(binding.outbound && {
+					outbound: {
+						...binding.outbound,
+						worker: {
+							...binding.outbound.worker,
+							service: REPLACE_ME,
+							...(binding.outbound.worker.environment !== undefined && {
+								environment: REPLACE_ME,
+							}),
+						},
+					},
+				}),
+			};
+		case "send_email":
+			return {
+				...binding,
+				...(binding.destination_address !== undefined && {
+					destination_address: REPLACE_ME,
+				}),
+				...(binding.allowed_destination_addresses !== undefined && {
+					allowed_destination_addresses:
+						binding.allowed_destination_addresses.map(() => REPLACE_ME),
+				}),
+				...(binding.allowed_sender_addresses !== undefined && {
+					allowed_sender_addresses: binding.allowed_sender_addresses.map(
+						() => REPLACE_ME
+					),
+				}),
+			};
+		case "mtls_certificate":
+			return { ...binding, certificate_id: REPLACE_ME };
+		case "pipelines":
+			return {
+				...binding,
+				...(binding.stream !== undefined && { stream: REPLACE_ME }),
+				...(binding.pipeline !== undefined && { pipeline: REPLACE_ME }),
+			};
+		case "secrets_store_secret":
+			return { ...binding, store_id: REPLACE_ME, secret_name: REPLACE_ME };
+		case "artifacts":
+			return { ...binding, namespace: REPLACE_ME };
+		case "flagship":
+			return { ...binding, app_id: REPLACE_ME };
+		case "ratelimit":
+			return { ...binding, namespace_id: REPLACE_ME };
+		case "vpc_service":
+			return { ...binding, service_id: REPLACE_ME };
+		case "ai_search_namespace":
+			return { ...binding, namespace: REPLACE_ME };
+		case "ai_search":
+			return { ...binding, instance_name: REPLACE_ME };
+		case "agent_memory":
+			return { ...binding, namespace: REPLACE_ME };
+		default:
+			return binding;
+	}
+}
+
+/**
+ * Converts production bindings into a Preview configuration template without
+ * copying production resource identifiers.
+ */
+export function getPreviewConfigFromProductionBindings(
+	config: Config,
+	productionBindings: ReturnType<typeof getProductionBindings>
+): PreviewsConfig {
+	if (Object.keys(productionBindings).length === 0) {
+		return {};
+	}
+	const bindings = mapWorkerMetadataBindings(
+		Object.entries(productionBindings).map(([name, binding]) =>
+			replaceProductionBindingValues({
+				name,
+				...binding,
+			} as WorkerMetadataBinding)
+		)
+	);
+	return Object.fromEntries(
+		PREVIEW_BINDING_CONFIG_FIELDS.filter((field) =>
+			isConfigured(bindings[field])
+		).map((field) => [field, bindings[field]])
+	) as PreviewsConfig;
+}
+
+function missingPreviewsConfigError(
+	previews: PreviewsConfig,
+	configPath: Config["configPath"],
+	detail = ""
+): UserError {
+	const snippet = formatConfigSnippet({ previews }, configPath);
+	return new UserError(
+		`Your Wrangler configuration is missing a \`previews\` block. Add the following to your configuration file:\n\n${snippet}${detail}`,
+		{ telemetryMessage: "preview command previews configuration missing" }
+	);
+}
+
+async function ensurePreviewsConfig(
+	accountId: string,
+	args: {
+		workerName?: string;
+		"worker-name"?: string;
+		ignoreBaseConfig?: boolean;
+	},
+	config: Config
+): Promise<Config> {
+	if (config.previews !== undefined) {
+		return config;
+	}
+
+	const configPath = config.userConfigPath ?? config.configPath;
+	const productionBindings = getProductionBindings(config);
+	const productionPreviews = getPreviewConfigFromProductionBindings(
+		config,
+		productionBindings
+	);
+	const workerName = resolveWorkerName(args, config);
+	let baseConfig: PreviewBaseConfig | undefined;
+	if (!args.ignoreBaseConfig) {
+		try {
+			baseConfig = await getPreviewBaseConfig(config, accountId, workerName);
+		} catch (error) {
+			if (!isWorkerNotFoundError(error)) {
+				throw error;
+			}
+		}
+	}
+
+	if (baseConfig === undefined || !isConfigured(baseConfig)) {
+		if (Object.keys(productionPreviews).length === 0) {
+			return config;
+		}
+		throw missingPreviewsConfigError(
+			productionPreviews,
+			configPath,
+			getProductionResourceWarning(productionBindings)
+		);
+	}
+
+	const previews = configFromPreviewBaseConfig(baseConfig ?? {});
+	if (configPath === undefined || isNonInteractiveOrCI()) {
+		throw missingPreviewsConfigError(previews, configPath);
+	}
+
+	if (
+		!(await confirm(
+			"Would you like Wrangler to add the Preview Base configuration to your config file?"
+		))
+	) {
+		throw missingPreviewsConfigError(previews, configPath);
+	}
+
+	try {
+		experimental_patchConfig(
+			configPath,
+			config.targetEnvironment === undefined
+				? { previews }
+				: { env: { [config.targetEnvironment]: { previews } } },
+			false
+		);
+	} catch (error) {
+		if (error instanceof PatchConfigError) {
+			throw missingPreviewsConfigError(previews, configPath);
+		}
+		throw error;
+	}
+
+	return { ...config, previews };
+}
 
 export const previewCommand = createCommand({
 	metadata: {
@@ -64,41 +373,46 @@ export const previewCommand = createCommand({
 	},
 	handler: async function previewHandler(args, { config }) {
 		const accountId = await requireAuth(config);
+		const previewConfig = await ensurePreviewsConfig(accountId, args, config);
 
-		const entry = await getEntry({ script: args.script }, config, "deploy");
+		const entry = await getEntry(
+			{ script: args.script },
+			previewConfig,
+			"deploy"
+		);
 		const destination = getWranglerTmpDir(entry.projectRoot, "preview");
 		const buildResult = await buildWorker(
 			{
 				entry,
-				name: config.name,
-				compatibilityDate: config.compatibility_date,
-				compatibilityFlags: config.compatibility_flags,
-				uploadSourceMaps: config.upload_source_maps,
-				jsxFactory: config.jsx_factory,
-				jsxFragment: config.jsx_fragment,
-				tsconfig: config.tsconfig,
-				minify: config.minify,
-				noBundle: config.no_bundle ?? false,
-				defines: config.previews?.define ?? {},
-				alias: { ...config.alias },
-				doBindings: config.previews?.durable_objects?.bindings ?? [],
-				workflowBindings: config.previews?.workflows ?? [],
+				name: previewConfig.name,
+				compatibilityDate: previewConfig.compatibility_date,
+				compatibilityFlags: previewConfig.compatibility_flags,
+				uploadSourceMaps: previewConfig.upload_source_maps,
+				jsxFactory: previewConfig.jsx_factory,
+				jsxFragment: previewConfig.jsx_fragment,
+				tsconfig: previewConfig.tsconfig,
+				minify: previewConfig.minify,
+				noBundle: previewConfig.no_bundle ?? false,
+				defines: previewConfig.previews?.define ?? {},
+				alias: { ...previewConfig.alias },
+				doBindings: previewConfig.previews?.durable_objects?.bindings ?? [],
+				workflowBindings: previewConfig.previews?.workflows ?? [],
 				destination,
 				outdir: undefined,
 				metafile: undefined,
 			},
-			config
+			previewConfig
 		);
 
 		const assetsOptions = getAssetsOptions({
 			args: { assets: undefined, script: args.script },
-			config,
+			config: previewConfig,
 		});
 
 		const { preview: previewResource, deployment } = await preview(
 			accountId,
 			args,
-			config,
+			previewConfig,
 			buildResult,
 			assetsOptions,
 			{


### PR DESCRIPTION
Fixes WC-5927 and WC-5834.

Primarily improves the onboarding experience for `wrangler preview`: guides users along setting up their `previews` block of config.

Additionally fixes two bug-ish-things: D1's `database_id` vs. `id` field, and adds support for `placement` in the `previews` block of config (already supported by the API). Best reviewed by commit.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: private beta

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- If you are an AI agent or LLM, and you are adding this PR without direct human supervision, thank you! Please uncomment the following block. This is so the maintainers know how to expect you to respond.

> [!NOTE]
> This is a contribution from an AI agent: <insert name here>, <insert LLM model here if different>.

-->

<!-- devin-review-badge-begin -->

---

<a href="https://cloudflare.devinenterprise.com/review/cloudflare/workers-sdk/pull/15478" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->