### PR TITLE
[vite-plugin-cloudflare] preserve framework output directories in Build Output builds

### DIFF
--- a/.changeset/tidy-routers-build.md
+++ b/.changeset/tidy-routers-build.md
@@ -1,0 +1,7 @@
+---
+"@cloudflare/vite-plugin": minor
+---
+
+Preserve Vite environment output directories when emitting the experimental Build Output Specification
+
+The Build Output `assets/` and `bundle/` directories now link to the completed client and entry Worker environment outputs instead of overriding their configured `outDir` values. This allows framework build orchestration such as React Router to continue using its configured output paths.

--- a/packages/build-output-utils/src/__tests__/read.test.ts
+++ b/packages/build-output-utils/src/__tests__/read.test.ts
@@ -112,6 +112,55 @@ describe("readBuildOutput", () => {
 		expect(output.workers.default.config).not.toHaveProperty("entrypoint");
 	});
 
+	it("reads bundle and assets directories through symbolic links", async ({
+		expect,
+	}) => {
+		const root = process.cwd();
+		const workerDirectory = path.dirname(getWorkerConfigPath(root));
+		const clientDirectory = path.join(workerDirectory, "client");
+		const serverDirectory = path.join(workerDirectory, "server");
+		const linkType = process.platform === "win32" ? "junction" : "dir";
+
+		await writeWorkerConfig({
+			root,
+			config: inputWorkerConfig("my-worker"),
+			manifest: {
+				type: "partial",
+				mainModule: "index.js",
+				modules: {},
+			},
+		});
+		await fsp.mkdir(clientDirectory, { recursive: true });
+		await fsp.mkdir(serverDirectory, { recursive: true });
+		await fsp.writeFile(path.join(clientDirectory, "index.html"), "hello");
+		await fsp.writeFile(path.join(serverDirectory, "index.js"), "export {};");
+		await fsp.symlink(
+			process.platform === "win32" ? clientDirectory : "client",
+			getWorkerAssetsDir(root),
+			linkType
+		);
+		await fsp.symlink(
+			process.platform === "win32" ? serverDirectory : "server",
+			getWorkerBundleDir(root),
+			linkType
+		);
+
+		const worker = (await readBuildOutput(root)).workers.default;
+
+		expect(worker.assetsDir).toBe(getWorkerAssetsDir(root));
+		expect(worker.bundleDir).toBe(getWorkerBundleDir(root));
+		expect(worker.config.manifest?.modules).toEqual({
+			"index.js": { type: "esm" },
+		});
+		const assetsDirectory = worker.assetsDir;
+		if (!assetsDirectory) {
+			throw new Error("Expected an assets directory");
+		}
+		expect(
+			await fsp.readFile(path.join(assetsDirectory, "index.html"), "utf8")
+		).toBe("hello");
+	});
+
 	it("reads Workers keyed by directory name", async ({ expect }) => {
 		const root = process.cwd();
 		await seedWorker(root);

--- a/packages/vite-plugin-cloudflare/playground/experimental-build-output/__tests__/build-output.spec.ts
+++ b/packages/vite-plugin-cloudflare/playground/experimental-build-output/__tests__/build-output.spec.ts
@@ -52,6 +52,22 @@ describe.runIf(isBuild)("Build Output Specification files", () => {
 		expect(fs.existsSync(assetsDir)).toBe(true);
 	});
 
+	test("links assets/ and bundle/ to the Vite environment outputs", ({
+		expect,
+	}) => {
+		const assetsDirectory = path.join(getBuildOutputDir(), "assets");
+		const bundleDirectory = path.join(getBuildOutputDir(), "bundle");
+
+		expect(fs.lstatSync(assetsDirectory).isSymbolicLink()).toBe(true);
+		expect(fs.realpathSync(assetsDirectory)).toBe(
+			fs.realpathSync(path.join(rootDir, "dist/client"))
+		);
+		expect(fs.lstatSync(bundleDirectory).isSymbolicLink()).toBe(true);
+		expect(fs.realpathSync(bundleDirectory)).toBe(
+			fs.realpathSync(path.join(rootDir, "dist/build_output_worker"))
+		);
+	});
+
 	test("strips `entrypoint` in config.json and adds `manifest`", ({
 		expect,
 	}) => {

--- a/packages/vite-plugin-cloudflare/src/__tests__/build-output.spec.ts
+++ b/packages/vite-plugin-cloudflare/src/__tests__/build-output.spec.ts
@@ -1,5 +1,11 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
 import { describe, it } from "vitest";
-import { detectModuleType } from "../plugins/build-output";
+import {
+	detectModuleType,
+	linkBuildOutputDirectory,
+} from "../plugins/build-output";
 
 describe("detectModuleType", () => {
 	const cases: Array<{ filename: string; expected: string }> = [
@@ -29,4 +35,87 @@ describe("detectModuleType", () => {
 			expect(detectModuleType(filename)).toBe(expected);
 		}
 	);
+});
+
+describe("linkBuildOutputDirectory", () => {
+	runInTempDir();
+
+	it("exposes an environment output directory through a directory link", ({
+		expect,
+	}) => {
+		const environmentOutputDirectory = path.resolve("dist/client");
+		const buildOutputDirectory = path.resolve(
+			".cloudflare/output/v0/workers/default/assets"
+		);
+		fs.mkdirSync(environmentOutputDirectory, { recursive: true });
+		fs.writeFileSync(
+			path.join(environmentOutputDirectory, "index.html"),
+			"hello"
+		);
+
+		linkBuildOutputDirectory(buildOutputDirectory, environmentOutputDirectory);
+
+		expect(fs.lstatSync(buildOutputDirectory).isSymbolicLink()).toBe(true);
+		expect(fs.realpathSync(buildOutputDirectory)).toBe(
+			fs.realpathSync(environmentOutputDirectory)
+		);
+		expect(
+			fs.readFileSync(path.join(buildOutputDirectory, "index.html"), "utf8")
+		).toBe("hello");
+		if (process.platform !== "win32") {
+			expect(path.isAbsolute(fs.readlinkSync(buildOutputDirectory))).toBe(
+				false
+			);
+		}
+	});
+
+	it("is idempotent when the directory already links to the output", ({
+		expect,
+	}) => {
+		const environmentOutputDirectory = path.resolve("dist/server");
+		const buildOutputDirectory = path.resolve(
+			".cloudflare/output/v0/workers/default/bundle"
+		);
+		fs.mkdirSync(environmentOutputDirectory, { recursive: true });
+
+		linkBuildOutputDirectory(buildOutputDirectory, environmentOutputDirectory);
+		expect(() =>
+			linkBuildOutputDirectory(buildOutputDirectory, environmentOutputDirectory)
+		).not.toThrow();
+	});
+
+	it("refuses to create an overlapping directory link", ({ expect }) => {
+		const environmentOutputDirectory = path.resolve(".");
+		const buildOutputDirectory = path.resolve(
+			".cloudflare/output/v0/workers/default/assets"
+		);
+
+		expect(() =>
+			linkBuildOutputDirectory(buildOutputDirectory, environmentOutputDirectory)
+		).toThrow(/overlapping environment output directory/);
+	});
+
+	it("does not replace an existing Build Output directory", ({ expect }) => {
+		const environmentOutputDirectory = path.resolve("dist/client");
+		const buildOutputDirectory = path.resolve(
+			".cloudflare/output/v0/workers/default/assets"
+		);
+		fs.mkdirSync(environmentOutputDirectory, { recursive: true });
+		fs.mkdirSync(buildOutputDirectory, { recursive: true });
+
+		expect(() =>
+			linkBuildOutputDirectory(buildOutputDirectory, environmentOutputDirectory)
+		).toThrow(/because it already exists/);
+	});
+
+	it("requires the environment output directory to exist", ({ expect }) => {
+		const environmentOutputDirectory = path.resolve("dist/client");
+		const buildOutputDirectory = path.resolve(
+			".cloudflare/output/v0/workers/default/assets"
+		);
+
+		expect(() =>
+			linkBuildOutputDirectory(buildOutputDirectory, environmentOutputDirectory)
+		).toThrow(/environment output directory .* does not exist/);
+	});
 });

--- a/packages/vite-plugin-cloudflare/src/__tests__/build-output.spec.ts
+++ b/packages/vite-plugin-cloudflare/src/__tests__/build-output.spec.ts
@@ -69,53 +69,17 @@ describe("linkBuildOutputDirectory", () => {
 		}
 	});
 
-	it("is idempotent when the directory already links to the output", ({
+	it("does nothing when the environment already uses the Build Output path", ({
 		expect,
 	}) => {
-		const environmentOutputDirectory = path.resolve("dist/server");
 		const buildOutputDirectory = path.resolve(
 			".cloudflare/output/v0/workers/default/bundle"
 		);
-		fs.mkdirSync(environmentOutputDirectory, { recursive: true });
-
-		linkBuildOutputDirectory(buildOutputDirectory, environmentOutputDirectory);
-		expect(() =>
-			linkBuildOutputDirectory(buildOutputDirectory, environmentOutputDirectory)
-		).not.toThrow();
-	});
-
-	it("refuses to create an overlapping directory link", ({ expect }) => {
-		const environmentOutputDirectory = path.resolve(".");
-		const buildOutputDirectory = path.resolve(
-			".cloudflare/output/v0/workers/default/assets"
-		);
-
-		expect(() =>
-			linkBuildOutputDirectory(buildOutputDirectory, environmentOutputDirectory)
-		).toThrow(/overlapping environment output directory/);
-	});
-
-	it("does not replace an existing Build Output directory", ({ expect }) => {
-		const environmentOutputDirectory = path.resolve("dist/client");
-		const buildOutputDirectory = path.resolve(
-			".cloudflare/output/v0/workers/default/assets"
-		);
-		fs.mkdirSync(environmentOutputDirectory, { recursive: true });
 		fs.mkdirSync(buildOutputDirectory, { recursive: true });
 
 		expect(() =>
-			linkBuildOutputDirectory(buildOutputDirectory, environmentOutputDirectory)
-		).toThrow(/because it already exists/);
-	});
-
-	it("requires the environment output directory to exist", ({ expect }) => {
-		const environmentOutputDirectory = path.resolve("dist/client");
-		const buildOutputDirectory = path.resolve(
-			".cloudflare/output/v0/workers/default/assets"
-		);
-
-		expect(() =>
-			linkBuildOutputDirectory(buildOutputDirectory, environmentOutputDirectory)
-		).toThrow(/environment output directory .* does not exist/);
+			linkBuildOutputDirectory(buildOutputDirectory, buildOutputDirectory)
+		).not.toThrow();
+		expect(fs.lstatSync(buildOutputDirectory).isDirectory()).toBe(true);
 	});
 });

--- a/packages/vite-plugin-cloudflare/src/plugins/build-output.ts
+++ b/packages/vite-plugin-cloudflare/src/plugins/build-output.ts
@@ -173,33 +173,6 @@ export function linkBuildOutputDirectory(
 		return;
 	}
 
-	const targetStats = fs.statSync(targetPath, { throwIfNoEntry: false });
-	if (!targetStats?.isDirectory()) {
-		throw new Error(
-			`Cannot link Build Output Specification directory "${linkPath}" because environment output directory "${targetPath}" does not exist.`
-		);
-	}
-
-	const linkStats = fs.lstatSync(linkPath, { throwIfNoEntry: false });
-	if (linkStats) {
-		if (
-			linkStats.isSymbolicLink() &&
-			fs.realpathSync(linkPath) === fs.realpathSync(targetPath)
-		) {
-			return;
-		}
-
-		throw new Error(
-			`Cannot link Build Output Specification directory "${linkPath}" because it already exists.`
-		);
-	}
-
-	if (areDirectoriesOverlapping(linkPath, targetPath)) {
-		throw new Error(
-			`Cannot link Build Output Specification directory "${linkPath}" to overlapping environment output directory "${targetPath}".`
-		);
-	}
-
 	fs.mkdirSync(path.dirname(linkPath), { recursive: true });
 	fs.symlinkSync(
 		process.platform === "win32"
@@ -208,41 +181,6 @@ export function linkBuildOutputDirectory(
 		linkPath,
 		process.platform === "win32" ? "junction" : "dir"
 	);
-}
-
-function areDirectoriesOverlapping(first: string, second: string): boolean {
-	const resolvedFirst = resolveFromExistingAncestor(first);
-	const resolvedSecond = resolveFromExistingAncestor(second);
-	return (
-		isDirectoryWithin(resolvedFirst, resolvedSecond) ||
-		isDirectoryWithin(resolvedSecond, resolvedFirst)
-	);
-}
-
-function isDirectoryWithin(parent: string, candidate: string): boolean {
-	const relativePath = path.relative(parent, candidate);
-	return (
-		relativePath === "" ||
-		(!path.isAbsolute(relativePath) &&
-			relativePath !== ".." &&
-			!relativePath.startsWith(`..${path.sep}`))
-	);
-}
-
-function resolveFromExistingAncestor(directory: string): string {
-	let ancestor = path.resolve(directory);
-	const missingSegments: string[] = [];
-
-	while (!fs.existsSync(ancestor)) {
-		const parent = path.dirname(ancestor);
-		if (parent === ancestor) {
-			return path.resolve(directory);
-		}
-		missingSegments.unshift(path.basename(ancestor));
-		ancestor = parent;
-	}
-
-	return path.join(fs.realpathSync(ancestor), ...missingSegments);
 }
 
 /**

--- a/packages/vite-plugin-cloudflare/src/plugins/build-output.ts
+++ b/packages/vite-plugin-cloudflare/src/plugins/build-output.ts
@@ -1,6 +1,9 @@
 import assert from "node:assert";
+import * as fs from "node:fs";
 import * as path from "node:path";
 import {
+	getWorkerAssetsDir,
+	getWorkerBundleDir,
 	writeSettingsConfig,
 	writeWorkerConfig,
 } from "@cloudflare/build-output-utils";
@@ -14,6 +17,39 @@ import type { ModuleType } from "@cloudflare/config";
  */
 export const buildOutputPlugin = createPlugin("build-output", (ctx) => {
 	return {
+		buildApp: {
+			order: "post",
+			async handler(builder) {
+				const clientEnvironment = builder.environments.client;
+				if (clientEnvironment?.isBuilt) {
+					linkBuildOutputDirectory(
+						getWorkerAssetsDir(builder.config.root),
+						path.resolve(
+							builder.config.root,
+							clientEnvironment.config.build.outDir
+						)
+					);
+				}
+
+				if (ctx.resolvedPluginConfig.type === "workers") {
+					const entryEnvironment =
+						builder.environments[
+							ctx.resolvedPluginConfig.entryWorkerEnvironmentName
+						];
+					assert(entryEnvironment, "Entry Worker environment not found");
+
+					if (entryEnvironment.isBuilt) {
+						linkBuildOutputDirectory(
+							getWorkerBundleDir(builder.config.root),
+							path.resolve(
+								builder.config.root,
+								entryEnvironment.config.build.outDir
+							)
+						);
+					}
+				}
+			},
+		},
 		async writeBundle(_, bundle) {
 			if (ctx.isChildEnvironment(this.environment.name)) {
 				return;
@@ -77,9 +113,9 @@ export const buildOutputPlugin = createPlugin("build-output", (ctx) => {
 				if (fileName === ".vite/manifest.json") {
 					continue;
 				}
-				// Skip Vite-imported static assets — they will be moved out of
-				// `bundle/` into the client `assets/` directory by the
-				// asset move loop in `createBuildApp`.
+				// Skip Vite-imported static assets — they will be moved from the
+				// entry Worker output into the client output by the asset move loop
+				// in `createBuildApp`.
 				if (importedAssetPaths.has(fileName)) {
 					continue;
 				}
@@ -121,6 +157,93 @@ export const buildOutputPlugin = createPlugin("build-output", (ctx) => {
 		);
 	}
 });
+
+/**
+ * Expose a Vite environment's output directory at the conventional Build
+ * Output Specification path without relocating the completed build.
+ */
+export function linkBuildOutputDirectory(
+	buildOutputDirectory: string,
+	environmentOutputDirectory: string
+): void {
+	const linkPath = path.resolve(buildOutputDirectory);
+	const targetPath = path.resolve(environmentOutputDirectory);
+
+	if (linkPath === targetPath) {
+		return;
+	}
+
+	const targetStats = fs.statSync(targetPath, { throwIfNoEntry: false });
+	if (!targetStats?.isDirectory()) {
+		throw new Error(
+			`Cannot link Build Output Specification directory "${linkPath}" because environment output directory "${targetPath}" does not exist.`
+		);
+	}
+
+	const linkStats = fs.lstatSync(linkPath, { throwIfNoEntry: false });
+	if (linkStats) {
+		if (
+			linkStats.isSymbolicLink() &&
+			fs.realpathSync(linkPath) === fs.realpathSync(targetPath)
+		) {
+			return;
+		}
+
+		throw new Error(
+			`Cannot link Build Output Specification directory "${linkPath}" because it already exists.`
+		);
+	}
+
+	if (areDirectoriesOverlapping(linkPath, targetPath)) {
+		throw new Error(
+			`Cannot link Build Output Specification directory "${linkPath}" to overlapping environment output directory "${targetPath}".`
+		);
+	}
+
+	fs.mkdirSync(path.dirname(linkPath), { recursive: true });
+	fs.symlinkSync(
+		process.platform === "win32"
+			? targetPath
+			: path.relative(path.dirname(linkPath), targetPath),
+		linkPath,
+		process.platform === "win32" ? "junction" : "dir"
+	);
+}
+
+function areDirectoriesOverlapping(first: string, second: string): boolean {
+	const resolvedFirst = resolveFromExistingAncestor(first);
+	const resolvedSecond = resolveFromExistingAncestor(second);
+	return (
+		isDirectoryWithin(resolvedFirst, resolvedSecond) ||
+		isDirectoryWithin(resolvedSecond, resolvedFirst)
+	);
+}
+
+function isDirectoryWithin(parent: string, candidate: string): boolean {
+	const relativePath = path.relative(parent, candidate);
+	return (
+		relativePath === "" ||
+		(!path.isAbsolute(relativePath) &&
+			relativePath !== ".." &&
+			!relativePath.startsWith(`..${path.sep}`))
+	);
+}
+
+function resolveFromExistingAncestor(directory: string): string {
+	let ancestor = path.resolve(directory);
+	const missingSegments: string[] = [];
+
+	while (!fs.existsSync(ancestor)) {
+		const parent = path.dirname(ancestor);
+		if (parent === ancestor) {
+			return path.resolve(directory);
+		}
+		missingSegments.unshift(path.basename(ancestor));
+		ancestor = parent;
+	}
+
+	return path.join(fs.realpathSync(ancestor), ...missingSegments);
+}
 
 /**
  * Map a bundle filename to its declared module type.

--- a/packages/vite-plugin-cloudflare/src/plugins/config.ts
+++ b/packages/vite-plugin-cloudflare/src/plugins/config.ts
@@ -3,8 +3,6 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import {
 	cleanBuildOutputDir,
-	getWorkerAssetsDir,
-	getWorkerBundleDir,
 	writeWorkerConfig,
 } from "@cloudflare/build-output-utils";
 import { normalizePath } from "vite";
@@ -17,17 +15,12 @@ import {
 import { assertIsNotPreview } from "../context";
 import { writeDeployConfig } from "../deploy-config";
 import { hasLocalDevVarsFileChanged } from "../dev-vars";
-import {
-	resolveDevOnly,
-	type AssetsOnlyResolvedConfig,
-	type WorkersResolvedConfig,
-} from "../plugin-config";
+import { resolveDevOnly } from "../plugin-config";
 import { createPlugin, debuglog, getOutputDirectory } from "../utils";
 import { validateWorkerEnvironmentOptions } from "../vite-config";
 import { getWarningForWorkersConfigs } from "../workers-configs";
 import type { PluginContext } from "../context";
 import type { EnvironmentOptions, UserConfig } from "vite";
-import type * as vite from "vite";
 import type { Unstable_RawConfig } from "wrangler";
 
 /**
@@ -103,7 +96,6 @@ export const configPlugin = createPlugin("config", (ctx) => {
 			);
 
 			if (ctx.resolvedPluginConfig.experimental.newConfig?.cfBuildOutput) {
-				forceBuildOutputDirs(ctx.resolvedPluginConfig, ctx.resolvedViteConfig);
 				if (ctx.resolvedViteConfig.command === "build") {
 					await cleanBuildOutputDir(ctx.resolvedViteConfig.root);
 				}
@@ -351,43 +343,6 @@ function getEnvironmentsConfig(
 			},
 		},
 	};
-}
-
-/**
- * When the Build Output Specification is enabled,
- * force every Worker environment's and the client environment's `build.outDir`
- * to the spec-mandated location.
- *
- * Runs after Vite's merge in `configResolved`, so it overrides any
- * user-supplied `build.outDir`
- */
-function forceBuildOutputDirs(
-	resolvedPluginConfig: AssetsOnlyResolvedConfig | WorkersResolvedConfig,
-	resolvedViteConfig: vite.ResolvedConfig
-): void {
-	const newConfig = resolvedPluginConfig.experimental.newConfig;
-	if (!newConfig?.cfBuildOutput) {
-		return;
-	}
-
-	const { root } = resolvedViteConfig;
-
-	// The Build Output Specification currently holds a single Worker in the
-	// `default` directory (the default export in `cloudflare.config.ts`). Only
-	// the entry Worker is emitted; auxiliary Worker environments keep their
-	// normal build output and are ignored by the spec.
-	if (resolvedPluginConfig.type === "workers") {
-		const entryName = resolvedPluginConfig.entryWorkerEnvironmentName;
-		const entryEnvironment = resolvedViteConfig.environments[entryName];
-		if (entryEnvironment) {
-			entryEnvironment.build.outDir = getWorkerBundleDir(root);
-		}
-	}
-
-	const clientEnvironment = resolvedViteConfig.environments.client;
-	if (clientEnvironment) {
-		clientEnvironment.build.outDir = getWorkerAssetsDir(root);
-	}
 }
 
 function getAllowedHosts(


### PR DESCRIPTION
React Router plans its build around `build/client` and `build/server`, and reads the client Vite manifest while compiling the server. The experimental Build Output integration previously changed the resolved Vite environment output directories to `.cloudflare/output`, leaving React Router looking for a manifest in its original location.

This change preserves each environment's resolved `outDir` and exposes the completed client and entry Worker directories through the Build Output `assets/` and `bundle/` paths. Unix uses relative symbolic links, while Windows uses directory junctions. If an environment already emits at the Build Output path, no link is needed.

This keeps the integration framework-agnostic, but it means `.cloudflare/output` is not independently self-contained: its directory links refer to the framework outputs elsewhere in the project. Windows junction behavior is covered conditionally in unit tests but was not exercised locally on Windows.

---

- Tests
  - [x] Tests included/updated
  - [x] Manual testing: React Router experimental build and preview; TanStack Start with `vite build`, `cf-vite build`, and a subsequent build with Build Output disabled
- Public documentation
  - [x] Documentation not necessary because this changes experimental Build Output integration behavior

Validation:

- `pnpm exec turbo check:lint check:type check:format type:tests --filter=@cloudflare/vite-plugin --filter=@cloudflare/build-output-utils`
- `pnpm -w test:ci -F @cloudflare/build-output-utils` (36 tests)
- `pnpm -w test:ci -F @cloudflare/vite-plugin` (204 tests)
- Focused experimental Build Output playground build (13 tests)
- React Router `0.0.0-experimental-7aea711dd`: production build plus preview requests for SSR HTML and a static asset (both 200)
