### PR TITLE
[vite-plugin] Ignore .wrangler persistence writes in Vite's file watcher

### DIFF
--- a/.changeset/vite-ignore-wrangler-watch.md
+++ b/.changeset/vite-ignore-wrangler-watch.md
@@ -1,0 +1,7 @@
+---
+"@cloudflare/vite-plugin": patch
+---
+
+Ignore `.wrangler` persistence writes in Vite's file watcher
+
+Miniflare stores local D1, KV, R2, and observability state under `.wrangler/state`. Those writes were watched as source changes on Linux and Windows, which fired every plugin `hotUpdate` hook and could make page loads take seconds. The plugin now ignores `**/.wrangler/**` while preserving any `server.watch.ignored` patterns already set by the user.

--- a/packages/vite-plugin-cloudflare/src/__tests__/config-watch.spec.ts
+++ b/packages/vite-plugin-cloudflare/src/__tests__/config-watch.spec.ts
@@ -1,5 +1,8 @@
 import { describe, test } from "vitest";
-import { withWranglerStateIgnored } from "../plugins/wrangler-watch-ignore";
+import {
+	getServerWatchConfig,
+	withWranglerStateIgnored,
+} from "../plugins/wrangler-watch-ignore";
 
 describe("withWranglerStateIgnored", () => {
 	test("ignores .wrangler when the user has no watch.ignored", ({ expect }) => {
@@ -15,5 +18,25 @@ describe("withWranglerStateIgnored", () => {
 			"**/node_modules/**",
 			"**/.wrangler/**",
 		]);
+	});
+});
+
+describe("getServerWatchConfig", () => {
+	test("does not re-enable watching when the user set server.watch to null", ({
+		expect,
+	}) => {
+		expect(getServerWatchConfig(null)).toBeNull();
+	});
+
+	test("ignores .wrangler when watching is enabled", ({ expect }) => {
+		expect(getServerWatchConfig(undefined)).toEqual({
+			ignored: "**/.wrangler/**",
+		});
+		expect(
+			getServerWatchConfig({ usePolling: true, ignored: "**/dist/**" })
+		).toEqual({
+			usePolling: true,
+			ignored: ["**/dist/**", "**/.wrangler/**"],
+		});
 	});
 });

--- a/packages/vite-plugin-cloudflare/src/__tests__/config-watch.spec.ts
+++ b/packages/vite-plugin-cloudflare/src/__tests__/config-watch.spec.ts
@@ -1,0 +1,19 @@
+import { describe, test } from "vitest";
+import { withWranglerStateIgnored } from "../plugins/wrangler-watch-ignore";
+
+describe("withWranglerStateIgnored", () => {
+	test("ignores .wrangler when the user has no watch.ignored", ({ expect }) => {
+		expect(withWranglerStateIgnored(undefined)).toBe("**/.wrangler/**");
+	});
+
+	test("appends .wrangler to existing ignore patterns", ({ expect }) => {
+		expect(withWranglerStateIgnored("**/dist/**")).toEqual([
+			"**/dist/**",
+			"**/.wrangler/**",
+		]);
+		expect(withWranglerStateIgnored(["**/node_modules/**"])).toEqual([
+			"**/node_modules/**",
+			"**/.wrangler/**",
+		]);
+	});
+});

