### PR TITLE
[containers-shared] Share local container option planning

### DIFF
--- a/packages/containers-shared/index.ts
+++ b/packages/containers-shared/index.ts
@@ -14,3 +14,4 @@ export * from "./src/inspect";
 export * from "./src/registry";
 export * from "./src/images";
 export * from "./src/spinner";
+export * from "./src/dev-options";

--- a/packages/containers-shared/src/dev-options.ts
+++ b/packages/containers-shared/src/dev-options.ts
@@ -1,0 +1,65 @@
+import path from "node:path";
+import {
+	isDockerfile,
+	isDurableObjectContainerApp,
+	resolveContainerClassName,
+} from "@cloudflare/workers-utils";
+import { getDevContainerImageName } from "./knobs";
+import type { ContainerDevOptions } from "./types";
+import type { Config } from "@cloudflare/workers-utils";
+
+/**
+ * Converts normalized Worker container configuration into local image build or
+ * pull options.
+ *
+ * @param options - Worker container configuration and generated build ID.
+ * @returns Local image options, or `undefined` when no containers are configured.
+ */
+export function createContainerDevOptions(options: {
+	containers: Config["containers"];
+	exports: Config["exports"];
+	containerBuildId: string;
+	configPath?: string;
+}): ContainerDevOptions[] | undefined {
+	const { containers, exports, containerBuildId, configPath } = options;
+
+	if (!containers?.length) {
+		return undefined;
+	}
+
+	return containers.flatMap((container): ContainerDevOptions[] => {
+		if (
+			isDurableObjectContainerApp(container) ||
+			container.image === undefined
+		) {
+			return [];
+		}
+
+		const className = resolveContainerClassName(container, exports);
+		if (className === undefined) {
+			return [];
+		}
+
+		const imageTag = getDevContainerImageName(className, containerBuildId);
+		if (isDockerfile(container.image, configPath)) {
+			return [
+				{
+					dockerfile: container.image,
+					image_build_context:
+						container.image_build_context ?? path.dirname(container.image),
+					image_vars: container.image_vars,
+					class_name: className,
+					image_tag: imageTag,
+				},
+			];
+		}
+
+		return [
+			{
+				image_uri: container.image,
+				class_name: className,
+				image_tag: imageTag,
+			},
+		];
+	});
+}

--- a/packages/containers-shared/tests/dev-options.test.ts
+++ b/packages/containers-shared/tests/dev-options.test.ts
@@ -1,0 +1,102 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
+import { describe, test } from "vitest";
+import { createContainerDevOptions } from "../src/dev-options";
+import type { ContainerApp, Exports } from "@cloudflare/workers-utils";
+
+function container(props: Partial<ContainerApp>): ContainerApp {
+	return { image: "./Dockerfile", ...props };
+}
+
+describe("createContainerDevOptions", () => {
+	runInTempDir();
+
+	test("creates Dockerfile build options", async ({ expect }) => {
+		const dockerfile = path.resolve("Dockerfile");
+		await fs.writeFile(dockerfile, "FROM scratch");
+
+		expect(
+			createContainerDevOptions({
+				containers: [
+					container({
+						class_name: "Browser",
+						image: dockerfile,
+						image_vars: { VERSION: "1" },
+					}),
+				],
+				exports: {},
+				containerBuildId: "build-123",
+				configPath: path.resolve("wrangler.jsonc"),
+			})
+		).toEqual([
+			{
+				dockerfile,
+				image_build_context: process.cwd(),
+				image_vars: { VERSION: "1" },
+				class_name: "Browser",
+				image_tag: "cloudflare-dev/browser:build-123",
+			},
+		]);
+	});
+
+	test("creates registry pull options from export associations", ({
+		expect,
+	}) => {
+		const exports: Exports = {
+			Browser: {
+				type: "durable-object",
+				storage: "sqlite",
+				container: "browser-container",
+			},
+		};
+
+		expect(
+			createContainerDevOptions({
+				containers: [
+					container({
+						name: "browser-container",
+						image: "docker.io/example/browser:latest",
+					}),
+				],
+				exports,
+				containerBuildId: "build-123",
+			})
+		).toEqual([
+			{
+				image_uri: "docker.io/example/browser:latest",
+				class_name: "Browser",
+				image_tag: "cloudflare-dev/browser:build-123",
+			},
+		]);
+	});
+
+	test("skips Durable Object-managed containers in mixed configurations", ({
+		expect,
+	}) => {
+		expect(
+			createContainerDevOptions({
+				containers: [
+					{
+						name: "managed-container",
+						class_name: "ManagedDO",
+						scheduling_policy: "durable_object",
+						images: { app: { dockerfile: "./Dockerfile" } },
+					},
+					container({
+						class_name: "Browser",
+						image: "docker.io/example/browser:latest",
+					}),
+				],
+				exports: {},
+				containerBuildId: "build-123",
+			})
+		).toEqual([
+			{
+				image_uri: "docker.io/example/browser:latest",
+				class_name: "Browser",
+				image_tag: "cloudflare-dev/browser:build-123",
+			},
+		]);
+	});
+});

