### PR TITLE
Add vite-plugin-v2 branch to codeowners.yml

### DIFF
--- a/.github/workflows/codeowners.yml
+++ b/.github/workflows/codeowners.yml
@@ -38,6 +38,7 @@ jobs:
     #   - the PR head is the changeset-release branch (auto-generated changeset PRs), or
     #   - the PR base is neither `main` nor `vite-plugin-v2` (other PRs against
     #     feature branches don't need formal review).
+    # TODO: Remove `vite-plugin-v2` when no longer used.
     steps:
       - name: "Checkout Base Branch"
         if: >-

--- a/.github/workflows/codeowners.yml
+++ b/.github/workflows/codeowners.yml
@@ -10,7 +10,16 @@ name: "Code Owners"
 #   - The action only reads config files and calls the GitHub API
 on:
   pull_request_target: # zizmor: ignore[dangerous-triggers] checks base branch ownership rules and fetches PR head for diff computation without executing PR code
-    types: [opened, edited, reopened, synchronize, ready_for_review, labeled, unlabeled]
+    types:
+      [
+        opened,
+        edited,
+        reopened,
+        synchronize,
+        ready_for_review,
+        labeled,
+        unlabeled,
+      ]
 
 concurrency:
   group: codeowners-${{ github.event.pull_request.number }}

--- a/.github/workflows/codeowners.yml
+++ b/.github/workflows/codeowners.yml
@@ -27,25 +27,33 @@ jobs:
     runs-on: ubuntu-latest
     # Each step is skipped when:
     #   - the PR head is the changeset-release branch (auto-generated changeset PRs), or
-    #   - the PR base is not `main` (PRs against feature branches don't need formal review).
-    # Note: if we ever introduce a maintenance branch (e.g. a long-lived release branch),
-    # it would need to be added to the base branch allowlist below.
+    #   - the PR base is neither `main` nor `vite-plugin-v2` (other PRs against
+    #     feature branches don't need formal review).
     steps:
       - name: "Checkout Base Branch"
-        if: github.event.pull_request.head.ref != 'changeset-release/main' && github.event.pull_request.base.ref == 'main'
+        if: >-
+          github.event.pull_request.head.ref != 'changeset-release/main' &&
+          (github.event.pull_request.base.ref == 'main' ||
+          github.event.pull_request.base.ref == 'vite-plugin-v2')
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
           persist-credentials: false
 
       - name: "Fetch PR Head (for diff computation)"
-        if: github.event.pull_request.head.ref != 'changeset-release/main' && github.event.pull_request.base.ref == 'main'
+        if: >-
+          github.event.pull_request.head.ref != 'changeset-release/main' &&
+          (github.event.pull_request.base.ref == 'main' ||
+          github.event.pull_request.base.ref == 'vite-plugin-v2')
         run: git fetch origin +refs/pull/${{ github.event.pull_request.number }}/head
         env:
           GITHUB_TOKEN: "${{ secrets.CODEOWNERS_GITHUB_PAT }}"
 
       - name: "Codeowners Plus"
-        if: github.event.pull_request.head.ref != 'changeset-release/main' && github.event.pull_request.base.ref == 'main'
+        if: >-
+          github.event.pull_request.head.ref != 'changeset-release/main' &&
+          (github.event.pull_request.base.ref == 'main' ||
+          github.event.pull_request.base.ref == 'vite-plugin-v2')
         uses: multimediallc/codeowners-plus@ff02aa993a92e8efe01642916d0877beb9439e9f # v1.9.0
         with:
           github-token: "${{ secrets.CODEOWNERS_GITHUB_PAT }}"

--- a/.github/workflows/codeowners.yml
+++ b/.github/workflows/codeowners.yml
@@ -10,7 +10,7 @@ name: "Code Owners"
 #   - The action only reads config files and calls the GitHub API
 on:
   pull_request_target: # zizmor: ignore[dangerous-triggers] checks base branch ownership rules and fetches PR head for diff computation without executing PR code
-    types: [opened, reopened, synchronize, ready_for_review, labeled, unlabeled]
+    types: [opened, edited, reopened, synchronize, ready_for_review, labeled, unlabeled]
 
 concurrency:
   group: codeowners-${{ github.event.pull_request.number }}


### PR DESCRIPTION
Add vite-plugin-v2 branch to codeowners.yml.

Also adds the `edited` event so that it is re-triggered when the target branch changes.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: CI change
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: CI change

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- If you are an AI agent or LLM, and you are adding this PR without direct human supervision, thank you! Please uncomment the following block. This is so the maintainers know how to expect you to respond.

> [!NOTE]
> This is a contribution from an AI agent: <insert name here>, <insert LLM model here if different>.

-->

<!-- devin-review-badge-begin -->

---

<a href="https://cloudflare.devinenterprise.com/review/cloudflare/workers-sdk/pull/15586" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->