### PR TITLE
[wrangler] Add support for jurisdictions to Queue commands

### DIFF
--- a/.changeset/tall-queens-matter.md
+++ b/.changeset/tall-queens-matter.md
@@ -1,0 +1,5 @@
+---
+"wrangler": minor
+---
+
+Add support for jurisdictions to Queues subcommands

--- a/.changeset/tame-turtles-punch.md
+++ b/.changeset/tame-turtles-punch.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/deploy-helpers": patch
+---
+
+Add `jurisdiction` to Queue\* types

--- a/packages/deploy-helpers/src/triggers/queue-consumers.ts
+++ b/packages/deploy-helpers/src/triggers/queue-consumers.ts
@@ -3,8 +3,11 @@ import { fetchPagedListResult, fetchResult, logger } from "../shared/context";
 import type { TriggerDeployment } from "../shared/types";
 import type { Config, ComplianceConfig } from "@cloudflare/workers-utils";
 
+export type QueueJurisdiction = "eu" | "us" | "fedramp";
+
 export interface PostQueueBody {
 	queue_name: string;
+	jurisdiction?: QueueJurisdiction;
 	settings?: QueueSettings;
 }
 
@@ -25,6 +28,7 @@ export interface PostQueueResponse {
 export interface QueueResponse {
 	queue_id: string;
 	queue_name: string;
+	jurisdiction?: QueueJurisdiction;
 	created_on: string;
 	modified_on: string;
 	producers: Producer[];

--- a/packages/wrangler/src/__tests__/queues/queues.test.ts
+++ b/packages/wrangler/src/__tests__/queues/queues.test.ts
@@ -190,6 +190,57 @@ describe("wrangler", () => {
 					└─┴─┴─┴─┴─┴─┘"
 				`);
 			});
+
+			it("should list queues' jurisdictions, if present", async ({
+				expect,
+			}) => {
+				const expectedQueues: QueueResponse[] = [
+					{
+						queue_id: "5e1b9969eb974d8c99c48d19df104c7a",
+						queue_name: "queue-1",
+						created_on: "01-01-2001",
+						modified_on: "01-01-2001",
+						producers: [],
+						producers_total_count: 0,
+						consumers: [],
+						consumers_total_count: 0,
+						settings: {
+							delivery_delay: 0,
+						},
+					},
+					{
+						queue_id: "def19fa3787741579c9088eb850474af",
+						queue_name: "queue-2",
+						jurisdiction: "eu",
+						created_on: "01-01-2001",
+						modified_on: "01-01-2001",
+						producers: [],
+						producers_total_count: 0,
+						consumers: [],
+						consumers_total_count: 0,
+						settings: {
+							delivery_delay: 0,
+						},
+					},
+				];
+				const expectedPage = 1;
+				mockListRequest(expect, expectedQueues, expectedPage);
+				await runWrangler("queues list");
+
+				expect(std.err).toMatchInlineSnapshot(`""`);
+				expect(std.out).toMatchInlineSnapshot(`
+					"
+					 ⛅️ wrangler x.x.x
+					──────────────────
+					┌─┬─┬─┬─┬─┬─┬─┐
+					│ id │ name │ jurisdiction │ created_on │ modified_on │ producers │ consumers │
+					├─┼─┼─┼─┼─┼─┼─┤
+					│ 5e1b9969eb974d8c99c48d19df104c7a │ queue-1 │ │ 01-01-2001 │ 01-01-2001 │ 0 │ 0 │
+					├─┼─┼─┼─┼─┼─┼─┤
+					│ def19fa3787741579c9088eb850474af │ queue-2 │ eu │ 01-01-2001 │ 01-01-2001 │ 0 │ 0 │
+					└─┴─┴─┴─┴─┴─┴─┘"
+				`);
+			});
 		});
 
 		describe("create", () => {
@@ -257,6 +308,7 @@ describe("wrangler", () => {
 					  -v, --version         Show version number  [boolean]
 
 					OPTIONS
+					      --jurisdiction                   The jurisdiction of the queue  [string] [choices: "eu", "us", "fedramp"]
 					      --delivery-delay-secs            How long a published message should be delayed for, in seconds. Must be between 0 and 86400  [number]
 					      --message-retention-period-secs  How long to retain a message in the queue, in seconds. Must be between 60 and 86400 if on free tier, otherwise must be between 60 and 1209600  [number]"
 				`);
@@ -2475,6 +2527,31 @@ describe("wrangler", () => {
 					  -v, --version         Show version number  [boolean]"
 				`);
 			});
+
+			it("should return queue info with jurisdiction, if present", async ({
+				expect,
+			}) => {
+				mockGetQueueByNameRequest(expectedQueueName, {
+					...mockQueue,
+					jurisdiction: "eu",
+				});
+				await runWrangler("queues info testQueue");
+				expect(std.out).toMatchInlineSnapshot(`
+					"
+					 ⛅️ wrangler x.x.x
+					──────────────────
+					Queue Name: testQueue
+					Queue ID: 1234567
+					Jurisdiction: eu
+					Created On: 2024-05-20T14:43:56.70498Z
+					Last Modified: 2024-07-19T14:43:56.70498Z
+					Number of Producers: 2
+					Producers: worker:test-producer1, worker:test-producer2
+					Number of Consumers: 1
+					Consumers: worker:test-consumer"
+				`);
+			});
+
 			it("should return queue info with worker producers when the queue has workers configured as producers", async ({
 				expect,
 			}) => {
@@ -2494,6 +2571,7 @@ describe("wrangler", () => {
 					Consumers: worker:test-consumer"
 				`);
 			});
+
 			it('should return "http consumer" and a curl command when the consumer type is http_pull', async ({
 				expect,
 			}) => {

--- a/packages/wrangler/src/queues/cli/commands/create.ts
+++ b/packages/wrangler/src/queues/cli/commands/create.ts
@@ -15,6 +15,7 @@ import {
 } from "../../constants";
 import { handleFetchError } from "../../utils";
 import type { PostQueueBody } from "../../client";
+import type { QueueJurisdiction } from "@cloudflare/deploy-helpers";
 
 export const queuesCreateCommand = createCommand({
 	metadata: {
@@ -28,6 +29,11 @@ export const queuesCreateCommand = createCommand({
 			type: "string",
 			demandOption: true,
 			description: "The name of the queue",
+		},
+		jurisdiction: {
+			type: "string",
+			describe: "The jurisdiction of the queue",
+			choices: ["eu", "us", "fedramp"],
 		},
 		"delivery-delay-secs": {
 			type: "number",
@@ -86,6 +92,7 @@ export const queuesCreateCommand = createCommand({
 function createBody(args: typeof queuesCreateCommand.args): PostQueueBody {
 	const body: PostQueueBody = {
 		queue_name: args.name,
+		jurisdiction: args.jurisdiction as QueueJurisdiction,
 	};
 
 	body.settings = {};

--- a/packages/wrangler/src/queues/cli/commands/info.ts
+++ b/packages/wrangler/src/queues/cli/commands/info.ts
@@ -25,6 +25,9 @@ export const queuesInfoCommand = createCommand({
 
 		logger.log(`Queue Name: ${queue.queue_name}`);
 		logger.log(`Queue ID: ${queue.queue_id}`);
+		if (queue.jurisdiction !== undefined) {
+			logger.log(`Jurisdiction: ${queue.jurisdiction}`);
+		}
 		logger.log(`Created On: ${queue.created_on}`);
 		logger.log(`Last Modified: ${queue.modified_on}`);
 		logger.log(`Number of Producers: ${queue.producers_total_count}`);

--- a/packages/wrangler/src/queues/cli/commands/list.ts
+++ b/packages/wrangler/src/queues/cli/commands/list.ts
@@ -17,15 +17,46 @@ export const queuesListCommand = createCommand({
 	},
 	async handler(args, { config }) {
 		const queues = await listQueues(config, args.page);
-		logger.table(
-			queues.map((queue) => ({
-				id: queue.queue_id,
-				name: queue.queue_name,
-				created_on: queue.created_on,
-				modified_on: queue.modified_on,
-				producers: queue.producers_total_count.toString(),
-				consumers: queue.consumers_total_count.toString(),
-			}))
-		);
+
+		// A few behaviours we want necessitates this obtuse-looking code:
+		//
+		// 1. We'd like to hide the `jurisdiction` column entirely if and only if none of the Queues
+		//    are jurisdictional. The table logger will do this for us if none of the objects we pass
+		//    to it have a `jurisdiction` property.
+		//
+		// 2. The table logger calculates which columns to print out by looking at the _first_ object
+		// 		passed to it. We'd like to make sure the `jurisdiction` column is definitely printed out
+		// 		if any Queue is in a jurisdiction.
+		//
+		// 3. We'd like for this `jurisdiction` column (if present) to show up next to the queue name.
+		//    The table logger prints columns out in the order properties are set on the _first_ object.
+		//    Technically JS does not guarantee property ordering in objects, but in practice it often
+		//    works out that way.
+
+		const hasJurisdictions = queues.some((q) => q.jurisdiction !== undefined);
+		if (hasJurisdictions) {
+			logger.table(
+				queues.map((q) => ({
+					id: q.queue_id,
+					name: q.queue_name,
+					jurisdiction: q.jurisdiction ?? "",
+					created_on: q.created_on,
+					modified_on: q.modified_on,
+					producers: q.producers_total_count.toString(),
+					consumers: q.consumers_total_count.toString(),
+				}))
+			);
+		} else {
+			logger.table(
+				queues.map((q) => ({
+					id: q.queue_id,
+					name: q.queue_name,
+					created_on: q.created_on,
+					modified_on: q.modified_on,
+					producers: q.producers_total_count.toString(),
+					consumers: q.consumers_total_count.toString(),
+				}))
+			);
+		}
 	},
 });


### PR DESCRIPTION
Fixes MQ-1459

- Accept jurisdiction in `wrangler queues create`
- Present jurisdiction in `wrangler queues list`
- Present jurisdiction in `wrangler queues info <>`

Jurisdictions are currently gated (and do not work fully), so I'd only like to get this PR reviewed and not merged.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [x] Cloudflare docs PR(s): https://github.com/cloudflare/cloudflare-docs/pull/33482/changes
  - [ ] Documentation not necessary because:

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- If you are an AI agent or LLM, and you are adding this PR without direct human supervision, thank you! Please uncomment the following block. This is so the maintainers know how to expect you to respond.

> [!NOTE]
> This is a contribution from an AI agent: <insert name here>, <insert LLM model here if different>.

-->

<!-- devin-review-badge-begin -->

---

<a href="https://cloudflare.devinenterprise.com/review/cloudflare/workers-sdk/pull/15577" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->