### PR TITLE
[pages-shared] Encode filenames in HTML redirects

### DIFF
--- a/.changeset/tidy-pages-unicode-redirects.md
+++ b/.changeset/tidy-pages-unicode-redirects.md
@@ -1,0 +1,8 @@
+---
+"@cloudflare/pages-shared": patch
+"wrangler": patch
+---
+
+Encode filenames in Pages HTML redirects
+
+Fix `wrangler pages dev` returning a 502 response when redirecting HTML paths containing Unicode characters. Keep reserved characters in filenames encoded in the redirect destination and preserve the request query string.

--- a/packages/pages-shared/__tests__/asset-server/handler.test.ts
+++ b/packages/pages-shared/__tests__/asset-server/handler.test.ts
@@ -10,6 +10,40 @@ import type { Metadata } from "../../asset-server/metadata";
 import type { RedirectRule } from "@cloudflare/workers-shared/utils/configuration/types";
 
 describe("asset-server handler", () => {
+	describe.each(["WHAT’S YOUR DREAM JOB", "café", "猫", "🚀", "a#b?c%d"])(
+		"HTML redirects for %s",
+		(name) => {
+			test.for([
+				["/index/", "/index.html", "/"],
+				["/", ".html", ""],
+				["/index.html", "/index.html", "/"],
+				[".html", ".html", ""],
+				["/index", "/index.html", "/"],
+				["", "/index.html", "/"],
+			])(
+				"encodes the destination for suffix %s",
+				async ([suffix, assetSuffix, destinationSuffix], { expect }) => {
+					const encodedName = encodeURIComponent(name);
+					const search = "?next=%2Fhome&tag=%23one";
+					const findAssetEntryForPath = async (path: string) =>
+						path === `/${name}${assetSuffix}` ? path : null;
+					const { response } = await getTestResponse({
+						request: `https://example.com/${encodedName}${suffix}${search}`,
+						findAssetEntryForPath,
+					});
+					const destination = `/${encodedName}${destinationSuffix}${search}`;
+					expect(response.status).toBe(308);
+					expect(response.headers.get("Location")).toBe(destination);
+					const { response: asset } = await getTestResponse({
+						request: `https://example.com${destination}`,
+						findAssetEntryForPath,
+					});
+					expect(asset.status).toBe(200);
+				}
+			);
+		}
+	);
+
 	test("Returns appropriate status codes", async ({ expect }) => {
 		const statuses = [301, 302, 303, 307, 308];
 		const metadata = createMetadataObjectWithRedirects(
@@ -121,7 +155,7 @@ describe("asset-server handler", () => {
 				findAssetEntryForPath,
 			});
 			expect(response.status).toBe(308);
-			expect(response.headers.get("Location")).toEqual("/www.example.com/	/");
+			expect(response.headers.get("Location")).toEqual("/www.example.com/%09/");
 		}
 		{
 			const { response } = await getTestResponse({
@@ -130,7 +164,7 @@ describe("asset-server handler", () => {
 				findAssetEntryForPath,
 			});
 			expect(response.status).toBe(308);
-			expect(response.headers.get("Location")).toEqual("/www.example.com/\\/");
+			expect(response.headers.get("Location")).toEqual("/www.example.com/%5C/");
 		}
 		{
 			const { response } = await getTestResponse({
@@ -148,7 +182,7 @@ describe("asset-server handler", () => {
 				findAssetEntryForPath,
 			});
 			expect(response.status).toBe(308);
-			expect(response.headers.get("Location")).toEqual("/www.example.com/\\/");
+			expect(response.headers.get("Location")).toEqual("/www.example.com/%5C/");
 		}
 		{
 			const { response } = await getTestResponse({

--- a/packages/pages-shared/asset-server/handler.ts
+++ b/packages/pages-shared/asset-server/handler.ts
@@ -232,6 +232,11 @@ export async function generateHandler<
 
 	let assetEntry: AssetEntry | null;
 
+	function redirectToPath(path: string): Response {
+		const encodedPath = path.split("/").map(encodeURIComponent).join("/");
+		return new PermanentRedirectResponse(`${encodedPath}${search}`);
+	}
+
 	async function generateResponse(): Promise<Response> {
 		const match =
 			staticRedirectsMatcher() || generateRedirectsMatcher()({ request })[0];
@@ -294,17 +299,13 @@ export async function generateHandler<
 			if ((assetEntry = await findAssetEntryForPath(`${pathname}index.html`))) {
 				return serveAsset(assetEntry);
 			} else if (pathname.endsWith("/index/")) {
-				return new PermanentRedirectResponse(
-					`/${pathname.slice(1, -"index/".length)}${search}`
-				);
+				return redirectToPath(`/${pathname.slice(1, -"index/".length)}`);
 			} else if (
 				(assetEntry = await findAssetEntryForPath(
 					`${pathname.replace(/\/$/, ".html")}`
 				))
 			) {
-				return new PermanentRedirectResponse(
-					`/${pathname.slice(1, -1)}${search}`
-				);
+				return redirectToPath(`/${pathname.slice(1, -1)}`);
 			} else {
 				return notFound();
 			}
@@ -317,30 +318,26 @@ export async function generateHandler<
 				// or if pathname is /.html
 				// FIXME: this doesn't handle files in directories ie: /foobar/.html
 				if (extensionlessPath.endsWith("/index")) {
-					return new PermanentRedirectResponse(
-						`${extensionlessPath.replace(/\/index$/, "/")}${search}`
-					);
+					return redirectToPath(extensionlessPath.replace(/\/index$/, "/"));
 				} else if (
 					(await findAssetEntryForPath(extensionlessPath)) ||
 					extensionlessPath === "/"
 				) {
 					return serveAsset(assetEntry);
 				} else {
-					return new PermanentRedirectResponse(`${extensionlessPath}${search}`);
+					return redirectToPath(extensionlessPath);
 				}
 			} else {
 				return serveAsset(assetEntry);
 			}
 		} else if (pathname.endsWith("/index")) {
-			return new PermanentRedirectResponse(
-				`/${pathname.slice(1, -"index".length)}${search}`
-			);
+			return redirectToPath(`/${pathname.slice(1, -"index".length)}`);
 		} else if ((assetEntry = await findAssetEntryForPath(`${pathname}.html`))) {
 			return serveAsset(assetEntry);
 		}
 
 		if ((assetEntry = await findAssetEntryForPath(`${pathname}/index.html`))) {
-			return new PermanentRedirectResponse(`${pathname}/${search}`);
+			return redirectToPath(`${pathname}/`);
 		} else {
 			return notFound();
 		}

--- a/packages/wrangler/e2e/pages-dev.test.ts
+++ b/packages/wrangler/e2e/pages-dev.test.ts
@@ -14,6 +14,29 @@ const port = await getPort();
 const inspectorPort = await getPort();
 const cmd = "wrangler pages dev";
 describe.sequential("wrangler pages dev", () => {
+	it("should redirect Unicode HTML paths and serve the decoded filename", async ({
+		expect,
+	}) => {
+		const helper = new WranglerE2ETestHelper();
+		await helper.seed({
+			"WHAT’S YOUR DREAM JOB/index.html": "<h1>hello</h1>",
+		});
+		const worker = helper.runLongLived(
+			`${cmd} --port ${port} --inspector-port ${inspectorPort} .`
+		);
+		const { url } = await worker.waitForReady();
+		const requestUrl = `${url}/WHAT%E2%80%99S%20YOUR%20DREAM%20JOB/index.html?lang=en`;
+		const redirect = await fetch(requestUrl, { redirect: "manual" });
+		expect(redirect.status).toBe(308);
+		expect(redirect.headers.get("Location")).toBe(
+			"/WHAT%E2%80%99S%20YOUR%20DREAM%20JOB/?lang=en"
+		);
+		await redirect.body?.cancel();
+		const response = await fetch(requestUrl);
+		expect(response.status).toBe(200);
+		expect(await response.text()).toBe("<h1>hello</h1>");
+	});
+
 	it("should warn if no [--compatibility_date] command line arg was specified", async ({
 		expect,
 	}) => {


### PR DESCRIPTION
Fixes #15559.

Pages HTML redirects now keep filenames percent-encoded in `Location`. A request for `/WHAT%E2%80%99S%20YOUR%20DREAM%20JOB/index.html` redirects to the directory URL and serves its index, instead of returning a ByteString-related 502 in `wrangler pages dev`. Reserved characters in filenames stay in the path, and the incoming query string is preserved.

The fix belongs in the shared Pages handler: file lookup still uses the decoded path, while canonical redirect destinations are encoded by segment. Explicit `_redirects` rules keep their existing behavior. The shared tests cover all six HTML canonicalization paths with Unicode and reserved characters; the Pages dev end-to-end regression exercises the built CLI and follows the redirect to the file contents.

Validation: 79 shared-package tests pass (one existing todo), 14 neighboring Wrangler unit tests pass, and the new CLI end-to-end test passes. Affected builds, package/test type checks, type-aware lint and formatting pass. Full `pnpm check` stops at the unchanged `fixtures/import-npm` clean-install script because native Windows cannot execute its POSIX `rm` command.

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: this restores existing Pages HTML redirect behavior; a patch changeset is included.

> [!NOTE]
> This is a contribution from an AI agent: Codex, GPT-6.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required; the regression covers the local Pages CLI and the shared redirect behavior without a new service or configuration surface.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)

<!-- devin-review-badge-begin -->

---

<a href="https://cloudflare.devinenterprise.com/review/cloudflare/workers-sdk/pull/15563" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->