### PR TITLE
[wrangler] Handle dynamic retry delays in workflows instances describe

### DIFF
--- a/.changeset/workflows-describe-dynamic-delay.md
+++ b/.changeset/workflows-describe-dynamic-delay.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Fix `wrangler workflows instances describe` crashing on dynamic retry delays
+
+The Workflows API serializes function retry delays as `"[dynamic]"`. The describe command previously parsed that as a duration, produced an Invalid Date, and threw `RangeError: Invalid time value` before printing remaining steps. It now renders `unknown (dynamic delay)` and also tolerates attempts whose `end` timestamp is missing.

--- a/packages/wrangler/src/__tests__/workflows.test.ts
+++ b/packages/wrangler/src/__tests__/workflows.test.ts
@@ -157,7 +157,7 @@ describe("wrangler workflows", () => {
 				`
 				"wrangler workflows
 
-				?? Manage Workflows
+				🔁 Manage Workflows
 
 				COMMANDS
 				  wrangler workflows list                     List Workflows associated to account
@@ -265,15 +265,15 @@ describe("wrangler workflows", () => {
 			expect(std.out).toMatchInlineSnapshot(
 				`
 				"
-				 ?? wrangler x.x.x
-				??????????????????
-				???????????
-				? Name ? Script name ? Class name ? Created ? Modified ?
-				???????????
-				? wf_1 ? wf_script_1 ? wf_class_1 ? [mock-create-date] ? [mock-modified-date] ?
-				???????????
-				? wf_2 ? wf_script_2 ? wf_class_2 ? [mock-create-date] ? [mock-modified-date] ?
-				???????????"
+				 ⛅️ wrangler x.x.x
+				──────────────────
+				┌─┬─┬─┬─┬─┐
+				│ Name │ Script name │ Class name │ Created │ Modified │
+				├─┼─┼─┼─┼─┤
+				│ wf_1 │ wf_script_1 │ wf_class_1 │ [mock-create-date] │ [mock-modified-date] │
+				├─┼─┼─┼─┼─┤
+				│ wf_2 │ wf_script_2 │ wf_class_2 │ [mock-create-date] │ [mock-modified-date] │
+				└─┴─┴─┴─┴─┘"
 			`
 			);
 		});
@@ -482,27 +482,27 @@ describe("wrangler workflows", () => {
 			expect(std.out).toMatchInlineSnapshot(
 				`
 				"
-				 ?? wrangler x.x.x
-				??????????????????
-				???????????
-				? Instance ID ? Version ? Created ? Modified ? Status ?
-				???????????
-				? a ? c ? [mock-create-date] ? [mock-modified-date] ? ? Completed ?
-				???????????
-				? b ? c ? [mock-create-date] ? [mock-modified-date] ? ? Errored ?
-				???????????
-				? c ? c ? [mock-create-date] ? [mock-modified-date] ? ?? Paused ?
-				???????????
-				? d ? c ? [mock-create-date] ? [mock-modified-date] ? ? Queued ?
-				???????????
-				? d ? c ? [mock-create-date] ? [mock-modified-date] ? ? Running ?
-				???????????
-				? e ? c ? [mock-create-date] ? [mock-modified-date] ? ?? Terminated ?
-				???????????
-				? f ? c ? [mock-create-date] ? [mock-modified-date] ? ? Waiting ?
-				???????????
-				? g ? c ? [mock-create-date] ? [mock-modified-date] ? ?? Waiting for Pause ?
-				???????????"
+				 ⛅️ wrangler x.x.x
+				──────────────────
+				┌─┬─┬─┬─┬─┐
+				│ Instance ID │ Version │ Created │ Modified │ Status │
+				├─┼─┼─┼─┼─┤
+				│ a │ c │ [mock-create-date] │ [mock-modified-date] │ ✅ Completed │
+				├─┼─┼─┼─┼─┤
+				│ b │ c │ [mock-create-date] │ [mock-modified-date] │ ❌ Errored │
+				├─┼─┼─┼─┼─┤
+				│ c │ c │ [mock-create-date] │ [mock-modified-date] │ ⏸️ Paused │
+				├─┼─┼─┼─┼─┤
+				│ d │ c │ [mock-create-date] │ [mock-modified-date] │ ⌛ Queued │
+				├─┼─┼─┼─┼─┤
+				│ d │ c │ [mock-create-date] │ [mock-modified-date] │ ▶ Running │
+				├─┼─┼─┼─┼─┤
+				│ e │ c │ [mock-create-date] │ [mock-modified-date] │ 🚫 Terminated │
+				├─┼─┼─┼─┼─┤
+				│ f │ c │ [mock-create-date] │ [mock-modified-date] │ ⏰ Waiting │
+				├─┼─┼─┼─┼─┤
+				│ g │ c │ [mock-create-date] │ [mock-modified-date] │ ⏱️ Waiting for Pause │
+				└─┴─┴─┴─┴─┘"
 			`
 			);
 		});
@@ -969,26 +969,26 @@ describe("wrangler workflows", () => {
 			await runWrangler(`workflows instances describe some-workflow bar`);
 			expect(std.out).toMatchInlineSnapshot(`
 				"
-				 ?? wrangler x.x.x
-				??????????????????
+				 ⛅️ wrangler x.x.x
+				──────────────────
 				  Name:      event
-				  Type:      ?? Waiting for event
+				  Type:      👀 Waiting for event
 				  Start:     [mock-start-date]
 				  End:       [mock-end-date]
 				  Duration:  4 years
 				  Output:    {}
 				  Name:      string
-				  Type:      ?? Step
+				  Type:      🎯 Step
 				  Start:     [mock-start-date]
 				  End:       [mock-end-date]
 				  Duration:  4 years
-				  Success:   ? Yes
+				  Success:   ✅ Yes
 				  Output:    {}
-				???????????
-				? Start ? End ? Duration ? State ? Error ?
-				???????????
-				? [mock-start-date] ? [mock-end-date] ? 4 years ? ? Success ? string: string ?
-				???????????"
+				┌─┬─┬─┬─┬─┐
+				│ Start │ End │ Duration │ State │ Error │
+				├─┼─┼─┼─┼─┤
+				│ [mock-start-date] │ [mock-end-date] │ 4 years │ ✅ Success │ string: string │
+				└─┴─┴─┴─┴─┘"
 			`);
 		});
 
@@ -1001,26 +1001,26 @@ describe("wrangler workflows", () => {
 			await runWrangler(`workflows instances describe some-workflow`);
 			expect(std.out).toMatchInlineSnapshot(`
 				"
-				 ?? wrangler x.x.x
-				??????????????????
+				 ⛅️ wrangler x.x.x
+				──────────────────
 				  Name:      event
-				  Type:      ?? Waiting for event
+				  Type:      👀 Waiting for event
 				  Start:     [mock-start-date]
 				  End:       [mock-end-date]
 				  Duration:  4 years
 				  Output:    {}
 				  Name:      string
-				  Type:      ?? Step
+				  Type:      🎯 Step
 				  Start:     [mock-start-date]
 				  End:       [mock-end-date]
 				  Duration:  4 years
-				  Success:   ? Yes
+				  Success:   ✅ Yes
 				  Output:    {}
-				???????????
-				? Start ? End ? Duration ? State ? Error ?
-				???????????
-				? [mock-start-date] ? [mock-end-date] ? 4 years ? ? Success ? string: string ?
-				???????????"
+				┌─┬─┬─┬─┬─┐
+				│ Start │ End │ Duration │ State │ Error │
+				├─┼─┼─┼─┼─┤
+				│ [mock-start-date] │ [mock-end-date] │ 4 years │ ✅ Success │ string: string │
+				└─┴─┴─┴─┴─┘"
 			`);
 		});
 
@@ -1208,7 +1208,7 @@ describe("wrangler workflows", () => {
 				"workflows instances send-event some-workflow bar --type my-event"
 			);
 			expect(std.info).toMatchInlineSnapshot(
-				`"?? The event with type "my-event" was sent to the instance "bar" from some-workflow"`
+				`"📤 The event with type "my-event" was sent to the instance "bar" from some-workflow"`
 			);
 		});
 
@@ -1223,7 +1223,7 @@ describe("wrangler workflows", () => {
 				`workflows instances send-event some-workflow bar --type my-event --payload '{"key": "value"}'`
 			);
 			expect(std.info).toMatchInlineSnapshot(
-				`"?? The event with type "my-event" and payload "{"key": "value"}" was sent to the instance "bar" from some-workflow"`
+				`"📤 The event with type "my-event" and payload "{"key": "value"}" was sent to the instance "bar" from some-workflow"`
 			);
 		});
 
@@ -1271,7 +1271,7 @@ describe("wrangler workflows", () => {
 
 			await runWrangler(`workflows instances pause some-workflow bar`);
 			expect(std.info).toMatchInlineSnapshot(
-				`"?? The instance "bar" from some-workflow was paused successfully"`
+				`"⏸️ The instance "bar" from some-workflow was paused successfully"`
 			);
 		});
 
@@ -1316,7 +1316,7 @@ describe("wrangler workflows", () => {
 
 			await runWrangler(`workflows instances resume some-workflow bar`);
 			expect(std.info).toMatchInlineSnapshot(
-				`"?? The instance "bar" from some-workflow was resumed successfully"`
+				`"🔄 The instance "bar" from some-workflow was resumed successfully"`
 			);
 		});
 
@@ -1364,7 +1364,7 @@ describe("wrangler workflows", () => {
 
 			await runWrangler(`workflows instances terminate some-workflow bar`);
 			expect(std.info).toMatchInlineSnapshot(
-				`"?? The instance "bar" from some-workflow was terminated successfully"`
+				`"🥷 The instance "bar" from some-workflow was terminated successfully"`
 			);
 		});
 
@@ -1380,7 +1380,7 @@ describe("wrangler workflows", () => {
 				`workflows instances terminate some-workflow bar --rollback`
 			);
 			expect(std.info).toMatchInlineSnapshot(
-				`"?? The instance "bar" from some-workflow was terminated successfully"`
+				`"🥷 The instance "bar" from some-workflow was terminated successfully"`
 			);
 		});
 
@@ -1571,7 +1571,7 @@ describe("wrangler workflows", () => {
 
 			await runWrangler(`workflows instances restart some-workflow bar`);
 			expect(std.info).toMatchInlineSnapshot(
-				`"?? The instance "bar" from some-workflow was restarted successfully"`
+				`"🥷 The instance "bar" from some-workflow was restarted successfully"`
 			);
 		});
 
@@ -1621,7 +1621,7 @@ describe("wrangler workflows", () => {
 				`workflows instances restart some-workflow bar --from-step-name process --from-step-count 2 --from-step-type do`
 			);
 			expect(std.info).toMatchInlineSnapshot(
-				`"?? The instance "bar" from some-workflow was restarted successfully"`
+				`"🥷 The instance "bar" from some-workflow was restarted successfully"`
 			);
 		});
 
@@ -1659,7 +1659,7 @@ describe("wrangler workflows", () => {
 
 			await runWrangler(`workflows instances terminate-all some-workflow`);
 			expect(std.info).toMatchInlineSnapshot(
-				`"?? A job to terminate instances from Workflow "some-workflow"  has been started. It might take a few minutes to complete."`
+				`"🥷 A job to terminate instances from Workflow "some-workflow"  has been started. It might take a few minutes to complete."`
 			);
 		});
 
@@ -1688,7 +1688,7 @@ describe("wrangler workflows", () => {
 
 			await runWrangler(`workflows instances terminate-all some-workflow`);
 			expect(std.info).toMatchInlineSnapshot(
-				`"?? A job to terminate instances from Workflow "some-workflow"  has been started. It might take a few minutes to complete."`
+				`"🥷 A job to terminate instances from Workflow "some-workflow"  has been started. It might take a few minutes to complete."`
 			);
 		});
 
@@ -1702,7 +1702,7 @@ describe("wrangler workflows", () => {
 				`workflows instances terminate-all some-workflow --status queued`
 			);
 			expect(std.info).toMatchInlineSnapshot(
-				`"?? A job to terminate instances from Workflow "some-workflow" with status "queued" has been started. It might take a few minutes to complete."`
+				`"🥷 A job to terminate instances from Workflow "some-workflow" with status "queued" has been started. It might take a few minutes to complete."`
 			);
 		});
 
@@ -1721,7 +1721,7 @@ describe("wrangler workflows", () => {
 				`workflows instances terminate-all some-workflow --status queued`
 			);
 			expect(std.info).toMatchInlineSnapshot(
-				`"?? A job to terminate instances from Workflow "some-workflow" with status "queued" is already running. It might take a few minutes to complete."`
+				`"🥷 A job to terminate instances from Workflow "some-workflow" with status "queued" is already running. It might take a few minutes to complete."`
 			);
 		});
 
@@ -1774,7 +1774,7 @@ describe("wrangler workflows", () => {
 			await runWrangler(`workflows trigger some-workflow`);
 			expect(std);
 			expect(std.info).toMatchInlineSnapshot(
-				`"?? Workflow instance "3c70754a-8435-4498-92ad-22e2e2c90853" has been queued successfully"`
+				`"🚀 Workflow instance "3c70754a-8435-4498-92ad-22e2e2c90853" has been queued successfully"`
 			);
 		});
 
@@ -1806,9 +1806,9 @@ describe("wrangler workflows", () => {
 			expect(std.out).toMatchInlineSnapshot(
 				`
 				"
-				 ?? wrangler x.x.x
-				??????????????????
-				? Workflow "some-workflow" removed successfully.
+				 ⛅️ wrangler x.x.x
+				──────────────────
+				✅ Workflow "some-workflow" removed successfully.
 				 Note that running instances might take a few minutes to be properly terminated."
 			`
 			);
@@ -2471,7 +2471,7 @@ describe("wrangler workflows", () => {
 	});
 
 	// =========================================================================
-	// Local commands (--local) ? hitting /cdn-cgi/local/explorer/api/workflows/...
+	// Local commands (--local) — hitting /cdn-cgi/local/explorer/api/workflows/...
 	// =========================================================================
 
 	describe("local", () => {
@@ -2659,7 +2659,7 @@ describe("wrangler workflows", () => {
 					`workflows trigger my-workflow '{"foo":"bar"}' --local`
 				);
 				expect(std.info).toMatchInlineSnapshot(
-					`"?? Workflow instance "local-instance-123" has been triggered successfully"`
+					`"🚀 Workflow instance "local-instance-123" has been triggered successfully"`
 				);
 			});
 
@@ -2681,7 +2681,7 @@ describe("wrangler workflows", () => {
 
 				await runWrangler("workflows trigger my-workflow --local");
 				expect(std.info).toMatchInlineSnapshot(
-					`"?? Workflow instance "local-instance-456" has been triggered successfully"`
+					`"🚀 Workflow instance "local-instance-456" has been triggered successfully"`
 				);
 			});
 		});
@@ -2938,7 +2938,7 @@ describe("wrangler workflows", () => {
 				await runWrangler(
 					"workflows instances describe my-workflow instance-123 --local"
 				);
-				// Step details go through logger.log ? std.out
+				// Step details go through logger.log → std.out
 				expect(std.out).toContain("step1");
 				expect(std.out).toContain("Step");
 			});
@@ -2972,7 +2972,7 @@ describe("wrangler workflows", () => {
 					"workflows instances pause my-workflow instance-123 --local"
 				);
 				expect(std.info).toMatchInlineSnapshot(
-					`"?? The instance "instance-123" from my-workflow was paused successfully"`
+					`"⏸️ The instance "instance-123" from my-workflow was paused successfully"`
 				);
 			});
 		});
@@ -3005,7 +3005,7 @@ describe("wrangler workflows", () => {
 					"workflows instances resume my-workflow instance-123 --local"
 				);
 				expect(std.info).toMatchInlineSnapshot(
-					`"?? The instance "instance-123" from my-workflow was resumed successfully"`
+					`"🔄 The instance "instance-123" from my-workflow was resumed successfully"`
 				);
 			});
 		});
@@ -3039,7 +3039,7 @@ describe("wrangler workflows", () => {
 					"workflows instances terminate my-workflow instance-123 --local"
 				);
 				expect(std.info).toMatchInlineSnapshot(
-					`"?? The instance "instance-123" from my-workflow was terminated successfully"`
+					`"🥷 The instance "instance-123" from my-workflow was terminated successfully"`
 				);
 			});
 
@@ -3070,7 +3070,7 @@ describe("wrangler workflows", () => {
 					"workflows instances terminate my-workflow instance-123 --local --rollback"
 				);
 				expect(std.info).toMatchInlineSnapshot(
-					`"?? The instance "instance-123" from my-workflow was terminated successfully"`
+					`"🥷 The instance "instance-123" from my-workflow was terminated successfully"`
 				);
 			});
 		});
@@ -3152,7 +3152,7 @@ describe("wrangler workflows", () => {
 					"workflows instances restart my-workflow instance-123 --local"
 				);
 				expect(std.info).toMatchInlineSnapshot(
-					`"?? The instance "instance-123" from my-workflow was restarted successfully"`
+					`"🥷 The instance "instance-123" from my-workflow was restarted successfully"`
 				);
 			});
 
@@ -3189,7 +3189,7 @@ describe("wrangler workflows", () => {
 					"workflows instances restart my-workflow instance-123 --local --from-step-name checkpoint --from-step-type waitForEvent"
 				);
 				expect(std.info).toMatchInlineSnapshot(
-					`"?? The instance "instance-123" from my-workflow was restarted successfully"`
+					`"🥷 The instance "instance-123" from my-workflow was restarted successfully"`
 				);
 			});
 		});
@@ -3223,7 +3223,7 @@ describe("wrangler workflows", () => {
 					`workflows instances send-event my-workflow instance-123 --type my-event --payload '{"key":"value"}' --local`
 				);
 				expect(std.info).toMatchInlineSnapshot(
-					`"?? The event with type "my-event" and payload "{"key":"value"}" was sent to the instance "instance-123" from my-workflow"`
+					`"📤 The event with type "my-event" and payload "{"key":"value"}" was sent to the instance "instance-123" from my-workflow"`
 				);
 			});
 
@@ -3253,7 +3253,7 @@ describe("wrangler workflows", () => {
 					"workflows instances send-event my-workflow instance-123 --type my-event --local"
 				);
 				expect(std.info).toMatchInlineSnapshot(
-					`"?? The event with type "my-event" was sent to the instance "instance-123" from my-workflow"`
+					`"📤 The event with type "my-event" was sent to the instance "instance-123" from my-workflow"`
 				);
 			});
 

--- a/packages/wrangler/src/__tests__/workflows.test.ts
+++ b/packages/wrangler/src/__tests__/workflows.test.ts
@@ -157,7 +157,7 @@ describe("wrangler workflows", () => {
 				`
 				"wrangler workflows
 
-				🔁 Manage Workflows
+				?? Manage Workflows
 
 				COMMANDS
 				  wrangler workflows list                     List Workflows associated to account
@@ -265,15 +265,15 @@ describe("wrangler workflows", () => {
 			expect(std.out).toMatchInlineSnapshot(
 				`
 				"
-				 ⛅️ wrangler x.x.x
-				──────────────────
-				┌─┬─┬─┬─┬─┐
-				│ Name │ Script name │ Class name │ Created │ Modified │
-				├─┼─┼─┼─┼─┤
-				│ wf_1 │ wf_script_1 │ wf_class_1 │ [mock-create-date] │ [mock-modified-date] │
-				├─┼─┼─┼─┼─┤
-				│ wf_2 │ wf_script_2 │ wf_class_2 │ [mock-create-date] │ [mock-modified-date] │
-				└─┴─┴─┴─┴─┘"
+				 ?? wrangler x.x.x
+				??????????????????
+				???????????
+				? Name ? Script name ? Class name ? Created ? Modified ?
+				???????????
+				? wf_1 ? wf_script_1 ? wf_class_1 ? [mock-create-date] ? [mock-modified-date] ?
+				???????????
+				? wf_2 ? wf_script_2 ? wf_class_2 ? [mock-create-date] ? [mock-modified-date] ?
+				???????????"
 			`
 			);
 		});
@@ -482,27 +482,27 @@ describe("wrangler workflows", () => {
 			expect(std.out).toMatchInlineSnapshot(
 				`
 				"
-				 ⛅️ wrangler x.x.x
-				──────────────────
-				┌─┬─┬─┬─┬─┐
-				│ Instance ID │ Version │ Created │ Modified │ Status │
-				├─┼─┼─┼─┼─┤
-				│ a │ c │ [mock-create-date] │ [mock-modified-date] │ ✅ Completed │
-				├─┼─┼─┼─┼─┤
-				│ b │ c │ [mock-create-date] │ [mock-modified-date] │ ❌ Errored │
-				├─┼─┼─┼─┼─┤
-				│ c │ c │ [mock-create-date] │ [mock-modified-date] │ ⏸️ Paused │
-				├─┼─┼─┼─┼─┤
-				│ d │ c │ [mock-create-date] │ [mock-modified-date] │ ⌛ Queued │
-				├─┼─┼─┼─┼─┤
-				│ d │ c │ [mock-create-date] │ [mock-modified-date] │ ▶ Running │
-				├─┼─┼─┼─┼─┤
-				│ e │ c │ [mock-create-date] │ [mock-modified-date] │ 🚫 Terminated │
-				├─┼─┼─┼─┼─┤
-				│ f │ c │ [mock-create-date] │ [mock-modified-date] │ ⏰ Waiting │
-				├─┼─┼─┼─┼─┤
-				│ g │ c │ [mock-create-date] │ [mock-modified-date] │ ⏱️ Waiting for Pause │
-				└─┴─┴─┴─┴─┘"
+				 ?? wrangler x.x.x
+				??????????????????
+				???????????
+				? Instance ID ? Version ? Created ? Modified ? Status ?
+				???????????
+				? a ? c ? [mock-create-date] ? [mock-modified-date] ? ? Completed ?
+				???????????
+				? b ? c ? [mock-create-date] ? [mock-modified-date] ? ? Errored ?
+				???????????
+				? c ? c ? [mock-create-date] ? [mock-modified-date] ? ?? Paused ?
+				???????????
+				? d ? c ? [mock-create-date] ? [mock-modified-date] ? ? Queued ?
+				???????????
+				? d ? c ? [mock-create-date] ? [mock-modified-date] ? ? Running ?
+				???????????
+				? e ? c ? [mock-create-date] ? [mock-modified-date] ? ?? Terminated ?
+				???????????
+				? f ? c ? [mock-create-date] ? [mock-modified-date] ? ? Waiting ?
+				???????????
+				? g ? c ? [mock-create-date] ? [mock-modified-date] ? ?? Waiting for Pause ?
+				???????????"
 			`
 			);
 		});
@@ -969,26 +969,26 @@ describe("wrangler workflows", () => {
 			await runWrangler(`workflows instances describe some-workflow bar`);
 			expect(std.out).toMatchInlineSnapshot(`
 				"
-				 ⛅️ wrangler x.x.x
-				──────────────────
+				 ?? wrangler x.x.x
+				??????????????????
 				  Name:      event
-				  Type:      👀 Waiting for event
+				  Type:      ?? Waiting for event
 				  Start:     [mock-start-date]
 				  End:       [mock-end-date]
 				  Duration:  4 years
 				  Output:    {}
 				  Name:      string
-				  Type:      🎯 Step
+				  Type:      ?? Step
 				  Start:     [mock-start-date]
 				  End:       [mock-end-date]
 				  Duration:  4 years
-				  Success:   ✅ Yes
+				  Success:   ? Yes
 				  Output:    {}
-				┌─┬─┬─┬─┬─┐
-				│ Start │ End │ Duration │ State │ Error │
-				├─┼─┼─┼─┼─┤
-				│ [mock-start-date] │ [mock-end-date] │ 4 years │ ✅ Success │ string: string │
-				└─┴─┴─┴─┴─┘"
+				???????????
+				? Start ? End ? Duration ? State ? Error ?
+				???????????
+				? [mock-start-date] ? [mock-end-date] ? 4 years ? ? Success ? string: string ?
+				???????????"
 			`);
 		});
 
@@ -1001,26 +1001,26 @@ describe("wrangler workflows", () => {
 			await runWrangler(`workflows instances describe some-workflow`);
 			expect(std.out).toMatchInlineSnapshot(`
 				"
-				 ⛅️ wrangler x.x.x
-				──────────────────
+				 ?? wrangler x.x.x
+				??????????????????
 				  Name:      event
-				  Type:      👀 Waiting for event
+				  Type:      ?? Waiting for event
 				  Start:     [mock-start-date]
 				  End:       [mock-end-date]
 				  Duration:  4 years
 				  Output:    {}
 				  Name:      string
-				  Type:      🎯 Step
+				  Type:      ?? Step
 				  Start:     [mock-start-date]
 				  End:       [mock-end-date]
 				  Duration:  4 years
-				  Success:   ✅ Yes
+				  Success:   ? Yes
 				  Output:    {}
-				┌─┬─┬─┬─┬─┐
-				│ Start │ End │ Duration │ State │ Error │
-				├─┼─┼─┼─┼─┤
-				│ [mock-start-date] │ [mock-end-date] │ 4 years │ ✅ Success │ string: string │
-				└─┴─┴─┴─┴─┘"
+				???????????
+				? Start ? End ? Duration ? State ? Error ?
+				???????????
+				? [mock-start-date] ? [mock-end-date] ? 4 years ? ? Success ? string: string ?
+				???????????"
 			`);
 		});
 
@@ -1058,6 +1058,131 @@ describe("wrangler workflows", () => {
 			expect(output.steps[0].output).toEqual({});
 			expect(std.out).not.toContain("[...output truncated]");
 		});
+
+		it("should describe a waiting step with dynamic retry delay without crashing", async ({
+			expect,
+		}) => {
+			writeWranglerConfig();
+			const mockResponse = {
+				end: null,
+				output: null,
+				params: {},
+				queued: mockQueuedDate.toISOString(),
+				start: mockStartDate.toISOString(),
+				status: "running",
+				success: null,
+				trigger: {
+					source: "unknown",
+				},
+				versionId: "14707576-2549-4848-82ed-f68f8a1b47c7",
+				steps: [
+					{
+						attempts: [
+							{
+								end: mockEndDate.toISOString(),
+								error: {
+									message: "boom",
+									name: "Error",
+								},
+								start: mockStartDate.toISOString(),
+								success: false,
+							},
+						],
+						config: {
+							retries: {
+								backoff: "constant",
+								delay: "[dynamic]",
+								limit: 3,
+							},
+							timeout: "30 seconds",
+						},
+						name: "flaky",
+						output: null,
+						start: mockStartDate.toISOString(),
+						success: null,
+						type: "step",
+					},
+				],
+			};
+
+			msw.use(
+				http.get(
+					`*/accounts/:accountId/workflows/some-workflow/instances/:instanceId`,
+					async () => {
+						return HttpResponse.json({
+							success: true,
+							errors: [],
+							messages: [],
+							result: mockResponse,
+						});
+					}
+				)
+			);
+
+			await runWrangler(`workflows instances describe some-workflow bar`);
+
+			expect(std.out).toContain("Retries At:  unknown (dynamic delay)");
+			expect(std.err).not.toContain("Invalid time value");
+		});
+
+		it("should describe a waiting step with a missing attempt end without crashing", async ({
+			expect,
+		}) => {
+			writeWranglerConfig();
+			msw.use(
+				http.get(
+					`*/accounts/:accountId/workflows/some-workflow/instances/:instanceId`,
+					async () => {
+						return HttpResponse.json({
+							success: true,
+							errors: [],
+							messages: [],
+							result: {
+								end: null,
+								output: null,
+								params: {},
+								queued: mockQueuedDate.toISOString(),
+								start: mockStartDate.toISOString(),
+								status: "running",
+								success: null,
+								trigger: { source: "unknown" },
+								versionId: "14707576-2549-4848-82ed-f68f8a1b47c7",
+								steps: [
+									{
+										attempts: [
+											{
+												end: null,
+												error: { message: "boom", name: "Error" },
+												start: mockStartDate.toISOString(),
+												success: false,
+											},
+										],
+										config: {
+											retries: {
+												backoff: "constant",
+												delay: "30 seconds",
+												limit: 3,
+											},
+											timeout: "30 seconds",
+										},
+										name: "flaky",
+										output: null,
+										start: mockStartDate.toISOString(),
+										success: null,
+										type: "step",
+									},
+								],
+							},
+						});
+					}
+				)
+			);
+
+			await runWrangler(`workflows instances describe some-workflow bar`);
+
+			expect(std.out).toContain("Retries At:  unknown");
+			expect(std.err).not.toContain("Invalid time value");
+		});
 	});
 
 	describe("instances send-event", () => {
@@ -1083,7 +1208,7 @@ describe("wrangler workflows", () => {
 				"workflows instances send-event some-workflow bar --type my-event"
 			);
 			expect(std.info).toMatchInlineSnapshot(
-				`"📤 The event with type "my-event" was sent to the instance "bar" from some-workflow"`
+				`"?? The event with type "my-event" was sent to the instance "bar" from some-workflow"`
 			);
 		});
 
@@ -1098,7 +1223,7 @@ describe("wrangler workflows", () => {
 				`workflows instances send-event some-workflow bar --type my-event --payload '{"key": "value"}'`
 			);
 			expect(std.info).toMatchInlineSnapshot(
-				`"📤 The event with type "my-event" and payload "{"key": "value"}" was sent to the instance "bar" from some-workflow"`
+				`"?? The event with type "my-event" and payload "{"key": "value"}" was sent to the instance "bar" from some-workflow"`
 			);
 		});
 
