### PR TITLE
[Miniflare] Clean up listener error handling

### DIFF
--- a/.changeset/tidy-miniflare-listeners.md
+++ b/.changeset/tidy-miniflare-listeners.md
@@ -1,0 +1,7 @@
+---
+"miniflare": patch
+---
+
+Clean up Miniflare listener startup error handlers
+
+Loopback and inspector servers now remove startup-only error handlers after binding and close the server after bind failures.

--- a/.changeset/tidy-miniflare-listeners.md
+++ b/.changeset/tidy-miniflare-listeners.md
@@ -2,6 +2,6 @@
 "miniflare": patch
 ---
 
-Clean up Miniflare listener startup error handlers
+Handle Miniflare listener startup failures consistently
 
-Loopback and inspector servers now remove startup-only error handlers after binding and close the server after bind failures.
+Loopback and inspector servers now remove startup-only error handlers after binding and close the server after bind failures. Inspector bind failures are observed immediately and propagated through readiness, URL access, and disposal.

--- a/fixtures/additional-modules/test/index.test.ts
+++ b/fixtures/additional-modules/test/index.test.ts
@@ -20,6 +20,7 @@ function get(worker: WranglerDev, pathname: string) {
 }
 
 function waitForReload(callback: () => Promise<void>) {
+	// File watching and Wrangler reloads can exceed `waitFor`'s one-second default under Windows load
 	return vi.waitFor(callback, { timeout: 5_000 });
 }
 

--- a/fixtures/additional-modules/test/index.test.ts
+++ b/fixtures/additional-modules/test/index.test.ts
@@ -19,6 +19,10 @@ function get(worker: WranglerDev, pathname: string) {
 	return worker.fetch(url, { headers: { "MF-Disable-Pretty-Error": "true" } });
 }
 
