### PR TITLE
[miniflare] add dispatchConnect() helper for testing Worker TCP handlers

### DIFF
--- a/.changeset/swift-sockets-connect.md
+++ b/.changeset/swift-sockets-connect.md
@@ -1,0 +1,7 @@
+---
+"miniflare": minor
+---
+
+Add `Miniflare#dispatchConnect()` for testing Worker TCP handlers
+
+Tests can now open a Node.js socket to a Worker's configured TCP trigger without reserving and connecting to a fixed port manually. Miniflare waits for startup, resolves OS-assigned ports, supports selecting Workers and triggers, and closes dispatched sockets during disposal.

--- a/packages/miniflare/README.md
+++ b/packages/miniflare/README.md
@@ -690,6 +690,15 @@ defined at the top-level.
   no need to do that yourself first. Additionally, the host of the request's URL
   is always ignored and replaced with the `workerd` server's.
 
+- `dispatchConnect(options?: { workerName?: string; port?: number }): Promise<net.Socket>`
+
+  Opens a TCP connection to a Worker's `connect()` trigger and returns a Node.js
+  `net.Socket`. This implicitly waits for the runtime to start and connects to
+  the trigger's allocated port when its configured port is `0`. If `workerName`
+  is omitted, the entrypoint Worker is selected. If `port` is omitted, the
+  selected Worker must have exactly one TCP trigger. Calling `dispose()` destroys
+  any sockets opened by this method.
+
 - `getBindings<Env extends Record<string, unknown> = Record<string, unknown>>(workerName?: string): Promise<Env>`
 
   Returns a `Promise` that resolves with a record mapping binding names to

--- a/packages/miniflare/src/index.ts
+++ b/packages/miniflare/src/index.ts
@@ -769,6 +769,14 @@ type PendingWorkflowStorageDelete = {
 	deleted: boolean;
 };
 
+/** Selects the Worker TCP trigger used by `Miniflare#dispatchConnect()`. */
+export interface DispatchConnectOptions {
+	/** Defaults to the entrypoint Worker. */
+	workerName?: string;
+	/** The configured trigger port, including `0` for an OS-assigned port. */
+	port?: number;
+}
+
 const WORKFLOW_STORAGE_EXTENSIONS = [".sqlite", ".sqlite-shm", ".sqlite-wal"];
 const WORKFLOW_STORAGE_DELETE_RETRY_INTERVAL_MS = 50;
 const WORKFLOW_STORAGE_DELETE_TIMEOUT_MS = 2_000;