--- a/packages/vite-plugin-cloudflare/src/plugins/config.ts
+++ b/packages/vite-plugin-cloudflare/src/plugins/config.ts
@@ -25,6 +25,7 @@ import {
 import { createPlugin, debuglog, getOutputDirectory } from "../utils";
 import { validateWorkerEnvironmentOptions } from "../vite-config";
 import { getWarningForWorkersConfigs } from "../workers-configs";
+import { withWranglerStateIgnored } from "./wrangler-watch-ignore";
 import type { PluginContext } from "../context";
 import type { EnvironmentOptions, UserConfig } from "vite";
 import type * as vite from "vite";
@@ -72,6 +73,9 @@ export const configPlugin = createPlugin("config", (ctx) => {
 						ctx.getTunnelHostnames(),
 						userConfig.server?.allowedHosts
 					),
+					watch: {
+						ignored: withWranglerStateIgnored(userConfig.server?.watch?.ignored),
+					},
 					fs: {
 						deny: [
 							...defaultDeniedFiles,

--- a/packages/vite-plugin-cloudflare/src/plugins/config.ts
+++ b/packages/vite-plugin-cloudflare/src/plugins/config.ts
@@ -25,7 +25,7 @@ import {
 import { createPlugin, debuglog, getOutputDirectory } from "../utils";
 import { validateWorkerEnvironmentOptions } from "../vite-config";
 import { getWarningForWorkersConfigs } from "../workers-configs";
-import { withWranglerStateIgnored } from "./wrangler-watch-ignore";
+import { getServerWatchConfig } from "./wrangler-watch-ignore";
 import type { PluginContext } from "../context";
 import type { EnvironmentOptions, UserConfig } from "vite";
 import type * as vite from "vite";
@@ -73,9 +73,7 @@ export const configPlugin = createPlugin("config", (ctx) => {
 						ctx.getTunnelHostnames(),
 						userConfig.server?.allowedHosts
 					),
-					watch: {
-						ignored: withWranglerStateIgnored(userConfig.server?.watch?.ignored),
-					},
+					watch: getServerWatchConfig(userConfig.server?.watch),
 					fs: {
 						deny: [
 							...defaultDeniedFiles,

--- a/packages/vite-plugin-cloudflare/src/plugins/wrangler-watch-ignore.ts
+++ b/packages/vite-plugin-cloudflare/src/plugins/wrangler-watch-ignore.ts
@@ -1,10 +1,20 @@
+import type { UserConfig } from "vite";
+
 const WRANGLER_STATE_WATCH_IGNORE = "**/.wrangler/**";
+
+type ServerWatch = NonNullable<UserConfig["server"]>["watch"];
+type WatchIgnored = NonNullable<ServerWatch>["ignored"];
 
 /**
  * Keep Miniflare persistence writes out of Vite's file watcher without
  * replacing any ignore patterns the user already configured.
+ *
+ * @param userIgnored - Existing `server.watch.ignored` patterns, if any
+ * @returns Ignore patterns that always include `.wrangler` directories
  */
-export function withWranglerStateIgnored(userIgnored: unknown): unknown {
+export function withWranglerStateIgnored(
+	userIgnored: WatchIgnored
+): NonNullable<WatchIgnored> {
 	if (userIgnored == null) {
 		return WRANGLER_STATE_WATCH_IGNORE;
 	}
@@ -14,4 +24,25 @@ export function withWranglerStateIgnored(userIgnored: unknown): unknown {
 	}
 
 	return [userIgnored, WRANGLER_STATE_WATCH_IGNORE];
+}
+
+/**
+ * Merge `.wrangler` into Vite's `server.watch` config.
+ *
+ * Returns `null` when the user disabled watching with `server.watch: null`,
+ * so this plugin does not turn the watcher back on.
+ *
+ * @param userWatch - The user's `server.watch` value from Vite config
+ * @returns `null` when watching is disabled, otherwise a watch object whose
+ *   `ignored` list includes `.wrangler` directories
+ */
+export function getServerWatchConfig(userWatch: ServerWatch): ServerWatch {
+	if (userWatch === null) {
+		return null;
+	}
+
+	return {
+		...userWatch,
+		ignored: withWranglerStateIgnored(userWatch?.ignored),
+	};
 }

--- a/packages/vite-plugin-cloudflare/src/plugins/wrangler-watch-ignore.ts
+++ b/packages/vite-plugin-cloudflare/src/plugins/wrangler-watch-ignore.ts
@@ -1,0 +1,17 @@
+const WRANGLER_STATE_WATCH_IGNORE = "**/.wrangler/**";
+
+/**
+ * Keep Miniflare persistence writes out of Vite's file watcher without
+ * replacing any ignore patterns the user already configured.
+ */
+export function withWranglerStateIgnored(userIgnored: unknown): unknown {
+	if (userIgnored == null) {
+		return WRANGLER_STATE_WATCH_IGNORE;
+	}
+
+	if (Array.isArray(userIgnored)) {
+		return [...userIgnored, WRANGLER_STATE_WATCH_IGNORE];
+	}
+
+	return [userIgnored, WRANGLER_STATE_WATCH_IGNORE];
+}


### PR DESCRIPTION
Fixes #15550.

Miniflare writes D1/KV/R2/observability state under `.wrangler/state`. That directory was already in `server.fs.deny`, but Vite's watcher still picked up the writes on Linux and Windows, so every plugin `hotUpdate` hook ran on ordinary requests.

This adds `**/.wrangler/**` to `server.watch.ignored`, appending to any ignore patterns the user already set.

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: this is internal Vite watcher configuration; there is no user-facing API or config change.


Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://cloudflare.devinenterprise.com/review/cloudflare/workers-sdk/pull/15574" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->