### PR TITLE
[wrangler] Correct Pages delegation analytics

### DIFF
--- a/.changeset/clean-delegation-analytics.md
+++ b/.changeset/clean-delegation-analytics.md
@@ -1,5 +1,5 @@
 ---
-"wrangler": minor
+"wrangler": patch
 ---
 
 Correct Pages-to-Workers delegation analytics for forced and ineligible commands

--- a/.changeset/clean-delegation-analytics.md
+++ b/.changeset/clean-delegation-analytics.md
@@ -1,0 +1,7 @@
+---
+"wrangler": minor
+---
+
+Correct Pages-to-Workers delegation analytics for forced and ineligible commands
+
+The legacy `forced` result counted every agent-driven Pages command using `--force`, including commands that could never have been delegated. Wrangler now emits `eligible_forced` only when `--force` prevents an otherwise eligible delegation, and records other agent commands as `ineligible` with a bounded reason and whether force was used.

--- a/packages/wrangler/src/__tests__/pages/delegate-to-workers.test.ts
+++ b/packages/wrangler/src/__tests__/pages/delegate-to-workers.test.ts
@@ -1,7 +1,7 @@
 import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
-import { beforeEach, describe, it, vi } from "vitest";
+import { beforeEach, describe, it, vi, type ExpectStatic } from "vitest";
 import { sendMetricsEvent } from "../../metrics";
 import {
 	logPagesToWorkersForceOptOutNotice,
@@ -22,6 +22,29 @@ function createFunctionsDir(dir: string): void {
 /** Create a named (empty) file marker inside `dir`. */
 function createFile(dir: string, name: string): void {
 	writeFileSync(join(dir, name), "");
+}
+
+/**
+ * Assert the bounded analytics emitted for an ineligible agent command.
+ *
+ * @param expect - The current test's expectation API.
+ * @param reason - Expected stable ineligibility reason.
+ * @param forceUsed - Whether the command included `--force`.
+ */
+function expectIneligibleMetrics(
+	expect: ExpectStatic,
+	reason: string,
+	forceUsed = false
+): void {
+	expect(sendMetricsEvent).toHaveBeenCalledWith(
+		"delegate pages to workers",
+		expect.objectContaining({
+			result: "ineligible",
+			reason,
+			forceUsed,
+		}),
+		expect.anything()
+	);
 }
 
 describe("maybeDelegatePagesToWorkers", () => {
@@ -47,9 +70,7 @@ describe("maybeDelegatePagesToWorkers", () => {
 		expect(sendMetricsEvent).not.toHaveBeenCalled();
 	});
 
-	it("does not delegate (or emit telemetry) when the deploy targets an existing Pages project", async ({
-		expect,
-	}) => {
+	it("records an existing Pages project as ineligible", async ({ expect }) => {
 		const result = await maybeDelegatePagesToWorkers({
 			command: "deploy",
 			projectPath: process.cwd(),
@@ -57,9 +78,7 @@ describe("maybeDelegatePagesToWorkers", () => {
 		});
 
 		expect(result).toEqual({ delegate: false });
-		// Skips are deterministic, expected non-cases, so they are not sent to
-		// telemetry.
-		expect(sendMetricsEvent).not.toHaveBeenCalled();
+		expectIneligibleMetrics(expect, "project_exists");
 	});
 
 	it("does not delegate when the target project's existence is unknown", async ({
@@ -71,7 +90,7 @@ describe("maybeDelegatePagesToWorkers", () => {
 		});
 
 		expect(result).toEqual({ delegate: false });
-		expect(sendMetricsEvent).not.toHaveBeenCalled();
+		expectIneligibleMetrics(expect, "project_existence_unknown");
 	});
 
 	it("delegates a new project even when the account already has other Pages projects", async ({
@@ -104,7 +123,7 @@ describe("maybeDelegatePagesToWorkers", () => {
 		});
 
 		expect(result).toEqual({ delegate: false });
-		expect(sendMetricsEvent).not.toHaveBeenCalled();
+		expectIneligibleMetrics(expect, "project_exists");
 	});
 
 	it("delegates when a lazy projectExists resolver reports the project is new", async ({
@@ -136,7 +155,7 @@ describe("maybeDelegatePagesToWorkers", () => {
 		});
 
 		expect(result).toEqual({ delegate: false });
-		expect(sendMetricsEvent).not.toHaveBeenCalled();
+		expectIneligibleMetrics(expect, "project_existence_lookup_failed");
 	});
 
 	it("does not delegate when project has a functions directory", async ({
@@ -150,7 +169,7 @@ describe("maybeDelegatePagesToWorkers", () => {
 		});
 
 		expect(result).toEqual({ delegate: false });
-		expect(sendMetricsEvent).not.toHaveBeenCalled();
+		expectIneligibleMetrics(expect, "unsupported_feature");
 	});
 
 	const unsupportedFileMarkers: [marker: string, reason: string][] = [
@@ -169,7 +188,7 @@ describe("maybeDelegatePagesToWorkers", () => {
 			});
 
 			expect(result).toEqual({ delegate: false });
-			expect(sendMetricsEvent).not.toHaveBeenCalled();
+			expectIneligibleMetrics(expect, "unsupported_feature");
 		});
 	}
 
@@ -187,7 +206,7 @@ describe("maybeDelegatePagesToWorkers", () => {
 		});
 
 		expect(result).toEqual({ delegate: false });
-		expect(sendMetricsEvent).not.toHaveBeenCalled();
+		expectIneligibleMetrics(expect, "unsupported_feature");
 	});
 
 	for (const marker of ["_redirects", "_headers"]) {
@@ -243,7 +262,7 @@ describe("maybeDelegatePagesToWorkers", () => {
 		});
 
 		expect(result).toEqual({ delegate: false });
-		expect(sendMetricsEvent).not.toHaveBeenCalled();
+		expectIneligibleMetrics(expect, "unsupported_args");
 	});
 
 	it("delegates a brand-new static deploy to Workers", async ({ expect }) => {
@@ -342,19 +361,42 @@ describe("maybeDelegatePagesToWorkers", () => {
 		});
 	});
 
-	it("does not delegate when --force is set, records the opt-out, and flags forcedOptOut", async ({
+	it("records a new opt-out result when --force prevents an eligible delegation", async ({
 		expect,
 	}) => {
 		const result = await maybeDelegatePagesToWorkers({
 			command: "deploy",
 			projectPath: process.cwd(),
+			projectExists: false,
 			force: true,
 		});
 
 		expect(result).toEqual({ delegate: false, forcedOptOut: true });
 		expect(sendMetricsEvent).toHaveBeenCalledWith(
 			"delegate pages to workers",
-			expect.objectContaining({ command: "deploy", result: "forced" }),
+			expect.objectContaining({
+				command: "deploy",
+				result: "eligible_forced",
+			}),
+			expect.anything()
+		);
+	});
+
+	it("records an ineligible --force command without flagging an opt-out", async ({
+		expect,
+	}) => {
+		const result = await maybeDelegatePagesToWorkers({
+			command: "deploy",
+			projectPath: process.cwd(),
+			projectExists: true,
+			force: true,
+		});
+
+		expect(result).toEqual({ delegate: false });
+		expectIneligibleMetrics(expect, "project_exists", true);
+		expect(sendMetricsEvent).not.toHaveBeenCalledWith(
+			"delegate pages to workers",
+			expect.objectContaining({ result: "eligible_forced" }),
 			expect.anything()
 		);
 	});

--- a/packages/wrangler/src/pages/delegate-to-workers.ts
+++ b/packages/wrangler/src/pages/delegate-to-workers.ts
@@ -76,8 +76,8 @@ export type PagesToWorkersDelegateResult =
 			delegate: false;
 			/**
 			 * True when the caller passed `--force` to opt this command out of
-			 * delegation. The caller uses it to emit the one-time `--force` notice
-			 * on the command's success path.
+			 * an otherwise eligible delegation. The caller uses it to emit the
+			 * one-time `--force` notice on the command's success path.
 			 */
 			forcedOptOut?: boolean;
 	  }
@@ -89,7 +89,20 @@ export type PagesToWorkersDelegateResult =
 	  };
 
 /** The outcome recorded against the `delegate pages to workers` metrics event. */
-type DelegateResult = "delegated" | "success" | "failure" | "forced";
+type DelegateResult =
+	| "delegated"
+	| "success"
+	| "failure"
+	| "eligible_forced"
+	| "ineligible";
+
+/** Stable reason recorded when an agent-driven Pages command cannot be delegated. */
+type DelegateIneligibleReason =
+	| "unsupported_args"
+	| "unsupported_feature"
+	| "project_existence_unknown"
+	| "project_existence_lookup_failed"
+	| "project_exists";
 
 /**
  * Status line emitted at the top of the deploy flow, before the Workers deploy
@@ -185,19 +198,13 @@ export async function maybeDelegatePagesToWorkers(
 		return { delegate: false };
 	}
 
-	// The agent explicitly opted out with `--force`. The only callers who should
-	// reach for `--force` are agents we previously delegated, so this is a
-	// strong signal of dissatisfaction with the delegation — record it. We flag
-	// `forcedOptOut` so the caller emits the one-time `--force` notice once the
-	// direct Pages command succeeds (see `logPagesToWorkersForceOptOutNotice`).
-	if (options.force) {
-		recordDelegate("forced", options, agent.id);
-		logger.debug("Pages-to-Workers delegation skipped: --force opt-out");
-		return { delegate: false, forcedOptOut: true };
-	}
-
 	if (options.unsupportedArgs && options.unsupportedArgs.length > 0) {
-		skipDelegate(`unsupported args: ${options.unsupportedArgs.join(", ")}`);
+		recordIneligible(
+			"unsupported_args",
+			`unsupported args: ${options.unsupportedArgs.join(", ")}`,
+			options,
+			agent.id
+		);
 		return { delegate: false };
 	}
 
@@ -208,7 +215,12 @@ export async function maybeDelegatePagesToWorkers(
 		options.assetsDirectory
 	);
 	if (unsupportedFeature) {
-		skipDelegate(unsupportedFeature);
+		recordIneligible(
+			"unsupported_feature",
+			unsupportedFeature,
+			options,
+			agent.id
+		);
 		return { delegate: false };
 	}
 
@@ -221,7 +233,12 @@ export async function maybeDelegatePagesToWorkers(
 	// cheaper, local skip reason above avoids it. If the lookup fails we skip
 	// delegation rather than risk delegating a project that may already exist.
 	if (options.projectExists === undefined) {
-		skipDelegate("target project existence is unknown");
+		recordIneligible(
+			"project_existence_unknown",
+			"target project existence is unknown",
+			options,
+			agent.id
+		);
 		return { delegate: false };
 	}
 
@@ -237,12 +254,35 @@ export async function maybeDelegatePagesToWorkers(
 				e instanceof Error ? e.message : String(e)
 			})`
 		);
-		skipDelegate("target project existence lookup failed");
+		recordIneligible(
+			"project_existence_lookup_failed",
+			"target project existence lookup failed",
+			options,
+			agent.id
+		);
 		return { delegate: false };
 	}
 	if (projectExists) {
-		skipDelegate("target is an established pages project");
+		recordIneligible(
+			"project_exists",
+			"target is an established pages project",
+			options,
+			agent.id
+		);
 		return { delegate: false };
+	}
+
+	// Only treat `--force` as an opt-out after confirming that the command would
+	// otherwise be delegated. The former `forced` result was emitted before the
+	// eligibility checks and therefore also counted established or unsupported
+	// Pages projects. Use a new result value so historical polluted data cannot be
+	// mistaken for this narrower signal.
+	if (options.force) {
+		recordDelegate("eligible_forced", options, agent.id);
+		logger.debug(
+			"Pages-to-Workers delegation skipped: eligible --force opt-out"
+		);
+		return { delegate: false, forcedOptOut: true };
 	}
 
 	// Eligible: commit to the Workers deploy. From here the caller owns the
@@ -315,16 +355,29 @@ function buildWorkersDeployArgs(
 }
 
 /**
- * Logs (at debug level, for local visibility) why a delegation was skipped.
+ * Records and logs why an agent-driven Pages command was ineligible for
+ * delegation.
  *
- * Skips are deliberately not sent to telemetry: they are deterministic, expected
- * non-cases (not an agent's brand-new static project — e.g. the target project
- * already exists, or the project uses an unsupported Pages feature), so the
- * volume carries no signal. The number of skipped commands is derivable from the
- * Pages command's own telemetry, so a dedicated event is not needed.
+ * `forceUsed` preserves visibility into agents that pass `--force` habitually,
+ * without conflating those ineligible commands with genuine opt-outs from an
+ * otherwise eligible delegation.
+ *
+ * @param reason - Stable analytics reason for the ineligibility.
+ * @param debugReason - More specific, locally logged explanation.
+ * @param options - The Pages command inputs considered for delegation.
+ * @param agentId - The detected agent identifier used for analytics.
  */
-function skipDelegate(reason: string): void {
-	logger.debug(`Pages-to-Workers delegation skipped: ${reason}`);
+function recordIneligible(
+	reason: DelegateIneligibleReason,
+	debugReason: string,
+	options: MaybeDelegatePagesToWorkersOptions,
+	agentId: string | null
+): void {
+	recordDelegate("ineligible", options, agentId, {
+		reason,
+		forceUsed: options.force === true,
+	});
+	logger.debug(`Pages-to-Workers delegation skipped: ${debugReason}`);
 }
 
 /** Sends a `delegate pages to workers` metrics event for the given outcome. */
@@ -332,7 +385,7 @@ function recordDelegate(
 	result: DelegateResult,
 	options: MaybeDelegatePagesToWorkersOptions,
 	agentId: string | null,
-	extra: Record<string, string> = {}
+	extra: Record<string, string | boolean> = {}
 ): void {
 	sendMetricsEvent(
 		"delegate pages to workers",
@@ -348,12 +401,12 @@ function recordDelegate(
 
 /**
  * A Pages feature that cannot be carried across to a Workers static-assets
- * deploy. The `reason` doubles as the telemetry/log label.
+ * deploy. The `reason` is used for local debug logging.
  */
 interface UnsupportedPagesFeature {
 	/** File or directory name to look for. */
 	marker: string;
-	/** Stable label used for logging and telemetry. */
+	/** Stable label used for local debug logging. */
 	reason: string;
 	/** When true, the marker only counts if it is a directory. */
 	directoryOnly?: boolean;


### PR DESCRIPTION
Corrects Pages-to-Workers delegation analytics so forced opt-outs are only recorded for commands that would otherwise have been delegated.

The legacy `forced` result was emitted before eligibility checks, so it also included established Pages projects and commands using unsupported Pages features or arguments. This change evaluates eligibility first, emits the new `eligible_forced` result for genuine opt-outs, and records other agent-driven commands as `ineligible` with a bounded reason and whether `--force` was used.

Ineligible commands also no longer receive the success notice describing them as having opted out of delegation.

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: This only changes internal analytics classification and does not change the public CLI interface.

<!-- devin-review-badge-begin -->

---

<a href="https://cloudflare.devinenterprise.com/review/cloudflare/workers-sdk/pull/15581" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->