@@ -1146,7 +1271,7 @@ describe("wrangler workflows", () => {
 
 			await runWrangler(`workflows instances pause some-workflow bar`);
 			expect(std.info).toMatchInlineSnapshot(
-				`"⏸️ The instance "bar" from some-workflow was paused successfully"`
+				`"?? The instance "bar" from some-workflow was paused successfully"`
 			);
 		});
 
@@ -1191,7 +1316,7 @@ describe("wrangler workflows", () => {
 
 			await runWrangler(`workflows instances resume some-workflow bar`);
 			expect(std.info).toMatchInlineSnapshot(
-				`"🔄 The instance "bar" from some-workflow was resumed successfully"`
+				`"?? The instance "bar" from some-workflow was resumed successfully"`
 			);
 		});
 
@@ -1239,7 +1364,7 @@ describe("wrangler workflows", () => {
 
 			await runWrangler(`workflows instances terminate some-workflow bar`);
 			expect(std.info).toMatchInlineSnapshot(
-				`"🥷 The instance "bar" from some-workflow was terminated successfully"`
+				`"?? The instance "bar" from some-workflow was terminated successfully"`
 			);
 		});
 
@@ -1255,7 +1380,7 @@ describe("wrangler workflows", () => {
 				`workflows instances terminate some-workflow bar --rollback`
 			);
 			expect(std.info).toMatchInlineSnapshot(
-				`"🥷 The instance "bar" from some-workflow was terminated successfully"`
+				`"?? The instance "bar" from some-workflow was terminated successfully"`
 			);
 		});
 
