### PR TITLE
[vitest-pool-workers] Fix import.meta.url source rewriting

### DIFF
--- a/.changeset/tidy-pandas-listen.md
+++ b/.changeset/tidy-pandas-listen.md
@@ -1,0 +1,7 @@
+---
+"@cloudflare/vitest-plugin": patch
+---
+
+Fix module fallback rewriting of `import.meta.url` inside dependency source text
+
+Only executable `import.meta.url` expressions are now rewritten, preserving occurrences in strings, comments, and template literal text. This prevents dependency diagnostics containing `import.meta.url` from becoming invalid JavaScript during Worker test startup.

--- a/packages/vitest-plugin/src/pool/module-fallback.ts
+++ b/packages/vitest-plugin/src/pool/module-fallback.ts
@@ -198,9 +198,30 @@ function withSourceUrl(contents: string, url: string | URL): string {
 	return contents + sourceURL;
 }
 
-function withImportMetaUrl(contents: string, url: string | URL): string {
-	// TODO(soon): this isn't perfect, ideally need `workerd` support
-	return contents.replaceAll("import.meta.url", JSON.stringify(url.toString()));
+async function withImportMetaUrl(
+	contents: string,
+	url: string | URL
+): Promise<string> {
+	// TODO(soon): ideally need `workerd` support
+	await esModuleLexer.init;
+	const [imports] = esModuleLexer.parse(contents);
+	const replacement = JSON.stringify(url.toString());
+	for (let i = imports.length - 1; i >= 0; i--) {
+		const imported = imports[i];
+		if (
+			imported.t !== esModuleLexer.ImportType.ImportMeta ||
+			!contents.startsWith(".url", imported.e)
+		) {
+			continue;
+		}
+		const end = imported.e + ".url".length;
+		if (/[$\p{ID_Continue}\u200C\u200D]/u.test(contents[end] ?? "")) {
+			continue;
+		}
+		contents =
+			contents.slice(0, imported.s) + replacement + contents.slice(end);
+	}
+	return contents;
 }
 
 // Extensions that Node's `require()` probes automatically but `workerd` won't.
@@ -641,7 +662,7 @@ async function load(
 
 	if (module.kind === "esm") {
 		// Respond with ES module
-		contents = withImportMetaUrl(contents, targetUrl);
+		contents = await withImportMetaUrl(contents, targetUrl);
 		debuglog(logBase, "esm:", filePath);
 		return buildModuleResponse(rawTarget, { esModule: contents });
 	}

--- a/packages/vitest-plugin/test/module-fallback.test.ts
+++ b/packages/vitest-plugin/test/module-fallback.test.ts
@@ -325,6 +325,57 @@ describe("handleModuleFallbackRequest non-ASCII paths", () => {
 	});
 });
 
+describe("handleModuleFallbackRequest import.meta.url rewriting", () => {
+	let tmp: string;
+
+	beforeEach(() => {
+		tmp = fs.realpathSync(
+			fs.mkdtempSync(path.join(os.tmpdir(), "mf-fallback-import-meta-"))
+		);
+	});
+
+	afterEach(() => {
+		removeDirSync(tmp);
+	});
+
+	it("only rewrites import.meta.url expressions", async ({ expect }) => {
+		const filePath = path.join(tmp, "module.mjs");
+		const contents = [
+			'const diagnostic = "createRequire(import.meta.url)";',
+			"// import.meta.url",
+			"/* import.meta.url */",
+			"const template = `import.meta.url ${import.meta.url}`;",
+			"export default import.meta.url;",
+		].join("\n");
+		fs.writeFileSync(filePath, contents);
+		const fileUrl = pathToFileURL(filePath).href;
+		const replacement = JSON.stringify(fileUrl);
+
+		const response = await handleModuleFallbackRequest(
+			fakeVite(),
+			moduleFallbackRequest({
+				method: "import",
+				specifier: toWorkerdSpecifier(filePath),
+				referrer: toWorkerdSpecifier(path.join(tmp, "entry.mjs")),
+			})
+		);
+
+		expect(response.status).toBe(200);
+		expect(await response.json()).toEqual({
+			name: toWorkerdSpecifier(filePath).replace(/^\//, ""),
+			esModule: [
+				'const diagnostic = "createRequire(import.meta.url)";',
+				"// import.meta.url",
+				"/* import.meta.url */",
+				`const template = \`import.meta.url \${${replacement}}\`;`,
+				`export default ${replacement};`,
+				`//# sourceURL=${fileUrl}`,
+				"",
+			].join("\n"),
+		});
+	});
+});
+
 // `workerd` resolves `node:*`/`cloudflare:*`/`workerd:*` specifiers at the
 // modules root rather than relative to the referrer, and strips the leading `/`
 // before asking us about them. Answering with a redirect to `/${target}` names


### PR DESCRIPTION
Fixes compatibility with Vitest 5.0.0-rc.4.

Vitest 5 added a diagnostic string containing `createRequire(import.meta.url)`. The module fallback's blind text replacement rewrote that occurrence inside the string and produced invalid JavaScript during Workerd startup.

This uses `es-module-lexer` to replace only executable `import.meta.url` expressions. A focused regression test covers strings, comments, template literal text, and expressions.

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: This is a compatibility bug fix with no user-facing API or configuration changes.

Validation run:

- `pnpm -w test:ci -F @cloudflare/vitest-plugin` (107 passed, 1 skipped)
- `pnpm --filter @cloudflare/vitest-plugin check:type`
- `pnpm exec oxlint --deny-warnings --type-aware packages/vitest-plugin/src/pool/module-fallback.ts packages/vitest-plugin/test/module-fallback.test.ts`
- `pnpm exec oxfmt --check packages/vitest-plugin/src/pool/module-fallback.ts packages/vitest-plugin/test/module-fallback.test.ts .changeset/tidy-pandas-listen.md`

<!-- devin-review-badge-begin -->

---

<a href="https://cloudflare.devinenterprise.com/review/cloudflare/workers-sdk/pull/15492" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->