### PR TITLE
Enable referencing Worker configs directly in cross-Worker bindings

### DIFF
--- a/.changeset/smart-workers-reference.md
+++ b/.changeset/smart-workers-reference.md
@@ -1,0 +1,7 @@
+---
+"@cloudflare/config": minor
+---
+
+Enable referencing Worker configs directly in cross-Worker bindings
+
+`defineWorker` and `defineSettings` now return ordinary config objects, functions, or promises. Cross-Worker bindings can use a `defineWorker` result as their `worker`, preserving type inference while resolving and parsing the referenced config only once.

--- a/packages/config/src/__tests__/config-loader.test.ts
+++ b/packages/config/src/__tests__/config-loader.test.ts
@@ -1,0 +1,362 @@
+import { describe, it, vi } from "vitest";
+import { bindings } from "../bindings";
+import { resolveAndValidateConfigExports } from "../config-loader";
+import { defineWorker } from "../worker-definition";
+import type { ConfigContext } from "../definition";
+import type {
+	WorkerConfigExport,
+	WorkerConfigInput,
+} from "../worker-definition";
+
+const compatibilityDate = "2026-09-02";
+const baseConfig = {
+	type: "worker",
+	name: "my-worker",
+	compatibilityDate,
+} as const;
+
+describe("resolveAndValidateConfigExports", () => {
+	it("parses Worker and settings exports", async ({ expect }) => {
+		const result = await resolveAndValidateConfigExports(
+			{
+				default: baseConfig,
+				api: { ...baseConfig, name: "api" },
+				settings: { type: "settings", accountId: "acc-123" },
+			},
+			{ mode: undefined }
+		);
+
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data.default?.name).toBe("my-worker");
+			expect(result.data.api?.name).toBe("api");
+			expect(result.data.settings?.accountId).toBe("acc-123");
+		}
+	});
+
+	it("collects settings and Worker validation errors", async ({ expect }) => {
+		const result = await resolveAndValidateConfigExports(
+			{
+				default: { ...baseConfig, compatibilityDate: 42 },
+				settings: { type: "settings", accountId: 42 },
+			},
+			{ mode: undefined }
+		);
+
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(result.error.issues.map((issue) => issue.path)).toEqual(
+				expect.arrayContaining([
+					["settings", "accountId"],
+					["default", "compatibilityDate"],
+				])
+			);
+		}
+	});
+
+	it("reports an invalid-discriminator issue keyed by export name", async ({
+		expect,
+	}) => {
+		const result = await resolveAndValidateConfigExports(
+			{
+				default: { name: "my-worker", compatibilityDate },
+			},
+			{ mode: undefined }
+		);
+
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(result.error.issues[0]?.path).toEqual(["default", "type"]);
+		}
+	});
+
+	it.for([
+		{
+			description: "object",
+			value: { staging: "staging-worker", production: "production-worker" },
+			path: ["WORKER_NAMES", "type"],
+		},
+		{
+			description: "primitive",
+			value: 42,
+			path: ["WORKER_NAMES"],
+		},
+	])(
+		"reports an actionable error for an unknown $description export",
+		async ({ value, path }, { expect }) => {
+			const result = await resolveAndValidateConfigExports(
+				{ default: baseConfig, WORKER_NAMES: value },
+				{ mode: undefined }
+			);
+
+			expect(result.success).toBe(false);
+			if (!result.success) {
+				expect(result.error.issues[0]).toMatchObject({
+					path,
+					message:
+						"The `WORKER_NAMES` export is not a supported export type. Move constants, helper functions, and other unsupported exports to a separate module.",
+				});
+			}
+		}
+	);
+
+	it("rejects a settings config on a non-settings export", async ({
+		expect,
+	}) => {
+		const result = await resolveAndValidateConfigExports(
+			{
+				default: baseConfig,
+				settings: { type: "settings" },
+				extraSettings: { type: "settings" },
+			},
+			{ mode: undefined }
+		);
+
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			const issue = result.error.issues.find((candidate) =>
+				candidate.message.includes(
+					"A `settings` config is only allowed on the `settings` export"
+				)
+			);
+			expect(issue?.path).toEqual(["extraSettings"]);
+		}
+	});
+
+	it("rejects a Worker config on the settings export", async ({ expect }) => {
+		const result = await resolveAndValidateConfigExports(
+			{
+				default: baseConfig,
+				settings: { ...baseConfig, name: "settings" },
+			},
+			{ mode: undefined }
+		);
+
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			const issue = result.error.issues.find((candidate) =>
+				candidate.message.includes(
+					"The `settings` export is reserved for a `settings` config"
+				)
+			);
+			expect(issue?.path).toEqual(["settings"]);
+		}
+	});
+
+	it("resolves object Worker references to names", async ({ expect }) => {
+		const auxiliary = defineWorker({
+			name: "auxiliary",
+			compatibilityDate,
+		});
+		const entry = defineWorker({
+			name: "entry",
+			compatibilityDate,
+			env: {
+				AUXILIARY: bindings.worker({ worker: auxiliary }),
+			},
+		});
+
+		const result = await resolveAndValidateConfigExports(
+			{ default: entry, auxiliary },
+			{ mode: "development" }
+		);
+
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data.default?.env?.AUXILIARY).toMatchObject({
+				type: "worker",
+				worker: "auxiliary",
+			});
+		}
+	});
+
+	it("resolves repeated Worker references once using the config context", async ({
+		expect,
+	}) => {
+		const auxiliaryFactory = vi.fn((ctx: ConfigContext) => ({
+			name: `auxiliary-${ctx.mode}`,
+			compatibilityDate,
+			exports: {
+				Counter: {
+					type: "durable-object" as const,
+					storage: "sqlite" as const,
+				},
+			},
+		}));
+		const auxiliary = defineWorker(auxiliaryFactory);
+		const entry = defineWorker({
+			name: "entry",
+			compatibilityDate,
+			env: {
+				FIRST: bindings.worker({ worker: auxiliary }),
+				SECOND: bindings.worker({ worker: auxiliary }),
+				COUNTER: bindings.durableObject({
+					worker: auxiliary,
+					exportName: "Counter",
+				}),
+			},
+		});
+
+		const ctx = { mode: "test" };
+		const result = await resolveAndValidateConfigExports(
+			{ default: entry },
+			ctx
+		);
+
+		expect(result.success).toBe(true);
+		expect(auxiliaryFactory).toHaveBeenCalledOnce();
+		expect(auxiliaryFactory).toHaveBeenCalledWith(ctx);
+		if (result.success) {
+			expect(result.data.default?.env).toMatchObject({
+				FIRST: { worker: "auxiliary-test" },
+				SECOND: { worker: "auxiliary-test" },
+				COUNTER: { worker: "auxiliary-test" },
+			});
+		}
+	});
+
+	it("does not parse unexported Worker references", async ({ expect }) => {
+		const invalidFactory = vi.fn(() => ({
+			name: "referenced-only",
+			compatibilityDate,
+			unexpected: true,
+		}));
+		const referencedOnly = defineWorker(
+			invalidFactory as unknown as () => WorkerConfigInput
+		);
+		const entry = defineWorker({
+			name: "entry",
+			compatibilityDate,
+			env: {
+				FIRST: bindings.worker({ worker: referencedOnly }),
+				SECOND: bindings.worker({ worker: referencedOnly }),
+			},
+		});
+
+		const result = await resolveAndValidateConfigExports(
+			{ default: entry },
+			{ mode: "development" }
+		);
+
+		expect(result.success).toBe(true);
+		expect(invalidFactory).toHaveBeenCalledOnce();
+		if (result.success) {
+			expect(result.data.default?.env).toMatchObject({
+				FIRST: { worker: "referenced-only" },
+				SECOND: { worker: "referenced-only" },
+			});
+		}
+	});
+
+	it("leaves string Worker references unchanged", async ({ expect }) => {
+		const entry = defineWorker({
+			name: "entry",
+			compatibilityDate,
+			env: {
+				EXTERNAL: bindings.worker({ worker: "external-worker" }),
+			},
+		});
+
+		const result = await resolveAndValidateConfigExports(
+			{ default: entry },
+			{ mode: undefined }
+		);
+
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data.default?.env?.EXTERNAL).toMatchObject({
+				worker: "external-worker",
+			});
+		}
+	});
+
+	it("stops after top-level export type errors", async ({ expect }) => {
+		const auxiliaryFactory = vi.fn(() => ({
+			name: "auxiliary",
+			compatibilityDate,
+		}));
+		const auxiliary = defineWorker(auxiliaryFactory);
+		const entry = defineWorker({
+			name: "entry",
+			compatibilityDate,
+			env: {
+				AUXILIARY: bindings.worker({ worker: auxiliary }),
+			},
+		});
+
+		const result = await resolveAndValidateConfigExports(
+			{ default: entry, UNSUPPORTED: 42 },
+			{ mode: undefined }
+		);
+
+		expect(result.success).toBe(false);
+		expect(auxiliaryFactory).not.toHaveBeenCalled();
+		if (!result.success) {
+			expect(result.error.issues).toHaveLength(1);
+			expect(result.error.issues[0]?.path).toEqual(["UNSUPPORTED"]);
+		}
+	});
+
+	it("supports mutually-referencing Worker factories", async ({ expect }) => {
+		const workers = {} as Record<"first" | "second", WorkerConfigExport>;
+
+		workers.first = defineWorker(() => ({
+			name: "first",
+			compatibilityDate,
+			env: { SECOND: bindings.worker({ worker: workers.second }) },
+		}));
+		workers.second = defineWorker(() => ({
+			name: "second",
+			compatibilityDate,
+			env: { FIRST: bindings.worker({ worker: workers.first }) },
+		}));
+
+		const result = await resolveAndValidateConfigExports(
+			{ default: workers.first, second: workers.second },
+			{ mode: "development" }
+		);
+
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data.default?.env?.SECOND).toMatchObject({
+				worker: "second",
+			});
+			expect(result.data.second?.env?.FIRST).toMatchObject({
+				worker: "first",
+			});
+		}
+	});
+
+	it("parses an exported referenced Worker once", async ({ expect }) => {
+		const invalidFactory = vi.fn(() => ({
+			name: "invalid",
+			compatibilityDate: 42,
+		}));
+		const invalid = defineWorker(
+			invalidFactory as unknown as () => WorkerConfigInput
+		);
+		const entry = defineWorker({
+			name: "entry",
+			compatibilityDate,
+			env: {
+				FIRST: bindings.worker({ worker: invalid }),
+				SECOND: bindings.worker({ worker: invalid }),
+			},
+		});
+
+		const result = await resolveAndValidateConfigExports(
+			{ default: entry, invalid },
+			{ mode: "development" }
+		);
+
+		expect(result.success).toBe(false);
+		expect(invalidFactory).toHaveBeenCalledOnce();
+		if (!result.success) {
+			expect(
+				result.error.issues.filter(
+					(issue) => issue.path.join(".") === "invalid.compatibilityDate"
+				)
+			).toHaveLength(1);
+		}
+	});
+});