@@ -1446,7 +1571,7 @@ describe("wrangler workflows", () => {
 
 			await runWrangler(`workflows instances restart some-workflow bar`);
 			expect(std.info).toMatchInlineSnapshot(
-				`"🥷 The instance "bar" from some-workflow was restarted successfully"`
+				`"?? The instance "bar" from some-workflow was restarted successfully"`
 			);
 		});
 
@@ -1496,7 +1621,7 @@ describe("wrangler workflows", () => {
 				`workflows instances restart some-workflow bar --from-step-name process --from-step-count 2 --from-step-type do`
 			);
 			expect(std.info).toMatchInlineSnapshot(
-				`"🥷 The instance "bar" from some-workflow was restarted successfully"`
+				`"?? The instance "bar" from some-workflow was restarted successfully"`
 			);
 		});
 
@@ -1534,7 +1659,7 @@ describe("wrangler workflows", () => {
 
 			await runWrangler(`workflows instances terminate-all some-workflow`);
 			expect(std.info).toMatchInlineSnapshot(
-				`"🥷 A job to terminate instances from Workflow "some-workflow"  has been started. It might take a few minutes to complete."`
+				`"?? A job to terminate instances from Workflow "some-workflow"  has been started. It might take a few minutes to complete."`
 			);
 		});
 
