### PR TITLE
fix(vitest-plugin): flush console logs from another I/O context without waiting for the runner's next message

### DIFF
--- a/.changeset/late-console-logs-flush.md
+++ b/.changeset/late-console-logs-flush.md
@@ -1,0 +1,7 @@
+---
+"@cloudflare/vitest-plugin": patch
+---
+
+fix: flush `console.log()` calls made from another I/O context without waiting for the runner's next message
+
+Vitest awaits every RPC call it made before it reports a test file as finished. A `console.log()` from another I/O context (a handler reached through `SELF`, a queue consumer, a `waitUntil()` callback) is buffered and sent with the runner's next message, so a log with nothing from the runner following it — the last batch of a queue consumed as the file ends, for example — left the run waiting on itself: the file's tests passed and vitest never finished. The buffer is now flushed from the runner's context as soon as a log is buffered.

--- a/packages/vitest-plugin/src/worker/index.ts
+++ b/packages/vitest-plugin/src/worker/index.ts
@@ -213,13 +213,18 @@ export class __VITEST_POOL_WORKERS_RUNNER_DURABLE_OBJECT__ extends DurableObject
 			await import("vitest/worker");
 
 		poolSocket.accept();
-		// Sending over the runner's WebSocket from another Durable Object requires
-		// I/O that cannot complete if that object's input gate breaks. Buffer console
-		// messages and flush them on the next successful post from the runner's
-		// context instead. In practice Vitest always sends further RPC messages
-		// (e.g. task updates/results) from the runner once execution returns to it,
-		// so buffered logs are flushed; there's no guarantee for logs emitted with
-		// nothing following, but dropping them is preferable to hanging teardown.
+		// Sending over the runner's WebSocket from another I/O context (a handler
+		// reached through `SELF`, a user Durable Object, a queue consumer, ...)
+		// fails. Buffer console messages and flush them from the runner's context
+		// instead: on the next successful post, and on a timer created here, in the
+		// runner's own context, because Vitest awaits every RPC call it made
+		// (`rpcDone()`) before it posts a file's result and a buffered log's call
+		// only settles once the message is sent — a log with nothing from the
+		// runner following it (a queue batch consumed as the file ends, a
+		// `waitUntil()` callback) would otherwise leave the run waiting on itself.
+		// The other context cannot resend from the runner reliably: an object
+		// whose input gate broke never completes that request (#14180), and
+		// neither does a handler that already answered.
 		const pendingConsoleLogs: unknown[] = [];
 		const sendPendingConsoleLogs = () => {
 			while (pendingConsoleLogs.length > 0) {
@@ -227,7 +232,20 @@ export class __VITEST_POOL_WORKERS_RUNNER_DURABLE_OBJECT__ extends DurableObject
 				pendingConsoleLogs.shift();
 			}
 		};