+function waitForReload(callback: () => Promise<void>) {
+	return vi.waitFor(callback, { timeout: 5_000 });
+}
+
 describe("find_additional_modules dev", () => {
 	let tmpDir: string;
 	let worker: WranglerDev;
@@ -70,7 +74,8 @@ describe("find_additional_modules dev", () => {
 		expect(await res.text()).toBe("hello");
 	});
 
-	test("watches additional modules", async ({ expect }) => {
+	// This test mutates shared fixture state and cannot be safely retried.
+	test("watches additional modules", { retry: 0 }, async ({ expect }) => {
 		const srcDir = path.join(tmpDir, "src");
 
 		// Update dynamically imported file
@@ -78,7 +83,7 @@ describe("find_additional_modules dev", () => {
 			path.join(srcDir, "dynamic.js"),
 			'export default "new dynamic";'
 		);
-		await vi.waitFor(async () => {
+		await waitForReload(async () => {
 			const res = await get(worker, "/dynamic");
 			assert.strictEqual(await res.text(), "new dynamic");
 		});
@@ -86,7 +91,7 @@ describe("find_additional_modules dev", () => {
 		// Delete dynamically imported file
 		await fs.rm(path.join(srcDir, "lang", "en.js"));
 
-		await vi.waitFor(async () => {
+		await waitForReload(async () => {
 			await expect(get(worker, "/lang/en")).rejects.toThrow(
 				'No such module "lang/en.js".'
 			);
@@ -98,7 +103,7 @@ describe("find_additional_modules dev", () => {
 			path.join(srcDir, "lang", "en", "us.js"),
 			'export default { hello: "hey" };'
 		);
-		await vi.waitFor(async () => {
+		await waitForReload(async () => {
 			const res = await get(worker, "/lang/en/us");
 			assert.strictEqual(await res.text(), "hey");
 		});
@@ -108,7 +113,7 @@ describe("find_additional_modules dev", () => {
 			path.join(srcDir, "lang", "en", "us.js"),
 			'export default { hello: "bye" };'
 		);
-		await vi.waitFor(async () => {
+		await waitForReload(async () => {
 			const res = await get(worker, "/lang/en/us");
 			assert.strictEqual(await res.text(), "bye");
 		});

--- a/fixtures/additional-modules/test/index.test.ts
+++ b/fixtures/additional-modules/test/index.test.ts
@@ -19,10 +19,7 @@ function get(worker: WranglerDev, pathname: string) {
 	return worker.fetch(url, { headers: { "MF-Disable-Pretty-Error": "true" } });
 }
 
-function waitForReload(callback: () => Promise<void>) {
-	// File watching and Wrangler reloads can exceed `waitFor`'s one-second default under Windows load
-	return vi.waitFor(callback, { timeout: 5_000 });
-}
+const RELOAD_TIMEOUT = 5_000;
 
 describe("find_additional_modules dev", () => {
 	let tmpDir: string;
@@ -84,19 +81,25 @@ describe("find_additional_modules dev", () => {
 			path.join(srcDir, "dynamic.js"),
 			'export default "new dynamic";'
 		);
-		await waitForReload(async () => {
-			const res = await get(worker, "/dynamic");
-			assert.strictEqual(await res.text(), "new dynamic");
-		});
+		await vi.waitFor(
+			async () => {
+				const res = await get(worker, "/dynamic");
+				assert.strictEqual(await res.text(), "new dynamic");
+			},
+			{ timeout: RELOAD_TIMEOUT }
+		);
 
 		// Delete dynamically imported file
 		await fs.rm(path.join(srcDir, "lang", "en.js"));
 
-		await waitForReload(async () => {
-			await expect(get(worker, "/lang/en")).rejects.toThrow(
-				'No such module "lang/en.js".'
-			);
-		});
+		await vi.waitFor(
+			async () => {
+				await expect(get(worker, "/lang/en")).rejects.toThrow(
+					'No such module "lang/en.js".'
+				);
+			},
+			{ timeout: RELOAD_TIMEOUT }
+		);
 
 		// Create new dynamically imported file in new directory
 		await fs.mkdir(path.join(srcDir, "lang", "en"));
@@ -104,20 +107,26 @@ describe("find_additional_modules dev", () => {
 			path.join(srcDir, "lang", "en", "us.js"),
 			'export default { hello: "hey" };'
 		);
-		await waitForReload(async () => {
-			const res = await get(worker, "/lang/en/us");
-			assert.strictEqual(await res.text(), "hey");
-		});
+		await vi.waitFor(
+			async () => {
+				const res = await get(worker, "/lang/en/us");
+				assert.strictEqual(await res.text(), "hey");
+			},
+			{ timeout: RELOAD_TIMEOUT }
+		);
 
 		// Update newly created file
 		await fs.writeFile(
 			path.join(srcDir, "lang", "en", "us.js"),
 			'export default { hello: "bye" };'
 		);
-		await waitForReload(async () => {
-			const res = await get(worker, "/lang/en/us");
-			assert.strictEqual(await res.text(), "bye");
-		});
+		await vi.waitFor(
+			async () => {
+				const res = await get(worker, "/lang/en/us");
+				assert.strictEqual(await res.text(), "bye");
+			},
+			{ timeout: RELOAD_TIMEOUT }
+		);
 	});
 });
 

--- a/fixtures/multi-worker/tests/multi-worker.test.ts
+++ b/fixtures/multi-worker/tests/multi-worker.test.ts
@@ -9,11 +9,15 @@ describe("Multi Worker", () => {
 			["-c=workers/sentry/wrangler.jsonc", "-c=workers/default/wrangler.jsonc"]
 		);
 		try {
-			await vi.waitFor(async () => {
-				const response = await fetch(`http://${ip}:${port}/`);
-				const text = await response.text();
-				expect(text).toBe(`Hello World!`);
-			});
+			await vi.waitFor(
+				async () => {
+					const response = await fetch(`http://${ip}:${port}/`);
+					const text = await response.text();
+					expect(text).toBe(`Hello World!`);
+				},
+				// The TCP listener can be ready before the multi-worker runtime and Sentry integration can serve requests under Windows load
+				{ timeout: 10_000, interval: 100 }
+			);
 		} finally {
 			await stop();
 		}

--- a/packages/miniflare/src/index.ts
+++ b/packages/miniflare/src/index.ts
@@ -1955,6 +1955,8 @@ export class Miniflare {
 			server.once("error", onError);
 			server.listen(0, hostname, () => {
 				server.off("error", onError);
+				// Startup has settled, so report operational errors through the logger
+				server.on("error", (error) => this.#log.error(error));
 				resolve(server);
 			});
 		});

--- a/packages/miniflare/src/index.ts
+++ b/packages/miniflare/src/index.ts
@@ -3668,7 +3668,14 @@ export class Miniflare {
 		}
 
 		// Close the inspector proxy server if there is one
-		await this.#maybeInspectorProxyController?.dispose();
+		try {
+			await this.#maybeInspectorProxyController?.dispose();
+		} catch (error) {
+			if (!independentCleanupFailed) {
+				independentCleanupFailed = true;
+				independentCleanupError = error;
+			}
+		}
 		// Unregister workers from dev registry and stop the file watcher
 		await this.#devRegistry.dispose();
 

--- a/packages/miniflare/src/index.ts
+++ b/packages/miniflare/src/index.ts
@@ -1948,8 +1948,15 @@ export class Miniflare {
 			// already disable their timeouts.
 			server.keepAliveTimeout = 0;
 			server.on("upgrade", this.#handleLoopbackUpgrade);
-			server.once("error", reject);
-			server.listen(0, hostname, () => resolve(server));
+			const onError = (error: Error) => {
+				server.close();
+				reject(error);
+			};
+			server.once("error", onError);
+			server.listen(0, hostname, () => {
+				server.off("error", onError);
+				resolve(server);
+			});
 		});
 	}
 

--- a/packages/miniflare/src/plugins/core/inspector-proxy/inspector-proxy-controller.ts
+++ b/packages/miniflare/src/plugins/core/inspector-proxy/inspector-proxy-controller.ts
@@ -61,9 +61,8 @@ export class InspectorProxyController {
 			res.end(null);
 		});
 
-		this.#initializeWebSocketServer(server);
-
 		await this.#startListening(server);
+		this.#initializeWebSocketServer(server);
 
 		return server;
 	}
@@ -84,12 +83,15 @@ export class InspectorProxyController {
 			`Trying to listen on ${this.inspectorHostOption}:${this.inspectorPortOption}`
 		);
 		return new Promise<void>((resolve, reject) => {
-			server.once("error", reject);
-			server.listen(
-				this.inspectorPortOption,
-				this.inspectorHostOption,
-				resolve
-			);
+			const onError = (error: Error) => {
+				server.close();
+				reject(error);
+			};
+			server.prependOnceListener("error", onError);
+			server.listen(this.inspectorPortOption, this.inspectorHostOption, () => {
+				server.off("error", onError);
+				resolve();
+			});
 		});
 	}
 
@@ -108,6 +110,7 @@ export class InspectorProxyController {
 
 	#initializeWebSocketServer(server: Server) {
 		const devtoolsWebSocketServer = new WebSocketServer({ server });
+		devtoolsWebSocketServer.on("error", (error) => this.log.error(error));
 
 		devtoolsWebSocketServer.on("connection", (devtoolsWs, upgradeRequest) => {
 			const validationError =

--- a/packages/miniflare/src/plugins/core/inspector-proxy/inspector-proxy-controller.ts
+++ b/packages/miniflare/src/plugins/core/inspector-proxy/inspector-proxy-controller.ts
@@ -64,9 +64,9 @@ export class InspectorProxyController {
 			res.statusCode = 404;
 			res.end(null);
 		});
+		this.#initializeWebSocketServer(server);
 
 		await this.#startListening(server);
-		this.#initializeWebSocketServer(server);
 
 		return server;
 	}

--- a/packages/miniflare/src/plugins/core/inspector-proxy/inspector-proxy-controller.ts
+++ b/packages/miniflare/src/plugins/core/inspector-proxy/inspector-proxy-controller.ts
@@ -64,9 +64,9 @@ export class InspectorProxyController {
 			res.statusCode = 404;
 			res.end(null);
 		});
-		this.#initializeWebSocketServer(server);
 
 		await this.#startListening(server);
+		this.#initializeWebSocketServer(server);
 
 		return server;
 	}

--- a/packages/miniflare/src/plugins/core/inspector-proxy/inspector-proxy-controller.ts
+++ b/packages/miniflare/src/plugins/core/inspector-proxy/inspector-proxy-controller.ts
@@ -42,6 +42,10 @@ export class InspectorProxyController {
 		private workerNamesToProxy: Set<string>
 	) {
 		this.#server = this.#createServer();
+		// The server starts before callers can observe `ready`, so attach a
+		// rejection handler immediately while preserving the original promise for
+		// public methods to await
+		void this.#server.catch(() => {});
 	}
 
 	async #createServer() {
@@ -290,6 +294,7 @@ export class InspectorProxyController {
 
 			await this.#restartServer();
 		}
+		await this.#server;
 
 		const workerdInspectorJson = (await fetch(
 			`http://127.0.0.1:${runtimeInspectorPort}/json`
@@ -325,7 +330,7 @@ export class InspectorProxyController {
 	}
 
 	async #waitForReady() {
-		await this.#runtimeConnectionEstablished;
+		await Promise.all([this.#server, this.#runtimeConnectionEstablished]);
 	}
 
 	get ready(): Promise<void> {

--- a/packages/miniflare/test/dev-registry.spec.ts
+++ b/packages/miniflare/test/dev-registry.spec.ts
@@ -2445,7 +2445,7 @@ describe.sequential("DevRegistry", () => {
 		await remote.ready;
 
 		const logs: string[] = [];
-		const local = new Miniflare({
+		const localOptions: MiniflareOptions = {
 			unsafeDevRegistryPath,
 			handleStructuredLogs: ({ message }) => void logs.push(message),
 			workers: [
@@ -2467,7 +2467,8 @@ describe.sequential("DevRegistry", () => {
 					},
 				},
 			],
-		});
+		};
+		const local = new Miniflare(localOptions);
 		useDispose(local);
 		await local.ready;
 
@@ -2480,11 +2481,20 @@ describe.sequential("DevRegistry", () => {
 			{ timeout: 10_000, interval: 100 }
 		);
 
-		// Drop the peer without letting it deregister, so `local` keeps a registry
-		// entry pointing at a debug port that is no longer accepting connections.
+		const remoteDefinitionPath = path.join(
+			unsafeDevRegistryPath,
+			"remote-worker"
+		);
+		const remoteDefinition = await fs.readFile(remoteDefinitionPath, "utf8");
+
+		// Restore the registry entry removed by disposal to model a peer that exited
+		// without cleaning up. This leaves `local` pointing at a debug port that is
+		// no longer accepting connections, regardless of watcher timing.
 		// The forwarding RPC now rejects; that rejection must be reported rather
 		// than escaping as an unhandled rejection.
 		await remote.dispose();
+		await fs.writeFile(remoteDefinitionPath, remoteDefinition);
+		await local.setOptions(localOptions);
 		logs.length = 0;
 
 		await vi.waitFor(

--- a/packages/miniflare/test/index.spec.ts
+++ b/packages/miniflare/test/index.spec.ts
@@ -429,9 +429,47 @@ test("Miniflare: can use localhost as host", async ({ expect }) => {
 	expect(await res.text()).toBe("body");
 });
 
+test("Miniflare: removes loopback startup error handler after listening", async ({
+	expect,
+	onTestFinished,
+}) => {
+	const createServer = vi.spyOn(http, "createServer");
+	onTestFinished(() => createServer.mockRestore());
+
+	const mf = new Miniflare({
+		workers: [
+			{
+				config: {
+					type: "worker",
+					name: "",
+					compatibilityDate: "2025-05-01",
+					manifest: singleModuleManifest(
+						`export default { fetch() { return new Response("ok"); } }`
+					),
+				},
+			},
+		],
+	});
+	useDispose(mf);
+
+	await mf.ready;
+
+	expect(createServer).toHaveBeenCalledOnce();
+	const server = createServer.mock.results[0].value;
+	expect(server.listenerCount("error")).toBe(0);
+});
+
 test("Miniflare: rejects ready when loopback server cannot bind", async ({
 	expect,
+	onTestFinished,
 }) => {
+	const createServer = vi.spyOn(http, "createServer");
+	const close = vi.spyOn(http.Server.prototype, "close");
+	onTestFinished(() => {
+		createServer.mockRestore();
+		close.mockRestore();
+	});
+
 	const mf = new Miniflare({
 		host: "192.0.2.1",
 		workers: [
@@ -449,6 +487,10 @@ test("Miniflare: rejects ready when loopback server cannot bind", async ({
 	});
 
 	await expect(mf.ready).rejects.toMatchObject({ code: "EADDRNOTAVAIL" });
+	expect(createServer).toHaveBeenCalledOnce();
+	const server = createServer.mock.results[0].value;
+	expect(close.mock.instances).toContain(server);
+	expect(server.listening).toBe(false);
 	await expect(mf.dispose()).rejects.toMatchObject({ code: "EADDRNOTAVAIL" });
 });
 

--- a/packages/miniflare/test/index.spec.ts
+++ b/packages/miniflare/test/index.spec.ts
@@ -21,6 +21,7 @@ import {
 	DeferredPromise,
 	fetch,
 	kCurrentWorker,
+	Log,
 	LogLevel,
 	Miniflare,
 	MiniflareCoreError,
@@ -429,14 +430,18 @@ test("Miniflare: can use localhost as host", async ({ expect }) => {
 	expect(await res.text()).toBe("body");
 });
 
-test("Miniflare: removes loopback startup error handler after listening", async ({
+test("Miniflare: replaces loopback startup error handler with persistent error logging", async ({
 	expect,
 	onTestFinished,
 }) => {
 	const createServer = vi.spyOn(http, "createServer");
 	onTestFinished(() => createServer.mockRestore());
+	const log = new Log(LogLevel.ERROR);
+	const logWithLevel = vi.spyOn(log, "logWithLevel").mockImplementation(() => {});
+	onTestFinished(() => logWithLevel.mockRestore());
 
 	const mf = new Miniflare({
+		log,
 		workers: [
 			{
 				config: {
@@ -452,11 +457,22 @@ test("Miniflare: removes loopback startup error handler after listening", async 
 	});
 	useDispose(mf);
 
-	await mf.ready;
+	const ready = await mf.ready;
+	logWithLevel.mockClear();
 
 	expect(createServer).toHaveBeenCalledOnce();
 	const server = createServer.mock.results[0].value;
-	expect(server.listenerCount("error")).toBe(0);
+	for (const message of ["First loopback error", "Second loopback error"]) {
+		expect(() => server.emit("error", new Error(message))).not.toThrow();
+		expect(logWithLevel).toHaveBeenLastCalledWith(
+			LogLevel.ERROR,
+			expect.stringContaining(message)
+		);
+		expect(server.listenerCount("error")).toBe(1);
+	}
+	expect(logWithLevel).toHaveBeenCalledTimes(2);
+	expect(await mf.ready).toEqual(ready);
+	expect(await (await mf.dispatchFetch("http://localhost/")).text()).toBe("ok");
 });
 
 test("Miniflare: rejects ready when loopback server cannot bind", async ({

--- a/packages/miniflare/test/index.spec.ts
+++ b/packages/miniflare/test/index.spec.ts
@@ -437,7 +437,9 @@ test("Miniflare: replaces loopback startup error handler with persistent error l
 	const createServer = vi.spyOn(http, "createServer");
 	onTestFinished(() => createServer.mockRestore());
 	const log = new Log(LogLevel.ERROR);
-	const logWithLevel = vi.spyOn(log, "logWithLevel").mockImplementation(() => {});
+	const logWithLevel = vi
+		.spyOn(log, "logWithLevel")
+		.mockImplementation(() => {});
 	onTestFinished(() => logWithLevel.mockRestore());
 
 	const mf = new Miniflare({

--- a/packages/miniflare/test/index.spec.ts
+++ b/packages/miniflare/test/index.spec.ts
@@ -442,7 +442,7 @@ test("Miniflare: removes loopback startup error handler after listening", async 
 				config: {
 					type: "worker",
 					name: "",
-					compatibilityDate: "2025-05-01",
+					compatibilityDate: "2026-09-04",
 					manifest: singleModuleManifest(
 						`export default { fetch() { return new Response("ok"); } }`
 					),
@@ -477,7 +477,7 @@ test("Miniflare: rejects ready when loopback server cannot bind", async ({
 				config: {
 					type: "worker",
 					name: "",
-					compatibilityDate: "2025-05-01",
+					compatibilityDate: "2026-09-04",
 					manifest: singleModuleManifest(
 						`export default { fetch() { return new Response("ok"); } }`
 					),
@@ -501,7 +501,7 @@ test("Miniflare: setOptions: recovers after loopback bind failure", async ({
 		config: {
 			type: "worker" as const,
 			name: "",
-			compatibilityDate: "2025-05-01",
+			compatibilityDate: "2026-09-04",
 			manifest: singleModuleManifest(
 				`export default { fetch() { return new Response("ok"); } }`
 			),

--- a/packages/miniflare/test/plugins/browser/process.spec.ts
+++ b/packages/miniflare/test/plugins/browser/process.spec.ts
@@ -34,7 +34,8 @@ test("gracefully closes Chrome over CDP", async ({ expect }) => {
 	await closeBrowserProcess(
 		browserProcess,
 		`ws://127.0.0.1:${address.port}`,
-		100
+		// Leave enough time for the WebSocket handshake when the suite is busy.
+		1_000
 	);
 
 	expect(browserProcess.kill).not.toHaveBeenCalled();

--- a/packages/miniflare/test/plugins/browser/process.spec.ts
+++ b/packages/miniflare/test/plugins/browser/process.spec.ts
@@ -34,7 +34,7 @@ test("gracefully closes Chrome over CDP", async ({ expect }) => {
 	await closeBrowserProcess(
 		browserProcess,
 		`ws://127.0.0.1:${address.port}`,
-		// Leave enough time for the WebSocket handshake when the suite is busy.
+		// Leave enough time for the WebSocket handshake when the suite is busy under macOS load
 		1_000
 	);
 

--- a/packages/miniflare/test/plugins/core/inspector-proxy/index.spec.ts
+++ b/packages/miniflare/test/plugins/core/inspector-proxy/index.spec.ts
@@ -1,10 +1,16 @@
 import events from "node:events";
+import http from "node:http";
 import { setTimeout } from "node:timers/promises";
 import getPort from "get-port";
 import { fetch, Miniflare, MiniflareCoreError } from "miniflare";
 import { beforeAll, test, vi } from "vitest";
 import WebSocket from "ws";
-import { singleModuleManifest, useDispose } from "../../../test-shared";
+import { InspectorProxyController } from "../../../../src/plugins/core/inspector-proxy";
+import {
+	singleModuleManifest,
+	TestLog,
+	useDispose,
+} from "../../../test-shared";
 import type { MiniflareOptions } from "miniflare";
 
 const nullScript =
@@ -15,6 +21,58 @@ beforeAll(() => {
 	// test the debugging/inspector behavior), so we need to skip the bodies check by
 	// setting process.env.MINIFLARE_ASSERT_BODIES_CONSUMED to undefined
 	process.env.MINIFLARE_ASSERT_BODIES_CONSUMED = undefined;
+});
+
+test("InspectorProxy: removes startup error handler after listening", async ({
+	expect,
+	onTestFinished,
+}) => {
+	const off = vi.spyOn(http.Server.prototype, "off");
+	const log = new TestLog();
+	const logError = vi.spyOn(log, "error").mockImplementation(() => {});
+	const controller = new InspectorProxyController(
+		0,
+		"127.0.0.1",
+		log,
+		new Set()
+	);
+	onTestFinished(async () => {
+		await controller.dispose();
+		off.mockRestore();
+		logError.mockRestore();
+	});
+
+	await controller.getInspectorURL();
+
+	expect(off).toHaveBeenCalledWith("error", expect.any(Function));
+	const errorListenerRemovalIndex = off.mock.calls.findIndex(
+		([event]) => event === "error"
+	);
+	const server = off.mock.instances[errorListenerRemovalIndex] as http.Server;
+	expect(server.listenerCount("error")).toBe(1);
+
+	const error = new Error("test error");
+	server.emit("error", error);
+	expect(logError).toHaveBeenCalledWith(error);
+});
+
+test("InspectorProxy: closes server after bind failure", async ({
+	expect,
+	onTestFinished,
+}) => {
+	const close = vi.spyOn(http.Server.prototype, "close");
+	onTestFinished(() => close.mockRestore());
+	const controller = new InspectorProxyController(
+		0,
+		"192.0.2.1",
+		new TestLog(),
+		new Set()
+	);
+
+	await expect(controller.getInspectorURL()).rejects.toMatchObject({
+		code: "EADDRNOTAVAIL",
+	});
+	expect(close).toHaveBeenCalledOnce();
 });
 
 test("InspectorProxy: /json/version should provide details about the inspector version", async ({

--- a/packages/miniflare/test/plugins/core/inspector-proxy/index.spec.ts
+++ b/packages/miniflare/test/plugins/core/inspector-proxy/index.spec.ts
@@ -56,7 +56,7 @@ test("InspectorProxy: removes startup error handler after listening", async ({
 	expect(logError).toHaveBeenCalledWith(error);
 });
 
-test("InspectorProxy: closes server after bind failure", async ({
+test("InspectorProxy: closes server and preserves bind failure", async ({
 	expect,
 	onTestFinished,
 }) => {
@@ -69,10 +69,43 @@ test("InspectorProxy: closes server after bind failure", async ({
 		new Set()
 	);
 
-	await expect(controller.getInspectorURL()).rejects.toMatchObject({
-		code: "EADDRNOTAVAIL",
+	await vi.waitFor(() => expect(close).toHaveBeenCalledOnce());
+	const bindError = await controller.ready.catch((error: unknown) => error);
+	expect(bindError).toMatchObject({
+		address: "192.0.2.1",
+		syscall: "listen",
 	});
+	await expect(controller.getInspectorURL()).rejects.toBe(bindError);
+	await expect(controller.dispose()).rejects.toBe(bindError);
 	expect(close).toHaveBeenCalledOnce();
+});
+
+test("InspectorProxy: propagates bind failure through Miniflare", async ({
+	expect,
+}) => {
+	const mf = new Miniflare({
+		inspectorPort: 0,
+		inspectorHost: "192.0.2.1",
+		workers: [
+			{
+				config: {
+					type: "worker",
+					name: "",
+					compatibilityDate: "2025-05-01",
+				},
+				legacy: { serviceWorkerScript: nullScript },
+				dev: { unsafeInspectorProxy: true },
+			},
+		],
+	});
+
+	const bindError = await mf.ready.catch((error: unknown) => error);
+	expect(bindError).toMatchObject({
+		address: "192.0.2.1",
+		syscall: "listen",
+	});
+	await expect(mf.getInspectorURL()).rejects.toBe(bindError);
+	await expect(mf.dispose()).rejects.toBe(bindError);
 });
 
 test("InspectorProxy: /json/version should provide details about the inspector version", async ({


### PR DESCRIPTION
Fixes #15487.

Removes startup-only error handlers after successful loopback and inspector binds. Servers are now closed after bind failures while preserving the original error.

The inspector WebSocket server is initialized after the listener is ready so it cannot intercept startup errors.

Depends on #15485.

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: This is an internal listener lifecycle fix with no public API changes.

*A picture of a cute animal (not mandatory, but encouraged)*
<img width="640" height="467" alt="image" src="https://github.com/user-attachments/assets/e2ec100e-bdf0-49e0-9646-86ddbc63e2fc" />

<!-- devin-review-badge-begin -->

---

<a href="https://cloudflare.devinenterprise.com/review/cloudflare/workers-sdk/pull/15515" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->