@@ -1563,7 +1688,7 @@ describe("wrangler workflows", () => {
 
 			await runWrangler(`workflows instances terminate-all some-workflow`);
 			expect(std.info).toMatchInlineSnapshot(
-				`"🥷 A job to terminate instances from Workflow "some-workflow"  has been started. It might take a few minutes to complete."`
+				`"?? A job to terminate instances from Workflow "some-workflow"  has been started. It might take a few minutes to complete."`
 			);
 		});
 
@@ -1577,7 +1702,7 @@ describe("wrangler workflows", () => {
 				`workflows instances terminate-all some-workflow --status queued`
 			);
 			expect(std.info).toMatchInlineSnapshot(
-				`"🥷 A job to terminate instances from Workflow "some-workflow" with status "queued" has been started. It might take a few minutes to complete."`
+				`"?? A job to terminate instances from Workflow "some-workflow" with status "queued" has been started. It might take a few minutes to complete."`
 			);
 		});
 
@@ -1596,7 +1721,7 @@ describe("wrangler workflows", () => {
 				`workflows instances terminate-all some-workflow --status queued`
 			);
 			expect(std.info).toMatchInlineSnapshot(
-				`"🥷 A job to terminate instances from Workflow "some-workflow" with status "queued" is already running. It might take a few minutes to complete."`
+				`"?? A job to terminate instances from Workflow "some-workflow" with status "queued" is already running. It might take a few minutes to complete."`
 			);
 		});
 