--- a/packages/config/src/__tests__/schema.test.ts
+++ b/packages/config/src/__tests__/schema.test.ts
@@ -2,7 +2,6 @@ import { describe, it } from "vitest";
 import { exports as exportConfig } from "../exports";
 import {
 	BindingSchema,
-	ConfigExportsSchema,
 	InputSettingsSchema,
 	InputWorkerSchema,
 	OutputSettingsSchema,
@@ -909,126 +908,6 @@ describe("OutputSettingsSchema", () => {
 		});
 
 		expect(result.success).toBe(false);
-	});
-});
-
-describe("ConfigExportsSchema", () => {
-	it("discriminates worker and settings exports by type", ({ expect }) => {
-		const result = ConfigExportsSchema.safeParse({
-			default: baseConfig,
-			settings: { type: "settings", accountId: "acc-123" },
-		});
-
-		expect(result.success).toBe(true);
-		if (result.success) {
-			expect(result.data.default?.name).toBe("my-worker");
-			expect(result.data.settings?.accountId).toBe("acc-123");
-		}
-	});
-
-	it("reports an invalid-discriminator issue keyed by export name", ({
-		expect,
-	}) => {
-		const result = ConfigExportsSchema.safeParse({
-			default: { name: "my-worker", compatibilityDate: "2026-06-01" },
-		});
-
-		expect(result.success).toBe(false);
-		if (!result.success) {
-			expect(result.error.issues[0]?.path).toEqual(["default", "type"]);
-		}
-	});
-
-	it.for([
-		{
-			description: "object",
-			value: { staging: "staging-worker", production: "production-worker" },
-			path: ["WORKER_NAMES", "type"],
-		},
-		{
-			description: "primitive",
-			value: 42,
-			path: ["WORKER_NAMES"],
-		},
-	])(
-		"reports an actionable error for an unknown $description export",
-		({ value, path }, { expect }) => {
-			const result = ConfigExportsSchema.safeParse({
-				default: baseConfig,
-				WORKER_NAMES: value,
-			});
-
-			expect(result.success).toBe(false);
-			if (!result.success) {
-				expect(result.error.issues[0]).toMatchObject({
-					path,
-					message:
-						"The `WORKER_NAMES` export is not a supported export type. Move constants, helper functions, and other unsupported exports to a separate module.",
-				});
-			}
-		}
-	);
-
-	it("rejects a settings config on a non-`settings` export", ({ expect }) => {
-		const result = ConfigExportsSchema.safeParse({
-			default: baseConfig,
-			settings: { type: "settings" },
-			extraSettings: { type: "settings" },
-		});
-
-		expect(result.success).toBe(false);
-		if (!result.success) {
-			const issue = result.error.issues.find((i) =>
-				i.message.includes(
-					"A `settings` config is only allowed on the `settings` export"
-				)
-			);
-			expect(issue?.path).toEqual(["extraSettings"]);
-		}
-	});
-
-	it("rejects a settings config on the `default` export", ({ expect }) => {
-		const result = ConfigExportsSchema.safeParse({
-			default: { type: "settings" },
-		});
-
-		expect(result.success).toBe(false);
-		if (!result.success) {
-			const issue = result.error.issues.find((i) =>
-				i.message.includes(
-					"A `settings` config is only allowed on the `settings` export"
-				)
-			);
-			expect(issue?.path).toEqual(["default"]);
-		}
-	});
-
-	it("rejects a worker config on the reserved `settings` export", ({
-		expect,
-	}) => {
-		const result = ConfigExportsSchema.safeParse({
-			default: baseConfig,
-			settings: { ...baseConfig, name: "settings" },
-		});
-
-		expect(result.success).toBe(false);
-		if (!result.success) {
-			const issue = result.error.issues.find((i) =>
-				i.message.includes(
-					"The `settings` export is reserved for a `settings` config"
-				)
-			);
-			expect(issue?.path).toEqual(["settings"]);
-		}
-	});
-
-	it("allows multiple worker exports", ({ expect }) => {
-		const result = ConfigExportsSchema.safeParse({
-			default: baseConfig,
-			api: { ...baseConfig, name: "api" },
-		});
-
-		expect(result.success).toBe(true);
 	});
 });
 

