### PR TITLE
fix(miniflare): reject loopback bind failures during startup

### DIFF
--- a/.changeset/miniflare-loopback-bind-error.md
+++ b/.changeset/miniflare-loopback-bind-error.md
@@ -1,0 +1,7 @@
+---
+"miniflare": patch
+---
+
+Reject loopback server bind failures during Miniflare startup instead of leaving `ready` and `dispose()` hanging
+
+`#startLoopbackServer` now attaches an `error` listener before `listen`, matching the inspector proxy. When the configured host cannot be bound (e.g. `192.0.2.1`), `ready` rejects and `dispose()` still settles even if the loopback server never started.

--- a/packages/miniflare/src/index.ts
+++ b/packages/miniflare/src/index.ts
@@ -1930,7 +1930,7 @@ export class Miniflare {
 			hostname = "::";
 		}
 
-		return new Promise((resolve) => {
+		return new Promise((resolve, reject) => {
 			const server = stoppable(
 				http.createServer(this.#handleLoopback),
 				/* grace */ 0
@@ -1944,14 +1944,18 @@ export class Miniflare {
 			// already disable their timeouts.
 			server.keepAliveTimeout = 0;
 			server.on("upgrade", this.#handleLoopbackUpgrade);
+			server.once("error", reject);
 			server.listen(0, hostname, () => resolve(server));
 		});
 	}
 
 	#stopLoopbackServer(): Promise<void> {
+		const loopbackServer = this.#loopbackServer;
+		if (loopbackServer === undefined) {
+			return Promise.resolve();
+		}
 		return new Promise((resolve, reject) => {
-			assert(this.#loopbackServer !== undefined);
-			this.#loopbackServer.stop((err) => (err ? reject(err) : resolve()));
+			loopbackServer.stop((err) => (err ? reject(err) : resolve()));
 		});
 	}
 

--- a/packages/miniflare/src/index.ts
+++ b/packages/miniflare/src/index.ts
@@ -1955,7 +1955,15 @@ export class Miniflare {
 			return Promise.resolve();
 		}
 		return new Promise((resolve, reject) => {
-			loopbackServer.stop((err) => (err ? reject(err) : resolve()));
+			loopbackServer.stop((err) => {
+				if (err) {
+					reject(err);
+					return;
+				}
+				this.#loopbackServer = undefined;
+				this.#loopbackHost = undefined;
+				resolve();
+			});
 		});
 	}
 

--- a/packages/miniflare/test/index.spec.ts
+++ b/packages/miniflare/test/index.spec.ts
@@ -429,6 +429,29 @@ test("Miniflare: can use localhost as host", async ({ expect }) => {
 	expect(await res.text()).toBe("body");
 });
 
+test("Miniflare: rejects ready when loopback server cannot bind", async ({
+	expect,
+}) => {
+	const mf = new Miniflare({
+		host: "192.0.2.1",
+		workers: [
+			{
+				config: {
+					type: "worker",
+					name: "",
+					compatibilityDate: "2025-05-01",
+					manifest: singleModuleManifest(
+						`export default { fetch() { return new Response("ok"); } }`
+					),
+				},
+			},
+		],
+	});
+
+	await expect(mf.ready).rejects.toMatchObject({ code: "EADDRNOTAVAIL" });
+	await expect(mf.dispose()).rejects.toMatchObject({ code: "EADDRNOTAVAIL" });
+});
+
 test("Miniflare: can use IPv6 loopback as host", async ({ expect }) => {
 	const mf = new Miniflare({
 		host: "::1",

--- a/packages/miniflare/test/index.spec.ts
+++ b/packages/miniflare/test/index.spec.ts
@@ -452,6 +452,34 @@ test("Miniflare: rejects ready when loopback server cannot bind", async ({
 	await expect(mf.dispose()).rejects.toMatchObject({ code: "EADDRNOTAVAIL" });
 });
 
+test("Miniflare: setOptions: recovers after loopback bind failure", async ({
+	expect,
+}) => {
+	const worker = {
+		config: {
+			type: "worker" as const,
+			name: "",
+			compatibilityDate: "2025-05-01",
+			manifest: singleModuleManifest(
+				`export default { fetch() { return new Response("ok"); } }`
+			),
+		},
+	};
+	const mf = new Miniflare({ host: "127.0.0.1", workers: [worker] });
+	useDispose(mf);
+
+	await mf.ready;
+
+	await expect(
+		mf.setOptions({ host: "192.0.2.1", workers: [worker] })
+	).rejects.toMatchObject({ code: "EADDRNOTAVAIL" });
+
+	await mf.setOptions({ host: "127.0.0.1", workers: [worker] });
+
+	const res = await mf.dispatchFetch("https://example.com");
+	expect(await res.text()).toBe("ok");
+});
+
 test("Miniflare: can use IPv6 loopback as host", async ({ expect }) => {
 	const mf = new Miniflare({
 		host: "::1",


### PR DESCRIPTION
## Summary
- Attach an `error` listener before `listen` in `#startLoopbackServer` so loopback bind failures reject `ready` instead of becoming uncaught exceptions.
- Guard `#stopLoopbackServer` when the loopback server never started so `dispose()` still settles after a startup failure.
- Clear cached loopback server/host after a successful stop so `setOptions()` can recover when a host update fails to bind.
- Add regression tests for startup bind failure and `setOptions` recovery.

Fixes #15466

## Test plan
- [x] `vitest run -t "rejects ready when loopback server cannot bind"`
- [x] `vitest run -t "setOptions: recovers after loopback bind failure"`

- [x] Tests included/updated
- [x] Documentation not necessary because: internal Miniflare error-handling fix with no user-facing API or docs changes.