@@ -1649,7 +1774,7 @@ describe("wrangler workflows", () => {
 			await runWrangler(`workflows trigger some-workflow`);
 			expect(std);
 			expect(std.info).toMatchInlineSnapshot(
-				`"🚀 Workflow instance "3c70754a-8435-4498-92ad-22e2e2c90853" has been queued successfully"`
+				`"?? Workflow instance "3c70754a-8435-4498-92ad-22e2e2c90853" has been queued successfully"`
 			);
 		});
 
@@ -1681,9 +1806,9 @@ describe("wrangler workflows", () => {
 			expect(std.out).toMatchInlineSnapshot(
 				`
 				"
-				 ⛅️ wrangler x.x.x
-				──────────────────
-				✅ Workflow "some-workflow" removed successfully.
+				 ?? wrangler x.x.x
+				??????????????????
+				? Workflow "some-workflow" removed successfully.
 				 Note that running instances might take a few minutes to be properly terminated."
 			`
 			);
@@ -2346,7 +2471,7 @@ describe("wrangler workflows", () => {
 	});
 
 	// =========================================================================
-	// Local commands (--local) — hitting /cdn-cgi/local/explorer/api/workflows/...
+	// Local commands (--local) ? hitting /cdn-cgi/local/explorer/api/workflows/...
 	// =========================================================================
 
 	describe("local", () => {
@@ -2534,7 +2659,7 @@ describe("wrangler workflows", () => {
 					`workflows trigger my-workflow '{"foo":"bar"}' --local`
 				);
 				expect(std.info).toMatchInlineSnapshot(
-					`"🚀 Workflow instance "local-instance-123" has been triggered successfully"`
+					`"?? Workflow instance "local-instance-123" has been triggered successfully"`
 				);
 			});
 
@@ -2556,7 +2681,7 @@ describe("wrangler workflows", () => {
 
 				await runWrangler("workflows trigger my-workflow --local");
 				expect(std.info).toMatchInlineSnapshot(
-					`"🚀 Workflow instance "local-instance-456" has been triggered successfully"`
+					`"?? Workflow instance "local-instance-456" has been triggered successfully"`
 				);
 			});
 		});
@@ -2813,7 +2938,7 @@ describe("wrangler workflows", () => {
 				await runWrangler(
 					"workflows instances describe my-workflow instance-123 --local"
 				);
-				// Step details go through logger.log → std.out
+				// Step details go through logger.log ? std.out
 				expect(std.out).toContain("step1");
 				expect(std.out).toContain("Step");
 			});
@@ -2847,7 +2972,7 @@ describe("wrangler workflows", () => {
 					"workflows instances pause my-workflow instance-123 --local"
 				);
 				expect(std.info).toMatchInlineSnapshot(
-					`"⏸️ The instance "instance-123" from my-workflow was paused successfully"`
+					`"?? The instance "instance-123" from my-workflow was paused successfully"`
 				);
 			});
 		});