--- a/packages/config/src/__tests__/worker-references.test-d.ts
+++ b/packages/config/src/__tests__/worker-references.test-d.ts
@@ -1,0 +1,112 @@
+import { DurableObject, WorkerEntrypoint } from "cloudflare:workers";
+import { bindings } from "../bindings";
+import { exports as workerExports } from "../exports";
+import { defineWorker } from "../worker-definition";
+import type { DurableObjectBinding, WorkerBinding } from "../bindings";
+import type { InferEnv, UnwrapConfig } from "../inference";
+
+class Admin extends WorkerEntrypoint {
+	adminMethod(): string {
+		return "admin";
+	}
+}
+
+class Counter extends DurableObject {
+	increment(): number {
+		return 1;
+	}
+}
+
+const entrypoint = {
+	default: { fetch: () => new Response() },
+	Admin,
+	Counter,
+};
+
+const auxiliary = defineWorker({
+	name: "auxiliary",
+	compatibilityDate: "2026-09-02",
+	entrypoint,
+	exports: {
+		Counter: workerExports.durableObject({ storage: "sqlite" }),
+	},
+});
+
+const auxiliaryFactory = defineWorker(() => ({
+	name: "auxiliary-factory",
+	compatibilityDate: "2026-09-02",
+	entrypoint,
+	/*
+	 * Deliberately omit `exports`: `entrypoint` alone provides enough
+	 * information to infer WorkerEntrypoint service bindings.
+	 */
+}));
+
+const config = defineWorker({
+	name: "entry",
+	compatibilityDate: "2026-09-02",
+	env: {
+		ADMIN: bindings.worker({ worker: auxiliary, exportName: "Admin" }),
+		DEFAULT: bindings.worker({ worker: auxiliary }),
+		FACTORY_ADMIN: bindings.worker({
+			worker: auxiliaryFactory,
+			exportName: "Admin",
+		}),
+		COUNTER: bindings.durableObject({
+			worker: auxiliary,
+			exportName: "Counter",
+		}),
+		DIRECT_ADMIN: {
+			type: "worker",
+			worker: auxiliary,
+			exportName: "Admin",
+		},
+		EXTERNAL: bindings.worker({
+			worker: "external-worker",
+			exportName: "AnyEntrypoint",
+		}),
+	},
+});
+
+bindings.worker({
+	worker: auxiliary,
+	// @ts-expect-error Only WorkerEntrypoint exports are accepted.
+	exportName: "Counter",
+});
+
+bindings.durableObject({
+	worker: auxiliary,
+	// @ts-expect-error Only configured Durable Object exports are accepted.
+	exportName: "Admin",
+});
+
+type Equal<T, U> =
+	(<V>() => V extends T ? 1 : 2) extends <V>() => V extends U ? 1 : 2
+		? true
+		: false;
+type Assert<T extends true> = T;
+type Env = InferEnv<UnwrapConfig<typeof config>>;
+type Auxiliary = typeof auxiliary;
+
+export type WorkerExportNameTest = Assert<
+	Equal<WorkerBinding<Auxiliary>["exportName"], "Admin" | undefined>
+>;
+export type DurableObjectExportNameTest = Assert<
+	Equal<DurableObjectBinding<Auxiliary>["exportName"], "Counter">
+>;
+// @ts-expect-error Worker binding export names come from the referenced Worker.
+export type InvalidWorkerExportNameTest = WorkerBinding<Auxiliary, "Counter">;
+// @ts-expect-error Durable Object export names come from the referenced Worker.
+export type InvalidDoExportNameTest = DurableObjectBinding<Auxiliary, "Admin">;
+export type AdminBindingTest = Assert<Equal<Env["ADMIN"], Fetcher<Admin>>>;
+export type DefaultBindingTest = Assert<Equal<Env["DEFAULT"], Fetcher>>;
+export type FactoryAdminBindingTest = Assert<
+	Equal<Env["FACTORY_ADMIN"], Fetcher<Admin>>
+>;
+export type DirectAdminBindingTest = Assert<
+	Equal<Env["DIRECT_ADMIN"], Fetcher<Admin>>
+>;
+export type CounterBindingTest = Assert<
+	Equal<Env["COUNTER"], DurableObjectNamespace<Counter>>
+>;
+export type ExternalBindingTest = Assert<Equal<Env["EXTERNAL"], Fetcher>>;

--- a/packages/config/src/bindings.ts
+++ b/packages/config/src/bindings.ts
@@ -1,4 +1,11 @@
+import type {
+	InferDurableNamespaces,
+	InferExportsByType,
+	InferWorkerEntrypointExports,
+	UnwrapConfig,
+} from "./inference";
 import type { Json } from "./utils";
+import type { WorkerConfigExport } from "./worker-definition";
 import type { PipelineRecord } from "cloudflare:pipelines";
 
 // JSDoc is derived from `packages/workers-utils/src/config/environment.ts` — keep both in sync.
@@ -177,37 +184,49 @@ export interface DispatchNamespaceBinding extends DispatchNamespaceBindingOption
 	type: "dispatch-namespace";
 }
 