@@ -806,6 +814,7 @@ export class Miniflare {
 	publicUrl?: string;
 	#socketPorts?: SocketPorts;
 	#runtimeDispatcher?: Dispatcher;
+	#dispatchConnectSockets = new Set<net.Socket>();
 	#proxyClient?: ProxyClient;
 	#runtimeRestartError?: MiniflareCoreError;
 	// Number of times workerd has crashed and been restarted for this instance.
@@ -3123,6 +3132,100 @@ export class Miniflare {
 		return response;
 	};
 
+	/**
+	 * Opens a TCP connection to a Worker's connect trigger.
+	 *
+	 * @param options Worker and trigger selection options
+	 * @returns A connected Node.js socket
+	 */
+	dispatchConnect = async (
+		options: DispatchConnectOptions = {}
+	): Promise<net.Socket> => {
+		this.#checkDisposed();
+		await this.ready;
+
+		const workerIndex = this.#findAndAssertWorkerIndex(options.workerName);
+		const workerOpts = this.#workerOpts[workerIndex];
+		const connectTriggers = getTriggersOfType(workerOpts.config, "connect");
+		const workerDescription =
+			options.workerName === undefined
+				? "entrypoint worker"
+				: `${JSON.stringify(options.workerName)} worker`;
+
+		let trigger: (typeof connectTriggers)[number] | undefined;
+		if (options.port === undefined) {
+			if (connectTriggers.length === 0) {
+				throw new TypeError(
+					`No TCP connect triggers configured for ${workerDescription}`
+				);
+			}
+			if (connectTriggers.length > 1) {
+				throw new TypeError(
+					`Multiple TCP connect triggers configured for ${workerDescription}; specify a port`
+				);
+			}
+			trigger = connectTriggers[0];
+		} else {
+			trigger = connectTriggers.find(({ port }) => port === options.port);
+			if (trigger === undefined) {
+				throw new TypeError(
+					`TCP connect trigger on port ${options.port} not found for ${workerDescription}`
+				);
+			}
+		}
+
+		assert(this.#socketPorts !== undefined);
+		const socketName = getConnectSocketName(
+			workerIndex,
+			trigger.protocol,
+			trigger.port
+		);
+		const port = this.#socketPorts.get(socketName);
+		assert(port !== undefined);
+
+		const configuredHost = trigger.address ?? DEFAULT_HOST;
+		const host =
+			configuredHost === "*" ||
+			configuredHost === "0.0.0.0" ||
+			configuredHost === "::"
+				? DEFAULT_HOST
+				: configuredHost;
+		const socket = net.connect({ host, port });
+		this.#dispatchConnectSockets.add(socket);
+		socket.once("close", () => this.#dispatchConnectSockets.delete(socket));
+
+		try {
+			await new Promise<void>((resolve, reject) => {
+				function cleanup() {
+					socket.off("connect", onConnect);
+					socket.off("error", onError);
+					socket.off("close", onClose);
+				}
+				function onConnect() {
+					cleanup();
+					resolve();
+				}
+				function onError(error: Error) {
+					cleanup();
+					reject(error);
+				}
+				function onClose() {
+					cleanup();
+					reject(new Error("Socket closed before connecting"));
+				}
+
+				socket.once("connect", onConnect);
+				socket.once("error", onError);
+				socket.once("close", onClose);
+			});
+		} catch (error) {
+			socket.destroy();
+			throw error;
+		}
+
+		return socket;
+	};
+
 	/** @internal */
 	async _getProxyClient(): Promise<ProxyClient> {
 		this.#checkDisposed();
@@ -3557,6 +3660,10 @@ export class Miniflare {
 
 	async dispose(): Promise<void> {
 		this.#disposeController.abort();
+		for (const socket of this.#dispatchConnectSockets) {
+			socket.destroy();
+		}
+		this.#dispatchConnectSockets.clear();
 		// The `ProxyServer` "heap" will be destroyed when `workerd` shuts down,
 		// invalidating all existing native references. Mark all proxies as invalid.
 		// Note `dispose()`ing the `#proxyClient` implicitly poison's proxies, but

--- a/packages/miniflare/src/index.ts
+++ b/packages/miniflare/src/index.ts
@@ -3185,11 +3185,12 @@ export class Miniflare {
 
 		const configuredHost = trigger.address ?? DEFAULT_HOST;
 		const host =
-			configuredHost === "*" ||
+			resolveLocalhost(configuredHost) ??
+			(configuredHost === "*" ||
 			configuredHost === "0.0.0.0" ||
 			configuredHost === "::"
 				? DEFAULT_HOST
-				: configuredHost;
+				: configuredHost);
 		const socket = net.connect({ host, port });
 		this.#dispatchConnectSockets.add(socket);
 		socket.once("close", () => this.#dispatchConnectSockets.delete(socket));

--- a/packages/miniflare/test/index.spec.ts
+++ b/packages/miniflare/test/index.spec.ts
@@ -3576,7 +3576,6 @@ test("Miniflare: connectHandlers deliver raw TCP connections to the Worker's con
 	expect,
 	onTestFinished,
 }) => {
-	const port = await getPort();
 	const mf = new Miniflare({
 		workers: [
 			{
@@ -3596,25 +3595,119 @@ test("Miniflare: connectHandlers deliver raw TCP connections to the Worker's con
 							},
 						};
 					`),
-					triggers: [{ type: "connect", protocol: "tcp", port }],
+					triggers: [{ type: "connect", protocol: "tcp", port: 0 }],
 				},
 			},
 		],
 	});
 	onTestFinished(() => mf.dispose());
-	await mf.ready;
 
-	const received = await new Promise<Buffer>((resolve, reject) => {
-		const socket = net.connect(port, "127.0.0.1", () => {
-			socket.write("hello");
-		});
-		const chunks: Buffer[] = [];
-		socket.on("data", (chunk) => chunks.push(chunk));
-		socket.on("end", () => resolve(Buffer.concat(chunks)));
-		socket.on("error", reject);
+	const socket = await mf.dispatchConnect();
+	socket.write("hello");
+	expect(await text(socket)).toBe("hello");
+});
+
+test("Miniflare: dispatchConnect selects Worker TCP triggers", async ({
+	expect,
+	onTestFinished,
+}) => {
+	const firstPort = await getPort();
+	const secondPort = await getPort({ exclude: [firstPort] });
+	const mf = new Miniflare({
+		workers: [
+			{
+				config: {
+					type: "worker",
+					name: "a",
+					compatibilityDate: "2025-05-01",
+					compatibilityFlags: ["experimental"],
+					manifest: singleModuleManifest(`
+						export default {
+							async connect(socket) {
+								const writer = socket.writable.getWriter();
+								await writer.write(new TextEncoder().encode("a"));
+								await writer.close();
+							},
+						};
+					`),
+					triggers: [
+						{ type: "connect", protocol: "tcp", port: firstPort },
+						{ type: "connect", protocol: "tcp", port: secondPort },
+					],
+				},
+			},
+			{
+				config: {
+					type: "worker",
+					name: "b",
+					compatibilityDate: "2025-05-01",
+					compatibilityFlags: ["experimental"],
+					manifest: singleModuleManifest(`
+						export default {
+							async connect(socket) {
+								const writer = socket.writable.getWriter();
+								await writer.write(new TextEncoder().encode("b"));
+								await writer.close();
+							},
+						};
+					`),
+					triggers: [{ type: "connect", protocol: "tcp", port: 0 }],
+				},
+			},
+		],
+	});
+	onTestFinished(() => mf.dispose());
+
+	await expect(mf.dispatchConnect()).rejects.toThrow(
+		"Multiple TCP connect triggers configured for entrypoint worker; specify a port"
+	);
+	await expect(mf.dispatchConnect({ port: 123 })).rejects.toThrow(
+		"TCP connect trigger on port 123 not found for entrypoint worker"
+	);
+
+	const firstSocket = await mf.dispatchConnect({ port: firstPort });
+	expect(await text(firstSocket)).toBe("a");
+	const secondWorkerSocket = await mf.dispatchConnect({ workerName: "b" });
+	expect(await text(secondWorkerSocket)).toBe("b");
+});
+
+test("Miniflare: dispatchConnect sockets are closed on dispose", async ({
+	expect,
+	onTestFinished,
+}) => {
+	const mf = new Miniflare({
+		workers: [
+			{
+				config: {
+					type: "worker",
+					name: "",
+					compatibilityDate: "2025-05-01",
+					compatibilityFlags: ["experimental"],
+					manifest: singleModuleManifest(`
+						export default {
+							async connect(socket) {
+								await socket.readable.pipeTo(socket.writable);
+							},
+						};
+					`),
+					triggers: [{ type: "connect", protocol: "tcp", port: 0 }],
+				},
+			},
+		],
+	});
+	let disposed = false;
+	onTestFinished(async () => {
+		if (!disposed) {
+			await mf.dispose();
+		}
 	});
 
-	expect(received.toString()).toBe("hello");
+	const socket = await mf.dispatchConnect();
+	const closed = once(socket, "close");
+	await mf.dispose();
+	disposed = true;
+	await closed;
+	expect(socket.destroyed).toBe(true);
 });
 
 test("Miniflare: allows RPC between multiple instances", async ({ expect }) => {


### PR DESCRIPTION
Helps for SHIP-1695

This PR adds a dispatchConnect() helper method to help testing connect() handlers.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: TCP workers feature is not GA yet, and gated behind an experimental flag

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- If you are an AI agent or LLM, and you are adding this PR without direct human supervision, thank you! Please uncomment the following block. This is so the maintainers know how to expect you to respond.

> [!NOTE]
> This is a contribution from an AI agent: <insert name here>, <insert LLM model here if different>.

-->

<!-- devin-review-badge-begin -->

---

<a href="https://cloudflare.devinenterprise.com/review/cloudflare/workers-sdk/pull/15578" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->