### PR TITLE
WC-5936 Honor Workers Builds worker name overrides in wrangler preview

### DIFF
--- a/.changeset/soft-seals-preview.md
+++ b/.changeset/soft-seals-preview.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Honor Workers Builds name overrides in `wrangler preview`
+
+Preview commands now target the Worker name supplied by Workers Builds instead of the name in local Wrangler configuration. This prevents preview builds from failing when the two names differ.

--- a/packages/deploy-helpers/src/preview/shared.ts
+++ b/packages/deploy-helpers/src/preview/shared.ts
@@ -2,6 +2,7 @@ import { execSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import {
 	configFileName,
+	getCIOverrideName,
 	getDurableObjectExports,
 	getWorkersCIBranchName,
 	UserError,
@@ -340,7 +341,11 @@ export function resolveWorkerName(
 	args: { workerName?: string; "worker-name"?: string },
 	config: Config
 ): string {
-	const workerName = args.workerName ?? args["worker-name"] ?? config.name;
+	const workerName =
+		getCIOverrideName() ??
+		args.workerName ??
+		args["worker-name"] ??
+		config.name;
 	if (!workerName) {
 		throw new UserError(
 			`Required Worker name missing. Please specify the Worker name in your ${configFileName(

--- a/packages/wrangler/src/__tests__/preview.test.ts
+++ b/packages/wrangler/src/__tests__/preview.test.ts
@@ -9,6 +9,7 @@ import {
 	getPullRequestMetadata,
 	getRepositoryUrl,
 	previewContainerAppName,
+	resolveWorkerName,
 } from "@cloudflare/deploy-helpers";
 import { defaultWranglerConfig } from "@cloudflare/workers-utils";
 import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
@@ -241,6 +242,21 @@ describe("wrangler preview", () => {
 		// restore that stub would outlive its test and silently grant the scope
 		// to every later test in the file.
 		vi.restoreAllMocks();
+	});
+
+	describe("resolveWorkerName", () => {
+		test("should prefer WRANGLER_CI_OVERRIDE_NAME over arguments and config", ({
+			expect,
+		}) => {
+			vi.stubEnv("WRANGLER_CI_OVERRIDE_NAME", "ci-worker");
+
+			expect(
+				resolveWorkerName(
+					{ workerName: "argument-worker" },
+					{ ...defaultWranglerConfig, name: "config-worker" }
+				)
+			).toBe("ci-worker");
+		});
 	});
 
 	describe("getBranchName", () => {


### PR DESCRIPTION
Fixes WC-5936

Workers Builds sets an override so a Worker keeps its dashboard name even when a project's Wrangler config uses a different one. `wrangler deploy` already honored that override, but `wrangler preview` and its secrets, settings, and delete subcommands read the configured name directly and failed with a name mismatch error.

Preview commands now check the override first, matching how deploy resolves the worker name.

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: this restores existing `deploy` behavior for `preview` and doesn't add anything new for users.

*A picture of a cute animal (not mandatory, but encouraged)*
<img width="452" height="420" alt="image" src="https://github.com/user-attachments/assets/5a600947-9892-4ca4-b47e-59d219b5d011" />


<!-- devin-review-badge-begin -->

---

<a href="https://cloudflare.devinenterprise.com/review/cloudflare/workers-sdk/pull/15499" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->