-interface DurableObjectBindingOptions {
-	/** The name of the Worker that defines the Durable Object class. */
-	worker: string;
+export type WorkerReference = string | WorkerConfigExport;
+
+type ReferencedWorkerConfig<TWorker extends WorkerReference> =
+	TWorker extends string ? never : UnwrapConfig<TWorker>;
+
+type DurableObjectExportName<TWorker extends WorkerReference> =
+	TWorker extends string
+		? string
+		: InferDurableNamespaces<ReferencedWorkerConfig<TWorker>>;
+
+type WorkerEntrypointExportName<TWorker extends WorkerReference> =
+	TWorker extends string
+		? string
+		: InferWorkerEntrypointExports<ReferencedWorkerConfig<TWorker>>;
+
+type WorkflowExportName<TWorker extends WorkerReference> =
+	TWorker extends string
+		? string
+		: InferExportsByType<ReferencedWorkerConfig<TWorker>, "workflow">;
+
+interface DurableObjectBindingOptions<
+	TWorker extends WorkerReference = WorkerReference,
+	TExportName extends DurableObjectExportName<TWorker> =
+		DurableObjectExportName<TWorker>,
+> {
+	/** The name or config of the Worker that defines the Durable Object class. */
+	worker: TWorker;
 	/** The exported class name of the Durable Object. */
-	exportName: string;
-}
-
-/**
- * Binding to a Durable Object class. `worker` is the name of the Worker
- * that defines the class; `exportName` is the exported class name.
- *
- * For reference, see https://developers.cloudflare.com/workers/wrangler/configuration/#durable-objects
- */
-export interface DurableObjectBinding extends DurableObjectBindingOptions {
-	type: "durable-object";
-}
-
-/**
- * Binding to a Durable Object class. `worker` is the name of the Worker
- * that defines the class; `exportName` is the exported class name.
- *
- * For reference, see https://developers.cloudflare.com/workers/wrangler/configuration/#durable-objects
- */
-export interface TypedDurableObjectBinding<
-	TConfig,
-	TExportName extends string,
-> extends DurableObjectBinding {
-	worker: string;
 	exportName: TExportName;
-	/** @internal Carries the config type for inference */
-	__config: TConfig;
+}
+
+/**
+ * Binding to a Durable Object class. `worker` is the name or config of the
+ * Worker that defines the class; `exportName` is the exported class name.
+ *
+ * For reference, see https://developers.cloudflare.com/workers/wrangler/configuration/#durable-objects
+ */
+export interface DurableObjectBinding<
+	TWorker extends WorkerReference = WorkerReference,
+	TExportName extends DurableObjectExportName<TWorker> =
+		DurableObjectExportName<TWorker>,
+> extends DurableObjectBindingOptions<TWorker, TExportName> {
+	type: "durable-object";
 }
 
 interface FlagshipBindingOptions {
@@ -590,11 +609,16 @@ export interface WebSearchBinding extends WebSearchBindingOptions {
 	type: "web-search";
 }
 
-interface WorkerBindingOptions {
-	/** The name of the bound Worker. */
-	worker: string;
+interface WorkerBindingOptions<
+	TWorker extends WorkerReference = WorkerReference,
+	TExportName extends WorkerEntrypointExportName<TWorker> | undefined =
+		| WorkerEntrypointExportName<TWorker>
+		| undefined,
+> {
+	/** The name or config of the bound Worker. */
+	worker: TWorker;
 	/** The named export to bind to (defaults to the default export). */
-	exportName?: string;
+	exportName?: TExportName;
 	/** Optional properties that will be made available to the service via `ctx.props`. */
 	props?: Record<string, unknown>;
 	/** Options that only apply during local development. */
@@ -602,31 +626,19 @@ interface WorkerBindingOptions {
 }
 
 /**
- * Service binding (Worker-to-Worker). `worker` is the name of the bound
- * Worker; `exportName` selects a named `WorkerEntrypoint` export (defaults to
- * the default export).
+ * Service binding (Worker-to-Worker). `worker` is the name or config of the
+ * bound Worker; `exportName` selects a named `WorkerEntrypoint` export
+ * (defaults to the default export).
  *
  * For reference, see https://developers.cloudflare.com/workers/wrangler/configuration/#service-bindings
  */
-export interface WorkerBinding extends WorkerBindingOptions {
+export interface WorkerBinding<
+	TWorker extends WorkerReference = WorkerReference,
+	TExportName extends WorkerEntrypointExportName<TWorker> | undefined =
+		| WorkerEntrypointExportName<TWorker>
+		| undefined,
+> extends WorkerBindingOptions<TWorker, TExportName> {
 	type: "worker";
-}
-
-/**
- * Service binding (Worker-to-Worker). `worker` is the name of the bound
- * Worker; `exportName` selects a named `WorkerEntrypoint` export (defaults to
- * the default export).
- *
- * For reference, see https://developers.cloudflare.com/workers/wrangler/configuration/#service-bindings
- */
-export interface TypedWorkerBinding<
-	TConfig,
-	TExportName extends string,
-> extends WorkerBinding {
-	worker: string;
-	exportName: TExportName;
-	/** @internal Carries the config type for inference */
-	__config: TConfig;
 }
 
 /** Binding to a Worker Loader. */
@@ -634,33 +646,26 @@ export interface WorkerLoaderBinding {
 	type: "worker-loader";
 }
 
-interface WorkflowBindingOptions {
-	/** The name of the Worker that defines the Workflow. */
-	worker: string;
+interface WorkflowBindingOptions<
+	TWorker extends WorkerReference = WorkerReference,
+	TExportName extends WorkflowExportName<TWorker> = WorkflowExportName<TWorker>,
+> {
+	/** The name or config of the Worker that defines the Workflow. */
+	worker: TWorker;
 	/** The exported class name of the Workflow. */
-	exportName: string;
-}
-
-/**
- * Binding to a Workflow. `worker` is the name of the Worker that defines
- * the Workflow; `exportName` is the exported `WorkflowEntrypoint` class name.
- */
-export interface WorkflowBinding extends WorkflowBindingOptions {
-	type: "workflow";
-}
-
-/**
- * Binding to a Workflow. `worker` is the name of the Worker that defines
- * the Workflow; `exportName` is the exported `WorkflowEntrypoint` class name.
- */
-export interface TypedWorkflowBinding<
-	TConfig,
-	TExportName extends string,
-> extends WorkflowBinding {
-	worker: string;
 	exportName: TExportName;
-	/** @internal Carries the config type for inference */
-	__config: TConfig;
+}
+
+/**
+ * Binding to a Workflow. `worker` is the name or config of the Worker that
+ * defines the Workflow; `exportName` is the exported `WorkflowEntrypoint`
+ * class name.
+ */
+export interface WorkflowBinding<
+	TWorker extends WorkerReference = WorkerReference,
+	TExportName extends WorkflowExportName<TWorker> = WorkflowExportName<TWorker>,
+> extends WorkflowBindingOptions<TWorker, TExportName> {
+	type: "workflow";
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -733,12 +738,17 @@ export interface Bindings {
 		options?: DispatchNamespaceBindingOptions
 	): DispatchNamespaceBinding;
 	/**
-	 * Binding to a Durable Object class. `worker` is the name of the Worker
-	 * that defines the class; `exportName` is the exported class name.
+	 * Binding to a Durable Object class. `worker` is the name or config of the
+	 * Worker that defines the class; `exportName` is the exported class name.
 	 *
 	 * For reference, see https://developers.cloudflare.com/workers/wrangler/configuration/#durable-objects
 	 */
-	durableObject(options: DurableObjectBindingOptions): DurableObjectBinding;
+	durableObject<
+		TWorker extends WorkerReference,
+		TExportName extends DurableObjectExportName<TWorker>,
+	>(
+		options: DurableObjectBindingOptions<TWorker, TExportName>
+	): DurableObjectBinding<TWorker, TExportName>;
 	/** Binding to a Flagship feature-flag service. */
 	flagship(options?: FlagshipBindingOptions): FlagshipBinding;
 	/**
@@ -846,19 +856,25 @@ export interface Bindings {
 	 */
 	webSearch(options?: WebSearchBindingOptions): WebSearchBinding;
 	/**
-	 * Service binding (Worker-to-Worker). `worker` is the name of the bound
-	 * Worker; `exportName` selects a named `WorkerEntrypoint` export (defaults to
-	 * the default export).
+	 * Service binding (Worker-to-Worker). `worker` is the name or config of the
+	 * bound Worker; `exportName` selects a named `WorkerEntrypoint` export
+	 * (defaults to the default export).
 	 *
 	 * For reference, see https://developers.cloudflare.com/workers/wrangler/configuration/#service-bindings
 	 */
-	worker(options: WorkerBindingOptions): WorkerBinding;
+	worker<
+		TWorker extends WorkerReference,
+		TExportName extends WorkerEntrypointExportName<TWorker> | undefined =
+			undefined,
+	>(
+		options: WorkerBindingOptions<TWorker, TExportName>
+	): WorkerBinding<TWorker, NoInfer<TExportName>>;
 	/** Binding to a Worker Loader. */
 	workerLoader(): WorkerLoaderBinding;
 	// TODO: re-enable when workflow bindings return.
 	// /**
 	//  * Create a Workflow binding.
-	//  * `worker` must match a known config's name (or any `string` for untyped bindings).
+	//  * `worker` may be a Worker config reference or a Worker name.
 	//  * `exportName` must be a valid `WorkflowEntrypoint` export for the given Worker.
 	//  */
 	// workflow(options: WorkflowBindingOptions): WorkflowBinding;

--- a/packages/config/src/config-loader.ts
+++ b/packages/config/src/config-loader.ts
@@ -1,22 +1,190 @@
-import { resolveExportDefinition } from "./definition";
+import * as z from "zod";
 import { loadConfig } from "./load";
-import { ConfigExportsSchema } from "./schema";
+import {
+	ConfigExportsTypeSchema,
+	InputSettingsSchema,
+	InputWorkerSchema,
+} from "./schema";
 import type { ConfigContext } from "./definition";
-import type { ParsedConfigExports } from "./schema";
-import type * as z from "zod";
+import type {
+	ParsedInputSettingsConfig,
+	ParsedInputWorkerConfig,
+} from "./schema";
+
+const CROSS_WORKER_BINDING_TYPES = new Set([
+	"durable-object",
+	"worker",
+	"workflow",
+]);
+
+type ResolveDefinition = (input: unknown) => Promise<unknown>;
+
+export type ParsedConfigExports = {
+	settings?: ParsedInputSettingsConfig;
+} & Record<string, ParsedInputWorkerConfig>;
+
+export type ConfigParseResult =
+	| z.ZodSafeParseSuccess<ParsedConfigExports>
+	| z.ZodSafeParseError<unknown>;
 
 export interface LoadAndValidateConfigResult {
 	/**
-	 * Zod result for the validated exports record, keyed by JS export name.
+	 * Zod result for the parsed exports record, keyed by JS export name.
 	 * Consumers format `result.error` themselves.
 	 */
-	result: z.ZodSafeParseResult<ParsedConfigExports>;
+	result: ConfigParseResult;
 	/** Transitive deps imported while resolving the config (node_modules excluded). */
 	dependencies: Set<string>;
 }
 
+function isRecord(value: unknown): value is Record<PropertyKey, unknown> {
+	return typeof value === "object" && value !== null;
+}
+
+function isConfigReference(value: unknown): boolean {
+	return typeof value === "function" || isRecord(value);
+}
+
+function createDefinitionResolver(ctx: ConfigContext): ResolveDefinition {
+	const resolvedDefinitions = new Map<unknown, Promise<unknown>>();
+
+	return (input) => {
+		const cached = resolvedDefinitions.get(input);
+		if (cached) {
+			return cached;
+		}
+
+		const resolved = (async () => {
+			const value =
+				typeof input === "function"
+					? (input as (ctx: ConfigContext) => unknown)(ctx)
+					: input;
+			return await value;
+		})();
+		resolvedDefinitions.set(input, resolved);
+		return resolved;
+	};
+}
+
+async function normalizeWorkerReferences(
+	resolved: unknown,
+	resolveDefinition: ResolveDefinition
+): Promise<unknown> {
+	if (!isRecord(resolved) || !isRecord(resolved.env)) {
+		return resolved;
+	}
+
+	const env: Record<PropertyKey, unknown> = { ...resolved.env };
+	for (const [bindingName, binding] of Object.entries(env)) {
+		if (
+			!isRecord(binding) ||
+			typeof binding.type !== "string" ||
+			!CROSS_WORKER_BINDING_TYPES.has(binding.type) ||
+			!isConfigReference(binding.worker)
+		) {
+			continue;
+		}
+
+		const target = await resolveDefinition(binding.worker);
+		env[bindingName] = {
+			...binding,
+			worker: isRecord(target) ? target.name : undefined,
+		};
+	}
+
+	return { ...resolved, env };
+}
+
+function prefixIssues(
+	issues: z.core.$ZodIssue[],
+	prefix: PropertyKey
+): z.core.$ZodIssue[] {
+	return issues.map((issue) => ({
+		...issue,
+		path: [prefix, ...issue.path],
+	}));
+}
+
 /**
- * Load a `cloudflare.config.ts`, resolve all exports, and validate against {@link ConfigExportsSchema}.
+ * Resolve and validate loaded `cloudflare.config.ts` exports.
+ *
+ * Config inputs are resolved once by identity. Top-level Worker exports are
+ * also parsed once by identity; unexported references are resolved only far
+ * enough to replace the reference with the Worker's name.
+ */
+export async function resolveAndValidateConfigExports(
+	exports: Record<string, unknown>,
+	ctx: ConfigContext
+): Promise<ConfigParseResult> {
+	const resolveDefinition = createDefinitionResolver(ctx);
+	const parsedWorkers = new Map<
+		unknown,
+		z.ZodSafeParseResult<ParsedInputWorkerConfig>
+	>();
+	const resolvedExports: Record<string, unknown> = {};
+
+	for (const [name, input] of Object.entries(exports)) {
+		resolvedExports[name] = await resolveDefinition(input);
+	}
+
+	const typeResult = ConfigExportsTypeSchema.safeParse(resolvedExports);
+	if (!typeResult.success) {
+		return typeResult;
+	}
+
+	const issues: z.core.$ZodIssue[] = [];
+	const data: ParsedConfigExports = {};
+
+	const resolvedSettings = resolvedExports.settings;
+	const settingsResult = resolvedSettings
+		? InputSettingsSchema.safeParse(resolvedSettings)
+		: undefined;
+	if (settingsResult) {
+		if (settingsResult.success) {
+			data.settings = settingsResult.data;
+		} else {
+			issues.push(...prefixIssues(settingsResult.error.issues, "settings"));
+		}
+	}
+
+	for (const [name, input] of Object.entries(exports)) {
+		const resolved = resolvedExports[name];
+		if (!isRecord(resolved)) {
+			continue;
+		}
+
+		if (resolved.type === "worker") {
+			let result = parsedWorkers.get(input);
+			if (!result) {
+				result = InputWorkerSchema.safeParse(
+					await normalizeWorkerReferences(resolved, resolveDefinition)
+				);
+				parsedWorkers.set(input, result);
+				if (!result.success) {
+					issues.push(...prefixIssues(result.error.issues, name));
+				}
+			}
+
+			if (result.success) {
+				data[name] = result.data;
+			}
+			continue;
+		}
+	}
+
+	return issues.length > 0
+		? {
+				success: false,
+				error: new z.ZodError(issues),
+			}
+		: {
+				success: true,
+				data,
+			};
+}
+
+/**
+ * Load a `cloudflare.config.ts`, resolve all exports, and validate them.
  */
 export async function loadAndValidateConfig(
 	configPath: string,
@@ -24,13 +192,7 @@ export async function loadAndValidateConfig(
 	options?: { include?: string[] }
 ): Promise<LoadAndValidateConfigResult> {
 	const { exports, dependencies } = await loadConfig(configPath, options);
-
-	const resolved: Record<string, unknown> = {};
-	for (const [name, value] of Object.entries(exports)) {
-		resolved[name] = await resolveExportDefinition(value, ctx);
-	}
-
-	const result = ConfigExportsSchema.safeParse(resolved);
+	const result = await resolveAndValidateConfigExports(exports, ctx);
 
 	return { result, dependencies };
 }

--- a/packages/config/src/definition.ts
+++ b/packages/config/src/definition.ts
@@ -8,10 +8,6 @@ export interface ConfigContext {
 	mode: string | undefined;
 }
 
-// We currently use Symbol.for rather than Symbol so that the symbol matches if duplicated across bundles
-// This wouldn't be necessary if @cloudflare/config was published and included as a dependency
-export const DEFINITION = Symbol.for("@cloudflare/config:definition");
-
 /**
  * The authored config in any of its supported shapes: a plain value, a promise,
  * or a function of {@link ConfigContext}.
@@ -21,36 +17,60 @@ export type ConfigInput<T> =
 	| Promise<T>
 	| ((ctx: ConfigContext) => T | Promise<T>);
 
-/**
- * Unwrap an authored config from its value / promise / function shape, awaiting
- * the result. A function config is invoked with {@link ConfigContext}.
- */
-async function unwrap(config: unknown, ctx: ConfigContext): Promise<unknown> {
-	return typeof config === "function"
-		? await (config as (ctx: ConfigContext) => unknown)(ctx)
-		: await config;
-}
+type ConfigObject = Record<string, unknown>;
 
-/**
- * Resolve any `cloudflare.config.ts` export to its plain config value.
- *
- * A `define*` helper stores its authored config plus `type` under the
- * {@link DEFINITION} symbol; here we unwrap the config and stamp `type` back on.
- * Every other export — a raw object/promise/function — is unwrapped as-is and
- * already carries its own `type`. Discrimination happens afterwards via `type`.
- */
-export async function resolveExportDefinition(
-	def: unknown,
+export type ConfigWithType<T extends ConfigObject, TType extends string> = T & {
+	type: TType;
+};
+
+type DefinedConfigValue<TValue, TType extends string> =
+	TValue extends Promise<infer TConfig extends ConfigObject>
+		? Promise<ConfigWithType<TConfig, TType>>
+		: TValue extends ConfigObject
+			? ConfigWithType<TValue, TType>
+			: never;
+
+type DefinedConfig<TInput, TType extends string> = TInput extends (
 	ctx: ConfigContext
-): Promise<unknown> {
-	if (typeof def === "object" && def !== null && DEFINITION in def) {
-		const { config, type } = (def as Record<symbol, unknown>)[DEFINITION] as {
-			config: unknown;
-			type: string;
-		};
-		const resolved = await unwrap(config, ctx);
-		return { ...(resolved as object), type };
+) => infer TResult
+	? (ctx: ConfigContext) => DefinedConfigValue<TResult, TType>
+	: DefinedConfigValue<TInput, TType>;
+
+/** Add a config type while preserving its value, promise, or function shape. */
+function addConfigType<
+	TConfig extends ConfigObject,
+	const TType extends string,
+>(
+	config: ConfigInput<TConfig>,
+	type: TType
+): ConfigInput<ConfigWithType<TConfig, TType>> {
+	function addType(value: TConfig): ConfigWithType<TConfig, TType> {
+		return { ...value, type };
 	}
 
-	return await unwrap(def, ctx);
+	if (typeof config === "function") {
+		return (ctx) => {
+			const result = config(ctx);
+			return result instanceof Promise ? result.then(addType) : addType(result);
+		};
+	}
+
+	return config instanceof Promise ? config.then(addType) : addType(config);
+}
+
+/** Create a type-safe config helper for a particular export type. */
+export function createConfigDefiner<
+	TConfigInput extends ConfigObject,
+	const TType extends string,
+>(type: TType) {
+	function define<const TInput extends ConfigInput<TConfigInput>>(
+		config: TInput
+	): DefinedConfig<TInput, TType>;
+	function define(
+		config: ConfigInput<TConfigInput>
+	): ConfigInput<ConfigWithType<TConfigInput, TType>> {
+		return addConfigType(config, type);
+	}
+
+	return define;
 }

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -4,7 +4,6 @@ export {
 	AssetsSchema,
 	BindingSchema,
 	BrowserBindingSchema,
-	ConfigExportsSchema,
 	D1BindingSchema,
 	DurableObjectCreatedExportSchema,
 	DurableObjectDeletedExportSchema,
@@ -32,12 +31,17 @@ export {
 export { generateTypes } from "./generate";
 export { convertToWranglerConfig } from "./convert";
 export { loadConfig, registerConfigHooks } from "./load";
-export { loadAndValidateConfig } from "./config-loader";
-export { resolveExportDefinition } from "./definition";
+export {
+	loadAndValidateConfig,
+	resolveAndValidateConfigExports,
+} from "./config-loader";
 export type { LoadConfigResult } from "./load";
-export type { LoadAndValidateConfigResult } from "./config-loader";
 export type {
+	ConfigParseResult,
+	LoadAndValidateConfigResult,
 	ParsedConfigExports,
+} from "./config-loader";
+export type {
 	ParsedInputSettingsConfig,
 	ParsedInputWorkerConfig,
 	ParsedOutputSettingsConfig,

--- a/packages/config/src/inference.ts
+++ b/packages/config/src/inference.ts
@@ -4,14 +4,11 @@ import type {
 	JsonBinding,
 	TextBinding,
 	TypedAiBinding,
-	TypedDurableObjectBinding,
 	TypedKvBinding,
 	TypedPipelineBinding,
 	TypedQueueBinding,
-	TypedWorkerBinding,
-	TypedWorkflowBinding,
+	WorkerReference,
 } from "./bindings";
-import type { WorkerConfigExport, WorkerDefinition } from "./worker-definition";
 import type { Pipeline } from "cloudflare:pipelines";
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -124,52 +121,76 @@ interface BindingTypeMap<TBinding> {
 	workflow: Workflow;
 }
 
+type SelectedWorkerExportName<TBinding> = TBinding extends {
+	exportName?: infer TExportName;
+}
+	? TExportName extends string
+		? TExportName
+		: "default"
+	: "default";
+
 type InferBindingType<TBinding> =
 	// Worker binding
-	TBinding extends TypedWorkerBinding<
-		infer TConfig,
-		infer TExportName extends string
-	>
-		? InferMainModule<TConfig> extends infer TModule extends WorkerModule
-			? TExportName extends keyof TModule
-				? TModule[TExportName] extends Constructor<any>
-					? Fetcher<
-							ExtractInstance<TModule[TExportName], Rpc.WorkerEntrypointBranded>
-						>
-					: Fetcher
-				: never
-			: never
-		: // Durable Object binding
-			TBinding extends TypedDurableObjectBinding<
-					infer TConfig,
-					infer TExportName extends string
-			  >
-			? InferMainModule<TConfig> extends infer TModule extends WorkerModule
-				? TExportName extends keyof TModule
-					? DurableObjectNamespace<
-							ExtractInstance<TModule[TExportName], Rpc.DurableObjectBranded>
-						>
-					: never
-				: never
-			: // Workflow binding
-				TBinding extends TypedWorkflowBinding<
-						infer TConfig,
-						infer TExportName extends string
-				  >
-				? InferMainModule<TConfig> extends infer TModule extends WorkerModule
+	TBinding extends {
+		type: "worker";
+		worker: infer TWorker extends WorkerReference;
+	}
+		? TWorker extends string
+			? Fetcher
+			: InferMainModule<UnwrapConfig<TWorker>> extends infer TModule extends
+						WorkerModule
+				? SelectedWorkerExportName<TBinding> extends infer TExportName
 					? TExportName extends keyof TModule
-						? ExtractInstance<
-								TModule[TExportName],
-								Rpc.WorkflowEntrypointBranded
-							> extends infer TWorkflow
-							? TWorkflow extends {
-									run(event: { payload: infer P }, step: any): any;
-								}
-								? Workflow<P>
-								: Workflow
-							: Workflow
+						? TModule[TExportName] extends Constructor<any>
+							? Fetcher<
+									ExtractInstance<
+										TModule[TExportName],
+										Rpc.WorkerEntrypointBranded
+									>
+								>
+							: Fetcher
 						: never
 					: never
+				: never
+		: // Durable Object binding
+			TBinding extends {
+					type: "durable-object";
+					worker: infer TWorker extends WorkerReference;
+					exportName: infer TExportName extends string;
+			  }
+			? TWorker extends string
+				? DurableObjectNamespace
+				: InferMainModule<UnwrapConfig<TWorker>> extends infer TModule extends
+							WorkerModule
+					? TExportName extends keyof TModule
+						? DurableObjectNamespace<
+								ExtractInstance<TModule[TExportName], Rpc.DurableObjectBranded>
+							>
+						: never
+					: never
+			: // Workflow binding
+				TBinding extends {
+						type: "workflow";
+						worker: infer TWorker extends WorkerReference;
+						exportName: infer TExportName extends string;
+				  }
+				? TWorker extends string
+					? Workflow
+					: InferMainModule<UnwrapConfig<TWorker>> extends infer TModule extends
+								WorkerModule
+						? TExportName extends keyof TModule
+							? ExtractInstance<
+									TModule[TExportName],
+									Rpc.WorkflowEntrypointBranded
+								> extends infer TWorkflow
+								? TWorkflow extends {
+										run(event: { payload: infer P }, step: any): any;
+									}
+									? Workflow<P>
+									: Workflow
+								: Workflow
+							: never
+						: never
 				: // Unsafe bindings
 					TBinding extends { type: `unsafe:${string}` }
 					? any
@@ -184,27 +205,6 @@ type InferBindingType<TBinding> =
 // CROSS-WORKER BINDING HELPERS (INTERNAL)
 // Types used by the Bindings interface for type-safe cross-worker bindings.
 // ═══════════════════════════════════════════════════════════════════════════
-
-/**
- * Infer the Worker name from a config.
- *
- * @example
- * ```typescript
- * import { defineWorker } from "@cloudflare/config";
- * import type { InferDurableNamespaces, UnwrapConfig } from "@cloudflare/config";
- *
- * const config = defineWorker({ name: "my-worker", ... });
- *
- * type WorkerConfig = UnwrapConfig<typeof config>;
- * // Inferred as: "my-worker"
- * type Name = InferWorkerName<WorkerConfig>;
- * ```
- */
-export type InferWorkerName<TUnwrappedConfig> = TUnwrappedConfig extends {
-	name: infer TName extends string;
-}
-	? TName
-	: never;
 
 /**
  * Infer export names from a config's exports, optionally filtered by type.
@@ -245,12 +245,13 @@ export type InferWorkerEntrypointExports<TUnwrappedConfig> = Exclude<
  * Unwrap function and promise types to get the underlying config.
  * Use this to normalize a config before passing it to other inference utilities.
  */
-export type UnwrapConfig<TConfig> =
-	TConfig extends WorkerDefinition<infer TUnwrappedConfig>
-		? TUnwrappedConfig
-		: TConfig extends WorkerConfigExport<infer TUnwrappedConfig>
-			? TUnwrappedConfig
-			: never;
+export type UnwrapConfig<TConfig> = TConfig extends (
+	...args: any[]
+) => infer TReturn
+	? UnwrapConfig<TReturn>
+	: TConfig extends Promise<infer TCompletion>
+		? UnwrapConfig<TCompletion>
+		: TConfig;
 
 /**
  * Infer the `Env` interface type from a Worker config.

--- a/packages/config/src/public.ts
+++ b/packages/config/src/public.ts
@@ -35,12 +35,9 @@ export type {
 	StreamBinding,
 	TextBinding,
 	TypedAiBinding,
-	TypedDurableObjectBinding,
 	TypedKvBinding,
 	TypedPipelineBinding,
 	TypedQueueBinding,
-	TypedWorkerBinding,
-	TypedWorkflowBinding,
 	UnsafeBinding,
 	VectorizeBinding,
 	VersionMetadataBinding,
@@ -49,6 +46,7 @@ export type {
 	WebSearchBinding,
 	WorkerBinding,
 	WorkerLoaderBinding,
+	WorkerReference,
 	WorkflowBinding,
 } from "./bindings";
 export { bindings } from "./bindings";
@@ -81,13 +79,12 @@ export type {
 export type { ConfigContext } from "./definition";
 export type { SettingsConfig, WorkerConfig } from "./types";
 export type {
-	TypedWorkerDefinition,
 	WorkerConfigExport,
 	WorkerConfigInput,
 } from "./worker-definition";
 export { defineWorker } from "./worker-definition";
 export type {
+	SettingsConfigExport,
 	SettingsConfigInput,
-	SettingsDefinition,
 } from "./settings-definition";
 export { defineSettings } from "./settings-definition";

--- a/packages/config/src/schema.ts
+++ b/packages/config/src/schema.ts
@@ -591,7 +591,7 @@ function invalidConfigExportMessage(exportName: string): string {
 	return `The \`${exportName}\` export is not a supported export type. Move constants, helper functions, and other unsupported exports to a separate module.`;
 }
 
-const ConfigExportsTypeSchema = z
+export const ConfigExportsTypeSchema = z
 	.record(z.string(), z.unknown())
 	.check((ctx) => {
 		for (const [key, value] of Object.entries(ctx.value)) {
@@ -626,25 +626,6 @@ const ConfigExportsTypeSchema = z
 			}
 		}
 	});
-
-const ConfigExportsObjectSchema = z
-	.object({
-		settings: InputSettingsSchema.optional(),
-	})
-	.catchall(InputWorkerSchema);
-
-/**
- * Schema for the resolved config exports, keyed by export
- * name. Each value is discriminated on its `type` field. Reserves the
- * `settings` export name exclusively for settings configs: a `settings`
- * config must live on the `settings` export, and the `settings` export
- * may only hold a `settings` config.
- */
-export const ConfigExportsSchema = ConfigExportsTypeSchema.pipe(
-	ConfigExportsObjectSchema
-);
-
-export type ParsedConfigExports = z.output<typeof ConfigExportsSchema>;
 
 export const ModuleTypeSchema = z.enum([
 	"esm",
@@ -726,23 +707,34 @@ const _assertSchemaMatchesWorkerConfig: _AssertSchemaMatchesWorkerConfig = [
 ];
 void _assertSchemaMatchesWorkerConfig;
 
+type _ResolvedBinding<TBinding> = TBinding extends {
+	type: "durable-object" | "worker" | "workflow";
+	worker: unknown;
+}
+	? Omit<TBinding, "worker"> & { worker: string }
+	: TBinding;
+
+type _ResolvedWorkerConfigEnv =
+	| Record<string, _ResolvedBinding<NonNullable<WorkerConfig["env"]>[string]>>
+	| undefined;
+
 /**
- * Drift checks between the schema and public `env` types. Schema input is
- * intentionally broader for bindings with cross-field validation, so only
- * assert that every public binding is accepted as input. After parsing, the
- * schema output and public types should match bidirectionally.
+ * Drift checks between the schema and resolved public `env` types. Authored
+ * cross-Worker bindings may contain a Worker config reference; the config
+ * loader replaces those references with names before parsing. Schema input is
+ * otherwise intentionally broader for bindings with cross-field validation.
  *
  * These checks catch fields or bindings that are missing, renamed, or typed
  * differently between the public definitions and the schema.
  */
 type _AssertSchemaEnvMatchesWorkerConfig = [
-	WorkerConfig["env"] extends z.input<typeof InputWorkerSchema>["env"]
+	_ResolvedWorkerConfigEnv extends z.input<typeof InputWorkerSchema>["env"]
 		? true
 		: false,
-	z.output<typeof InputWorkerSchema>["env"] extends WorkerConfig["env"]
+	z.output<typeof InputWorkerSchema>["env"] extends _ResolvedWorkerConfigEnv
 		? true
 		: false,
-	WorkerConfig["env"] extends z.output<typeof InputWorkerSchema>["env"]
+	_ResolvedWorkerConfigEnv extends z.output<typeof InputWorkerSchema>["env"]
 		? true
 		: false,
 ];

--- a/packages/config/src/settings-definition.ts
+++ b/packages/config/src/settings-definition.ts
@@ -1,6 +1,9 @@
-import { DEFINITION } from "./definition";
+import { createConfigDefiner } from "./definition";
 import type { ConfigInput } from "./definition";
 import type { SettingsConfig } from "./types";
+
+export type SettingsConfigExport<T extends SettingsConfig = SettingsConfig> =
+	ConfigInput<T>;
 
 /**
  * Authored settings config shape — {@link SettingsConfig} without the `type`
@@ -9,21 +12,10 @@ import type { SettingsConfig } from "./types";
 export type SettingsConfigInput = Omit<SettingsConfig, "type">;
 
 /**
- * A settings definition created by {@link defineSettings}.
- */
-export interface SettingsDefinition {
-	[DEFINITION]: {
-		config: ConfigInput<SettingsConfigInput>;
-		type: "settings";
-	};
-}
-
-/**
  * Declare shared settings.
  * Authored as a named `settings` export.
  */
-export function defineSettings(
-	config: ConfigInput<SettingsConfigInput>
-): SettingsDefinition {
-	return { [DEFINITION]: { config, type: "settings" } };
-}
+export const defineSettings = createConfigDefiner<
+	SettingsConfigInput,
+	"settings"
+>("settings");

--- a/packages/config/src/worker-definition.ts
+++ b/packages/config/src/worker-definition.ts
@@ -1,75 +1,6 @@
-import { DEFINITION } from "./definition";
-import type {
-	BindingDevOptions,
-	Bindings,
-	TypedDurableObjectBinding,
-	TypedWorkerBinding,
-} from "./bindings";
-import type { ConfigContext, ConfigInput } from "./definition";
-import type {
-	InferDurableNamespaces,
-	InferWorkerName,
-	InferWorkerEntrypointExports,
-} from "./inference";
+import { createConfigDefiner } from "./definition";
+import type { ConfigInput } from "./definition";
 import type { WorkerConfig } from "./types";
-
-/**
- * Base shape of a Worker definition. Carries the authored config (under
- * {@link DEFINITION}) and the untyped cross-worker binding helpers.
- */
-export interface WorkerDefinition<
-	TConfig extends WorkerConfig = WorkerConfig,
-> extends Pick<Bindings, "durableObject" | "worker"> {
-	// The authored config is stored without its `type` discriminant (the helper
-	// omits it); `type` sits alongside it and is stamped back on during
-	// resolution. `TConfig` is still referenced so `UnwrapConfig` can recover it.
-	[DEFINITION]: { config: ConfigInput<Omit<TConfig, "type">>; type: "worker" };
-}
-
-/**
- * Worker definition with typed cross-worker binding helpers.
- */
-export interface TypedWorkerDefinition<
-	TConfig extends WorkerConfig,
-	TWorkerName extends string = InferWorkerName<TConfig>,
-> extends WorkerDefinition<TConfig> {
-	/**
-	 * Binding to a Durable Object class. `worker` is the name of the Worker
-	 * that defines the class; `exportName` is the exported class name.
-	 *
-	 * For reference, see https://developers.cloudflare.com/workers/wrangler/configuration/#durable-objects
-	 */
-	durableObject<TExportName extends InferDurableNamespaces<TConfig>>(options: {
-		worker: TWorkerName;
-		exportName: TExportName;
-	}): TypedDurableObjectBinding<TConfig, TExportName>;
-	/**
-	 * Service binding (Worker-to-Worker). `worker` is the name of the bound
-	 * Worker; `exportName` selects a named `WorkerEntrypoint` export (defaults to
-	 * the default export).
-	 *
-	 * For reference, see https://developers.cloudflare.com/workers/wrangler/configuration/#service-bindings
-	 */
-	worker<
-		TExportName extends InferWorkerEntrypointExports<TConfig> | undefined =
-			undefined,
-	>(options: {
-		worker: TWorkerName;
-		exportName?: TExportName;
-		props?: Record<string, unknown>;
-		dev?: BindingDevOptions;
-	}): TypedWorkerBinding<
-		TConfig,
-		TExportName extends string ? TExportName : "default"
-	>;
-	// TODO: re-enable when workflow bindings return.
-	// workflow<
-	// 	TExportName extends InferExportsByType<TConfig, "workflow">,
-	// >(options: {
-	// 	worker: TWorkerName;
-	// 	exportName: TExportName;
-	// }): TypedWorkflowBinding<TConfig, TExportName>;
-}
 
 export type WorkerConfigExport<T extends WorkerConfig = WorkerConfig> =
 	ConfigInput<T>;
@@ -80,32 +11,6 @@ export type WorkerConfigExport<T extends WorkerConfig = WorkerConfig> =
  */
 export type WorkerConfigInput = Omit<WorkerConfig, "type">;
 
-export type WorkerConfigInputExport<
-	T extends WorkerConfigInput = WorkerConfigInput,
-> = ConfigInput<T>;
-
-export function defineWorker<const T extends WorkerConfigInput>(
-	config: (
-		ctx: ConfigContext
-	) => (WorkerConfigInput & T) | Promise<WorkerConfigInput & T>
-): TypedWorkerDefinition<T & { type: "worker" }>;
-export function defineWorker<const T extends WorkerConfigInput>(
-	config: (WorkerConfigInput & T) | Promise<WorkerConfigInput & T>
-): TypedWorkerDefinition<T & { type: "worker" }>;
-export function defineWorker(
-	config: WorkerConfigInputExport
-): WorkerDefinition {
-	return {
-		[DEFINITION]: { config, type: "worker" },
-		durableObject(options) {
-			return { type: "durable-object", ...options };
-		},
-		worker(options) {
-			return { type: "worker", ...options };
-		},
-		// TODO: re-enable when workflow bindings return.
-		// workflow(options) {
-		// 	return { type: "workflow", ...options };
-		// },
-	};
-}
+export const defineWorker = createConfigDefiner<WorkerConfigInput, "worker">(
+	"worker"
+);

--- a/packages/wrangler/src/__tests__/helpers/mock-new-config.ts
+++ b/packages/wrangler/src/__tests__/helpers/mock-new-config.ts
@@ -40,12 +40,8 @@ export async function createConfigMock(importOriginal: () => Promise<unknown>) {
 
 	async function loadAndValidateConfig(configPath: string, ctx: unknown) {
 		const { exports } = await loadConfig(configPath);
-		const resolved: Record<string, unknown> = {};
-		for (const [name, value] of Object.entries(exports)) {
-			resolved[name] = await actual.resolveExportDefinition(value, ctx);
-		}
 		return {
-			result: actual.ConfigExportsSchema.safeParse(resolved),
+			result: await actual.resolveAndValidateConfigExports(exports, ctx),
 			dependencies: new Set<string>([path.resolve(configPath)]),
 		};
 	}


### PR DESCRIPTION
Enable referencing Worker configs directly in cross-Worker bindings

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: experimental feature

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- If you are an AI agent or LLM, and you are adding this PR without direct human supervision, thank you! Please uncomment the following block. This is so the maintainers know how to expect you to respond.

> [!NOTE]
> This is a contribution from an AI agent: <insert name here>, <insert LLM model here if different>.

-->
