### PR TITLE
Fix wrangler d1 execute performance for local

### DIFF
--- a/.changeset/wrangler-d1-execute-local-performance.md
+++ b/.changeset/wrangler-d1-execute-local-performance.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Fix `wrangler d1 execute --local` being extremely slow with large SQL files or commands
+
+The local SQL splitter consumed quoted strings and comments character-by-character, re-checking the full accumulated string each time. This made splitting a large quoted value or comment quadratic, so seed files could take tens of seconds to run. The splitter now only inspects a bounded trailing window on each step, making splitting effectively linear. The remote path is unaffected as it imports the file server-side.

--- a/packages/wrangler/src/__tests__/d1/splitter.test.ts
+++ b/packages/wrangler/src/__tests__/d1/splitter.test.ts
@@ -1,3 +1,4 @@
+import { performance } from "node:perf_hooks";
 import { describe, it } from "vitest";
 import {
 	mayContainMultipleStatements,
@@ -454,5 +455,45 @@ describe("splitSqlQuery()", () => {
 						END ; END",
 			]
 		`);
+	});
+
+	describe("performance tests", () => {
+		it("should split a file with a lot of commands", ({ expect }) => {
+			const sql = "INSERT INTO blobs (id, data) VALUES (1, 'xxx');\n".repeat(5 * 1024);
+
+			const startedAt = performance.now();
+			const statements = splitSqlQuery(sql);
+			const elapsedMs = performance.now() - startedAt;
+
+			expect(statements).toHaveLength(5 * 1024);
+			expect(statements[0]).toBe("INSERT INTO blobs (id, data) VALUES (1, 'xxx')");
+			expect(elapsedMs).toBeLessThan(1000);
+		});
+
+		it("should split a file with a large quoted value quickly", ({ expect }) => {
+			const largeValue = "x".repeat(256 * 1024);
+			const sql = `INSERT INTO blobs (id, data) VALUES (1, '${largeValue}');\nSELECT count(*) FROM blobs;`;
+
+			const startedAt = performance.now();
+			const statements = splitSqlQuery(sql);
+			const elapsedMs = performance.now() - startedAt;
+
+			expect(statements).toEqual([
+				`INSERT INTO blobs (id, data) VALUES (1, '${largeValue}')`,
+				"SELECT count(*) FROM blobs"
+			]);
+			expect(elapsedMs).toBeLessThan(1000);
+		});
+
+		it("should split a file with very long comments quickly", ({ expect }) => {
+			const sql = "SELECT 1; -- " + "c".repeat(256 * 1024) + "\nSELECT 2;";
+
+			const startedAt = performance.now();
+			const statements = splitSqlQuery(sql);
+			const elapsedMs = performance.now() - startedAt;
+
+			expect(statements).toEqual(["SELECT 1", "SELECT 2"]);
+			expect(elapsedMs).toBeLessThan(1000);
+		});
 	});
 });

--- a/packages/wrangler/src/__tests__/d1/splitter.test.ts
+++ b/packages/wrangler/src/__tests__/d1/splitter.test.ts
@@ -459,18 +459,24 @@ describe("splitSqlQuery()", () => {
 
 	describe("performance tests", () => {
 		it("should split a file with a lot of commands", ({ expect }) => {
-			const sql = "INSERT INTO blobs (id, data) VALUES (1, 'xxx');\n".repeat(5 * 1024);
+			const sql = "INSERT INTO blobs (id, data) VALUES (1, 'xxx');\n".repeat(
+				5 * 1024
+			);
 
 			const startedAt = performance.now();
 			const statements = splitSqlQuery(sql);
 			const elapsedMs = performance.now() - startedAt;
 
 			expect(statements).toHaveLength(5 * 1024);
-			expect(statements[0]).toBe("INSERT INTO blobs (id, data) VALUES (1, 'xxx')");
+			expect(statements[0]).toBe(
+				"INSERT INTO blobs (id, data) VALUES (1, 'xxx')"
+			);
 			expect(elapsedMs).toBeLessThan(1000);
 		});
 
-		it("should split a file with a large quoted value quickly", ({ expect }) => {
+		it("should split a file with a large quoted value quickly", ({
+			expect,
+		}) => {
 			const largeValue = "x".repeat(256 * 1024);
 			const sql = `INSERT INTO blobs (id, data) VALUES (1, '${largeValue}');\nSELECT count(*) FROM blobs;`;
 
@@ -480,7 +486,7 @@ describe("splitSqlQuery()", () => {
 
 			expect(statements).toEqual([
 				`INSERT INTO blobs (id, data) VALUES (1, '${largeValue}')`,
-				"SELECT count(*) FROM blobs"
+				"SELECT count(*) FROM blobs",
 			]);
 			expect(elapsedMs).toBeLessThan(1000);
 		});

--- a/packages/wrangler/src/d1/splitter.ts
+++ b/packages/wrangler/src/d1/splitter.ts
@@ -233,7 +233,11 @@ function consumeWhile(
  * Pulls characters from the string iterator until the `endMarker` is found.
  */
 function consumeUntilMarker(iterator: Iterator<string>, endMarker: string) {
-	return consumeWhile(iterator, (str) => !str.endsWith(endMarker), endMarker.length);
+	return consumeWhile(
+		iterator,
+		(str) => !str.endsWith(endMarker),
+		endMarker.length
+	);
 }
 
 /**

--- a/packages/wrangler/src/d1/splitter.ts
+++ b/packages/wrangler/src/d1/splitter.ts
@@ -208,16 +208,20 @@ function splitSqlIntoStatements(sql: string): string[] {
 
 /**
  * Pulls characters from the string iterator while the predicate remains true.
+ * Only the bounded trailing window is passed to the predicate.
  */
 function consumeWhile(
 	iterator: Iterator<string>,
-	predicate: (str: string) => boolean
+	predicate: (str: string) => boolean,
+	window: number = 16
 ) {
 	let next = iterator.next();
 	let str = "";
+	let tail = "";
 	while (!next.done) {
 		str += next.value;
-		if (!predicate(str)) {
+		tail = (tail + next.value).slice(-window);
+		if (!predicate(tail)) {
 			break;
 		}
 		next = iterator.next();
@@ -229,7 +233,7 @@ function consumeWhile(
  * Pulls characters from the string iterator until the `endMarker` is found.
  */
 function consumeUntilMarker(iterator: Iterator<string>, endMarker: string) {
-	return consumeWhile(iterator, (str) => !str.endsWith(endMarker));
+	return consumeWhile(iterator, (str) => !str.endsWith(endMarker), endMarker.length);
 }
 
 /**


### PR DESCRIPTION
Fixes #15556.

### Root cause

`splitSqlIntoStatements()` in `packages/wrangler/src/d1/splitter.ts` consumes quoted strings and comments character-by-character via `consumeWhile()` / `consumeUntilMarker()`. 
Each iteration appends to an ever-growing `str` and then evaluates the predicate against the **whole accumulated string** (e.g. `str.endsWith(endMarker)`), forcing the JS engine to flatten/copy the growing string on every character — O(n²) in the length of the quoted value or comment.
This only bites the local path because remote file execution never runs the client-side splitter.

### Measurements

Timing `splitSqlQuery()` on a single 256 KB quoted value / a 256 KB `--` comment:

| Input                     | before (wrangler 4.129) | after fix |
| ------------------------- | ----------------------- | --------- |
| single ~256 KB quoted value | ~17–24 s                | ~20–40 ms |
| ~256 KB line comment        | ~18–19 s                | ~17 ms    |
| 5k small INSERTs            | ~40 ms                  | ~40 ms    |

---


- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: it doesn't change API 

<!-- devin-review-badge-begin -->

---

<a href="https://cloudflare.devinenterprise.com/review/cloudflare/workers-sdk/pull/15557" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->