### PR TITLE
fix(wrangler): avoid RangeError in workflows describe for dynamic retry delays

### DIFF
--- a/.changeset/fix-workflows-describe-dynamic-delay.md
+++ b/.changeset/fix-workflows-describe-dynamic-delay.md
@@ -1,0 +1,7 @@
+﻿---
+"wrangler": patch
+---
+
+Fix `wrangler workflows instances describe` crashing on dynamic retry delays
+
+Fixed an issue where `wrangler workflows instances describe` crashed with `RangeError: Invalid time value` when describing a workflow instance with a dynamic retry delay (`[dynamic]`) waiting between retry attempts. The `Retries At` column now displays `unknown (dynamic delay)` instead of throwing an unhandled exception.

--- a/packages/wrangler/src/__tests__/workflows.test.ts
+++ b/packages/wrangler/src/__tests__/workflows.test.ts
@@ -1058,6 +1058,75 @@ describe("wrangler workflows", () => {
 			expect(output.steps[0].output).toEqual({});
 			expect(std.out).not.toContain("[...output truncated]");
 		});
+
+		it("should describe an instance with dynamic retry delay without throwing RangeError", async ({
+			expect,
+		}) => {
+			writeWranglerConfig();
+			const mockDynamicResponse = {
+				end: null,
+				output: null,
+				params: {},
+				queued: mockQueuedDate.toISOString(),
+				start: mockStartDate.toISOString(),
+				status: "running",
+				success: null,
+				trigger: {
+					source: "unknown",
+				},
+				versionId: "14707576-2549-4848-82ed-f68f8a1b47c7",
+				steps: [
+					{
+						attempts: [
+							{
+								end: mockEndDate.toISOString(),
+								error: {
+									message: "Something failed",
+									name: "Error",
+								},
+								start: mockStartDate.toISOString(),
+								success: false,
+							},
+						],
+						config: {
+							retries: {
+								backoff: "constant",
+								delay: "[dynamic]",
+								limit: 3,
+							},
+							timeout: "10 minutes",
+						},
+						end: null,
+						name: "step-with-dynamic-delay",
+						output: null,
+						start: mockStartDate.toISOString(),
+						success: null,
+						type: "step",
+					},
+				],
+			};
+
+			msw.use(
+				http.get(
+					`*/accounts/:accountId/workflows/some-workflow/instances/:instanceId`,
+					async () => {
+						return HttpResponse.json({
+							success: true,
+							errors: [],
+							messages: [],
+							result: mockDynamicResponse,
+						});
+					},
+					{ once: true }
+				)
+			);
+
+			await runWrangler(
+				`workflows instances describe some-workflow instance-with-dynamic-delay`
+			);
+			expect(std.out).toContain("Retries At:  unknown (dynamic delay)");
+			expect(std.out).toContain("Name:        step-with-dynamic-delay");
+		});
 	});
 
 	describe("instances send-event", () => {

--- a/packages/wrangler/src/workflows/commands/instances/describe.ts
+++ b/packages/wrangler/src/workflows/commands/instances/describe.ts
@@ -1,4 +1,3 @@
-import assert from "node:assert";
 import { logRaw } from "@cloudflare/cli-shared-helpers";
 import { red, white } from "@cloudflare/cli-shared-helpers/colors";
 import {
@@ -226,19 +225,21 @@ function logStep(
 
 		if (step.success === null) {
 			const latestAttempt = step.attempts.at(-1);
-			let delay = step.config.retries.delay;
+			const delay = step.config.retries.delay;
 			if (latestAttempt !== undefined && latestAttempt.success === false) {
-				assert(
-					latestAttempt.end,
-					"end date always exists in the API for completed attempts"
-				);
-				const endDate = new Date(latestAttempt.end);
-				if (typeof delay === "string") {
-					delay = ms(delay);
+				if (delay === "[dynamic]") {
+					formattedStep["Retries At"] = "unknown (dynamic delay)";
+				} else if (latestAttempt.end) {
+					const delayMs = typeof delay === "string" ? ms(delay) : delay;
+					if (typeof delayMs === "number" && !Number.isNaN(delayMs)) {
+						const endDate = new Date(latestAttempt.end);
+						const retryDate = addMilliseconds(endDate, delayMs);
+						if (!Number.isNaN(retryDate.getTime())) {
+							formattedStep["Retries At"] =
+								`${retryDate.toLocaleString()} (in ${formatDistanceToNowStrict(retryDate)} from now)`;
+						}
+					}
 				}
-				const retryDate = addMilliseconds(endDate, delay);
-				formattedStep["Retries At"] =
-					`${retryDate.toLocaleString()} (in ${formatDistanceToNowStrict(retryDate)} from now)`;
 			}
 		}
 	}


### PR DESCRIPTION
Fixes #15548

### Summary of Changes

When a Workflows step defines a dynamic retry delay (e.g. `delay: () => ...`), the Workflows API returns `step.config.retries.delay` as the sentinel string `"[dynamic]"`.

In `wrangler workflows instances describe`, this string was passed to `ms(delay)`, which returns `NaN`. Adding `NaN` to `latestAttempt.end` produced an invalid `Date`, which threw `RangeError: Invalid time value` inside `formatDistanceToNowStrict(retryDate)`.

This PR:
1. Checks for `delay === "[dynamic]"` and formats `"Retries At"` as `"unknown (dynamic delay)"`.
2. Validates that `delayMs` and `retryDate` are valid numbers/dates before calling date-formatting utilities.
3. Replaces `assert(latestAttempt.end)` with a null-safe guard `else if (latestAttempt.end)`.
4. Adds a unit test in `packages/wrangler/src/__tests__/workflows.test.ts` verifying that `instances describe` renders instances with dynamic retry delays without throwing `RangeError`.
5. Adds a patch changeset for `wrangler`.

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: internal CLI output formatting bug fix

<!-- devin-review-badge-begin -->

---

<a href="https://cloudflare.devinenterprise.com/review/cloudflare/workers-sdk/pull/15562" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->