### PR TITLE
fix(wrangler): include transferred_classes in DurableObjectMigration schema

### DIFF
--- a/.changeset/migration-transferred-classes-schema.md
+++ b/.changeset/migration-transferred-classes-schema.md
@@ -5,11 +5,6 @@
 
 Add the missing `transferred_classes` migration to the config schema
 
-`DurableObjectMigration` described `new_classes`, `new_sqlite_classes`,
-`renamed_classes` and `deleted_classes`, but not `transferred_classes`.
-`normalizeAndValidateConfig` has always validated that key, and the deploy path
-forwards it to the API along with the rest of the step, so Transfer migrations
-worked — but `config-schema.json` is generated from the type, so an editor
-resolving `$schema` reported a valid, documented migration as an unknown key.
+`DurableObjectMigration` described `new_classes`, `new_sqlite_classes`, `renamed_classes` and `deleted_classes`, but not `transferred_classes`. `normalizeAndValidateConfig` has always validated that key, and the deploy path forwards it to the API along with the rest of the step, so Transfer migrations worked — but `config-schema.json` is generated from the type, so an editor resolving `$schema` reported a valid, documented migration as an unknown key.
 
 Adding the field to the type puts it in the generated schema. No runtime change.

--- a/.changeset/migration-transferred-classes-schema.md
+++ b/.changeset/migration-transferred-classes-schema.md
@@ -1,0 +1,15 @@
+---
+"@cloudflare/workers-utils": patch
+"wrangler": patch
+---
+
+Add the missing `transferred_classes` migration to the config schema
+
+`DurableObjectMigration` described `new_classes`, `new_sqlite_classes`,
+`renamed_classes` and `deleted_classes`, but not `transferred_classes`.
+`normalizeAndValidateConfig` has always validated that key, and the deploy path
+forwards it to the API along with the rest of the step, so Transfer migrations
+worked — but `config-schema.json` is generated from the type, so an editor
+resolving `$schema` reported a valid, documented migration as an unknown key.
+
+Adding the field to the type puts it in the generated schema. No runtime change.

--- a/packages/workers-utils/src/config/environment.ts
+++ b/packages/workers-utils/src/config/environment.ts
@@ -362,6 +362,12 @@ export type DurableObjectMigration = {
 		from: string;
 		to: string;
 	}[];
+	/** The Durable Objects being transferred from another Worker. */
+	transferred_classes?: {
+		from: string;
+		from_script: string;
+		to: string;
+	}[];
 	/** The Durable Objects being removed. */
 	deleted_classes?: string[];
 };

--- a/packages/workers-utils/src/worker.ts
+++ b/packages/workers-utils/src/worker.ts
@@ -443,6 +443,11 @@ export interface CfDurableObjectMigrations {
 			from: string;
 			to: string;
 		}[];
+		transferred_classes?: {
+			from: string;
+			from_script: string;
+			to: string;
+		}[];
 		deleted_classes?: string[];
 	}[];
 }

--- a/packages/wrangler/src/__tests__/config-schema.test.ts
+++ b/packages/wrangler/src/__tests__/config-schema.test.ts
@@ -6,6 +6,7 @@ type WranglerSchema = {
 	$ref?: string;
 	allOf?: { $ref: string }[];
 	allowTrailingCommas?: boolean;
+	definitions?: Record<string, { properties?: Record<string, unknown> }>;
 };
 
 function readSchema(): WranglerSchema {
@@ -25,5 +26,24 @@ describe("config schema", () => {
 		expect(schema.allowTrailingCommas).toBe(true);
 		expect(schema).not.toHaveProperty("$ref");
 		expect(schema.allOf).toEqual([{ $ref: "#/definitions/RawConfig" }]);
+	});
+
+	it("describes every migration operation wrangler accepts", ({ expect }) => {
+		const schema = readSchema();
+		const migration = schema.definitions?.DurableObjectMigration;
+
+		// The schema is generated from `DurableObjectMigration`, so anything missing
+		// from that type is reported by editors as an unknown key, even though
+		// `normalizeAndValidateConfig` accepts it and the deploy succeeds. All four
+		// operations below are documented on the legacy class-migrations page.
+		expect(Object.keys(migration?.properties ?? {})).toEqual(
+			expect.arrayContaining([
+				"new_classes",
+				"new_sqlite_classes",
+				"renamed_classes",
+				"transferred_classes",
+				"deleted_classes",
+			])
+		);
 	});
 });


### PR DESCRIPTION
## Summary
Add missing `transferred_classes` to `DurableObjectMigration` so generated `config-schema.json` matches what wrangler already validates and deploys.

Fixes #15537

- [x] Tests included/updated
- [x] Documentation not necessary because: this only aligns the JSON schema/types with existing validated runtime behavior; no user-facing docs change.