### PR TITLE
Vite plugin v2 - Default the entry Worker to the ssr Vite environment

### DIFF
--- a/packages/vite-plugin-cloudflare/e2e/fixtures/invalid-worker-environment-options/vite.config.ts
+++ b/packages/vite-plugin-cloudflare/e2e/fixtures/invalid-worker-environment-options/vite.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
 		}),
 	],
 	environments: {
-		worker: {
+		ssr: {
 			resolve: {
 				external: true,
 			},

--- a/packages/vite-plugin-cloudflare/e2e/nodejs-compat-warnings.test.ts
+++ b/packages/vite-plugin-cloudflare/e2e/nodejs-compat-warnings.test.ts
@@ -13,7 +13,7 @@ describe("nodejs_compat warnings - Node.js built-ins imported directly", () => {
 		expect(await proc.exitCode).not.toBe(0);
 		const errorLogs = proc.stderr.replaceAll("\\", "/");
 		expect(errorLogs).toContain(
-			'Unexpected Node.js imports for environment "worker". Do you need to enable the "nodejs_compat" compatibility flag? Refer to https://developers.cloudflare.com/workers/runtime-apis/nodejs/ for more details.'
+			'Unexpected Node.js imports for environment "ssr". Do you need to enable the "nodejs_compat" compatibility flag? Refer to https://developers.cloudflare.com/workers/runtime-apis/nodejs/ for more details.'
 		);
 		expect(errorLogs).toContain('- "node:assert/strict" imported from');
 		expect(errorLogs).toContain('- "node:perf_hooks" imported from');
@@ -32,7 +32,7 @@ describe("nodejs_compat warnings - Node.js built-ins imported via dependency", (
 		expect(await proc.exitCode).not.toBe(0);
 		const errorLogs = proc.stderr.replaceAll("\\", "/");
 		expect(errorLogs).toContain(
-			'Unexpected Node.js imports for environment "worker". Do you need to enable the "nodejs_compat" compatibility flag? Refer to https://developers.cloudflare.com/workers/runtime-apis/nodejs/ for more details.'
+			'Unexpected Node.js imports for environment "ssr". Do you need to enable the "nodejs_compat" compatibility flag? Refer to https://developers.cloudflare.com/workers/runtime-apis/nodejs/ for more details.'
 		);
 		expect(errorLogs).toContain('- "node:fs" imported from');
 	});

--- a/packages/vite-plugin-cloudflare/playground/assets/vite.config.cf-build-output.ts
+++ b/packages/vite-plugin-cloudflare/playground/assets/vite.config.cf-build-output.ts
@@ -3,7 +3,7 @@ import { defineConfig } from "vite";
 
 export default defineConfig({
 	environments: {
-		worker: {
+		ssr: {
 			build: {
 				assetsInlineLimit: 0,
 			},

--- a/packages/vite-plugin-cloudflare/playground/assets/vite.config.no-client-entry.ts
+++ b/packages/vite-plugin-cloudflare/playground/assets/vite.config.no-client-entry.ts
@@ -3,7 +3,7 @@ import { defineConfig } from "vite";
 
 export default defineConfig({
 	environments: {
-		worker: {
+		ssr: {
 			build: {
 				assetsInlineLimit: 0,
 			},

--- a/packages/vite-plugin-cloudflare/playground/assets/vite.config.public-dir-only.ts
+++ b/packages/vite-plugin-cloudflare/playground/assets/vite.config.public-dir-only.ts
@@ -3,7 +3,7 @@ import { defineConfig } from "vite";
 
 export default defineConfig({
 	environments: {
-		worker: {
+		ssr: {
 			build: {
 				assetsInlineLimit: 0,
 			},

--- a/packages/vite-plugin-cloudflare/playground/assets/vite.config.ts
+++ b/packages/vite-plugin-cloudflare/playground/assets/vite.config.ts
@@ -11,7 +11,7 @@ export default defineConfig({
 				},
 			},
 		},
-		worker: {
+		ssr: {
 			build: {
 				assetsInlineLimit: 0,
 			},

--- a/packages/vite-plugin-cloudflare/playground/build-output/vite.config.ts
+++ b/packages/vite-plugin-cloudflare/playground/build-output/vite.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from "vite";
 
 export default defineConfig({
 	environments: {
-		build_output_worker: {
+		ssr: {
 			build: {
 				sourcemap: true,
 			},

--- a/packages/vite-plugin-cloudflare/playground/config-changes/__tests__/config-changes.spec.ts
+++ b/packages/vite-plugin-cloudflare/playground/config-changes/__tests__/config-changes.spec.ts
@@ -57,7 +57,7 @@ describe("config-changes", () => {
 
 			await vi.waitFor(async () => {
 				expect(serverLogs.errors.join()).toMatch(
-					/Failed to resolve Worker entrypoint ".+non-existing-file\.ts" for environment "worker"/
+					/Failed to resolve Worker entrypoint ".+non-existing-file\.ts" for environment "ssr"/
 				);
 			}, WAIT_FOR_OPTIONS);
 		}

--- a/packages/vite-plugin-cloudflare/playground/custom-build-app/vite.config.ts
+++ b/packages/vite-plugin-cloudflare/playground/custom-build-app/vite.config.ts
@@ -5,10 +5,10 @@ import { defineConfig } from "vite";
 export default defineConfig({
 	builder: {
 		async buildApp(builder) {
-			const workerEnvironment = builder.environments.worker;
+			const workerEnvironment = builder.environments.ssr;
 			const clientEnvironment = builder.environments.client;
 
-			assert(workerEnvironment, `No "worker" environment`);
+			assert(workerEnvironment, `No "ssr" environment`);
 			assert(clientEnvironment, `No "client" environment`);
 
 			builder.config.logger.info("__before-build__");

--- a/packages/vite-plugin-cloudflare/playground/dynamic-import-paths/vite.config.ts
+++ b/packages/vite-plugin-cloudflare/playground/dynamic-import-paths/vite.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from "vite";
 
 export default defineConfig({
 	environments: {
-		worker: {
+		ssr: {
 			build: {
 				rollupOptions: {
 					output: {

--- a/packages/vite-plugin-cloudflare/playground/hot-channel/vite.config.ts
+++ b/packages/vite-plugin-cloudflare/playground/hot-channel/vite.config.ts
@@ -7,8 +7,8 @@ export default defineConfig({
 		{
 			name: "test-plugin",
 			configureServer(viteDevServer) {
-				const worker = viteDevServer.environments.worker;
-				assert(worker, `'worker' environment not found`);
+				const worker = viteDevServer.environments.ssr;
+				assert(worker, `'ssr' environment not found`);
 
 				return () => {
 					viteDevServer.middlewares.use(async (_, __, next) => {

--- a/packages/vite-plugin-cloudflare/playground/main-resolution/vite.config.package-export-main.ts
+++ b/packages/vite-plugin-cloudflare/playground/main-resolution/vite.config.package-export-main.ts
@@ -4,7 +4,7 @@ import { defineConfig } from "vite";
 export default defineConfig({
 	mode: "package-export-main",
 	environments: {
-		worker: {
+		ssr: {
 			optimizeDeps: {
 				exclude: ["@playground/main-resolution-package"],
 			},

--- a/packages/vite-plugin-cloudflare/playground/main-resolution/vite.config.ts
+++ b/packages/vite-plugin-cloudflare/playground/main-resolution/vite.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from "vite";
 
 export default defineConfig({
 	environments: {
-		worker: {
+		ssr: {
 			build: {
 				rollupOptions: {
 					output: {

--- a/packages/vite-plugin-cloudflare/playground/module-resolution/vite.config.nodejs-compat.ts
+++ b/packages/vite-plugin-cloudflare/playground/module-resolution/vite.config.nodejs-compat.ts
@@ -11,7 +11,7 @@ export default defineConfig({
 		},
 	},
 	environments: {
-		worker: {
+		ssr: {
 			optimizeDeps: {
 				exclude: ["@playground/module-resolution-excludes"],
 			},

--- a/packages/vite-plugin-cloudflare/playground/module-resolution/vite.config.ts
+++ b/packages/vite-plugin-cloudflare/playground/module-resolution/vite.config.ts
@@ -11,7 +11,7 @@ export default defineConfig({
 		},
 	},
 	environments: {
-		worker: {
+		ssr: {
 			optimizeDeps: {
 				exclude: ["@playground/module-resolution-excludes"],
 			},

--- a/packages/vite-plugin-cloudflare/playground/multi-worker/vite.config.custom-build-app.ts
+++ b/packages/vite-plugin-cloudflare/playground/multi-worker/vite.config.custom-build-app.ts
@@ -8,8 +8,8 @@ export default defineConfig({
 	},
 	builder: {
 		async buildApp(builder) {
-			const workerAEnvironment = builder.environments.worker_a;
-			assert(workerAEnvironment, `No "worker_a" environment`);
+			const workerAEnvironment = builder.environments.ssr;
+			assert(workerAEnvironment, `No "ssr" environment`);
 
 			// We deliberately build just the entry Worker environment to test that the plugin builds any remaining Worker environments
 			await builder.build(workerAEnvironment);

--- a/packages/vite-plugin-cloudflare/playground/node-compat/vite.config.worker-resolve-externals.ts
+++ b/packages/vite-plugin-cloudflare/playground/node-compat/vite.config.worker-resolve-externals.ts
@@ -21,7 +21,7 @@ export default defineConfig({
 		{
 			name: "test-plugin",
 			async configureServer(viteDevServer) {
-				const workerEnvironment = viteDevServer.environments.worker;
+				const workerEnvironment = viteDevServer.environments.ssr;
 				assert(workerEnvironment);
 
 				const resolved =

--- a/packages/vite-plugin-cloudflare/playground/spa-with-api/vite.config.child-compiler.ts
+++ b/packages/vite-plugin-cloudflare/playground/spa-with-api/vite.config.child-compiler.ts
@@ -29,7 +29,7 @@ function childCompilerPlugin(): Plugin {
 			// or module pruning calls hot.send() on the worker environment, but
 			// the WebSocket was never initialized because configureServer (which
 			// calls initRunner) was stripped.
-			const workerEnvironment = childServer.environments.worker;
+			const workerEnvironment = childServer.environments.ssr;
 			if (workerEnvironment) {
 				workerEnvironment.hot.send({ type: "full-reload", path: "*" });
 			}

--- a/packages/vite-plugin-cloudflare/src/__tests__/cloudflare-config.spec.ts
+++ b/packages/vite-plugin-cloudflare/src/__tests__/cloudflare-config.spec.ts
@@ -86,10 +86,8 @@ describe("cloudflare.config.ts", () => {
 		expect(result.configPaths).toContain(
 			path.join(root, "cloudflare.config.ts")
 		);
-		expect(result.entryWorkerEnvironmentName).toBe("entry_worker");
-		expect(
-			result.environmentNameToWorkerMap.get("entry_worker")?.config
-		).toMatchObject({
+		expect(result.entryWorkerEnvironmentName).toBe("ssr");
+		expect(result.environmentNameToWorkerMap.get("ssr")?.config).toMatchObject({
 			name: "entry-worker",
 			compatibilityDate: "2024-12-30",
 			entrypoint: "./src/index.ts",
@@ -145,7 +143,7 @@ describe("cloudflare.config.ts", () => {
 			viteEnv
 		)) as WorkersResolvedConfig;
 
-		const entry = result.environmentNameToWorkerMap.get("entry_worker");
+		const entry = result.environmentNameToWorkerMap.get("ssr");
 		expect(entry?.config.env).toMatchObject({
 			FILE_ONLY: { type: "text", value: "file" },
 			PLUGIN_ONLY: { type: "text", value: "plugin" },

--- a/packages/vite-plugin-cloudflare/src/__tests__/resolve-plugin-config.spec.ts
+++ b/packages/vite-plugin-cloudflare/src/__tests__/resolve-plugin-config.spec.ts
@@ -102,7 +102,7 @@ describe("resolvePluginConfig", () => {
 		)) as WorkersResolvedConfig;
 
 		expect(
-			result.environmentNameToWorkerMap.get("entry_worker")?.config.entrypoint
+			result.environmentNameToWorkerMap.get("ssr")?.config.entrypoint
 		).toBe(entrypoint);
 	});
 
@@ -118,7 +118,7 @@ describe("resolvePluginConfig", () => {
 		)) as WorkersResolvedConfig;
 
 		expect(
-			result.environmentNameToWorkerMap.get("entry_worker")?.config.entrypoint
+			result.environmentNameToWorkerMap.get("ssr")?.config.entrypoint
 		).toBe(entrypoint);
 	});
 
@@ -133,7 +133,8 @@ describe("resolvePluginConfig", () => {
 			)) as WorkersResolvedConfig;
 
 			expect(
-				result.environmentNameToWorkerMap.get("entry_worker")?.config.entrypoint
+				result.environmentNameToWorkerMap.get(result.entryWorkerEnvironmentName)
+					?.config.entrypoint
 			).toBe(entrypoint);
 		}
 	);
@@ -378,10 +379,9 @@ describe("resolvePluginConfig", () => {
 			buildEnv
 		)) as WorkersResolvedConfig;
 
-		expect(result.prerenderWorkerEnvironmentName).toBe("prerender_worker");
+		expect(result.prerenderWorkerEnvironmentName).toBe("prerender");
 		expect(
-			result.environmentNameToWorkerMap.get("prerender_worker")?.config
-				.entrypoint
+			result.environmentNameToWorkerMap.get("prerender")?.config.entrypoint
 		).toBe("./src/prerender.ts");
 	});
 
@@ -439,10 +439,9 @@ describe("resolvePluginConfig", () => {
 			buildEnv
 		)) as WorkersResolvedConfig;
 
-		expect(result.prerenderWorkerEnvironmentName).toBe("prerender_worker");
+		expect(result.prerenderWorkerEnvironmentName).toBe("prerender");
 		expect(
-			result.environmentNameToWorkerMap.get("prerender_worker")?.config
-				.entrypoint
+			result.environmentNameToWorkerMap.get("prerender")?.config.entrypoint
 		).toBe("./src/prerender.ts");
 	});
 

--- a/packages/vite-plugin-cloudflare/src/plugin-config.ts
+++ b/packages/vite-plugin-cloudflare/src/plugin-config.ts
@@ -420,8 +420,7 @@ export async function resolvePluginConfig(
 		});
 
 		prerenderWorkerEnvironmentName =
-			prerenderWorkerConfig?.viteEnvironment?.name ??
-			workerNameToEnvironmentName(workerResolvedConfig.config.name);
+			prerenderWorkerConfig?.viteEnvironment?.name ?? "prerender";
 
 		validateAndAddEnvironmentName(prerenderWorkerEnvironmentName);
 
@@ -476,8 +475,7 @@ export async function resolvePluginConfig(
 	}
 
 	const entryWorkerEnvironmentName =
-		pluginConfig.viteEnvironment?.name ??
-		workerNameToEnvironmentName(entryWorkerResolvedConfig.config.name);
+		pluginConfig.viteEnvironment?.name ?? "ssr";
 
 	validateAndAddEnvironmentName(entryWorkerEnvironmentName);
 
@@ -604,11 +602,6 @@ function addAuxiliaryWorkers(options: {
 			);
 		}
 	}
-}
-
-// Worker names can only contain alphanumeric characters and '-' whereas environment names can only contain alphanumeric characters and '$', '_'
-function workerNameToEnvironmentName(workerName: string) {
-	return workerName.replaceAll("-", "_");
 }
 
 const RESERVED_WORKER_EXPORT_NAMES = new Set(["default", "prerender"]);


### PR DESCRIPTION
Vite plugin v2 - Default the entry Worker to the `ssr` Vite environment.

The prerender Worker now also defaults to the `prerender` environment.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: release notes to follow

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- If you are an AI agent or LLM, and you are adding this PR without direct human supervision, thank you! Please uncomment the following block. This is so the maintainers know how to expect you to respond.

> [!NOTE]
> This is a contribution from an AI agent: <insert name here>, <insert LLM model here if different>.

-->