-
+		const flushPendingConsoleLogs = setInterval(() => {
+			if (pendingConsoleLogs.length === 0) {
+				return;
+			}
+			try {
+				sendPendingConsoleLogs();
+			} catch (error) {
+				clearInterval(flushPendingConsoleLogs);
+				__console.error("Error flushing console logs from the runner:", error);
+			}
+		}, 50);
+		poolSocket.addEventListener("close", () => {
+			clearInterval(flushPendingConsoleLogs);
+		});
 		init({
 			post: (response) => {
 				try {

--- a/packages/vitest-plugin/test/console.test.ts
+++ b/packages/vitest-plugin/test/console.test.ts
@@ -158,3 +158,56 @@ test("does not hang after logging from a rejected Durable Object input gate", as
 	expect(result.stdout).toMatch(/before rejection 1[\s\S]*before rejection 2/);
 	expect(result.stdout.match(/before rejection/g)).toHaveLength(2);
 });
+
+test("does not hang when the last console.log() of a file comes from another I/O context", async ({
+	expect,
+	seed,
+	vitestRun,
+}) => {
+	await seed({
+		"vitest.config.mts": vitestConfig(
+			{
+				main: "./index.ts",
+				miniflare: {
+					compatibilityDate: "2025-12-02",
+					compatibilityFlags: ["nodejs_compat"],
+				},
+			},
+			{ reporters: ["default", "./slow-reporter.mjs"] }
+		),
+		// Delays the replies to the file's last task updates, which is when a log
+		// from another context has no further message from the runner following
+		// it. Without the flush from the runner's context the run waits for that
+		// log's reply, which is only sent with the next message.
+		"slow-reporter.mjs": dedent`
+			const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+			export default class SlowReporter {
+				async onTaskUpdate() { await sleep(500); }
+				async onTestCaseResult() { await sleep(500); }
+				async onTestModuleEnd() { await sleep(500); }
+			}
+		`,
+		"index.ts": dedent`
+			export default {
+				fetch(request, env, ctx) {
+					ctx.waitUntil(new Promise((resolve) => setTimeout(() => {
+						console.log("late log");
+						resolve();
+					}, 200)));
+					return new Response();
+				}
+			}
+		`,
+		"index.test.ts": dedent`
+			import { SELF } from "cloudflare:test";
+			import { expect, it } from "vitest";
+			it("sends request", async () => {
+				const response = await SELF.fetch("https://example.com");
+				expect(response.ok).toBe(true);
+			});
+		`,
+	});
+	const result = await vitestRun();
+	expect(await result.exitCode).toBe(0);
+	expect(result.stdout).toMatch("late log");
+});


### PR DESCRIPTION
Fixes #15498.

A test file whose last `console.log()` comes from another I/O context never finishes: its tests pass, the reporter prints them, and vitest waits forever with no error.

## Why

Vitest awaits every RPC call it made (`rpcDone()` in `vitest/worker`) before it posts a file's `testfileFinished`. Since #14678, a `console.log()` made from another I/O context (a handler reached through `SELF`, a user Durable Object, a queue consumer, a `waitUntil()` callback) is buffered in `pendingConsoleLogs` and only sent with the runner's **next** `post`. When the log lands after the file's last task update — for example the last batch of a queue consumed as the file ends — there is no next post: vitest is waiting for that log's reply, and the log is waiting for vitest's next message. The comment above the buffer assumed such a log would simply be dropped; vitest awaits it instead.

Traced in a real project (38 files, `@cloudflare/vitest-pool-workers` 0.22.0, GitHub-hosted Linux runner): the runner received the reply to the file's last `onTaskUpdate`, five `onUserConsoleLog` posts from the queue consumer's context then threw `Cannot perform I/O on behalf of a different request` and were buffered, `finishSendTasksUpdate` completed, and nothing followed. On a fast machine the batch lands after `testfileFinished` and everything works, which is why it looks like a flaky CI-only hang.

## Fix

The context that logged cannot resend from the runner reliably — from an object whose input gate broke that request never completes (#14180), and neither does it from a handler that has already answered (a `waitUntil()` timer) — so the runner's own context, which owns the socket, drains the buffer on a timer created inside it. The next successful post still flushes the buffer as before.

## Test

The new test in `test/console.test.ts` makes the race deterministic: a reporter delays the replies to the last task updates, and a `waitUntil()` timer in a `SELF` handler logs inside that window. Without the fix the seeded run never exits; with it, it exits 0 and prints the log.

Verified on the seeded scenarios directly against the built package (the new one, the `SELF` one and the #14180 one), and with the equivalent patch on 0.22.0 in the project above: 10 consecutive CI runs without a stall, after the job had stalled in 4 of the previous 11 runs on that branch and in 12 of 12 diagnostic jobs that afternoon.

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: it's a bug fix

> [!NOTE]
> This is a contribution from an AI agent: Claude Code (Claude Fable 5.1), working at the request of @luccamordente, who will follow up on the review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013iFkoM7ViertzyX8r3tBUv