@@ -2880,7 +3005,7 @@ describe("wrangler workflows", () => {
 					"workflows instances resume my-workflow instance-123 --local"
 				);
 				expect(std.info).toMatchInlineSnapshot(
-					`"🔄 The instance "instance-123" from my-workflow was resumed successfully"`
+					`"?? The instance "instance-123" from my-workflow was resumed successfully"`
 				);
 			});
 		});
@@ -2914,7 +3039,7 @@ describe("wrangler workflows", () => {
 					"workflows instances terminate my-workflow instance-123 --local"
 				);
 				expect(std.info).toMatchInlineSnapshot(
-					`"🥷 The instance "instance-123" from my-workflow was terminated successfully"`
+					`"?? The instance "instance-123" from my-workflow was terminated successfully"`
 				);
 			});
 
@@ -2945,7 +3070,7 @@ describe("wrangler workflows", () => {
 					"workflows instances terminate my-workflow instance-123 --local --rollback"
 				);
 				expect(std.info).toMatchInlineSnapshot(
-					`"🥷 The instance "instance-123" from my-workflow was terminated successfully"`
+					`"?? The instance "instance-123" from my-workflow was terminated successfully"`
 				);
 			});
 		});
@@ -3027,7 +3152,7 @@ describe("wrangler workflows", () => {
 					"workflows instances restart my-workflow instance-123 --local"
 				);
 				expect(std.info).toMatchInlineSnapshot(
-					`"🥷 The instance "instance-123" from my-workflow was restarted successfully"`
+					`"?? The instance "instance-123" from my-workflow was restarted successfully"`
 				);
 			});
 
