### PR TITLE
[autoconfig] Support Astro 7

### DIFF
--- a/.changeset/tidy-astro-seven.md
+++ b/.changeset/tidy-astro-seven.md
@@ -1,0 +1,7 @@
+---
+"@cloudflare/autoconfig": patch
+---
+
+Recognize Astro 7 as officially supported by autoconfig
+
+Astro 7 projects no longer receive an unsupported-version warning during automatic configuration. Astro 7 uses the existing native `astro add cloudflare` configuration path introduced for Astro 6.

--- a/packages/autoconfig/src/frameworks/all-frameworks.ts
+++ b/packages/autoconfig/src/frameworks/all-frameworks.ts
@@ -60,7 +60,7 @@ export const allKnownFrameworks = [
 			// in https://github.com/cloudflare/workers-sdk/pull/12938
 			// earlier versions might also be supported but we haven't checked them
 			minimumVersion: "4.0.0",
-			maximumKnownMajorVersion: "6",
+			maximumKnownMajorVersion: "7",
 		},
 		supported: true,
 	},

--- a/packages/autoconfig/tests/frameworks/validate-framework-version.test.ts
+++ b/packages/autoconfig/tests/frameworks/validate-framework-version.test.ts
@@ -1,6 +1,7 @@
 import { mockConsoleMethods } from "@cloudflare/workers-utils/test-helpers";
 import { describe, it, vi } from "vitest";
 import { AutoConfigFrameworkConfigurationError } from "../../src/errors";
+import { getFrameworkPackageInfo } from "../../src/frameworks/all-frameworks";
 import { Framework } from "../../src/frameworks/framework-class";
 import { getInstalledPackageVersion } from "../../src/frameworks/utils/packages";
 import { createMockContext } from "../helpers/mock-context";
@@ -135,6 +136,21 @@ describe("Framework.validateFrameworkVersion()", () => {
 		expect(std.warn).toContain('"5.0.0"');
 		expect(std.warn).toContain("Test");
 		expect(std.warn).toContain("is not officially supported");
+	});
+
+	it("does not warn for Astro 7", ({ expect }) => {
+		vi.mocked(getInstalledPackageVersion).mockReturnValue("7.3.0");
+		const framework = new TestFramework({ id: "astro", name: "Astro" });
+		const packageInfo = getFrameworkPackageInfo("astro");
+
+		expect(packageInfo).toBeDefined();
+		if (packageInfo === undefined) {
+			throw new Error("Expected Astro to have package information");
+		}
+		framework.validateFrameworkVersion("/project", packageInfo, context);
+
+		expect(framework.frameworkVersion).toBe("7.3.0");
+		expect(std.warn).toBe("");
 	});
 
 	it("throws an AssertionError when frameworkVersion getter is accessed before validateFrameworkVersion is called", ({


### PR DESCRIPTION
Astro 7.3.0 currently triggers an unsupported-version warning because autoconfig's maximum known Astro major is still 6. Astro 7 uses the same native `astro add cloudflare` path as Astro 6, so this updates the maximum known major to 7 and adds regression coverage for 7.3.0.

I also audited the npm `latest` version of every other supported framework; all of their configured maximum known majors are current.

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: This only updates internal supported-version metadata to match Astro's current release.

Verification: `pnpm -w test:ci -F @cloudflare/autoconfig` (204 tests), autoconfig type checks, and formatting checks.

<!-- devin-review-badge-begin -->

---

<a href="https://cloudflare.devinenterprise.com/review/cloudflare/workers-sdk/pull/15491" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->