### PR TITLE
[Miniflare] Wait for dev registry watcher readiness

### DIFF
--- a/.changeset/calm-spiders-watch.md
+++ b/.changeset/calm-spiders-watch.md
@@ -1,0 +1,7 @@
+---
+"miniflare": patch
+---
+
+Prevent short-lived Miniflare instances from hanging during disposal
+
+Wait for the development registry's filesystem watcher to finish initialising before runtime startup completes, ensuring the watcher can always be closed cleanly.

--- a/packages/miniflare/src/shared/dev-registry.ts
+++ b/packages/miniflare/src/shared/dev-registry.ts
@@ -47,6 +47,7 @@ export class DevRegistry {
 		}
 	> = new Map();
 	private watcher: FSWatcher | undefined;
+	private watcherReadyPromise: Promise<void> | undefined;
 
 	// UUID to let us tell whether a dev registry entry was added by _this_ Miniflare process
 	public instanceId: string;
@@ -62,7 +63,7 @@ export class DevRegistry {
 	/**
 	 * Watch files inside the registry directory for changes.
 	 */
-	public watch(
+	public async watch(
 		services: Map<
 			string,
 			{
@@ -72,7 +73,7 @@ export class DevRegistry {
 		>,
 		watchQueueConsumers = false,
 		watchStorageCandidates = false
-	): void {
+	): Promise<void> {
 		if (
 			(services.size === 0 &&
 				!watchQueueConsumers &&
@@ -95,7 +96,7 @@ export class DevRegistry {
 		mkdirSync(this.registryPath, { recursive: true });
 
 		if (!this.watcher) {
-			this.watcher = watch(this.registryPath, {
+			const watcher = watch(this.registryPath, {
 				// On Windows, chokidar's default `fs.watch` backend
 				// (`ReadDirectoryChangesW`) frequently drops or delays create
 				// events for files added shortly after the watcher attaches —
@@ -108,7 +109,16 @@ export class DevRegistry {
 			}).on("all", () => {
 				this.refresh();
 			});
+			this.watcher = watcher;
+			// Chokidar installs native watchers asynchronously during its initial
+			// scan. Wait until their closers are registered before allowing disposal.
+			this.watcherReadyPromise = new Promise((resolve) => {
+				watcher.once("ready", resolve);
+			});
 		}
+
+		assert(this.watcherReadyPromise !== undefined);
+		await this.watcherReadyPromise;
 	}
 
 	/**
@@ -126,6 +136,7 @@ export class DevRegistry {
 		// Only this step is async and could be awaited
 		return this.watcher?.close().finally(() => {
 			this.watcher = undefined;
+			this.watcherReadyPromise = undefined;
 		});
 	}
 

--- a/packages/miniflare/test/dev-registry.spec.ts
+++ b/packages/miniflare/test/dev-registry.spec.ts
@@ -17,6 +17,29 @@ import type {
 } from "miniflare";
 
 describe.sequential("DevRegistry", () => {
+	test("waits for the filesystem watcher to be ready", async ({ expect }) => {
+		const unsafeDevRegistryPath = await useTmp();
+		const registry = new DevRegistry(
+			unsafeDevRegistryPath,
+			undefined,
+			new TestLog()
+		);
+
+		try {
+			const watching = registry.watch(
+				new Map([["worker", { classNames: new Set(), entrypoints: new Set() }]])
+			);
+			expect(watching).toBeInstanceOf(Promise);
+			await watching;
+
+			// Subsequent calls must reuse the settled readiness promise rather than
+			// waiting for another `ready` event that will never be emitted.
+			await registry.watch(new Map(), true);
+		} finally {
+			await registry.dispose();
+		}
+	});
+
 	test("surfaces fresh legacy entries and removes them when stale", async ({
 		expect,
 	}) => {


### PR DESCRIPTION
Short-lived Miniflare instances could begin disposal while Chokidar was still installing native filesystem watchers for the development registry. This left an unregistered watcher closer behind, causing the Node.js process to remain alive after runtime disposal.

Make DevRegistry.watch() await Chokidar's initial ready event and reuse that readiness promise for subsequent calls. This ensures all native watcher closers are registered before Miniflare startup completes and disposal can begin.

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: this is an internal lifecycle bug fix.
<!-- devin-review-badge-begin -->

---

<a href="https://cloudflare.devinenterprise.com/review/cloudflare/workers-sdk/pull/15495" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->