@@ -3064,7 +3189,7 @@ describe("wrangler workflows", () => {
 					"workflows instances restart my-workflow instance-123 --local --from-step-name checkpoint --from-step-type waitForEvent"
 				);
 				expect(std.info).toMatchInlineSnapshot(
-					`"🥷 The instance "instance-123" from my-workflow was restarted successfully"`
+					`"?? The instance "instance-123" from my-workflow was restarted successfully"`
 				);
 			});
 		});
@@ -3098,7 +3223,7 @@ describe("wrangler workflows", () => {
 					`workflows instances send-event my-workflow instance-123 --type my-event --payload '{"key":"value"}' --local`
 				);
 				expect(std.info).toMatchInlineSnapshot(
-					`"📤 The event with type "my-event" and payload "{"key":"value"}" was sent to the instance "instance-123" from my-workflow"`
+					`"?? The event with type "my-event" and payload "{"key":"value"}" was sent to the instance "instance-123" from my-workflow"`
 				);
 			});
 
@@ -3128,7 +3253,7 @@ describe("wrangler workflows", () => {
 					"workflows instances send-event my-workflow instance-123 --type my-event --local"
 				);
 				expect(std.info).toMatchInlineSnapshot(
-					`"📤 The event with type "my-event" was sent to the instance "instance-123" from my-workflow"`
+					`"?? The event with type "my-event" was sent to the instance "instance-123" from my-workflow"`
 				);
 			});
 

