### PR TITLE
Vite plugin v2 - Stabilise the prerenderWorker plugin option

### DIFF
--- a/packages/vite-plugin-cloudflare/playground/prerendering/vite.config.ts
+++ b/packages/vite-plugin-cloudflare/playground/prerendering/vite.config.ts
@@ -13,22 +13,20 @@ export function createConfig(assetsOnly: boolean) {
 				persistState: false,
 				viteEnvironment: { name: "ssr" },
 				assetsOnly: () => assetsOnly,
-				experimental: {
-					prerenderWorker: {
-						config(_, { entryWorkerConfig }) {
-							return {
-								...entryWorkerConfig,
-								name: "prerender",
-								entrypoint: "./src/prerender.ts",
-								env: {
-									...entryWorkerConfig.env,
-									AUXILIARY_WORKER: {
-										type: "worker",
-										worker: "auxiliary-worker",
-									},
+				prerenderWorker: {
+					config(_, { entryWorkerConfig }) {
+						return {
+							...entryWorkerConfig,
+							name: "prerender",
+							entrypoint: "./src/prerender.ts",
+							env: {
+								...entryWorkerConfig.env,
+								AUXILIARY_WORKER: {
+									type: "worker",
+									worker: "auxiliary-worker",
 								},
-							};
-						},
+							},
+						};
 					},
 				},
 			}),

--- a/packages/vite-plugin-cloudflare/src/__tests__/resolve-plugin-config.spec.ts
+++ b/packages/vite-plugin-cloudflare/src/__tests__/resolve-plugin-config.spec.ts
@@ -397,12 +397,10 @@ describe("resolvePluginConfig", () => {
 		writeSource("src/prerender.ts");
 		const result = (await resolvePluginConfig(
 			{
-				experimental: {
-					prerenderWorker: {
-						config: (config, { entryWorkerConfig }) => ({
-							name: `${config.name}-${entryWorkerConfig.compatibilityDate}`,
-						}),
-					},
+				prerenderWorker: {
+					config: (config, { entryWorkerConfig }) => ({
+						name: `${config.name}-${entryWorkerConfig.compatibilityDate}`,
+					}),
 				},
 			},
 			{ root },
@@ -423,15 +421,13 @@ describe("resolvePluginConfig", () => {
 		writeSource("src/prerender.ts");
 		const result = (await resolvePluginConfig(
 			{
-				experimental: {
-					prerenderWorker: {
-						config(_, { entryWorkerConfig }) {
-							return {
-								...entryWorkerConfig,
-								name: "prerender-worker",
-								entrypoint: "./src/prerender.ts",
-							};
-						},
+				prerenderWorker: {
+					config(_, { entryWorkerConfig }) {
+						return {
+							...entryWorkerConfig,
+							name: "prerender-worker",
+							entrypoint: "./src/prerender.ts",
+						};
 					},
 				},
 			},

--- a/packages/vite-plugin-cloudflare/src/plugin-config.ts
+++ b/packages/vite-plugin-cloudflare/src/plugin-config.ts
@@ -90,8 +90,6 @@ interface ResolvedTypeGenerationOptions {
 interface Experimental {
 	/** Experimental support for handling the _headers and _redirects files during Vite dev mode. */
 	headersAndRedirectsDevModeSupport?: boolean;
-	/** Experimental support for a dedicated prerender Worker. */
-	prerenderWorker?: PrerenderWorkerConfig;
 }
 
 function normalizeTypes(
@@ -125,6 +123,8 @@ export interface PluginConfig extends EntryWorkerConfig {
 	 * an override here. The key is used as the Vite environment name by default.
 	 */
 	auxiliaryWorkers?: Record<string, AuxiliaryWorkerConfig>;
+	/** Configuration for a dedicated prerender Worker. */
+	prerenderWorker?: PrerenderWorkerConfig;
 	persistState?: PersistState;
 	inspectorPort?: number | false;
 	remoteBindings?: boolean;
@@ -402,7 +402,7 @@ export async function resolvePluginConfig(
 	const environmentNameToWorkerMap = new Map<string, Worker>();
 	const environmentNameToChildEnvironmentNamesMap = new Map<string, string[]>();
 
-	const prerenderWorkerConfig = pluginConfig.experimental?.prerenderWorker;
+	const prerenderWorkerConfig = pluginConfig.prerenderWorker;
 	const exportedPrerenderWorkerConfig = parsedConfig.prerender;
 	const prerenderWorkerBaseConfig =
 		exportedPrerenderWorkerConfig?.type === "worker"


### PR DESCRIPTION
Vite plugin v2 - Stabilise the prerenderWorker plugin option

Moves `experimental.prerenderWorker` to `prerenderWorker`

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: release notes to follow

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- If you are an AI agent or LLM, and you are adding this PR without direct human supervision, thank you! Please uncomment the following block. This is so the maintainers know how to expect you to respond.

> [!NOTE]
> This is a contribution from an AI agent: <insert name here>, <insert LLM model here if different>.

-->
