### PR TITLE
Revert "fix(wrangler): tolerate missing KV access when deleting Workers"

### DIFF
--- a/.changeset/fuzzy-waves-delete.md
+++ b/.changeset/fuzzy-waves-delete.md
@@ -1,7 +1,0 @@
----
-"wrangler": patch
----
-
-Allow `wrangler delete` to succeed without Workers KV permissions
-
-Deleting a Worker no longer reports a failure when the API token cannot perform optional cleanup of legacy Workers Sites KV namespaces. Wrangler instead warns that the legacy asset namespaces were not removed.

--- a/packages/wrangler/src/__tests__/delete.test.ts
+++ b/packages/wrangler/src/__tests__/delete.test.ts
@@ -224,35 +224,6 @@ describe("delete", () => {
 		`);
 	});
 
-	it("should succeed when the API token cannot clean up legacy Workers Sites namespaces", async ({
-		expect,
-	}) => {
-		msw.use(
-			http.get(
-				"*/accounts/:accountId/storage/kv/namespaces",
-				() =>
-					HttpResponse.json(
-						{
-							success: false,
-							errors: [{ code: 10000, message: "Authentication error" }],
-							messages: [],
-							result: null,
-						},
-						{ status: 403 }
-					),
-				{ once: true }
-			)
-		);
-		mockDeleteWorkerRequest(expect, { name: "my-script", force: true });
-
-		await runWrangler("delete --name my-script --force");
-
-		expect(std.out).toContain("Successfully deleted my-script");
-		expect(std.warn).toContain(
-			"The Worker was deleted, but Wrangler could not clean up legacy Workers Sites asset namespaces because the API token does not have Workers KV permissions."
-		);
-	});
-
 	it("should delete a site namespace associated with a worker, including it's preview namespace", async ({
 		expect,
 	}) => {

--- a/packages/wrangler/src/delete.ts
+++ b/packages/wrangler/src/delete.ts
@@ -2,7 +2,6 @@ import assert from "node:assert";
 import { APIError, configFileName, UserError } from "@cloudflare/workers-utils";
 import { fetchResult } from "./cfetch";
 import { createCommand } from "./core/create-command";
-import { isAuthenticationError } from "./core/handle-errors";
 import { confirm } from "./dialogs";
 import {
 	deleteKVNamespace,
@@ -159,16 +158,7 @@ export const deleteCommand = createCommand({
 				new URLSearchParams({ force: needsForceDelete.toString() })
 			);
 
-			try {
-				await deleteSiteNamespaceIfExisting(config, scriptName, accountId);
-			} catch (error) {
-				if (!isAuthenticationError(error)) {
-					throw error;
-				}
-				logger.warn(
-					"The Worker was deleted, but Wrangler could not clean up legacy Workers Sites asset namespaces because the API token does not have Workers KV permissions."
-				);
-			}
+			await deleteSiteNamespaceIfExisting(config, scriptName, accountId);
 
 			logger.log("Successfully deleted", scriptName);
 		}


### PR DESCRIPTION
Reverts cloudflare/workers-sdk#15443

Sorry! I also made this fix here and that got merged earlier, so now this PR is causing some test failures due to conflicts: https://github.com/cloudflare/workers-sdk/pull/15472

Just going to revert because the fix is already in place.


<!-- devin-review-badge-begin -->

---

<a href="https://cloudflare.devinenterprise.com/review/cloudflare/workers-sdk/pull/15549" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->