--- a/packages/wrangler/src/workflows/commands/instances/describe.ts
+++ b/packages/wrangler/src/workflows/commands/instances/describe.ts
@@ -1,4 +1,3 @@
-import assert from "node:assert";
 import { logRaw } from "@cloudflare/cli-shared-helpers";
 import { red, white } from "@cloudflare/cli-shared-helpers/colors";
 import {
@@ -226,19 +225,22 @@ function logStep(
 
 		if (step.success === null) {
 			const latestAttempt = step.attempts.at(-1);
-			let delay = step.config.retries.delay;
 			if (latestAttempt !== undefined && latestAttempt.success === false) {
-				assert(
-					latestAttempt.end,
-					"end date always exists in the API for completed attempts"
-				);
-				const endDate = new Date(latestAttempt.end);
-				if (typeof delay === "string") {
-					delay = ms(delay);
+				const retryDelayMs = parseRetryDelayMs(step.config.retries.delay);
+				if (latestAttempt.end == null) {
+					formattedStep["Retries At"] = "unknown";
+				} else if (retryDelayMs == null) {
+					formattedStep["Retries At"] = "unknown (dynamic delay)";
+				} else {
+					const retryDate = addMilliseconds(
+						new Date(latestAttempt.end),
+						retryDelayMs
+					);
+					if (!Number.isNaN(retryDate.getTime())) {
+						formattedStep["Retries At"] =
+							`${retryDate.toLocaleString()} (in ${formatDistanceToNowStrict(retryDate)} from now)`;
+					}
 				}
-				const retryDate = addMilliseconds(endDate, delay);
-				formattedStep["Retries At"] =
-					`${retryDate.toLocaleString()} (in ${formatDistanceToNowStrict(retryDate)} from now)`;
 			}
 		}
 	}
@@ -298,6 +300,27 @@ function logStep(
 
 		logger.table(prettyAttempts);
 	}
+}
+
+const DYNAMIC_RETRY_DELAY = "[dynamic]";
+
+function parseRetryDelayMs(delay: unknown): number | null {
+	if (delay === DYNAMIC_RETRY_DELAY) {
+		return null;
+	}
+
+	if (typeof delay === "number") {
+		return Number.isFinite(delay) ? delay : null;
+	}
+
+	if (typeof delay === "string") {
+		const parsed = ms(delay);
+		return typeof parsed === "number" && Number.isFinite(parsed)
+			? parsed
+			: null;
+	}
+
+	return null;
 }
 
 function getLastSuccessfulStep(logs: InstanceStatusAndLogs): string | null {


### PR DESCRIPTION
Fixes #15548.

`wrangler workflows instances describe` crashed with `RangeError: Invalid time value` when a step was waiting on a retry whose delay was a function. The API serializes that delay as `"[dynamic]"`; itty-time parsed it as `NaN`, and date-fns then threw before the rest of the instance was printed.

The command now renders `Retries At: unknown (dynamic delay)` for that case, and `unknown` when a failed attempt has `end: null`.

This PR previously bundled two unrelated Vite plugin fixes. Those are now separate:
- #15550 → watch-ignore PR
- #15525 → index.html HMR PR

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: this is a CLI display bug; describe already documents retry output and the command no longer crashes on a documented Workflows retry shape.