--- a/packages/vite-plugin-cloudflare/src/containers.ts
+++ b/packages/vite-plugin-cloudflare/src/containers.ts
@@ -1,16 +1,13 @@
-import path from "node:path";
 import {
 	configureOpenAPIForContainerPull,
-	getDevContainerImageName,
+	createContainerDevOptions,
 } from "@cloudflare/containers-shared";
 import {
 	COMPLIANCE_REGION_CONFIG_UNKNOWN,
 	getCloudflareApiBaseUrl,
-	isDockerfile,
-	isDurableObjectContainerApp,
-	resolveContainerClassName,
 } from "@cloudflare/workers-utils";
 import type { ResolvedWorkerConfig } from "./plugin-config";
+import type { ContainerDevOptions } from "@cloudflare/containers-shared";
 import type { ComplianceConfig } from "@cloudflare/workers-utils";
 
 /**
@@ -62,51 +59,12 @@ export function getContainerOptions(options: {
 	configPath?: string;
 }) {
 	const { containersConfig, exports, containerBuildId, configPath } = options;
-
-	if (!containersConfig?.length) {
-		return undefined;
-	}
-
-	return containersConfig
-		.map((container) => {
-			if (
-				isDurableObjectContainerApp(container) ||
-				container.image === undefined
-			) {
-				return undefined;
-			}
-
-			// A container is linked to its Durable Object either by its own `class_name`,
-			// or by the Durable Object's `exports` entry naming it via `container`.
-			// Config validation rejects containers with neither.
-			const className = resolveContainerClassName(container, exports);
-			if (className === undefined) {
-				return undefined;
-			}
-
-			const image_tag = getDevContainerImageName(className, containerBuildId);
-
-			if (isDockerfile(container.image, configPath)) {
-				return {
-					dockerfile: container.image,
-					image_build_context:
-						container.image_build_context ?? path.dirname(container.image),
-					image_vars: container.image_vars,
-					class_name: className,
-					image_tag,
-				};
-			} else {
-				return {
-					image_uri: container.image,
-					class_name: className,
-					image_tag,
-				};
-			}
-		})
-		.filter((container) => container !== undefined);
+	return createContainerDevOptions({
+		containers: containersConfig,
+		exports,
+		containerBuildId,
+		configPath,
+	});
 }
 
-export type ContainerTagToOptionsMap = Map<
-	string,
-	NonNullable<ReturnType<typeof getContainerOptions>>[number]
->;
+export type ContainerTagToOptionsMap = Map<string, ContainerDevOptions>;


### PR DESCRIPTION
Related to #15480.

Extract Vite's container-to-local-image mapping into `@cloudflare/containers-shared` so Wrangler, Vite, and later Vitest use one planner.

Behavior is unchanged, including the existing skip for Durable Object-managed named images.

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: internal extraction with no user-facing behavior change.
