### PR TITLE
Support V8 code coverage in the Workers Vitest integration

### DIFF
--- a/.changeset/tidy-rice-remember.md
+++ b/.changeset/tidy-rice-remember.md
@@ -1,0 +1,7 @@
+---
+"@cloudflare/vitest-plugin": minor
+---
+
+Support V8 code coverage in the Workers Vitest integration
+
+Vitest's default V8 coverage provider now collects and reports coverage for tests running locally in the Workers runtime.

--- a/packages/vitest-plugin/src/pool/index.ts
+++ b/packages/vitest-plugin/src/pool/index.ts
@@ -412,6 +412,22 @@ async function buildProjectWorkerOptions(
 	ensureFeature(runnerWorker.compatibilityFlags, "nodejs_v8_module");
 	ensureFeature(runnerWorker.compatibilityFlags, "nodejs_process_v2");
 
+	// V8 coverage drives the isolate's Profiler domain through node:inspector.
+	// The real Session implementation is intentionally local-dev-only.
+	const { coverage } = project.serializedConfig;
+	if (coverage.enabled && coverage.provider === "v8") {
+		ensureFeature(
+			runnerWorker.compatibilityFlags,
+			"nodejs_inspector_module",
+			'because Vitest\'s `coverage.provider` is set to `"v8"`'
+		);
+		ensureFeature(
+			runnerWorker.compatibilityFlags,
+			"nodejs_inspector_local_dev",
+			'because Vitest\'s `coverage.provider` is set to `"v8"`'
+		);
+	}
+
 	// Make sure we define an unsafe eval binding and enable the fallback service
 	runnerWorker.unsafeEvalBinding = "__VITEST_POOL_WORKERS_UNSAFE_EVAL";
 	runnerWorker.unsafeUseModuleFallbackService = true;
@@ -855,20 +871,27 @@ export function assertCompatibleVitestVersion(ctx: Vitest) {
  * Ensures that the specified compatibility feature is enabled for Vitest to work.
  * @param compatibilityFlags The list of current compatibility flags.
  * @param feature The name of the feature to enable.
+ * @param reason An optional explanation of why the feature is needed.
+ * @returns Nothing.
  */
-function ensureFeature(compatibilityFlags: string[], feature: string) {
+function ensureFeature(
+	compatibilityFlags: string[],
+	feature: string,
+	reason = "to support the Vitest runner"
+): void {
 	const flagToEnable = `enable_${feature}`;
 	const flagToDisable = `disable_${feature}`;
 	if (!compatibilityFlags.includes(flagToEnable)) {
 		debug(
-			"Adding `%s` compatibility flag during tests as this feature is needed to support the Vitest runner.",
-			flagToEnable
+			"Adding `%s` compatibility flag during tests as this feature is needed %s.",
+			flagToEnable,
+			reason
 		);
 		compatibilityFlags.push(flagToEnable);
 	}
 	if (compatibilityFlags.includes(flagToDisable)) {
 		log.warn(
-			`Removing \`${flagToDisable}\` compatibility flag during tests as that feature is needed to support the Vitest runner.`
+			`Removing \`${flagToDisable}\` compatibility flag during tests as that feature is needed ${reason}.`
 		);
 		compatibilityFlags.splice(compatibilityFlags.indexOf(flagToDisable), 1);
 	}

--- a/packages/vitest-plugin/src/pool/plugin.ts
+++ b/packages/vitest-plugin/src/pool/plugin.ts
@@ -96,29 +96,6 @@ export function cloudflareTest(
 			config.test.server ??= {};
 			config.test.server.deps ??= {};
 
-			// V8 coverage requires `node:inspector` to collect coverage data from
-			// V8's profiler. workerd provides `node:inspector` as a non-functional
-			// stub, so V8 coverage silently fails or crashes. Istanbul works because
-			// it instruments source code at build time without needing V8 access.
-			// See: https://github.com/cloudflare/workers-sdk/issues/5266
-			const coverage = config.test.coverage;
-			if (coverage && coverage.enabled) {
-				const provider = "provider" in coverage ? coverage.provider : undefined;
-				if (provider === "v8" || provider === undefined) {
-					const lines = [
-						'Coverage provider "v8" is not supported by `@cloudflare/vitest-plugin`.',
-						"V8 native coverage requires `node:inspector` which is not functional in the Workers runtime.",
-						"",
-						"Use Istanbul instead — it works by instrumenting source code and runs on any JavaScript runtime:",
-						"",
-						"  1. Install: npm i -D @vitest/coverage-istanbul",
-						'  2. Set `test.coverage.provider` to "istanbul" in your Vitest config',
-						"",
-						"See https://vitest.dev/guide/coverage#istanbul-provider for more details.",
-					];
-					throw new Error(lines.join("\n"));
-				}
-			}
 			// See https://vitest.dev/config/server.html#inline
 			// Without this Vitest delegates to native import() for external deps in node_modules
 			config.test.server.deps.inline = true;

--- a/packages/vitest-plugin/src/worker/index.ts
+++ b/packages/vitest-plugin/src/worker/index.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import * as vm from "node:vm";
 import defines from "__VITEST_POOL_WORKERS_DEFINES";
 import {
@@ -17,6 +18,23 @@ import {
 import { markCreateRequireUrl } from "../shared/module-path";
 
 type CreateRequire = (url: string) => (specifier: string) => unknown;
+
+interface InlinedModule {
+	id: string;
+	file?: string;
+}
+
+type RunInlinedModule = (
+	context: unknown,
+	code: string,
+	module: InlinedModule
+) => unknown;
+
+interface ModuleEvaluator {
+	createRequire?: CreateRequire;
+	runInlinedModule?: RunInlinedModule;
+	options?: { moduleExecutionInfo?: Map<string, unknown> };
+}
 
 function structuredSerializableStringify(value: unknown): string {
 	return devalue.stringify(value, structuredSerializableReducers);
@@ -211,6 +229,8 @@ export class __VITEST_POOL_WORKERS_RUNNER_DURABLE_OBJECT__ extends DurableObject
 
 		const { init, runBaseTests, setupEnvironment } =
 			await import("vitest/worker");
+		let v8CoverageEnabled = false;
+		const v8CoverageEvaluators = new WeakSet<ModuleEvaluator>();
 
 		poolSocket.accept();
 		// Sending over the runner's WebSocket from another Durable Object requires
@@ -267,8 +287,18 @@ export class __VITEST_POOL_WORKERS_RUNNER_DURABLE_OBJECT__ extends DurableObject
 					callback(structuredSerializableParse(m.data));
 				});
 			},
-			runTests: (state, traces) => runBaseTests("run", state, traces),
-			collectTests: (state, traces) => runBaseTests("collect", state, traces),
+			runTests: (state, traces) => {
+				v8CoverageEnabled =
+					state.ctx.config.coverage.enabled &&
+					state.ctx.config.coverage.provider === "v8";
+				return runBaseTests("run", state, traces);
+			},
+			collectTests: (state, traces) => {
+				v8CoverageEnabled =
+					state.ctx.config.coverage.enabled &&
+					state.ctx.config.coverage.provider === "v8";
+				return runBaseTests("collect", state, traces);
+			},
 			setup: setupEnvironment,
 			// Patch the module runner's transport so that `invoke()` calls always
 			// execute inside the Runner DO's I/O context. Without this, a dynamic
@@ -277,7 +307,7 @@ export class __VITEST_POOL_WORKERS_RUNNER_DURABLE_OBJECT__ extends DurableObject
 			// Durable Object". See: https://github.com/cloudflare/workers-sdk/issues/12924
 			onModuleRunner(moduleRunner: unknown) {
 				const runner = moduleRunner as {
-					evaluator?: { createRequire?: CreateRequire };
+					evaluator?: ModuleEvaluator;
 					options?: {
 						createImportMeta?: (
 							modulePath: string
@@ -328,6 +358,49 @@ export class __VITEST_POOL_WORKERS_RUNNER_DURABLE_OBJECT__ extends DurableObject
 						"[vitest-plugin] Could not patch module runner transport. " +
 							"Dynamic import() inside entrypoint/DO handlers may fail."
 					);
+				}
+
+				const evaluator = runner.evaluator;
+				if (
+					v8CoverageEnabled &&
+					evaluator?.runInlinedModule !== undefined &&
+					!v8CoverageEvaluators.has(evaluator)
+				) {
+					v8CoverageEvaluators.add(evaluator);
+					const originalRunInlinedModule =
+						evaluator.runInlinedModule.bind(evaluator);
+					evaluator.runInlinedModule = async (context, code, module) => {
+						if (!v8CoverageEnabled) {
+							return originalRunInlinedModule(context, code, module);
+						}
+						const id = module.id;
+						const isWindowsDrivePath = /^[a-zA-Z]:[\\/]/.test(id);
+						if (
+							(!id.startsWith("/") && !isWindowsDrivePath) ||
+							id.includes("\0")
+						) {
+							return originalRunInlinedModule(context, code, module);
+						}
+
+						// V8 reports the evaluator filename as its script URL, and Vitest's
+						// V8 collector only retains file URLs.
+						const fileUrl = pathToFileURL(
+							isWindowsDrivePath ? `/${id.replaceAll("\\", "/")}` : id
+						).href;
+						try {
+							return await originalRunInlinedModule(context, code, {
+								...module,
+								id: fileUrl,
+							});
+						} finally {
+							// The collector looks up Vitest's wrapper offset by filesystem path.
+							const info = evaluator.options?.moduleExecutionInfo;
+							const filePath = fileURLToPath(fileUrl);
+							if (info?.has(fileUrl) && !info.has(filePath)) {
+								info.set(filePath, info.get(fileUrl));
+							}
+						}
+					};
 				}
 			},
 		});

--- a/packages/vitest-plugin/test/coverage.test.ts
+++ b/packages/vitest-plugin/test/coverage.test.ts
@@ -3,6 +3,83 @@ import path from "node:path";
 import dedent from "ts-dedent";
 import { test } from "./helpers";
 
+test(
+	"v8 coverage reports source files with the default provider",
+	{ timeout: 60_000 },
+	async ({ expect, seed, vitestRun, tmpPath }) => {
+		await seed({
+			"vitest.config.mts": dedent /* javascript */ `
+				import { cloudflareTest } from "@cloudflare/vitest-plugin";
+
+				export default {
+					plugins: [
+						cloudflareTest({
+							miniflare: {
+								compatibilityDate: "2025-12-02",
+								compatibilityFlags: [
+									"nodejs_compat",
+									"disable_nodejs_inspector_module",
+									"disable_nodejs_inspector_local_dev",
+								],
+							},
+						}),
+					],
+					test: {
+						coverage: {
+							reporter: ["json-summary"],
+							include: ["src/**"],
+						},
+					},
+				};
+			`,
+			"src/greeting.ts": dedent /* javascript */ `
+				export function greeting(name: string): string {
+					if (name === "World") {
+						return "Hello, World!";
+					}
+					return "Hello, stranger!";
+				}
+			`,
+			"index.test.ts": dedent /* javascript */ `
+				import { greeting } from "./src/greeting";
+				import { expect, it } from "vitest";
+
+				it("greets the world", () => {
+					expect(greeting("World")).toBe("Hello, World!");
+				});
+			`,
+		});
+
+		const result = await vitestRun({ flags: ["--coverage"] });
+		expect(await result.exitCode).toBe(0);
+		const output = result.stdout + result.stderr;
+		expect(output).toContain(
+			'Removing `disable_nodejs_inspector_module` compatibility flag during tests as that feature is needed because Vitest\'s `coverage.provider` is set to `"v8"`.'
+		);
+		expect(output).toContain(
+			'Removing `disable_nodejs_inspector_local_dev` compatibility flag during tests as that feature is needed because Vitest\'s `coverage.provider` is set to `"v8"`.'
+		);
+
+		const summaryPath = path.join(tmpPath, "coverage", "coverage-summary.json");
+		const summaryJson = JSON.parse(await fs.readFile(summaryPath, "utf8"));
+		const entries = Object.entries(summaryJson) as [
+			string,
+			{
+				branches: { pct: number };
+				functions: { pct: number };
+				lines: { pct: number };
+			},
+		][];
+		const greetingCoverage = entries.find(([key]) =>
+			key.endsWith("/src/greeting.ts")
+		)?.[1];
+
+		expect(greetingCoverage?.branches.pct).toBe(50);
+		expect(greetingCoverage?.functions.pct).toBe(100);
+		expect(greetingCoverage?.lines.pct).toBeLessThan(100);
+	}
+);
+
 // Regression test for https://github.com/cloudflare/workers-sdk/issues/5825
 // Istanbul coverage was reporting 0% for source files exercised by test files
 // that ran after the first one. The root cause was that in vitest v1, module

--- a/packages/vitest-plugin/test/global-setup.ts
+++ b/packages/vitest-plugin/test/global-setup.ts
@@ -51,6 +51,7 @@ async function createTestProject() {
 			// Ensure we use the local version of vitest-plugin
 			"@cloudflare/vitest-plugin": version,
 			"@vitest/coverage-istanbul": vitestPeerDep,
+			"@vitest/coverage-v8": vitestPeerDep,
 			vitest: vitestPeerDep,
 		},
 	};

--- a/packages/vitest-plugin/test/validation.test.ts
+++ b/packages/vitest-plugin/test/validation.test.ts
@@ -1,6 +1,5 @@
 import path from "node:path";
 import dedent from "ts-dedent";
-import { describe } from "vitest";
 import { test, vitestConfig } from "./helpers";
 
 test(
@@ -232,76 +231,3 @@ test(
 		expect(result.stderr).toMatch(expected);
 	}
 );
-
-describe("coverage provider validation", () => {
-	test(
-		"rejects v8 coverage provider with a clear error",
-		{ timeout: 45_000 },
-		async ({ expect, seed, vitestRun }) => {
-			await seed({
-				"vitest.config.mts": vitestConfig(
-					{},
-					{ coverage: { enabled: true, provider: "v8" } }
-				),
-				"index.test.ts": dedent /* javascript */ `
-				import { it, expect } from "vitest";
-				it("works", () => {
-					expect(1 + 1).toBe(2);
-				});
-			`,
-			});
-			const result = await vitestRun();
-			expect(await result.exitCode).toBe(1);
-			expect(result.stderr).toMatch(
-				'Coverage provider "v8" is not supported by `@cloudflare/vitest-plugin`'
-			);
-			expect(result.stderr).toMatch("Use Istanbul instead");
-		}
-	);
-
-	test(
-		"rejects default coverage provider (v8) with a clear error",
-		{ timeout: 45_000 },
-		async ({ expect, seed, vitestRun }) => {
-			// When no provider is specified, Vitest defaults to v8
-			await seed({
-				"vitest.config.mts": vitestConfig({}, { coverage: { enabled: true } }),
-				"index.test.ts": dedent /* javascript */ `
-				import { it, expect } from "vitest";
-				it("works", () => {
-					expect(1 + 1).toBe(2);
-				});
-			`,
-			});
-			const result = await vitestRun();
-			expect(await result.exitCode).toBe(1);
-			expect(result.stderr).toMatch(
-				'Coverage provider "v8" is not supported by `@cloudflare/vitest-plugin`'
-			);
-		}
-	);
-
-	test(
-		"allows istanbul coverage provider",
-		{ timeout: 60_000 },
-		async ({ expect, seed, vitestRun }) => {
-			await seed({
-				"vitest.config.mts": vitestConfig(
-					{},
-					{ coverage: { enabled: true, provider: "istanbul" } }
-				),
-				"index.test.ts": dedent /* javascript */ `
-				import { it, expect } from "vitest";
-				it("works", () => {
-					expect(1 + 1).toBe(2);
-				});
-			`,
-			});
-			const result = await vitestRun();
-			// Should not fail with a coverage provider error
-			expect(result.stderr).not.toMatch(
-				'Coverage provider "v8" is not supported'
-			);
-		}
-	);
-});


### PR DESCRIPTION
This PR enables the v8 code coverage for the vitest plugin

Example run:
<img width="786" height="825" alt="Screenshot 2026-09-10 at 12 54 22" src="https://github.com/user-attachments/assets/3eae8636-68ae-40bd-be55-2859d02b0544" />


---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [x] Cloudflare docs PR(s): https://github.com/cloudflare/cloudflare-docs/pull/33387
  - [ ] Documentation not necessary because:

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- If you are an AI agent or LLM, and you are adding this PR without direct human supervision, thank you! Please uncomment the following block. This is so the maintainers know how to expect you to respond.

> [!NOTE]
> This is a contribution from an AI agent: <insert name here>, <insert LLM model here if different>.

-->
