### PR TITLE
[containers] Use one local Docker endpoint

### DIFF
--- a/.changeset/fuzzy-cats-share.md
+++ b/.changeset/fuzzy-cats-share.md
@@ -1,0 +1,8 @@
+---
+"@cloudflare/vite-plugin": patch
+"wrangler": patch
+---
+
+Use the configured container engine for local Docker operations
+
+Container image builds, pulls, inspection, rebuilds, and cleanup now use the same Docker endpoint as the local workerd runtime. Multi-Worker Vite and Wrangler sessions now report conflicting endpoints.

--- a/packages/containers-shared/index.ts
+++ b/packages/containers-shared/index.ts
@@ -7,3 +7,4 @@ export * from "./src/types";
 export * from "./src/inspect";
 export * from "./src/registry";
 export * from "./src/images";
+export { getDockerHostFromContainerEngine } from "./src/docker-command";

--- a/packages/containers-shared/src/build.ts
+++ b/packages/containers-shared/src/build.ts
@@ -1,6 +1,7 @@
 import { spawn } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { UserError } from "@cloudflare/workers-utils/errors";
+import { getDockerCommandArgs } from "./docker-command";
 import { verifyDockerInstalled } from "./utils";
 import type {
 	BuildArgs,
@@ -54,6 +55,7 @@ export async function constructBuildCommand(
  * @param options.dockerfile - The Dockerfile content to pipe into stdin.
  * @param options.verifyDockerIsRunning - When `true` (the default), verifies Docker is installed
  *   and the daemon is running before spawning the build. Set to `false` to skip the check.
+ * @param options.dockerHost - Optional Docker daemon endpoint for verification and the build.
  *
  * @returns An object with an `abort` function and a `ready` promise.
  */
@@ -63,11 +65,13 @@ export async function dockerBuild(
 		buildCmd: string[];
 		dockerfile: string;
 		verifyDockerIsRunning?: boolean;
+		dockerHost?: string;
 	}
 ): Promise<{ abort: () => void; ready: Promise<void> }> {
 	if (options.verifyDockerIsRunning !== false) {
 		await verifyDockerInstalled({
 			dockerPath,
+			dockerHost: options.dockerHost,
 			imageNoun: "the image",
 		});
 	}
@@ -80,18 +84,22 @@ export async function dockerBuild(
 		reject = rej;
 	});
 
-	const child = spawn(dockerPath, options.buildCmd, {
-		stdio: ["pipe", "inherit", "inherit"],
-		// We need to set detached to true so that the child process
-		// will control all of its child processes and we can kill
-		// all of them in case we need to abort the build process.
-		// On Windows, detached: true opens a new console window per child
-		// process, so we only set it on non-Windows platforms.
-		detached: process.platform !== "win32",
-		// Prevent child processes from opening visible console windows on Windows.
-		// This is a no-op on non-Windows platforms.
-		windowsHide: true,
-	});
+	const child = spawn(
+		dockerPath,
+		getDockerCommandArgs(options.buildCmd, options.dockerHost),
+		{
+			stdio: ["pipe", "inherit", "inherit"],
+			// We need to set detached to true so that the child process
+			// will control all of its child processes and we can kill
+			// all of them in case we need to abort the build process.
+			// On Windows, detached: true opens a new console window per child
+			// process, so we only set it on non-Windows platforms.
+			detached: process.platform !== "win32",
+			// Prevent child processes from opening visible console windows on Windows.
+			// This is a no-op on non-Windows platforms.
+			windowsHide: true,
+		}
+	);
 	if (child.stdin !== null) {
 		child.stdin.write(options.dockerfile);
 		child.stdin.end();
@@ -142,13 +150,15 @@ export async function dockerBuild(
  * @param verifyDockerIsRunning - When `true` (the default), verifies Docker is installed
  *   and the daemon is running before building. Set to `false` when the caller has already
  *   performed this check.
+ * @param dockerHost - Optional Docker daemon endpoint for the build.
  *
  * @returns An object with an `abort` function and a `ready` promise.
  */
 export async function buildImage(
 	dockerPath: string,
 	options: Exclude<ContainerDevOptions, ImageURIConfig>,
-	verifyDockerIsRunning?: boolean
+	verifyDockerIsRunning?: boolean,
+	dockerHost?: string
 ) {
 	const { buildCmd, dockerfile } = await constructBuildCommand({
 		tag: options.image_tag,
@@ -162,5 +172,6 @@ export async function buildImage(
 		buildCmd,
 		dockerfile,
 		verifyDockerIsRunning,
+		dockerHost,
 	});
 }

--- a/packages/containers-shared/src/docker-command.ts
+++ b/packages/containers-shared/src/docker-command.ts
@@ -1,0 +1,32 @@
+import type { ContainerEngine } from "@cloudflare/workers-utils";
+
+/**
+ * Adds an explicit daemon endpoint to a Docker CLI invocation.
+ *
+ * Docker global options must precede the subcommand, so callers should pass
+ * arguments beginning with the Docker command name.
+ *
+ * @param args - Docker CLI arguments beginning with the command name.
+ * @param dockerHost - Docker daemon endpoint selected for the runtime.
+ * @returns Arguments with the global `--host` option when an endpoint is set.
+ */
+export function getDockerCommandArgs(
+	args: string[],
+	dockerHost?: string
+): string[] {
+	return dockerHost === undefined ? args : ["--host", dockerHost, ...args];
+}
+
+/**
+ * Returns the Docker endpoint represented by a Miniflare container engine.
+ *
+ * @param containerEngine - Runtime container-engine configuration.
+ * @returns The Docker socket or endpoint used by the runtime.
+ */
+export function getDockerHostFromContainerEngine(
+	containerEngine: ContainerEngine
+): string {
+	return typeof containerEngine === "string"
+		? containerEngine
+		: containerEngine.localDocker.socketPath;
+}

--- a/packages/containers-shared/src/images.ts
+++ b/packages/containers-shared/src/images.ts
@@ -32,8 +32,15 @@ export function getEgressInterceptorImage(): string {
 	);
 }
 
+/**
+ * Pulls the container egress interceptor image for local development.
+ *
+ * @param dockerPath - Path to the Docker CLI executable.
+ * @param dockerHost - Optional Docker daemon endpoint for the pull.
+ */
 export async function pullEgressInterceptorImage(
-	dockerPath: string
+	dockerPath: string,
+	dockerHost?: string
 ): Promise<void> {
 	const image = getEgressInterceptorImage();
 	const platform = getEgressInterceptorPlatform();
@@ -41,7 +48,7 @@ export async function pullEgressInterceptorImage(
 	if (platform !== undefined) {
 		args.push("--platform", platform);
 	}
-	await runDockerCmd(dockerPath, args);
+	await runDockerCmd(dockerPath, args, undefined, dockerHost);
 }
 
 /**
@@ -51,20 +58,22 @@ export async function pullEgressInterceptorImage(
  * @param options - Container image and local development tag configuration.
  * @param logger - Logger used for recoverable registry credential warnings.
  * @param complianceConfig - Compliance configuration used to identify the managed registry.
+ * @param dockerHost - Optional Docker daemon endpoint for login, pull, and tagging.
  * @returns An object with an `abort` function and a `ready` promise.
  */
 export async function pullImage(
 	dockerPath: string,
 	options: Exclude<ContainerDevOptions, DockerfileConfig>,
 	logger: WranglerLogger | ViteLogger,
-	complianceConfig?: ComplianceConfig
+	complianceConfig?: ComplianceConfig,
+	dockerHost?: string
 ): Promise<{ abort: () => void; ready: Promise<void> }> {
 	const domain = new URL(`http://${options.image_uri}`).hostname;
 
 	const isExternalRegistry =
 		domain !== getCloudflareContainerRegistry(complianceConfig);
 	try {
-		await dockerLoginImageRegistry(dockerPath, domain);
+		await dockerLoginImageRegistry(dockerPath, domain, dockerHost);
 	} catch (e) {
 		if (!isExternalRegistry) {
 			throw e;
@@ -76,21 +85,27 @@ export async function pullImage(
 		);
 	}
 
-	const pull = runDockerCmd(dockerPath, [
-		"pull",
-		options.image_uri,
-		// All containers running on our platform need to be built for amd64 architecture, but by default docker pull seems to look for an image matching the host system, so we need to specify this here
-		"--platform",
-		"linux/amd64",
-	]);
+	const pull = runDockerCmd(
+		dockerPath,
+		[
+			"pull",
+			options.image_uri,
+			// All containers running on our platform need to be built for amd64 architecture, but by default docker pull seems to look for an image matching the host system, so we need to specify this here
+			"--platform",
+			"linux/amd64",
+		],
+		undefined,
+		dockerHost
+	);
 	const ready = pull.ready.then(async ({ aborted }: { aborted: boolean }) => {
 		if (!aborted) {
 			// re-tag image with the expected dev-formatted image tag for consistency
-			await runDockerCmd(dockerPath, [
-				"tag",
-				options.image_uri,
-				options.image_tag,
-			]);
+			await runDockerCmd(
+				dockerPath,
+				["tag", options.image_uri, options.image_tag],
+				undefined,
+				dockerHost
+			);
 		}
 	});
 
@@ -117,6 +132,7 @@ export async function pullImage(
  */
 export async function prepareContainerImagesForDev(args: {
 	dockerPath: string;
+	dockerHost: string;
 	containerOptions: ContainerDevOptions[];
 	onContainerImagePreparationStart: (args: {
 		containerOptions: ContainerDevOptions;
@@ -130,6 +146,7 @@ export async function prepareContainerImagesForDev(args: {
 }): Promise<void> {
 	const {
 		dockerPath,
+		dockerHost,
 		containerOptions,
 		onContainerImagePreparationStart,
 		onContainerImagePreparationEnd,
@@ -143,6 +160,7 @@ export async function prepareContainerImagesForDev(args: {
 	}
 	await verifyDockerInstalled({
 		dockerPath,
+		dockerHost,
 		operation: "running dev",
 		imageNoun:
 			containerOptions.length !== 1
@@ -152,7 +170,7 @@ export async function prepareContainerImagesForDev(args: {
 	});
 	for (const options of containerOptions) {
 		if ("dockerfile" in options) {
-			const build = await buildImage(dockerPath, options, false);
+			const build = await buildImage(dockerPath, options, false, dockerHost);
 			onContainerImagePreparationStart({
 				containerOptions: options,
 				abort: () => {
@@ -170,7 +188,8 @@ export async function prepareContainerImagesForDev(args: {
 				dockerPath,
 				options,
 				args.logger,
-				args.complianceConfig
+				args.complianceConfig,
+				dockerHost
 			);
 			onContainerImagePreparationStart({
 				containerOptions: options,
@@ -186,16 +205,20 @@ export async function prepareContainerImagesForDev(args: {
 		}
 		if (!aborted) {
 			// Clean up duplicate image tags. This is scoped to cloudflare-dev only
-			await cleanupDuplicateImageTags(dockerPath, options.image_tag);
+			await cleanupDuplicateImageTags(
+				dockerPath,
+				options.image_tag,
+				dockerHost
+			);
 
-			await checkExposedPorts(dockerPath, options);
+			await checkExposedPorts(dockerPath, options, dockerHost);
 		}
 	}
 
 	// Pull the egress interceptor image used to intercept outbound HTTP from
 	// containers and route it back to workerd (e.g. for interceptOutboundHttp).
 	if (!aborted) {
-		await pullEgressInterceptorImage(dockerPath);
+		await pullEgressInterceptorImage(dockerPath, dockerHost);
 	}
 }
 

--- a/packages/containers-shared/src/inspect.ts
+++ b/packages/containers-shared/src/inspect.ts
@@ -1,14 +1,25 @@
 import { spawn } from "node:child_process";
 import { UserError } from "@cloudflare/workers-utils/errors";
+import { getDockerCommandArgs } from "./docker-command";
 
 export async function dockerImageInspect(
 	dockerPath: string,
-	options: { imageTag: string; formatString: string }
+	options: { imageTag: string; formatString: string },
+	dockerHost?: string
 ): Promise<string> {
 	return new Promise((resolve, reject) => {
 		const proc = spawn(
 			dockerPath,
-			["image", "inspect", options.imageTag, "--format", options.formatString],
+			getDockerCommandArgs(
+				[
+					"image",
+					"inspect",
+					options.imageTag,
+					"--format",
+					options.formatString,
+				],
+				dockerHost
+			),
 			{
 				stdio: ["ignore", "pipe", "pipe"],
 			}

--- a/packages/containers-shared/src/login.ts
+++ b/packages/containers-shared/src/login.ts
@@ -2,6 +2,7 @@ import { spawn } from "node:child_process";
 import { UserError } from "@cloudflare/workers-utils/errors";
 import { ImageRegistriesService, ImageRegistryPermissions } from "./client";
 import { OpenAPI } from "./client/core/OpenAPI";
+import { getDockerCommandArgs } from "./docker-command";
 
 export function configureOpenAPIForContainerPull(
 	accountId: string,
@@ -25,7 +26,8 @@ export function configureOpenAPIForContainerPull(
  */
 export async function dockerLoginImageRegistry(
 	pathToDocker: string,
-	domain: string
+	domain: string,
+	dockerHost?: string
 ) {
 	// how long the credentials should be valid for
 	const expirationMinutes = 15;
@@ -41,7 +43,10 @@ export async function dockerLoginImageRegistry(
 
 	const child = spawn(
 		pathToDocker,
-		["login", "--password-stdin", "--username", credentials.username, domain],
+		getDockerCommandArgs(
+			["login", "--password-stdin", "--username", credentials.username, domain],
+			dockerHost
+		),
 		{ stdio: ["pipe", "inherit", "inherit"] }
 	).on("error", (err) => {
 		throw err;

--- a/packages/containers-shared/src/utils.ts
+++ b/packages/containers-shared/src/utils.ts
@@ -8,6 +8,7 @@ import { randomUUID } from "node:crypto";
 import { existsSync } from "node:fs";
 import { release } from "node:os";
 import { UserError } from "@cloudflare/workers-utils/errors";
+import { getDockerCommandArgs } from "./docker-command";
 import { dockerImageInspect } from "./inspect";
 import type { ContainerDevOptions } from "./types";
 
@@ -15,7 +16,8 @@ import type { ContainerDevOptions } from "./types";
 export const runDockerCmd = (
 	dockerPath: string,
 	args: string[],
-	stdio?: StdioOptions
+	stdio?: StdioOptions,
+	dockerHost?: string
 ): {
 	abort: () => void;
 	ready: Promise<{ aborted: boolean }>;
@@ -29,7 +31,8 @@ export const runDockerCmd = (
 		resolve = res;
 		reject = rej;
 	});
-	const child = spawn(dockerPath, args, {
+	const dockerArgs = getDockerCommandArgs(args, dockerHost);
+	const child = spawn(dockerPath, dockerArgs, {
 		stdio: stdio ?? "inherit",
 		// We need to set detached to true so that the child process
 		// will control all of its child processes and we can kill
@@ -86,13 +89,18 @@ export const runDockerCmd = (
 	};
 };
 
-export const runDockerCmdWithOutput = (dockerPath: string, args: string[]) => {
+export const runDockerCmdWithOutput = (
+	dockerPath: string,
+	args: string[],
+	dockerHost?: string
+) => {
+	const dockerArgs = getDockerCommandArgs(args, dockerHost);
 	try {
-		const stdout = execFileSync(dockerPath, args, { encoding: "utf8" });
+		const stdout = execFileSync(dockerPath, dockerArgs, { encoding: "utf8" });
 		return stdout.trim();
 	} catch (error) {
 		throw new UserError(
-			`Failed running docker command: ${(error as Error).message}. Command: ${dockerPath} ${args.join(" ")}`,
+			`Failed running docker command: ${(error as Error).message}. Command: ${dockerPath} ${dockerArgs.join(" ")}`,
 			{ telemetryMessage: false }
 		);
 	}
@@ -181,9 +189,17 @@ function detectWsl(): boolean {
 }
 
 /** Checks whether docker is running on the system */
-export const isDockerRunning = async (dockerPath: string) => {
+export const isDockerRunning = async (
+	dockerPath: string,
+	dockerHost?: string
+) => {
 	try {
-		await runDockerCmd(dockerPath, ["info"], ["inherit", "pipe", "pipe"]);
+		await runDockerCmd(
+			dockerPath,
+			["info"],
+			["inherit", "pipe", "pipe"],
+			dockerHost
+		);
 	} catch {
 		// We assume this command is unlikely to fail for reasons other than the Docker daemon not running, or the Docker CLI not being installed or in the PATH.
 		return false;
@@ -195,6 +211,8 @@ export const isDockerRunning = async (dockerPath: string) => {
 export type VerifyDockerInstalledOptions = {
 	/** Path to the Docker CLI executable. */
 	dockerPath: string;
+	/** Docker daemon endpoint selected for the runtime. */
+	dockerHost?: string;
 	/**
 	 * Human-readable description of the operation that requires Docker,
 	 * e.g. `"running dev"`, `"deploying"`.
@@ -228,11 +246,12 @@ export type VerifyDockerInstalledOptions = {
  */
 export const verifyDockerInstalled = async ({
 	dockerPath,
+	dockerHost,
 	operation,
 	imageNoun,
 	hint,
 }: VerifyDockerInstalledOptions) => {
-	const dockerIsRunning = await isDockerRunning(dockerPath);
+	const dockerIsRunning = await isDockerRunning(dockerPath, dockerHost);
 	if (!dockerIsRunning) {
 		throw new UserError(
 			getFailedToRunDockerErrorMessage({
@@ -261,7 +280,7 @@ function getFailedToRunDockerErrorMessage({
 	operation,
 	imageNoun,
 	hint,
-}: Omit<VerifyDockerInstalledOptions, "dockerPath">): string {
+}: Omit<VerifyDockerInstalledOptions, "dockerPath" | "dockerHost">): string {
 	const beforeOperation = operation ? ` before ${operation}` : "";
 	const headline = `The Docker CLI is needed to build ${imageNoun}${beforeOperation} but could not be launched.`;
 
@@ -296,18 +315,27 @@ function getFailedToRunDockerErrorMessage({
  */
 export const cleanupContainers = (
 	dockerPath: string,
-	imageTags: Set<string>
+	imageTags: Set<string>,
+	dockerHost: string
 ) => {
 	try {
 		// Find all containers (stopped and running) for each built image
-		const containerIds = getContainerIdsByImageTags(dockerPath, imageTags);
+		const containerIds = getContainerIdsByImageTags(
+			dockerPath,
+			imageTags,
+			dockerHost
+		);
 
 		if (containerIds.length === 0) {
 			return true;
 		}
 
 		// Workerd should have stopped all containers, but clean up any in case. Sends a sigkill.
-		runDockerCmdWithOutput(dockerPath, ["rm", "--force", ...containerIds]);
+		runDockerCmdWithOutput(
+			dockerPath,
+			["rm", "--force", ...containerIds],
+			dockerHost
+		);
 		return true;
 	} catch {
 		return false;
@@ -323,14 +351,16 @@ export const cleanupContainers = (
  */
 export function getContainerIdsByImageTags(
 	dockerPath: string,
-	imageTags: Set<string>
+	imageTags: Set<string>,
+	dockerHost?: string
 ): string[] {
 	const ids = new Set<string>();
 
 	for (const imageTag of imageTags) {
 		const containerIdsFromImage = getContainerIdsFromImage(
 			dockerPath,
-			imageTag
+			imageTag,
+			dockerHost
 		);
 		containerIdsFromImage.forEach((id) => ids.add(id));
 	}
@@ -340,16 +370,21 @@ export function getContainerIdsByImageTags(
 
 export const getContainerIdsFromImage = (
 	dockerPath: string,
-	ancestorImage: string
+	ancestorImage: string,
+	dockerHost?: string
 ) => {
-	const output = runDockerCmdWithOutput(dockerPath, [
-		"ps",
-		"-a",
-		"--filter",
-		`ancestor=${ancestorImage}`,
-		"--format",
-		"{{.ID}}",
-	]);
+	const output = runDockerCmdWithOutput(
+		dockerPath,
+		[
+			"ps",
+			"-a",
+			"--filter",
+			`ancestor=${ancestorImage}`,
+			"--format",
+			"{{.ID}}",
+		],
+		dockerHost
+	);
 	return output.split("\n").filter((line) => line.trim());
 };
 
@@ -363,12 +398,17 @@ export const getContainerIdsFromImage = (
  */
 export async function checkExposedPorts(
 	dockerPath: string,
-	options: ContainerDevOptions
+	options: ContainerDevOptions,
+	dockerHost?: string
 ) {
-	const output = await dockerImageInspect(dockerPath, {
-		imageTag: options.image_tag,
-		formatString: "{{ len .Config.ExposedPorts }}",
-	});
+	const output = await dockerImageInspect(
+		dockerPath,
+		{
+			imageTag: options.image_tag,
+			formatString: "{{ len .Config.ExposedPorts }}",
+		},
+		dockerHost
+	);
 	if (output === "0") {
 		throw new UserError(
 			`The container "${options.class_name}" does not expose any ports. In your Dockerfile, please expose any ports you intend to connect to.\n` +
@@ -472,13 +512,18 @@ export const getDockerHostFromEnv = (): string => {
  */
 export async function getImageRepoTags(
 	dockerPath: string,
-	imageTag: string
+	imageTag: string,
+	dockerHost?: string
 ): Promise<string[]> {
 	try {
-		const output = await dockerImageInspect(dockerPath, {
-			imageTag,
-			formatString: "{{ range .RepoTags }}{{ . }}\n{{ end }}",
-		});
+		const output = await dockerImageInspect(
+			dockerPath,
+			{
+				imageTag,
+				formatString: "{{ range .RepoTags }}{{ . }}\n{{ end }}",
+			},
+			dockerHost
+		);
 		return output.split("\n").filter((tag) => tag.trim() !== "");
 	} catch {
 		return [];
@@ -491,10 +536,11 @@ export async function getImageRepoTags(
  */
 export async function cleanupDuplicateImageTags(
 	dockerPath: string,
-	imageTag: string
+	imageTag: string,
+	dockerHost?: string
 ): Promise<void> {
 	try {
-		const repoTags = await getImageRepoTags(dockerPath, imageTag);
+		const repoTags = await getImageRepoTags(dockerPath, imageTag, dockerHost);
 		const currentBuildId = getImageTag(imageTag);
 		// Remove all cloudflare-dev tags from previous sessions except the current dev session.
 		const tagsToRemove = repoTags.filter(
@@ -502,7 +548,7 @@ export async function cleanupDuplicateImageTags(
 				tag.startsWith("cloudflare-dev") && getImageTag(tag) !== currentBuildId
 		);
 		if (tagsToRemove.length > 0) {
-			runDockerCmdWithOutput(dockerPath, ["rmi", ...tagsToRemove]);
+			runDockerCmdWithOutput(dockerPath, ["rmi", ...tagsToRemove], dockerHost);
 		}
 	} catch {}
 }

--- a/packages/containers-shared/tests/build.test.ts
+++ b/packages/containers-shared/tests/build.test.ts
@@ -68,6 +68,7 @@ describe("dockerBuild", () => {
 			buildCmd: ["build", "-t", "test"],
 			dockerfile: "FROM node:18",
 			verifyDockerIsRunning: false,
+			dockerHost: "unix:///custom/docker.sock",
 		});
 
 		// The promise should resolve without calling docker info first.
@@ -75,7 +76,7 @@ describe("dockerBuild", () => {
 		expect(spawn).toHaveBeenCalledTimes(1);
 		expect(spawn).toHaveBeenCalledWith(
 			"docker",
-			["build", "-t", "test"],
+			["--host", "unix:///custom/docker.sock", "build", "-t", "test"],
 			expect.any(Object)
 		);
 

--- a/packages/containers-shared/tests/docker-command.test.ts
+++ b/packages/containers-shared/tests/docker-command.test.ts
@@ -1,0 +1,28 @@
+import { describe, it } from "vitest";
+import {
+	getDockerCommandArgs,
+	getDockerHostFromContainerEngine,
+} from "../src/docker-command";
+
+const dockerHost = "unix:///custom/docker.sock";
+
+describe("Docker endpoint helpers", () => {
+	it("places an explicit host before the command", ({ expect }) => {
+		expect(getDockerCommandArgs(["context", "ls"])).toEqual(["context", "ls"]);
+		expect(getDockerCommandArgs(["image", "inspect"], dockerHost)).toEqual([
+			"--host",
+			dockerHost,
+			"image",
+			"inspect",
+		]);
+	});
+
+	it("reads string and structured container engines", ({ expect }) => {
+		expect(getDockerHostFromContainerEngine(dockerHost)).toBe(dockerHost);
+		expect(
+			getDockerHostFromContainerEngine({
+				localDocker: { socketPath: dockerHost },
+			})
+		).toBe(dockerHost);
+	});
+});

--- a/packages/containers-shared/tests/docker-context.test.ts
+++ b/packages/containers-shared/tests/docker-context.test.ts
@@ -1,6 +1,6 @@
 import { execFileSync } from "node:child_process";
 import { UserError } from "@cloudflare/workers-utils";
-import { afterEach, describe, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, it, vi } from "vitest";
 import { resolveDockerHost } from "../src/utils";
 
 vi.mock("node:child_process");
@@ -9,6 +9,12 @@ vi.mock("node:child_process");
 describe.skipIf(process.platform !== "linux" && process.env.CI === "true")(
 	"resolveDockerHost",
 	() => {
+		beforeEach(() => {
+			vi.stubEnv("WRANGLER_DOCKER_HOST", undefined);
+			vi.stubEnv("DOCKER_HOST", undefined);
+			vi.mocked(execFileSync).mockReset();
+		});
+
 		afterEach(() => {
 			vi.unstubAllEnvs();
 		});
@@ -42,6 +48,11 @@ describe.skipIf(process.platform !== "linux" && process.env.CI === "true")(
 {"Current":false,"Description":"Docker Desktop","DockerEndpoint":"unix:///FROM/OTHER/CONTEXT/run/docker.sock","Error":"","Name":"desktop-linux"}`);
 			const result = resolveDockerHost("/no/op/docker");
 			expect(result).toBe("unix:///FROM/CURRENT/CONTEXT/run/docker.sock");
+			expect(execFileSync).toHaveBeenCalledWith(
+				"/no/op/docker",
+				["context", "ls", "--format", "json"],
+				{ encoding: "utf8" }
+			);
 		});
 
 		it("should fall back to platform default when context fails", ({

--- a/packages/containers-shared/tests/images.test.ts
+++ b/packages/containers-shared/tests/images.test.ts
@@ -1,14 +1,32 @@
 import { beforeEach, describe, it, vi } from "vitest";
+import { buildImage } from "../src/build";
 import { ExternalRegistryKind } from "../src/client/models/ExternalRegistryKind";
 import {
 	getEgressInterceptorPlatform,
 	pullEgressInterceptorImage,
 	getAndValidateRegistryType,
+	prepareContainerImagesForDev,
 	validateAndEncodeGarKey,
 } from "../src/images";
-import { runDockerCmd } from "../src/utils";
+import { dockerLoginImageRegistry } from "../src/login";
+import {
+	checkExposedPorts,
+	cleanupDuplicateImageTags,
+	runDockerCmd,
+	verifyDockerInstalled,
+} from "../src/utils";
+
+vi.mock("../src/build", () => ({
+	buildImage: vi.fn(() => ({ abort: vi.fn(), ready: Promise.resolve() })),
+}));
+
+vi.mock("../src/login", () => ({
+	dockerLoginImageRegistry: vi.fn(),
+}));
 
 vi.mock("../src/utils", () => ({
+	checkExposedPorts: vi.fn(),
+	cleanupDuplicateImageTags: vi.fn(),
 	runDockerCmd: vi.fn(() => ({
 		abort: vi.fn(),
 		ready: Promise.resolve({ aborted: false }),
@@ -16,6 +34,7 @@ vi.mock("../src/utils", () => ({
 			resolve();
 		},
 	})),
+	verifyDockerInstalled: vi.fn(),
 }));
 
 describe("getEgressInterceptorPlatform", () => {
@@ -40,19 +59,6 @@ describe("pullEgressInterceptorImage", () => {
 		vi.mocked(runDockerCmd).mockClear();
 	});
 
-	it("pulls the egress interceptor image without forcing a platform by default", async ({
-		expect,
-	}) => {
-		vi.stubEnv("MINIFLARE_CONTAINER_EGRESS_IMAGE", "proxy-everything:test");
-
-		await pullEgressInterceptorImage("docker");
-
-		expect(runDockerCmd).toHaveBeenCalledWith("docker", [
-			"pull",
-			"proxy-everything:test",
-		]);
-	});
-
 	it("pulls the egress interceptor image for the configured platform", async ({
 		expect,
 	}) => {
@@ -61,11 +67,83 @@ describe("pullEgressInterceptorImage", () => {
 
 		await pullEgressInterceptorImage("docker");
 
-		expect(runDockerCmd).toHaveBeenCalledWith("docker", [
-			"pull",
-			"proxy-everything:test",
-			"--platform",
-			"linux/arm64",
+		expect(runDockerCmd).toHaveBeenCalledWith(
+			"docker",
+			["pull", "proxy-everything:test", "--platform", "linux/arm64"],
+			undefined,
+			undefined
+		);
+	});
+});
+
+describe("prepareContainerImagesForDev", () => {
+	beforeEach(() => {
+		vi.unstubAllEnvs();
+		vi.mocked(buildImage).mockClear();
+		vi.mocked(checkExposedPorts).mockClear();
+		vi.mocked(cleanupDuplicateImageTags).mockClear();
+		vi.mocked(dockerLoginImageRegistry).mockReset();
+		vi.mocked(runDockerCmd).mockClear();
+		vi.mocked(verifyDockerInstalled).mockClear();
+	});
+
+	it("uses the selected Docker host for every preparation step", async ({
+		expect,
+	}) => {
+		const dockerHost = "unix:///custom/docker.sock";
+		const builtImage = {
+			dockerfile: "Dockerfile",
+			image_build_context: ".",
+			image_tag: "cloudflare-dev/built:build-123",
+			class_name: "BuiltContainer",
+		} as const;
+		const pulledImage = {
+			image_uri: "docker.io/example/image:latest",
+			image_tag: "cloudflare-dev/container:build-123",
+			class_name: "Container",
+		} as const;
+
+		await prepareContainerImagesForDev({
+			dockerPath: "docker",
+			dockerHost,
+			containerOptions: [builtImage, pulledImage],
+			onContainerImagePreparationStart: vi.fn(),
+			onContainerImagePreparationEnd: vi.fn(),
+			logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+		});
+
+		expect(verifyDockerInstalled).toHaveBeenCalledWith(
+			expect.objectContaining({ dockerHost })
+		);
+		expect({
+			build: vi.mocked(buildImage).mock.calls[0]?.[3],
+			login: vi.mocked(dockerLoginImageRegistry).mock.calls[0]?.[2],
+			duplicateTagCleanup: vi
+				.mocked(cleanupDuplicateImageTags)
+				.mock.calls.map((call) => call[2]),
+			portInspection: vi
+				.mocked(checkExposedPorts)
+				.mock.calls.map((call) => call[2]),
+		}).toEqual({
+			build: dockerHost,
+			login: dockerHost,
+			duplicateTagCleanup: [dockerHost, dockerHost],
+			portInspection: [dockerHost, dockerHost],
+		});
+		expect(vi.mocked(runDockerCmd).mock.calls).toEqual([
+			[
+				"docker",
+				["pull", pulledImage.image_uri, "--platform", "linux/amd64"],
+				undefined,
+				dockerHost,
+			],
+			[
+				"docker",
+				["tag", pulledImage.image_uri, pulledImage.image_tag],
+				undefined,
+				dockerHost,
+			],
+			["docker", ["pull", expect.any(String)], undefined, dockerHost],
 		]);
 	});
 });

--- a/packages/containers-shared/tests/utils.test.ts
+++ b/packages/containers-shared/tests/utils.test.ts
@@ -12,6 +12,7 @@ import {
 	checkExposedPorts,
 	cleanupDuplicateImageTags,
 	containerPrivilegesAllowed,
+	runDockerCmdWithOutput,
 	verifyDockerInstalled,
 } from "./../src/utils";
 import type { ContainerDevOptions } from "../src/types";
@@ -43,7 +44,9 @@ vi.mock("../src/inspect", async (importOriginal) => {
 
 const containerConfig = {
 	dockerfile: "",
+	image_build_context: "",
 	class_name: "MyContainer",
+	image_tag: "cloudflare-dev/mycontainer:build-123",
 } as ContainerDevOptions;
 describe("checkExposedPorts", () => {
 	beforeEach(() => {
@@ -113,6 +116,29 @@ describe("cleanupDuplicateImageTags", () => {
 		expect(execFileSync).toHaveBeenCalledWith(
 			"docker",
 			["rmi", "cloudflare-dev/egresstestcontainer:build-122"],
+			{ encoding: "utf8" }
+		);
+	});
+});
+
+describe("runDockerCmdWithOutput", () => {
+	beforeEach(() => {
+		vi.mocked(execFileSync).mockReset();
+	});
+
+	it("uses the selected Docker host", ({ expect }) => {
+		vi.mocked(execFileSync).mockReturnValue("container-id\n");
+
+		expect(
+			runDockerCmdWithOutput(
+				"docker",
+				["ps", "-a"],
+				"unix:///custom/docker.sock"
+			)
+		).toBe("container-id");
+		expect(execFileSync).toHaveBeenCalledWith(
+			"docker",
+			["--host", "unix:///custom/docker.sock", "ps", "-a"],
 			{ encoding: "utf8" }
 		);
 	});

--- a/packages/vite-plugin-cloudflare/src/__tests__/containers.spec.ts
+++ b/packages/vite-plugin-cloudflare/src/__tests__/containers.spec.ts
@@ -1,10 +1,36 @@
+import { execFileSync } from "node:child_process";
 import { OpenAPI } from "@cloudflare/containers-shared";
 import { afterEach, beforeEach, describe, test, vi } from "vitest";
-import { configureContainerPull, getContainerOptions } from "../containers";
+import {
+	configureContainerPull,
+	getContainerOptions,
+	selectViteContainerEngine,
+} from "../containers";
 import type { ResolvedWorkerConfig } from "../plugin-config";
 
 type Containers = ResolvedWorkerConfig["containers"];
 type Exports = ResolvedWorkerConfig["exports"];
+
+function containerWorker(
+	name: string,
+	containerEngine?: ResolvedWorkerConfig["dev"]["container_engine"],
+	enableContainers = true
+) {
+	return {
+		config: {
+			name,
+			containers: enableContainers
+				? [{ name: "container", image: "docker.io/example/image:latest" }]
+				: undefined,
+			dev: {
+				enable_containers: enableContainers,
+				container_engine: containerEngine,
+			},
+		},
+	};
+}
+
+vi.mock("node:child_process");
 
 describe("getContainerOptions", () => {
 	test("returns undefined when no containers are configured", ({ expect }) => {
@@ -117,6 +143,75 @@ describe("getContainerOptions", () => {
 				containerBuildId: "build-id",
 			})
 		).toEqual([]);
+	});
+});
+
+describe("Vite container engine selection", () => {
+	beforeEach(() => {
+		vi.stubEnv("WRANGLER_DOCKER_HOST", undefined);
+		vi.stubEnv("DOCKER_HOST", undefined);
+		vi.mocked(execFileSync).mockReset();
+	});
+
+	afterEach(() => {
+		vi.unstubAllEnvs();
+	});
+
+	test("uses the resolved Docker host by default", ({ expect }) => {
+		vi.stubEnv("WRANGLER_DOCKER_HOST", "unix:///wrangler/docker.sock");
+
+		expect(
+			selectViteContainerEngine([containerWorker("worker")], "docker")
+		).toBe("unix:///wrangler/docker.sock");
+	});
+
+	test("uses an explicit string engine without inspecting Docker contexts", ({
+		expect,
+	}) => {
+		expect(
+			selectViteContainerEngine(
+				[
+					containerWorker("inactive-worker", undefined, false),
+					containerWorker("worker", "unix:///custom/docker.sock"),
+				],
+				"docker"
+			)
+		).toBe("unix:///custom/docker.sock");
+		expect(execFileSync).not.toHaveBeenCalled();
+	});
+
+	test("uses the endpoint from an explicit local Docker engine", ({
+		expect,
+	}) => {
+		const containerEngine = {
+			localDocker: {
+				socketPath: "unix:///custom/docker.sock",
+				containerEgressInterceptorImage: "custom-egress",
+			},
+		};
+
+		expect(
+			selectViteContainerEngine(
+				[
+					containerWorker("worker", containerEngine),
+					containerWorker("second-worker", "unix:///custom/docker.sock"),
+				],
+				"docker"
+			)
+		).toBe(containerEngine);
+		expect(execFileSync).not.toHaveBeenCalled();
+	});
+
+	test("rejects conflicting endpoints across Workers", ({ expect }) => {
+		expect(() =>
+			selectViteContainerEngine(
+				[
+					containerWorker("first-worker", "unix:///first.sock"),
+					containerWorker("second-worker", "unix:///second.sock"),
+				],
+				"docker"
+			)
+		).toThrow(/must use the same dev\.container_engine/);
 	});
 });
 

--- a/packages/vite-plugin-cloudflare/src/containers.ts
+++ b/packages/vite-plugin-cloudflare/src/containers.ts
@@ -2,15 +2,74 @@ import path from "node:path";
 import {
 	configureOpenAPIForContainerPull,
 	getDevContainerImageName,
+	getDockerHostFromContainerEngine,
+	resolveDockerHost,
 } from "@cloudflare/containers-shared";
 import {
 	COMPLIANCE_REGION_CONFIG_UNKNOWN,
 	getCloudflareApiBaseUrl,
 	isDockerfile,
 	resolveContainerClassName,
+	UserError,
 } from "@cloudflare/workers-utils";
 import type { ResolvedWorkerConfig } from "./plugin-config";
-import type { ComplianceConfig } from "@cloudflare/workers-utils";
+import type {
+	ComplianceConfig,
+	ContainerEngine,
+} from "@cloudflare/workers-utils";
+
+type WorkerWithContainerEngineConfig = {
+	config: Pick<ResolvedWorkerConfig, "containers"> & {
+		name?: string;
+		dev: Pick<
+			ResolvedWorkerConfig["dev"],
+			"container_engine" | "enable_containers"
+		>;
+	};
+};
+
+/**
+ * Selects Vite's single Miniflare container engine and rejects conflicting
+ * per-Worker endpoints.
+ *
+ * @param workers - Workers whose active container engines should be combined.
+ * @param dockerPath - Docker CLI executable used for context discovery.
+ * @returns The first active container engine, or `undefined` without containers.
+ */
+export function selectViteContainerEngine(
+	workers: Iterable<WorkerWithContainerEngineConfig>,
+	dockerPath: string
+): ContainerEngine | undefined {
+	let selected: ContainerEngine | undefined;
+	for (const { config } of workers) {
+		if (!config.dev.enable_containers || !config.containers?.length) {
+			continue;
+		}
+
+		const current =
+			config.dev.container_engine ?? resolveDockerHost(dockerPath);
+		const currentDockerHost = getDockerHostFromContainerEngine(current);
+		const selectedDockerHost =
+			selected === undefined
+				? undefined
+				: getDockerHostFromContainerEngine(selected);
+		if (
+			selectedDockerHost !== undefined &&
+			selectedDockerHost !== currentDockerHost
+		) {
+			throw new UserError(
+				`All Workers with containers in a Vite project must use the same dev.container_engine. ` +
+					`Worker "${config.name ?? "<unnamed Worker>"}" resolves to "${currentDockerHost}", but another Worker resolves to "${selectedDockerHost}". ` +
+					"Configure every Worker with the same endpoint and restart the Vite server.",
+				{ telemetryMessage: false }
+			);
+		}
+
+		selected ??= current;
+	}
+
+	return selected;
+}
 
 /**
  * Configures the Containers API client used to retrieve image pull credentials.

--- a/packages/vite-plugin-cloudflare/src/miniflare-options.ts
+++ b/packages/vite-plugin-cloudflare/src/miniflare-options.ts
@@ -5,10 +5,7 @@ import * as path from "node:path";
 import * as timers from "node:timers/promises";
 import { fileURLToPath } from "node:url";
 import { format } from "node:util";
-import {
-	generateContainerBuildId,
-	resolveDockerHost,
-} from "@cloudflare/containers-shared";
+import { generateContainerBuildId } from "@cloudflare/containers-shared";
 import { maybeStartOrUpdateRemoteProxySession } from "@cloudflare/remote-bindings";
 import {
 	getBrowserRenderingHeadfulFromEnv,
@@ -35,7 +32,11 @@ import {
 	ROUTER_WORKER_NAME,
 	VITE_PROXY_WORKER_NAME,
 } from "./constants";
-import { getContainerOptions, getDockerPath } from "./containers";
+import {
+	getContainerOptions,
+	getDockerPath,
+	selectViteContainerEngine,
+} from "./containers";
 import { getInputInspectorPort } from "./debug";
 import { additionalModuleRE } from "./plugins/additional-modules";
 import { ENVIRONMENT_NAME_HEADER } from "./shared";
@@ -339,7 +340,13 @@ export async function getDevMiniflareOptions(
 	];
 
 	const containerTagToOptionsMap: ContainerTagToOptionsMap = new Map();
-	let containerEngine: string | undefined;
+	const containerEngine =
+		resolvedPluginConfig.type === "workers"
+			? selectViteContainerEngine(
+					resolvedPluginConfig.environmentNameToWorkerMap.values(),
+					getDockerPath()
+				)
+			: undefined;
 
 	const workersFromConfig =
 		resolvedPluginConfig.type === "workers"
@@ -388,8 +395,6 @@ export async function getDevMiniflareOptions(
 								worker.config.containers?.length &&
 								worker.config.dev.enable_containers
 							) {
-								const dockerPath = getDockerPath();
-								containerEngine = resolveDockerHost(dockerPath);
 								containerBuildId = generateContainerBuildId();
 
 								const options = getContainerOptions({
@@ -763,7 +768,10 @@ export async function getPreviewMiniflareOptions(
 	);
 	const { resolvedPluginConfig, resolvedViteConfig } = ctx;
 	const containerTagToOptionsMap: ContainerTagToOptionsMap = new Map();
-	let containerEngine: string | undefined;
+	const containerEngine = selectViteContainerEngine(
+		resolvedPluginConfig.workers,
+		getDockerPath()
+	);
 
 	const workers: Array<V4WorkerOptions> = (
 		await Promise.all(
@@ -810,8 +818,6 @@ export async function getPreviewMiniflareOptions(
 					workerConfig.containers?.length &&
 					workerConfig.dev.enable_containers
 				) {
-					const dockerPath = getDockerPath();
-					containerEngine = resolveDockerHost(dockerPath);
 					containerBuildId = generateContainerBuildId();
 
 					const options = getContainerOptions({

--- a/packages/vite-plugin-cloudflare/src/plugins/dev.ts
+++ b/packages/vite-plugin-cloudflare/src/plugins/dev.ts
@@ -1,9 +1,10 @@
 import assert from "node:assert";
 import {
+	cleanupContainers,
 	getCloudflareContainerRegistry,
+	getDockerHostFromContainerEngine,
 	prepareContainerImagesForDev,
 } from "@cloudflare/containers-shared";
-import { cleanupContainers } from "@cloudflare/containers-shared/src/utils";
 import { generateStaticRoutingRuleMatcher } from "@cloudflare/workers-shared/asset-worker/src/utils/rules-engine";
 import { UserError } from "@cloudflare/workers-utils";
 import { buildPublicUrl, CoreHeaders } from "miniflare";
@@ -31,6 +32,7 @@ import {
 } from "../utils";
 import { handleWebSocket } from "../websockets";
 import type { StaticRouting } from "@cloudflare/workers-shared/utils/types";
+import type { ContainerEngine } from "@cloudflare/workers-utils";
 
 let exitCallback = () => {};
 
@@ -43,6 +45,21 @@ process.on("exit", () => {
  */
 export const devPlugin = createPlugin("dev", (ctx) => {
 	let containerImageTags = new Set<string>();
+	let containerEngine: ContainerEngine | undefined;
+	function cleanupContainerInstances(): void {
+		if (!containerImageTags.size) {
+			return;
+		}
+		assert(
+			containerEngine,
+			"Expected a container engine for configured containers"
+		);
+		cleanupContainers(
+			getDockerPath(),
+			containerImageTags,
+			getDockerHostFromContainerEngine(containerEngine)
+		);
+	}
 
 	return {
 		buildEnd() {
@@ -53,8 +70,7 @@ export const devPlugin = createPlugin("dev", (ctx) => {
 				ctx.isRestartingDevServer &&
 				containerImageTags.size
 			) {
-				const dockerPath = getDockerPath();
-				cleanupContainers(dockerPath, containerImageTags);
+				cleanupContainerInstances();
 			}
 		},
 		async configureServer(viteDevServer) {
@@ -62,6 +78,7 @@ export const devPlugin = createPlugin("dev", (ctx) => {
 
 			const initialOptions = await getDevMiniflareOptions(ctx, viteDevServer);
 			let containerTagToOptionsMap = initialOptions.containerTagToOptionsMap;
+			containerEngine = initialOptions.miniflareOptions.containerEngine;
 
 			await ctx.startOrUpdateMiniflare(initialOptions.miniflareOptions);
 
@@ -76,9 +93,7 @@ export const devPlugin = createPlugin("dev", (ctx) => {
 					await closeServer();
 				} finally {
 					if (!ctx.isRestartingDevServer) {
-						if (containerImageTags.size) {
-							cleanupContainers(getDockerPath(), containerImageTags);
-						}
+						cleanupContainerInstances();
 						try {
 							await ctx.disposeMiniflare();
 						} catch (error) {
@@ -133,6 +148,7 @@ export const devPlugin = createPlugin("dev", (ctx) => {
 						viteDevServer
 					);
 					containerTagToOptionsMap = updatedOptions.containerTagToOptionsMap;
+					containerEngine = updatedOptions.miniflareOptions.containerEngine;
 					await ctx.startOrUpdateMiniflare(updatedOptions.miniflareOptions);
 					await initRunners(
 						ctx.resolvedPluginConfig,
@@ -235,6 +251,10 @@ export const devPlugin = createPlugin("dev", (ctx) => {
 				}
 
 				if (containerTagToOptionsMap.size) {
+					assert(
+						containerEngine,
+						"Expected a container engine for configured containers"
+					);
 					viteDevServer.config.logger.info(
 						colors.dim(
 							colors.yellow(
@@ -273,6 +293,7 @@ export const devPlugin = createPlugin("dev", (ctx) => {
 
 					await prepareContainerImagesForDev({
 						dockerPath: getDockerPath(),
+						dockerHost: getDockerHostFromContainerEngine(containerEngine),
 						containerOptions: [...containerTagToOptionsMap.values()],
 						onContainerImagePreparationStart: () => {},
 						onContainerImagePreparationEnd: () => {},
@@ -303,11 +324,7 @@ export const devPlugin = createPlugin("dev", (ctx) => {
 					 * not to be emitted).
 					 *
 					 */
-					exitCallback = () => {
-						if (containerImageTags.size) {
-							cleanupContainers(getDockerPath(), containerImageTags);
-						}
-					};
+					exitCallback = cleanupContainerInstances;
 				}
 			}
 

--- a/packages/vite-plugin-cloudflare/src/plugins/preview.ts
+++ b/packages/vite-plugin-cloudflare/src/plugins/preview.ts
@@ -1,8 +1,10 @@
+import assert from "node:assert";
 import {
+	cleanupContainers,
 	getCloudflareContainerRegistry,
+	getDockerHostFromContainerEngine,
 	prepareContainerImagesForDev,
 } from "@cloudflare/containers-shared";
-import { cleanupContainers } from "@cloudflare/containers-shared/src/utils";
 import { UserError } from "@cloudflare/workers-utils";
 import { buildPublicUrl, Request as MiniflareRequest } from "miniflare";
 import colors from "picocolors";
@@ -60,6 +62,13 @@ export const previewPlugin = createPlugin("preview", (ctx) => {
 			}
 
 			if (containerTagToOptionsMap.size) {
+				const { containerEngine } = miniflareOptions;
+				assert(
+					containerEngine,
+					"Expected a container engine for configured containers"
+				);
+				const containerDockerHost =
+					getDockerHostFromContainerEngine(containerEngine);
 				const dockerPath = getDockerPath();
 
 				vitePreviewServer.config.logger.info(
@@ -97,7 +106,8 @@ export const previewPlugin = createPlugin("preview", (ctx) => {
 				}
 
 				await prepareContainerImagesForDev({
-					dockerPath: getDockerPath(),
+					dockerPath,
+					dockerHost: containerDockerHost,
 					containerOptions: [...containerTagToOptionsMap.values()],
 					onContainerImagePreparationStart: () => {},
 					onContainerImagePreparationEnd: () => {},
@@ -112,7 +122,11 @@ export const previewPlugin = createPlugin("preview", (ctx) => {
 
 				exitCallback = () => {
 					if (containerImageTags.size) {
-						cleanupContainers(dockerPath, containerImageTags);
+						cleanupContainers(
+							dockerPath,
+							containerImageTags,
+							containerDockerHost
+						);
 					}
 				};
 			}

--- a/packages/wrangler/src/__tests__/api/startDevWorker/LocalRuntimeController.test.ts
+++ b/packages/wrangler/src/__tests__/api/startDevWorker/LocalRuntimeController.test.ts
@@ -3,12 +3,13 @@ import fs, { readFileSync } from "node:fs";
 import net from "node:net";
 import path from "node:path";
 import util from "node:util";
+import { prepareContainerImagesForDev } from "@cloudflare/containers-shared";
 import { removeDirSync } from "@cloudflare/workers-utils";
 import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
 import { DeferredPromise, Response } from "miniflare";
 import dedent from "ts-dedent";
 import { fetch } from "undici";
-import { assert, describe, it } from "vitest";
+import { assert, describe, it, vi } from "vitest";
 import WebSocket from "ws";
 import { createPostgresEchoHandler } from "../../../../e2e/helpers/postgres-echo-handler";
 import {
@@ -25,6 +26,12 @@ import { useTeardown } from "../../helpers/teardown";
 import { unusable } from "../../helpers/unusable";
 import type { Bundle, File, StartDevWorkerOptions } from "../../../api";
 import type { Config, Rule } from "@cloudflare/workers-utils";
+
+vi.mock("@cloudflare/containers-shared", async (importOriginal) => ({
+	...(await importOriginal<typeof import("@cloudflare/containers-shared")>()),
+	cleanupContainers: vi.fn(),
+	prepareContainerImagesForDev: vi.fn(),
+}));
 
 export type Module<ModuleType extends Rule["type"] = Rule["type"]> = File<
 	string | Uint8Array
@@ -134,6 +141,44 @@ function configDefaults(
 	};
 }
 
+const testContainers = [
+	{
+		name: "container",
+		class_name: "Container",
+		image_uri: "docker.io/example/image:latest",
+	} as NonNullable<StartDevWorkerOptions["containers"]>[number],
+];
+
+function containerConfig(
+	name: string,
+	containerBuildId: string,
+	containerEngine: NonNullable<StartDevWorkerOptions["dev"]>["containerEngine"]
+): StartDevWorkerOptions {
+	return configDefaults({
+		name,
+		containers: testContainers,
+		dev: {
+			persist: "./persist",
+			remote: false,
+			enableContainers: true,
+			containerBuildId,
+			containerEngine,
+			dockerPath: "docker",
+		},
+	});
+}
+
+function sendBundle(
+	controller: LocalRuntimeController,
+	config: StartDevWorkerOptions
+): void {
+	controller.onBundleComplete({
+		type: "bundleComplete",
+		config,
+		bundle: makeEsbuildBundle("export default { fetch() {} }") as Bundle,
+	});
+}
+
 describe("LocalRuntimeController", () => {
 	mockConsoleMethods();
 	runInTempDir();
@@ -183,6 +228,41 @@ describe("LocalRuntimeController", () => {
 	});
 
 	describe("Core", () => {
+		it("rejects conflicting multiworker container engines", async ({
+			expect,
+		}) => {
+			vi.mocked(prepareContainerImagesForDev).mockReset();
+			const bus = new FakeBus();
+			const controller = new MultiworkerRuntimeController(bus, 2);
+			teardown(() => controller.teardown());
+
+			sendBundle(
+				controller,
+				containerConfig("first-worker", "build-1", "unix:///first.sock")
+			);
+			await vi.waitFor(() => {
+				expect(prepareContainerImagesForDev).toHaveBeenCalledOnce();
+			});
+
+			const conflictError = bus.waitFor("error");
+			sendBundle(
+				controller,
+				containerConfig("second-worker", "build-2", "unix:///second.sock")
+			);
+
+			await expect(conflictError).resolves.toMatchObject({
+				cause: expect.objectContaining({
+					message: expect.stringMatching(
+						/must use the same dev\.container_engine/
+					),
+				}),
+			});
+			expect(prepareContainerImagesForDev).toHaveBeenCalledOnce();
+			expect(prepareContainerImagesForDev).toHaveBeenCalledWith(
+				expect.objectContaining({ dockerHost: "unix:///first.sock" })
+			);
+		});
+
 		it("dispatches a typed runtimeError for an uncaught Worker exception", async ({
 			expect,
 		}) => {
@@ -1691,6 +1771,53 @@ describe("MultiworkerRuntimeController", () => {
 	runInTempDir();
 	// Make sure teardown is declared after runInTempDir so it runs before we delete the temp directory
 	const teardown = useTeardown();
+
+	it("preserves a structured container engine in merged options", async ({
+		expect,
+	}) => {
+		const containerEngine = {
+			localDocker: {
+				socketPath: "unix:///custom/docker.sock",
+				containerEgressInterceptorImage: "custom-egress",
+			},
+		};
+		const primaryConfig = configDefaults({
+			name: "primary-worker",
+			dev: {
+				persist: "./persist",
+				remote: false,
+				multiworkerPrimary: true,
+			},
+		});
+		const secondaryConfig = configDefaults({
+			name: "secondary-worker",
+			dev: {
+				persist: "./persist",
+				remote: false,
+				multiworkerPrimary: false,
+				containerEngine,
+			},
+		});
+		const bus = new FakeBus();
+		const controller = new MultiworkerRuntimeController(bus, 2);
+		teardown(() => controller.teardown());
+
+		const initialReload = bus.waitFor("reloadComplete");
+		sendBundle(controller, primaryConfig);
+		sendBundle(controller, secondaryConfig);
+		await initialReload;
+
+		assert(controller.mf);
+		const setOptions = vi.spyOn(controller.mf, "setOptions");
+		const updatedReload = bus.waitFor("reloadComplete");
+		sendBundle(controller, primaryConfig);
+		await updatedReload;
+
+		expect(setOptions).toHaveBeenCalledOnce();
+		expect(setOptions.mock.calls[0]?.[0].containerEngine).toEqual(
+			containerEngine
+		);
+	});
 
 	// The multiworker controller builds its Miniflare options through its own
 	// code path, so the runtimeError wiring must be pinned separately from the

--- a/packages/wrangler/src/api/startDevWorker/LocalRuntimeController.ts
+++ b/packages/wrangler/src/api/startDevWorker/LocalRuntimeController.ts
@@ -4,6 +4,7 @@ import { readFile } from "node:fs/promises";
 import {
 	cleanupContainers,
 	getDevContainerImageName,
+	getDockerHostFromContainerEngine,
 	prepareContainerImagesForDev,
 	runDockerCmdWithOutput,
 } from "@cloudflare/containers-shared";
@@ -268,6 +269,8 @@ export class LocalRuntimeController extends RuntimeController {
 	containerImageTagsSeen: Set<string> = new Set();
 	// Stored here, so it can be used in `cleanupContainers()`
 	dockerPath: string | undefined;
+	// Docker endpoint paired with the Miniflare container engine.
+	dockerHost: string | undefined;
 	// If this doesn't match what is in config, trigger a rebuild.
 	// Used for the rebuild hotkey
 	#currentContainerBuildId: string | undefined;
@@ -343,17 +346,27 @@ export class LocalRuntimeController extends RuntimeController {
 			}
 
 			// Assemble container options and build if necessary
+			const hasEnabledContainers = Boolean(
+				data.config.containers?.length && data.config.dev.enableContainers
+			);
 
 			if (
-				data.config.containers?.length &&
-				data.config.dev.enableContainers &&
+				hasEnabledContainers &&
 				this.#currentContainerBuildId !== data.config.dev.containerBuildId
 			) {
 				this.dockerPath = data.config.dev?.dockerPath ?? getDockerPath();
 				assert(
+					data.config.dev.containerEngine,
+					"Container engine should be set if containers are enabled and defined"
+				);
+				this.dockerHost = getDockerHostFromContainerEngine(
+					data.config.dev.containerEngine
+				);
+				assert(
 					data.config.dev.containerBuildId,
 					"Build ID should be set if containers are enabled and defined"
 				);
+				assert(data.config.containers);
 				const containerDevOptions = await getContainerDevOptions(
 					data.config.containers,
 					data.config.dev.containerBuildId
@@ -362,19 +375,24 @@ export class LocalRuntimeController extends RuntimeController {
 				for (const container of containerDevOptions) {
 					// if this was triggered by the rebuild hotkey, delete the old image
 					if (this.#currentContainerBuildId !== undefined) {
-						runDockerCmdWithOutput(this.dockerPath, [
-							"rmi",
-							getDevContainerImageName(
-								container.class_name,
-								this.#currentContainerBuildId
-							),
-						]);
+						runDockerCmdWithOutput(
+							this.dockerPath,
+							[
+								"rmi",
+								getDevContainerImageName(
+									container.class_name,
+									this.#currentContainerBuildId
+								),
+							],
+							this.dockerHost
+						);
 					}
 					this.containerImageTagsSeen.add(container.image_tag);
 				}
 				logger.log(chalk.dim("⎔ Preparing container image(s)..."));
 				await prepareContainerImagesForDev({
 					dockerPath: this.dockerPath,
+					dockerHost: this.dockerHost,
 					containerOptions: containerDevOptions,
 					onContainerImagePreparationStart: (buildStartEvent) => {
 						this.containerBeingBuilt = {
@@ -540,7 +558,15 @@ export class LocalRuntimeController extends RuntimeController {
 			this.dockerPath,
 			"Docker path should have been set if containers are enabled"
 		);
-		cleanupContainers(this.dockerPath, this.containerImageTagsSeen);
+		assert(
+			this.dockerHost,
+			"Docker host should have been set if containers are enabled"
+		);
+		cleanupContainers(
+			this.dockerPath,
+			this.containerImageTagsSeen,
+			this.dockerHost
+		);
 	};
 
 	#teardown = async (): Promise<void> => {

--- a/packages/wrangler/src/api/startDevWorker/MultiworkerRuntimeController.ts
+++ b/packages/wrangler/src/api/startDevWorker/MultiworkerRuntimeController.ts
@@ -1,7 +1,10 @@
 import assert from "node:assert";
 import { randomUUID } from "node:crypto";
-import { prepareContainerImagesForDev } from "@cloudflare/containers-shared";
-import { getDockerPath } from "@cloudflare/workers-utils";
+import {
+	getDockerHostFromContainerEngine,
+	prepareContainerImagesForDev,
+} from "@cloudflare/containers-shared";
+import { getDockerPath, UserError } from "@cloudflare/workers-utils";
 import chalk from "chalk";
 import { convertV4MiniflareOptions, Miniflare, Mutex } from "miniflare";
 import * as MF from "../../dev/miniflare";
@@ -172,8 +175,33 @@ export class MultiworkerRuntimeController extends LocalRuntimeController {
 				return;
 			}
 
+			const hasEnabledContainers = Boolean(
+				data.config.containers?.length && data.config.dev.enableContainers
+			);
+			let configuredDockerHost: string | undefined;
+			if (hasEnabledContainers) {
+				assert(
+					data.config.dev.containerEngine,
+					"Container engine should be set if containers are enabled and defined"
+				);
+				configuredDockerHost = getDockerHostFromContainerEngine(
+					data.config.dev.containerEngine
+				);
+				if (
+					this.dockerHost !== undefined &&
+					this.dockerHost !== configuredDockerHost
+				) {
+					throw new UserError(
+						`All Workers with containers in a multiworker session must use the same dev.container_engine. ` +
+							`Worker "${workerName}" resolves to "${configuredDockerHost}", but this session already uses "${this.dockerHost}". ` +
+							"Configure every Worker with the same endpoint and restart the session.",
+						{ telemetryMessage: false }
+					);
+				}
+			}
+
 			if (
-				data.config.containers?.length &&
+				hasEnabledContainers &&
 				this.#currentContainerBuildId !== data.config.dev.containerBuildId
 			) {
 				logger.log(chalk.dim("⎔ Preparing container image(s)..."));
@@ -182,17 +210,23 @@ export class MultiworkerRuntimeController extends LocalRuntimeController {
 					data.config.dev.containerBuildId,
 					"Build ID should be set if containers are enabled and defined"
 				);
+				assert(data.config.containers);
 				const containerOptions = await getContainerDevOptions(
 					data.config.containers,
 					data.config.dev.containerBuildId
 				);
-				this.dockerPath = data.config.dev?.dockerPath ?? getDockerPath();
+				// Miniflare supports one top-level container engine, so every worker
+				// must prepare images through the first selected endpoint.
+				this.dockerPath ??= data.config.dev?.dockerPath ?? getDockerPath();
+				assert(configuredDockerHost);
+				this.dockerHost ??= configuredDockerHost;
 				// keep track of them so we can clean up later
 				for (const container of containerOptions ?? []) {
 					this.containerImageTagsSeen.add(container.image_tag);
 				}
 				await prepareContainerImagesForDev({
 					dockerPath: this.dockerPath,
+					dockerHost: this.dockerHost,
 					containerOptions,
 					onContainerImagePreparationStart: (buildStartEvent) => {
 						this.containerBeingBuilt = {


### PR DESCRIPTION
**[WIP] I'm still debating if this change is strictly needed, even though it improves correctness. Will open for review once I have a few more related changes landed and get more clarity on whether or not to keep this.**

Local container development currently splits Docker access. workerd already uses the selected `dev.container_engine`, but Wrangler and Vite still run image build, pull, login, inspect, tag, rebuild, and cleanup against the default Docker context. On Colima, a custom socket, or `DOCKER_HOST` / `WRANGLER_DOCKER_HOST`, that can prepare or delete images on one daemon while the runtime talks to another.

This change threads the selected engine through those Docker CLI calls. Multi-Worker Vite and Wrangler sessions now fail if Workers resolve to different engines.

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: existing local-container docs already cover `dev.container_engine` and Docker host env vars. This change makes local Docker operations honour that already-documented engine rather than adding a new option or workflow.
<!-- devin-review-badge-begin -->

---

<a href="https://cloudflare.devinenterprise.com/review/cloudflare/workers-sdk/pull/15546" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->