### PR TITLE
[wrangler] Improve custom domain Preview deployment feedback

### DIFF
--- a/.changeset/calm-clouds-preview.md
+++ b/.changeset/calm-clouds-preview.md
@@ -1,0 +1,10 @@
+---
+"@cloudflare/deploy-helpers": patch
+"wrangler": patch
+---
+
+Add a provisioning delay note when custom domain Preview URLs change
+
+Wrangler now explains that DNS and TLS certificate provisioning may continue after a deploy adds a custom domain or enables its Preview URLs. Stable redeploys don't repeat the note.
+
+This assumes that a request which matches the stored custom domain state doesn't restart provisioning. The client infers this from the API changeset and current domain record because this repository can't verify the backend behavior.

--- a/.changeset/clear-domain-route-labels.md
+++ b/.changeset/clear-domain-route-labels.md
@@ -1,0 +1,8 @@
+---
+"@cloudflare/deploy-helpers": patch
+"wrangler": patch
+---
+
+Clarify production status labels for custom domain routes
+
+Wrangler now prefixes explicit custom domain production states with `production:` so they match Preview labels. The updated labels appear in deployed trigger output and `WRANGLER_OUTPUT_FILE_PATH`.

--- a/.changeset/fuzzy-dogs-prompt.md
+++ b/.changeset/fuzzy-dogs-prompt.md
@@ -1,0 +1,8 @@
+---
+"@cloudflare/deploy-helpers": patch
+"wrangler": patch
+---
+
+Avoid replacement prompts for custom domains already on the Worker
+
+Wrangler now updates Preview settings without asking to replace a custom domain when that domain already belongs to the deployed Worker. It still asks before replacing domains attached to another Worker.

--- a/.changeset/quiet-pandas-preview.md
+++ b/.changeset/quiet-pandas-preview.md
@@ -1,0 +1,10 @@
+---
+"@cloudflare/deploy-helpers": patch
+"wrangler": patch
+---
+
+Explain how to enable Preview URLs when a Preview deployment has none
+
+`wrangler preview` now shows URL shapes and configuration snippets for Workers.dev and custom domains. The custom domain snippet preserves every configured route, and the guidance distinguishes missing settings from disabled ones.
+
+This changes a private beta feature. The warning also makes clear that `wrangler deploy` publishes code from the current checkout.

--- a/packages/deploy-helpers/src/preview/preview.ts
+++ b/packages/deploy-helpers/src/preview/preview.ts
@@ -2,6 +2,7 @@ import path from "node:path";
 import { verifyDockerInstalled } from "@cloudflare/containers-shared";
 import {
 	configFileName,
+	formatConfigSnippet,
 	getBindings,
 	getBindingTypeFriendlyName,
 	getDockerPath,
@@ -52,7 +53,10 @@ import type { ContainerNormalizedConfig } from "@cloudflare/containers-shared";
 import type {
 	Config,
 	ContainerApp,
+	CustomDomainRoute,
 	PreviewsConfig,
+	RawEnvironment,
+	Route,
 } from "@cloudflare/workers-utils";
 
 export type PreviewArgs = {
@@ -293,7 +297,119 @@ async function prepareContainersForPreview(
 }
 
 export const NO_ACTIVE_PREVIEW_URLS_MESSAGE =
-	"Note: This Preview deployment has no active URLs. To get one, enable Preview Deployments on workers.dev or a custom domain. See https://developers.cloudflare.com/workers/previews/custom-domains/ for more information";
+	"Note: This Preview deployment has no active URLs.";
+
+function isCustomDomainRoute(route: Route): route is CustomDomainRoute {
+	return typeof route === "object" && route.custom_domain === true;
+}
+
+function formatPreviewConfigUpdate(
+	config: Config,
+	update: RawEnvironment
+): string {
+	const configPath = config.userConfigPath ?? config.configPath;
+	if (!config.targetEnvironment) {
+		return formatConfigSnippet(update, configPath).trimEnd();
+	}
+
+	return formatConfigSnippet(
+		{ env: { [config.targetEnvironment]: update } },
+		configPath
+	).trimEnd();
+}
+
+export function formatNoActivePreviewUrlsMessage(config: Config): string {
+	const customDomainRouteEntries = (config.routes ?? [])
+		.filter(isCustomDomainRoute)
+		.map((route) => ({ route, singular: false }));
+	if (config.route && isCustomDomainRoute(config.route)) {
+		customDomainRouteEntries.push({ route: config.route, singular: true });
+	}
+	const customDomainRouteEntry =
+		customDomainRouteEntries.find(
+			({ route }) => route.previews_enabled === true
+		) ?? customDomainRouteEntries[0];
+	const customDomainRoute = customDomainRouteEntry?.route;
+	const customDomain = customDomainRoute?.pattern ?? "previews.example.com";
+	const configPath = config.userConfigPath ?? config.configPath;
+	const configName = configFileName(configPath);
+	const workersDevConfig = formatPreviewConfigUpdate(config, {
+		preview_urls: true,
+	});
+	const customDomainRouteConfig: CustomDomainRoute = {
+		...(customDomainRoute ?? {
+			pattern: customDomain,
+			custom_domain: true,
+			enabled: false,
+		}),
+		previews_enabled: true,
+	};
+	let customDomainConfigUpdate: RawEnvironment;
+	if (customDomainRouteEntry?.singular) {
+		customDomainConfigUpdate = { route: customDomainRouteConfig };
+	} else if (customDomainRoute) {
+		customDomainConfigUpdate = {
+			routes: (config.routes ?? []).map((route) =>
+				route === customDomainRoute ? customDomainRouteConfig : route
+			),
+		};
+	} else {
+		const routes = config.routes ?? (config.route ? [config.route] : []);
+		customDomainConfigUpdate = {
+			routes: [...routes, customDomainRouteConfig],
+		};
+	}
+	const customDomainConfig = formatPreviewConfigUpdate(
+		config,
+		customDomainConfigUpdate
+	);
+	let productionStatus = "disabled";
+	if (customDomainRoute?.enabled === true) {
+		productionStatus = "enabled";
+	} else if (customDomainRoute?.enabled === undefined && customDomainRoute) {
+		productionStatus = "enabled (default)";
+	}
+	const workersDevAlreadyConfigured = config.preview_urls === true;
+	const customDomainAlreadyConfigured =
+		customDomainRoute?.previews_enabled === true;
+	const cautionText =
+		workersDevAlreadyConfigured && customDomainAlreadyConfigured
+			? "Caution: `wrangler deploy` publishes the code in your current checkout to the deployed Worker. If you have already made this change, confirm it was applied by running `wrangler deploy` from a clean checkout of your production branch. Then return to your feature branch and run `wrangler preview` again."
+			: "Caution: `wrangler deploy` publishes the code in your current checkout to the deployed Worker, not only these settings. If you use Git, commit the configuration change and run `wrangler deploy` from a clean checkout of your production branch. Then return to your feature branch and run `wrangler preview` again.";
+	let workersDevInstruction = `Add this to your ${configName}:`;
+	if (config.preview_urls === true) {
+		workersDevInstruction = `Your ${configName} already contains:`;
+	} else if (config.preview_urls === false) {
+		workersDevInstruction = `Update this in your ${configName}:`;
+	}
+	let customDomainInstruction = `Add or update this route in your ${configName}:`;
+	if (customDomainRoute?.previews_enabled === true) {
+		customDomainInstruction = `Your ${configName} already contains:`;
+	} else if (customDomainRoute === undefined && config.route !== undefined) {
+		customDomainInstruction = `Replace \`route\` with this in your ${configName}:`;
+	}
+
+	return [
+		NO_ACTIVE_PREVIEW_URLS_MESSAGE,
+		"",
+		"For a Workers.dev URL such as:",
+		"  https://<preview-name>-<worker>.<subdomain>.workers.dev",
+		workersDevInstruction,
+		workersDevConfig,
+		"",
+		"For a custom-domain URL such as:",
+		`  https://<preview-name>.${customDomain}`,
+		customDomainInstruction,
+		customDomainConfig,
+		"Resulting route behavior:",
+		`  Production: ${productionStatus}`,
+		"  Previews: enabled",
+		"",
+		cautionText,
+		"",
+		"See https://developers.cloudflare.com/workers/previews/custom-domains/ for more information.",
+	].join("\n");
+}
 
 function getPreviewMigrationsToUpload(
 	workerName: string,
@@ -567,6 +683,7 @@ function formatUrlLines(label: string, urls: string[] | undefined): string[] {
 }
 
 function formatPreviewDeploymentSummary(
+	config: Config,
 	previewResource: PreviewResource,
 	deployment: DeploymentResource,
 	isNew: boolean,
@@ -595,7 +712,7 @@ function formatPreviewDeploymentSummary(
 					}`,
 				]
 			: []),
-		...(hasActiveUrls ? [] : [NO_ACTIVE_PREVIEW_URLS_MESSAGE]),
+		...(hasActiveUrls ? [] : [formatNoActivePreviewUrlsMessage(config)]),
 	].join("\n");
 }
 
@@ -824,6 +941,7 @@ export async function preview(
 	} else {
 		logger.log(
 			formatPreviewDeploymentSummary(
+				config,
 				previewResource,
 				deployment,
 				isNewPreview,

--- a/packages/deploy-helpers/src/shared/types.ts
+++ b/packages/deploy-helpers/src/shared/types.ts
@@ -158,6 +158,7 @@ export type WorkerBuildResult = {
 
 export interface TriggerDeployment {
 	targets: string[];
+	changed?: boolean;
 	category?: string;
 	resource?: string;
 	error?: Error;

--- a/packages/deploy-helpers/src/triggers/deploy.ts
+++ b/packages/deploy-helpers/src/triggers/deploy.ts
@@ -27,6 +27,9 @@ import type { TriggerDeployment, TriggerProps } from "../shared/types";
 import type { RouteObject } from "./publish-routes";
 import type { Config, Route } from "@cloudflare/workers-utils";
 
+export const PREVIEW_DOMAIN_PROVISIONING_NOTE =
+	"Note: DNS and TLS certificate provisioning for Preview domains may continue after this deploy. If a new Preview URL does not work immediately, wait a few minutes and retry.";
+
 export async function triggersDeploy(
 	props: TriggerProps
 ): Promise<string[] | void> {
@@ -217,6 +220,7 @@ export async function triggersDeploy(
 				config,
 				workerUrl,
 				accountId,
+				scriptName,
 				customDomainsOnly
 			).then(
 				(result) => ({ ...result, category: "Custom domains" }),
@@ -485,6 +489,21 @@ export async function triggersDeploy(
 		}
 	} else {
 		logger.log("No targets deployed for", workerName, formatTime(deployMs));
+	}
+
+	const customDomainDeployment = completedDeployments.find(
+		(deployment) => deployment.category === "Custom domains"
+	);
+	if (
+		customDomainsOnly.some(
+			(domain) =>
+				"previews_enabled" in domain && domain.previews_enabled === true
+		) &&
+		customDomainDeployment !== undefined &&
+		customDomainDeployment.changed === true &&
+		customDomainDeployment.error === undefined
+	) {
+		logger.log(PREVIEW_DOMAIN_PROVISIONING_NOTE);
 	}
 
 	const failedDeployments = completedDeployments.filter(

--- a/packages/deploy-helpers/src/triggers/publish-routes.ts
+++ b/packages/deploy-helpers/src/triggers/publish-routes.ts
@@ -66,7 +66,9 @@ export function renderRoute(route: Route): string {
 		if (isCustomDomain) {
 			const flags: string[] = [];
 			if ("enabled" in route && route.enabled !== undefined) {
-				flags.push(route.enabled ? "enabled" : "disabled");
+				flags.push(
+					route.enabled ? "production: enabled" : "production: disabled"
+				);
 			}
 			if ("previews_enabled" in route && route.previews_enabled !== undefined) {
 				flags.push(

--- a/packages/deploy-helpers/src/triggers/publish-routes.ts
+++ b/packages/deploy-helpers/src/triggers/publish-routes.ts
@@ -254,6 +254,7 @@ export async function publishCustomDomains(
 	complianceConfig: ComplianceConfig,
 	workerUrl: string,
 	accountId: string,
+	scriptName: string,
 	domains: Array<RouteObject>
 ): Promise<TriggerDeployment> {
 	const options = {
@@ -273,10 +274,61 @@ export async function publishCustomDomains(
 					: undefined,
 		};
 	});
+	let changeset: CustomDomainChangeset;
+	try {
+		changeset = await fetchResult<CustomDomainChangeset>(
+			complianceConfig,
+			`${workerUrl}/domains/changeset?replace_state=true`,
+			{
+				method: "POST",
+				body: JSON.stringify(origins),
+				headers: {
+					"Content-Type": "application/json",
+				},
+			}
+		);
+	} catch (error) {
+		if (process.stdout.isTTY) {
+			throw error;
+		}
+		changeset = { added: [], removed: [], updated: [], conflicting: [] };
+	}
+	const updatesRequired = changeset.updated.filter((domain) => domain.modified);
+	const previewUpdates = updatesRequired.filter(
+		(domain) => domain.previews_enabled === true
+	);
+	const fetchExistingDomain = (domain: UpdatedCustomDomain) =>
+		fetchResult<CustomDomain>(
+			complianceConfig,
+			`/accounts/${accountId}/workers/domains/records/${domain.id}`
+		);
+	let existing: CustomDomain[];
+	if (process.stdout.isTTY) {
+		existing = await Promise.all(updatesRequired.map(fetchExistingDomain));
+	} else {
+		const results = await Promise.allSettled(
+			previewUpdates.map(fetchExistingDomain)
+		);
+		existing = results.flatMap((result) =>
+			result.status === "fulfilled" ? [result.value] : []
+		);
+	}
+	const existingById = new Map(existing.map((domain) => [domain.id, domain]));
+	const changed =
+		changeset.added.some((domain) => domain.previews_enabled === true) ||
+		previewUpdates.some((domain) => {
+			const existingDomain = existingById.get(domain.id);
+			return (
+				existingDomain !== undefined &&
+				(existingDomain.service !== scriptName ||
+					existingDomain.previews_enabled !== true)
+			);
+		});
 
 	const fail = (): TriggerDeployment => {
 		return {
 			targets: [],
+			changed,
 			error: new UserError(
 				domains.length > 1
 					? `Publishing to ${domains.length} Custom Domains was skipped, fix conflicts and try again`
@@ -290,41 +342,23 @@ export async function publishCustomDomains(
 		options.override_existing_origin = true;
 		options.override_existing_dns_record = true;
 	} else {
-		const changeset = await fetchResult<CustomDomainChangeset>(
-			complianceConfig,
-			`${workerUrl}/domains/changeset?replace_state=true`,
-			{
-				method: "POST",
-				body: JSON.stringify(origins),
-				headers: {
-					"Content-Type": "application/json",
-				},
-			}
-		);
-
-		const updatesRequired = changeset.updated.filter(
-			(domain) => domain.modified
-		);
 		if (updatesRequired.length > 0) {
-			const existing = await Promise.all(
-				updatesRequired.map((domain) =>
-					fetchResult<CustomDomain>(
-						complianceConfig,
-						`/accounts/${accountId}/workers/domains/records/${domain.id}`
-					)
-				)
+			const existingForOtherWorkers = existing.filter(
+				(domain) => domain.service !== scriptName
 			);
-			const existingRendered = existing
-				.map(
-					(domain) =>
-						`\t• ${domain.hostname} (used as a domain for "${domain.service}")`
-				)
-				.join("\n");
-			const message = `Custom Domains already exist for these domains:
+			if (existingForOtherWorkers.length > 0) {
+				const existingRendered = existingForOtherWorkers
+					.map(
+						(domain) =>
+							`\t• ${domain.hostname} (used as a domain for "${domain.service}")`
+					)
+					.join("\n");
+				const message = `Custom Domains already exist for these domains:
 ${existingRendered}
 Update them to point to this script instead?`;
-			if (!(await confirm(message))) {
-				return fail();
+				if (!(await confirm(message))) {
+					return fail();
+				}
 			}
 			options.override_existing_origin = true;
 		}
@@ -351,5 +385,5 @@ Update them to point to this script instead?`;
 		},
 	});
 
-	return { targets: domains.map((domain) => renderRoute(domain)) };
+	return { targets: domains.map((domain) => renderRoute(domain)), changed };
 }

--- a/packages/deploy-helpers/tests/publish-custom-domains.test.ts
+++ b/packages/deploy-helpers/tests/publish-custom-domains.test.ts
@@ -1,0 +1,295 @@
+import { afterEach, beforeEach, describe, it } from "vitest";
+import { initDeployHelpersContext } from "../src/shared/context";
+import { publishCustomDomains } from "../src/triggers/publish-routes";
+import type {
+	CustomDomain,
+	CustomDomainChangeset,
+	RouteObject,
+} from "../src/triggers/publish-routes";
+import type { ComplianceConfig } from "@cloudflare/workers-utils";
+
+const ACCOUNT_ID = "some-account-id";
+const SCRIPT_NAME = "test-name";
+const WORKER_URL = `/accounts/${ACCOUNT_ID}/workers/scripts/${SCRIPT_NAME}`;
+
+function createCustomDomain(
+	overrides: Partial<CustomDomain> = {}
+): CustomDomain {
+	return {
+		id: "101",
+		zone_id: "",
+		zone_name: "",
+		hostname: "api.example.com",
+		service: SCRIPT_NAME,
+		environment: "",
+		enabled: true,
+		previews_enabled: false,
+		...overrides,
+	};
+}
+
+describe("publishCustomDomains", () => {
+	const originalStdoutIsTTY = process.stdout.isTTY;
+	let confirmRequests: number;
+	let confirmMessages: string[];
+	let changeset: CustomDomainChangeset;
+	let changesetLookupError: boolean;
+	let domainLookupError: boolean;
+	let existingDomains: Record<string, CustomDomain>;
+	let publishedBody: unknown;
+
+	beforeEach(() => {
+		confirmRequests = 0;
+		confirmMessages = [];
+		changesetLookupError = false;
+		domainLookupError = false;
+		const existingDomain = createCustomDomain();
+		changeset = {
+			added: [],
+			removed: [],
+			updated: [
+				{
+					...existingDomain,
+					previews_enabled: true,
+					modified: true,
+				},
+			],
+			conflicting: [],
+		};
+		existingDomains = { "101": existingDomain };
+		publishedBody = undefined;
+		Object.defineProperty(process.stdout, "isTTY", {
+			value: true,
+			configurable: true,
+		});
+
+		initDeployHelpersContext({
+			logger: {
+				debug() {},
+				error() {},
+				info() {},
+				log() {},
+				warn() {},
+			},
+			fetchResult: fetchResult as never,
+			fetchListResult: (() => {}) as never,
+			fetchPagedListResult: (() => {}) as never,
+			fetchKVGetValue: (() => {}) as never,
+			confirm: async (message) => {
+				confirmRequests++;
+				confirmMessages.push(message);
+				return true;
+			},
+			prompt: (() => {}) as never,
+			select: (() => {}) as never,
+		});
+	});
+
+	afterEach(() => {
+		Object.defineProperty(process.stdout, "isTTY", {
+			value: originalStdoutIsTTY,
+			configurable: true,
+		});
+	});
+
+	async function fetchResult(
+		_config: ComplianceConfig,
+		path: string,
+		init?: RequestInit
+	): Promise<unknown> {
+		const body =
+			typeof init?.body === "string" ? JSON.parse(init.body) : undefined;
+
+		if (path === `${WORKER_URL}/domains/changeset?replace_state=true`) {
+			if (changesetLookupError) {
+				throw new Error("Changeset lookup failed");
+			}
+			return changeset;
+		}
+
+		const domainRecordPrefix = `/accounts/${ACCOUNT_ID}/workers/domains/records/`;
+		if (path.startsWith(domainRecordPrefix)) {
+			if (domainLookupError) {
+				throw new Error("Domain lookup failed");
+			}
+			const domain = existingDomains[path.slice(domainRecordPrefix.length)];
+			if (domain !== undefined) {
+				return domain;
+			}
+		}
+
+		if (path === `${WORKER_URL}/domains/records`) {
+			publishedBody = body;
+			return null;
+		}
+
+		throw new Error(`Unexpected request: ${init?.method ?? "GET"} ${path}`);
+	}
+
+	function publishDomains(
+		domains: RouteObject[] = [
+			{
+				pattern: "api.example.com",
+				custom_domain: true,
+				previews_enabled: true,
+			},
+		]
+	) {
+		return publishCustomDomains(
+			{} as ComplianceConfig,
+			WORKER_URL,
+			ACCOUNT_ID,
+			SCRIPT_NAME,
+			domains
+		);
+	}
+
+	it.for([
+		{
+			name: "interactive",
+			isTTY: true,
+			lookupFails: false,
+			changesetFails: false,
+			changed: true,
+		},
+		{
+			name: "non-interactive",
+			isTTY: false,
+			lookupFails: false,
+			changesetFails: false,
+			changed: true,
+		},
+		{
+			name: "non-interactive with a failed state lookup",
+			isTTY: false,
+			lookupFails: true,
+			changesetFails: false,
+			changed: false,
+		},
+		{
+			name: "non-interactive with a failed changeset lookup",
+			isTTY: false,
+			lookupFails: false,
+			changesetFails: true,
+			changed: false,
+		},
+	])("handles Preview enablement when $name", async (testCase, { expect }) => {
+		domainLookupError = testCase.lookupFails;
+		changesetLookupError = testCase.changesetFails;
+		Object.defineProperty(process.stdout, "isTTY", {
+			value: testCase.isTTY,
+			configurable: true,
+		});
+
+		const result = await publishDomains();
+
+		expect(result).toEqual({
+			targets: ["api.example.com (custom domain) [previews: enabled]"],
+			changed: testCase.changed,
+		});
+		expect(publishedBody).toMatchObject({
+			origins: [
+				{
+					hostname: "api.example.com",
+					previews_enabled: true,
+				},
+			],
+		});
+		expect(confirmRequests).toBe(0);
+	});
+
+	it("requires the changeset in an interactive deploy", async ({ expect }) => {
+		changesetLookupError = true;
+
+		await expect(publishDomains()).rejects.toThrow("Changeset lookup failed");
+		expect(publishedBody).toBeUndefined();
+	});
+
+	it("ignores changes to a different domain without Previews", async ({
+		expect,
+	}) => {
+		changeset.added = [
+			createCustomDomain({ id: "102", hostname: "other.example.com" }),
+		];
+		changeset.updated = [];
+
+		const result = await publishDomains([
+			{
+				pattern: "api.example.com",
+				custom_domain: true,
+				previews_enabled: true,
+			},
+			{
+				pattern: "other.example.com",
+				custom_domain: true,
+				previews_enabled: false,
+			},
+		]);
+
+		expect(result.changed).toBe(false);
+	});
+
+	it("ignores an unrelated update to a same-Worker Preview domain", async ({
+		expect,
+	}) => {
+		const existingDomain = createCustomDomain({ previews_enabled: true });
+		existingDomains["101"] = existingDomain;
+		changeset.updated = [{ ...existingDomain, enabled: false, modified: true }];
+
+		const result = await publishDomains();
+
+		expect(result.changed).toBe(false);
+	});
+
+	it("prompts only for a foreign domain when updates have mixed ownership", async ({
+		expect,
+	}) => {
+		const sameDomain = createCustomDomain({
+			hostname: "same.example.com",
+			enabled: false,
+			previews_enabled: true,
+		});
+		const otherDomain = createCustomDomain({
+			id: "102",
+			hostname: "other.example.com",
+			service: "other-script",
+			previews_enabled: true,
+		});
+		changeset.updated = [
+			{ ...sameDomain, enabled: true, modified: true },
+			{ ...otherDomain, service: SCRIPT_NAME, modified: true },
+		];
+		existingDomains = { "101": sameDomain, "102": otherDomain };
+
+		const result = await publishDomains([
+			{
+				pattern: "same.example.com",
+				custom_domain: true,
+				previews_enabled: true,
+			},
+			{
+				pattern: "other.example.com",
+				custom_domain: true,
+				previews_enabled: true,
+			},
+		]);
+
+		expect(result.changed).toBe(true);
+		expect(confirmRequests).toBe(1);
+		expect(confirmMessages[0]).toContain("other.example.com");
+		expect(confirmMessages[0]).not.toContain("same.example.com");
+		expect(publishedBody).toMatchObject({
+			override_existing_origin: true,
+			origins: [
+				{
+					hostname: "same.example.com",
+					previews_enabled: true,
+				},
+				{
+					hostname: "other.example.com",
+					previews_enabled: true,
+				},
+			],
+		});
+	});
+});

--- a/packages/deploy-helpers/tests/publish-routes.test.ts
+++ b/packages/deploy-helpers/tests/publish-routes.test.ts
@@ -1,0 +1,46 @@
+import { describe, it } from "vitest";
+import { renderRoute } from "../src/triggers/publish-routes";
+import type { Route } from "@cloudflare/workers-utils";
+
+const customDomain = { pattern: "example.com", custom_domain: true } as const;
+
+describe("renderRoute", () => {
+	it.for<{ route: Route; expected: string }>([
+		{
+			route: { ...customDomain, enabled: true },
+			expected: "example.com (custom domain) [production: enabled]",
+		},
+		{
+			route: { ...customDomain, enabled: false },
+			expected: "example.com (custom domain) [production: disabled]",
+		},
+		{
+			route: { ...customDomain, previews_enabled: true },
+			expected: "example.com (custom domain) [previews: enabled]",
+		},
+		{
+			route: { ...customDomain, previews_enabled: false },
+			expected: "example.com (custom domain) [previews: disabled]",
+		},
+		{
+			route: customDomain,
+			expected: "example.com (custom domain)",
+		},
+		{
+			route: { ...customDomain, enabled: false, previews_enabled: true },
+			expected:
+				"example.com (custom domain) [production: disabled, previews: enabled]",
+		},
+		{ route: "example.com/*", expected: "example.com/*" },
+		{
+			route: { pattern: "example.com/*", zone_id: "zone-id" },
+			expected: "example.com/* (zone id: zone-id)",
+		},
+		{
+			route: { pattern: "example.com/*", zone_name: "example.com" },
+			expected: "example.com/* (zone name: example.com)",
+		},
+	])("renders $expected", ({ route, expected }, { expect }) => {
+		expect(renderRoute(route)).toBe(expected);
+	});
+});

--- a/packages/wrangler/src/__tests__/deploy/helpers.ts
+++ b/packages/wrangler/src/__tests__/deploy/helpers.ts
@@ -154,13 +154,15 @@ export function mockCustomDomainLookup(origin: CustomDomain) {
 }
 
 export function mockCustomDomainsChangesetRequest({
-	originConflicts = [],
+	updatedDomains = [],
 	dnsRecordConflicts = [],
 	env = undefined,
+	changeset = {},
 }: {
-	originConflicts?: Array<CustomDomain>;
+	updatedDomains?: Array<CustomDomain>;
 	dnsRecordConflicts?: Array<CustomDomain>;
 	env?: string | undefined;
+	changeset?: Partial<CustomDomainChangeset>;
 }) {
 	msw.use(
 		http.post<{ accountId: string; scriptName: string; envName: string }>(
@@ -172,10 +174,14 @@ export function mockCustomDomainsChangesetRequest({
 				);
 
 				const domains = (await request.json()) as Array<
-					{ hostname: string } & ({ zone_id?: string } | { zone_name?: string })
+					{
+						hostname: string;
+						enabled?: boolean;
+						previews_enabled?: boolean;
+					} & ({ zone_id?: string } | { zone_name?: string })
 				>;
 
-				const changeset: CustomDomainChangeset = {
+				const responseChangeset: CustomDomainChangeset = {
 					added: domains.map((domain) => {
 						return {
 							...domain,
@@ -184,22 +190,23 @@ export function mockCustomDomainsChangesetRequest({
 							environment: env ?? "",
 							zone_name: "",
 							zone_id: "",
-							enabled: true,
-							previews_enabled: false,
+							enabled: domain.enabled ?? true,
+							previews_enabled: domain.previews_enabled ?? false,
 						};
 					}),
 					removed: [],
 					updated:
-						originConflicts?.map((domain) => {
+						updatedDomains.map((domain) => {
 							return {
 								...domain,
 								modified: true,
 							};
 						}) ?? [],
 					conflicting: dnsRecordConflicts,
+					...changeset,
 				};
 
-				return HttpResponse.json(createFetchResult(changeset));
+				return HttpResponse.json(createFetchResult(responseChangeset));
 			},
 			{ once: true }
 		)

--- a/packages/wrangler/src/__tests__/deploy/routes.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/routes.test.ts
@@ -503,7 +503,7 @@ describe("deploy", () => {
 				});
 				await runWrangler("deploy ./index");
 				expect(std.out).toContain("api.example.com (custom domain)");
-				expect(std.out).toContain("[enabled, previews: enabled]");
+				expect(std.out).toContain("[production: enabled, previews: enabled]");
 				expect(std.out).toContain(PREVIEW_DOMAIN_PROVISIONING_NOTE);
 				expect(
 					std.out.indexOf(PREVIEW_DOMAIN_PROVISIONING_NOTE)

--- a/packages/wrangler/src/__tests__/deploy/routes.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/routes.test.ts
@@ -1,4 +1,5 @@
 import { getInstalledPackageVersion } from "@cloudflare/autoconfig";
+import { PREVIEW_DOMAIN_PROVISIONING_NOTE } from "@cloudflare/deploy-helpers";
 import {
 	runInTempDir,
 	writeWranglerConfig,
@@ -503,6 +504,142 @@ describe("deploy", () => {
 				await runWrangler("deploy ./index");
 				expect(std.out).toContain("api.example.com (custom domain)");
 				expect(std.out).toContain("[enabled, previews: enabled]");
+				expect(std.out).toContain(PREVIEW_DOMAIN_PROVISIONING_NOTE);
+				expect(
+					std.out.indexOf(PREVIEW_DOMAIN_PROVISIONING_NOTE)
+				).toBeGreaterThan(std.out.indexOf("api.example.com (custom domain)"));
+			});
+
+			it("should not print the Preview provisioning note for an unchanged Preview domain", async ({
+				expect,
+			}) => {
+				writeWranglerConfig({
+					routes: [
+						{
+							pattern: "api.example.com",
+							custom_domain: true,
+							previews_enabled: true,
+						},
+					],
+				});
+				writeWorkerSource();
+				mockUpdateWorkerSubdomain({ enabled: false });
+				mockUploadWorkerRequest({ expectedType: "esm" });
+				mockGetZones(expect, "api.example.com", [{ id: "api-example-com-id" }]);
+				mockGetZoneWorkerRoutes(expect, "api-example-com-id", []);
+				mockCustomDomainsChangesetRequest({
+					changeset: { added: [], updated: [] },
+				});
+				mockPublishCustomDomainsRequest({
+					publishFlags: {
+						override_scope: true,
+						override_existing_origin: false,
+						override_existing_dns_record: false,
+					},
+					domains: [
+						{
+							hostname: "api.example.com",
+							previews_enabled: true,
+						},
+					],
+				});
+
+				await runWrangler("deploy ./index");
+
+				expect(std.out).not.toContain(PREVIEW_DOMAIN_PROVISIONING_NOTE);
+			});
+
+			it("should not print the Preview provisioning note when previews_enabled is false or omitted", async ({
+				expect,
+			}) => {
+				writeWranglerConfig({
+					routes: [
+						{
+							pattern: "api.example.com",
+							custom_domain: true,
+							previews_enabled: false,
+						},
+						{
+							pattern: "app.example.com",
+							custom_domain: true,
+						},
+					],
+				});
+				writeWorkerSource();
+				mockUpdateWorkerSubdomain({ enabled: false });
+				mockUploadWorkerRequest({ expectedType: "esm" });
+				mockGetZonesMulti(expect, {
+					"api.example.com": {
+						accountId: "some-account-id",
+						zones: [{ id: "api-example-com-id" }],
+					},
+					"app.example.com": {
+						accountId: "some-account-id",
+						zones: [{ id: "app-example-com-id" }],
+					},
+				});
+				mockGetZoneWorkerRoutesMulti(expect, {
+					"api-example-com-id": [],
+					"app-example-com-id": [],
+				});
+				mockCustomDomainsChangesetRequest({});
+				mockPublishCustomDomainsRequest({
+					publishFlags: {
+						override_scope: true,
+						override_existing_origin: false,
+						override_existing_dns_record: false,
+					},
+					domains: [
+						{
+							hostname: "api.example.com",
+							previews_enabled: false,
+						},
+						{ hostname: "app.example.com" },
+					],
+				});
+
+				await runWrangler("deploy ./index");
+
+				expect(std.out).not.toContain(PREVIEW_DOMAIN_PROVISIONING_NOTE);
+			});
+
+			it("should not print the Preview provisioning note when custom-domain publishing fails", async ({
+				expect,
+			}) => {
+				writeWranglerConfig({
+					routes: [
+						{
+							pattern: "api.example.com",
+							custom_domain: true,
+							previews_enabled: true,
+						},
+					],
+				});
+				writeWorkerSource();
+				mockUpdateWorkerSubdomain({ enabled: false });
+				mockUploadWorkerRequest({ expectedType: "esm" });
+				mockGetZones(expect, "api.example.com", [{ id: "api-example-com-id" }]);
+				mockGetZoneWorkerRoutes(expect, "api-example-com-id", []);
+				mockCustomDomainsChangesetRequest({});
+				msw.use(
+					http.put(
+						"*/accounts/:accountId/workers/scripts/:scriptName/domains/records",
+						() =>
+							HttpResponse.json(
+								createFetchResult(null, false, [
+									{
+										code: 100159,
+										message: "Custom-domain publishing failed",
+									},
+								])
+							),
+						{ once: true }
+					)
+				);
+
+				await expect(runWrangler("deploy ./index")).rejects.toThrow();
+
+				expect(std.out).not.toContain(PREVIEW_DOMAIN_PROVISIONING_NOTE);
 			});
 
 			it("should confirm override if custom domain deploy would override an existing domain", async ({
@@ -520,7 +657,7 @@ describe("deploy", () => {
 				mockGetZoneWorkerRoutes(expect, "api-example-com-id", []);
 				// ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 				mockCustomDomainsChangesetRequest({
-					originConflicts: [
+					updatedDomains: [
 						{
 							id: "101",
 							zone_id: "",
@@ -559,6 +696,76 @@ Update them to point to this script instead?`,
 				});
 				await runWrangler("deploy ./index");
 				expect(std.out).toContain("api.example.com (custom domain)");
+			});
+
+			it("should override a custom domain without confirmation if it already belongs to this Worker environment", async ({
+				expect,
+			}) => {
+				writeWranglerConfig({
+					env: {
+						dev: {
+							routes: [
+								{
+									pattern: "api.example.com",
+									custom_domain: true,
+									previews_enabled: true,
+								},
+							],
+						},
+					},
+				});
+				writeWorkerSource();
+				mockUpdateWorkerSubdomain({ enabled: false, env: "dev" });
+				mockUploadWorkerRequest({ expectedType: "esm", env: "dev" });
+				mockGetZones(expect, "api.example.com", [{ id: "api-example-com-id" }]);
+				mockGetZoneWorkerRoutes(expect, "api-example-com-id", []);
+				mockCustomDomainsChangesetRequest({
+					env: "dev",
+					updatedDomains: [
+						{
+							id: "101",
+							zone_id: "",
+							zone_name: "",
+							hostname: "api.example.com",
+							service: "test-name-dev",
+							environment: "dev",
+							enabled: true,
+							previews_enabled: true,
+						},
+					],
+				});
+				mockCustomDomainLookup({
+					id: "101",
+					zone_id: "",
+					zone_name: "",
+					hostname: "api.example.com",
+					service: "test-name-dev",
+					environment: "dev",
+					enabled: true,
+					previews_enabled: false,
+				});
+				mockPublishCustomDomainsRequest({
+					env: "dev",
+					publishFlags: {
+						override_scope: true,
+						override_existing_origin: true,
+						override_existing_dns_record: false,
+					},
+					domains: [
+						{
+							hostname: "api.example.com",
+							previews_enabled: true,
+						},
+					],
+				});
+
+				await runWrangler("deploy ./index --env dev");
+
+				expect(std.out).toContain(
+					"api.example.com (custom domain) [previews: enabled]"
+				);
+				expect(std.out).toContain(PREVIEW_DOMAIN_PROVISIONING_NOTE);
+				expect(std.out).not.toContain("Custom Domains already exist");
 			});
 
 			it("should confirm override if custom domain deploy contains a conflicting DNS record", async ({
@@ -622,7 +829,7 @@ Update them to point to this script instead?`,
 				mockGetZoneWorkerRoutes(expect, "api-example-com-id", []);
 				// ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 				mockCustomDomainsChangesetRequest({
-					originConflicts: [
+					updatedDomains: [
 						{
 							id: "101",
 							zone_id: "",
@@ -729,7 +936,7 @@ Update them to point to this script instead?`,
 				mockGetZoneWorkerRoutes(expect, "api-example-com-id", []);
 				// ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 				mockCustomDomainsChangesetRequest({
-					originConflicts: [
+					updatedDomains: [
 						{
 							id: "101",
 							zone_id: "",
@@ -1430,7 +1637,7 @@ Update them to point to this script instead?`,
 			mockGetZones(expect, "api.example.com", [{ id: "api-example-com-id" }]);
 			mockGetZoneWorkerRoutes(expect, "api-example-com-id", []);
 			mockCustomDomainsChangesetRequest({
-				originConflicts: [
+				updatedDomains: [
 					{
 						id: "101",
 						zone_id: "",

--- a/packages/wrangler/src/__tests__/preview.secret.test.ts
+++ b/packages/wrangler/src/__tests__/preview.secret.test.ts
@@ -21,7 +21,7 @@ const BRANCH_ENV_VARS = [
 	"CI_COMMIT_REF_NAME",
 ] as const;
 const NO_ACTIVE_PREVIEW_URLS_MESSAGE =
-	"Note: This Preview deployment has no active URLs. To get one, enable Preview Deployments on workers.dev or a custom domain. See https://developers.cloudflare.com/workers/previews/custom-domains/ for more information";
+	"Note: This Preview deployment has no active URLs.";
 
 async function withoutBranchEnvVars<T>(callback: () => Promise<T>): Promise<T> {
 	const originalBranchEnv = Object.fromEntries(
@@ -188,6 +188,7 @@ describe("wrangler preview", () => {
 				expect(std.out).toContain(
 					"is now live at https://test-preview.example.workers.dev"
 				);
+				expect(std.out).not.toContain(NO_ACTIVE_PREVIEW_URLS_MESSAGE);
 				expect(std.out).not.toContain("preview-secret");
 			});
 
@@ -203,6 +204,15 @@ describe("wrangler preview", () => {
 
 				expect(std.out).toContain("Created Preview deployment deployment-1");
 				expect(std.out).toContain(NO_ACTIVE_PREVIEW_URLS_MESSAGE);
+				expect(std.out).toContain(
+					"https://<preview-name>.previews.example.com"
+				);
+				expect(std.out).toContain('"preview_urls": true');
+				expect(std.out).toContain('"enabled": false');
+				expect(std.out).toContain('"previews_enabled": true');
+				expect(std.out).toContain(
+					"run `wrangler deploy` from a clean checkout of your production branch"
+				);
 				expect(std.out).not.toContain("is now live at");
 			});
 
@@ -394,6 +404,7 @@ describe("wrangler preview", () => {
 				expect(std.out).toContain(
 					"is now live at https://test-preview.example.workers.dev"
 				);
+				expect(std.out).not.toContain(NO_ACTIVE_PREVIEW_URLS_MESSAGE);
 			});
 
 			test("notes when the new Preview deployment has no active URLs", async ({
@@ -631,6 +642,7 @@ describe("wrangler preview", () => {
 				expect(std.out).toContain(
 					"is now live at https://test-preview.example.workers.dev"
 				);
+				expect(std.out).not.toContain(NO_ACTIVE_PREVIEW_URLS_MESSAGE);
 				expect(std.out).not.toContain("one");
 				expect(std.out).not.toContain("two");
 			});

--- a/packages/wrangler/src/__tests__/preview.test.ts
+++ b/packages/wrangler/src/__tests__/preview.test.ts
@@ -4,6 +4,7 @@ import { stripVTControlCharacters } from "node:util";
 import * as streams from "@cloudflare/cli-shared-helpers/streams";
 import {
 	extractConfigBindings,
+	formatNoActivePreviewUrlsMessage,
 	getBranchName,
 	getCommitSha,
 	getPullRequestMetadata,
@@ -28,7 +29,10 @@ import {
 	writeWranglerConfig,
 } from "./helpers/write-wrangler-config";
 import type { OutputEntry } from "../output";
-import type { Config, PreviewsConfig } from "@cloudflare/workers-utils";
+import type { Config, PreviewsConfig, Route } from "@cloudflare/workers-utils";
+
+const NO_ACTIVE_PREVIEW_URLS_MESSAGE =
+	"Note: This Preview deployment has no active URLs.";
 
 vi.mock("node:child_process", async () => {
 	const actual =
@@ -45,6 +49,31 @@ function configWithPreviews(previews: PreviewsConfig): Config {
 		previews,
 	};
 }
+
+function configForUrlGuidance(config: Partial<Config>): Config {
+	return {
+		...defaultWranglerConfig,
+		configPath: "/test/wrangler.json",
+		...config,
+	};
+}
+
+const explicitlyEnabledPreviewRoute = {
+	pattern: "explicit.example.com",
+	custom_domain: true,
+	enabled: true,
+	previews_enabled: true,
+} satisfies Route;
+const existingRoutes = [
+	{ pattern: "shop.example.com", zone_id: "z1" },
+	{ pattern: "app.example.com", custom_domain: true, enabled: true },
+	{
+		pattern: "beta.example.com",
+		custom_domain: true,
+		enabled: false,
+		previews_enabled: true,
+	},
+] satisfies Route[];
 
 type PreviewDeploymentModulePart = {
 	name: string;
@@ -256,6 +285,224 @@ describe("wrangler preview", () => {
 					{ ...defaultWranglerConfig, name: "config-worker" }
 				)
 			).toBe("ci-worker");
+		});
+	});
+
+	describe("formatNoActivePreviewUrlsMessage", () => {
+		test.for([
+			{
+				name: "a new Preview-only custom domain",
+				config: configForUrlGuidance({}),
+				expectedCustomDomainConfig: {
+					routes: [
+						{
+							pattern: "previews.example.com",
+							custom_domain: true,
+							enabled: false,
+							previews_enabled: true,
+						},
+					],
+				},
+				expectedProductionStatus: "disabled",
+			},
+			{
+				name: "an existing implicitly enabled production domain",
+				config: configForUrlGuidance({
+					routes: [
+						{
+							pattern: "implicit.example.com",
+							custom_domain: true,
+						},
+					],
+				}),
+				expectedCustomDomainConfig: {
+					routes: [
+						{
+							pattern: "implicit.example.com",
+							custom_domain: true,
+							previews_enabled: true,
+						},
+					],
+				},
+				expectedProductionStatus: "enabled (default)",
+			},
+			{
+				name: "an existing explicitly enabled production domain",
+				config: configForUrlGuidance({
+					routes: [explicitlyEnabledPreviewRoute],
+				}),
+				expectedCustomDomainConfig: {
+					routes: [explicitlyEnabledPreviewRoute],
+				},
+				expectedProductionStatus: "enabled",
+			},
+			{
+				name: "an existing multi-route config with a non-custom-domain and another custom-domain route",
+				config: configForUrlGuidance({ routes: existingRoutes }),
+				expectedCustomDomainConfig: { routes: existingRoutes },
+				expectedProductionStatus: "disabled",
+			},
+			{
+				name: "an existing singular non-custom-domain route",
+				config: configForUrlGuidance({
+					route: { pattern: "shop.example.com", zone_id: "z1" },
+				}),
+				expectedCustomDomainConfig: {
+					routes: [
+						{ pattern: "shop.example.com", zone_id: "z1" },
+						{
+							pattern: "previews.example.com",
+							custom_domain: true,
+							enabled: false,
+							previews_enabled: true,
+						},
+					],
+				},
+				expectedProductionStatus: "disabled",
+			},
+		])(
+			"shows exact configuration for $name",
+			(
+				{ config, expectedCustomDomainConfig, expectedProductionStatus },
+				{ expect }
+			) => {
+				const message = formatNoActivePreviewUrlsMessage(config);
+
+				expect(message).toContain(
+					JSON.stringify({ preview_urls: true }, null, 2)
+				);
+				expect(message).toContain(
+					JSON.stringify(expectedCustomDomainConfig, null, 2)
+				);
+				expect(message).toContain(
+					`Resulting route behavior:\n  Production: ${expectedProductionStatus}\n  Previews: enabled`
+				);
+			}
+		);
+
+		test("preserves a singular non-custom-domain route in TOML guidance", ({
+			expect,
+		}) => {
+			const message = formatNoActivePreviewUrlsMessage({
+				...configForUrlGuidance({
+					route: { pattern: "shop.example.com", zone_id: "z1" },
+				}),
+				configPath: "/test/wrangler.toml",
+			});
+
+			expect(message).toContain('pattern = "shop.example.com"');
+			expect(message).toContain('zone_id = "z1"');
+			expect(message).toContain('pattern = "previews.example.com"');
+			expect(message).toContain(
+				"Replace `route` with this in your wrangler.toml"
+			);
+		});
+
+		test.for([
+			{
+				configPath: "/test/wrangler.json",
+				userConfigPath: undefined,
+				configName: "wrangler.json",
+				expectedWorkersDevConfig: JSON.stringify(
+					{ env: { staging: { preview_urls: true } } },
+					null,
+					2
+				),
+				expectedCustomDomainConfig: JSON.stringify(
+					{
+						env: {
+							staging: {
+								routes: [
+									{
+										pattern: "app.example.com",
+										custom_domain: true,
+										previews_enabled: true,
+									},
+								],
+							},
+						},
+					},
+					null,
+					2
+				),
+			},
+			{
+				configPath: "/test/wrangler.toml",
+				userConfigPath: undefined,
+				configName: "wrangler.toml",
+				expectedWorkersDevConfig: "[env.staging]\npreview_urls = true",
+				expectedCustomDomainConfig:
+					'[[env.staging.routes]]\npattern = "app.example.com"\ncustom_domain = true\npreviews_enabled = true',
+			},
+			{
+				configPath: "/test/generated/wrangler.json",
+				userConfigPath: "/test/wrangler.toml",
+				configName: "wrangler.toml",
+				expectedWorkersDevConfig: "[env.staging]\npreview_urls = true",
+				expectedCustomDomainConfig:
+					'[[env.staging.routes]]\npattern = "app.example.com"\ncustom_domain = true\npreviews_enabled = true',
+			},
+		])(
+			"scopes URL guidance to the selected environment in $configPath",
+			(
+				{
+					configPath,
+					userConfigPath,
+					configName,
+					expectedWorkersDevConfig,
+					expectedCustomDomainConfig,
+				},
+				{ expect }
+			) => {
+				const message = formatNoActivePreviewUrlsMessage({
+					...configForUrlGuidance({
+						preview_urls: false,
+						routes: [
+							{
+								pattern: "app.example.com",
+								custom_domain: true,
+								previews_enabled: false,
+							},
+						],
+					}),
+					configPath,
+					userConfigPath,
+					targetEnvironment: "staging",
+				});
+
+				expect(message).toContain(`Update this in your ${configName}`);
+				expect(message).toContain(expectedWorkersDevConfig);
+				expect(message).toContain(expectedCustomDomainConfig);
+			}
+		);
+
+		test("does not ask the user to commit a change when both settings are already present", ({
+			expect,
+		}) => {
+			const message = formatNoActivePreviewUrlsMessage(
+				configForUrlGuidance({
+					preview_urls: true,
+					routes: [
+						{
+							pattern: "app.example.com",
+							custom_domain: true,
+							previews_enabled: true,
+						},
+					],
+				})
+			);
+
+			expect(message).not.toContain("commit the configuration change");
+		});
+
+		test("tells the user to update, not add, an explicit preview_urls: false", ({
+			expect,
+		}) => {
+			const message = formatNoActivePreviewUrlsMessage(
+				configForUrlGuidance({ preview_urls: false })
+			);
+
+			expect(message).toContain("Update this in your wrangler.json");
 		});
 	});
 
@@ -1893,10 +2140,50 @@ describe("wrangler preview", () => {
 			expect(std.out).toContain("Deployment URLs:");
 			expect(std.out).toContain("  https://dep-one.test-worker.cloudflare.app");
 			expect(std.out).toContain("  https://dep-two.test-worker.cloudflare.app");
-			expect(std.out).not.toContain("no active URLs");
+			expect(std.out).not.toContain(NO_ACTIVE_PREVIEW_URLS_MESSAGE);
 		});
 
-		test("should note when URL arrays are empty", async ({ expect }) => {
+		test.for<{
+			name: string;
+			previewUrls: string[];
+			deploymentUrls: string[];
+			shouldShowGuidance: boolean;
+		}>([
+			{
+				name: "both URL arrays are empty",
+				previewUrls: [],
+				deploymentUrls: [],
+				shouldShowGuidance: true,
+			},
+			{
+				name: "the Preview URL array is active",
+				previewUrls: ["https://empty-urls-preview.test-worker.workers.dev"],
+				deploymentUrls: [],
+				shouldShowGuidance: false,
+			},
+			{
+				name: "the deployment URL array is active",
+				previewUrls: [],
+				deploymentUrls: [
+					"https://deployment-id-empty-urls.test-worker.workers.dev",
+				],
+				shouldShowGuidance: false,
+			},
+		])("handles URL guidance when $name", async (testCase, { expect }) => {
+			writeWranglerConfig(
+				{
+					main: "src/index.ts",
+					routes: [
+						{
+							pattern: "previews.example.com",
+							custom_domain: true,
+							enabled: false,
+							previews_enabled: true,
+						},
+					],
+				},
+				"wrangler.json"
+			);
 			msw.use(
 				http.get(
 					`*/accounts/:accountId/workers/workers/:workerId/previews/:previewId`,
@@ -1920,7 +2207,7 @@ describe("wrangler preview", () => {
 									id: "preview-id-empty-urls",
 									name: "empty-urls-preview",
 									slug: "empty-urls-preview",
-									urls: [],
+									urls: testCase.previewUrls,
 									worker_name: "test-worker",
 									created_on: new Date().toISOString(),
 								},
@@ -1938,7 +2225,7 @@ describe("wrangler preview", () => {
 									id: "deployment-id-empty-urls",
 									preview_id: "preview-id-empty-urls",
 									preview_name: "empty-urls-preview",
-									urls: [],
+									urls: testCase.deploymentUrls,
 									compatibility_date: "2025-01-01",
 									env: {},
 									created_on: new Date().toISOString(),
@@ -1951,6 +2238,11 @@ describe("wrangler preview", () => {
 
 			await runWrangler("preview --name empty-urls-preview");
 
+			if (!testCase.shouldShowGuidance) {
+				expect(std.out).not.toContain(NO_ACTIVE_PREVIEW_URLS_MESSAGE);
+				return;
+			}
+
 			const summaryLines = stripVTControlCharacters(std.out)
 				.split("\n")
 				.filter(
@@ -1960,9 +2252,8 @@ describe("wrangler preview", () => {
 				"Preview: empty-urls-preview (new)",
 				"Deployment ID: deployment-id-empty-urls",
 			]);
-			expect(std.out).toContain(
-				"Note: This Preview deployment has no active URLs. To get one, enable Preview Deployments on workers.dev or a custom domain. See https://developers.cloudflare.com/workers/previews/custom-domains/ for more information"
-			);
+			expect(std.out).toContain(NO_ACTIVE_PREVIEW_URLS_MESSAGE);
+			expect(std.out).toContain('"preview_urls": true');
 		});
 
 		test("should use the URL-encoded preview name as the Preview identifier in path params", async ({

--- a/packages/wrangler/src/preview/secrets/bulk.ts
+++ b/packages/wrangler/src/preview/secrets/bulk.ts
@@ -5,7 +5,7 @@ import { logger } from "../../logger";
 import { parseBulkInputToObject } from "../../secret";
 import { requireAuth } from "../../user";
 import {
-	NO_ACTIVE_PREVIEW_URLS_MESSAGE,
+	formatNoActivePreviewUrlsMessage,
 	patchPreviewDeploymentSecrets,
 	resolvePreviewName,
 	toSecretBindingsPatch,
@@ -107,7 +107,7 @@ export const previewSecretBulkCommand = createCommand({
 					? `\n➡️  Your Preview "${previewName}" is now live at ${liveUrls
 							.map((url) => chalk.bold.underline(url))
 							.join(", ")}`
-					: `\n${NO_ACTIVE_PREVIEW_URLS_MESSAGE}`)
+					: `\n${formatNoActivePreviewUrlsMessage(config)}`)
 		);
 	},
 });

--- a/packages/wrangler/src/preview/secrets/delete.ts
+++ b/packages/wrangler/src/preview/secrets/delete.ts
@@ -5,7 +5,7 @@ import { confirm } from "../../dialogs";
 import { logger } from "../../logger";
 import { requireAuth } from "../../user";
 import {
-	NO_ACTIVE_PREVIEW_URLS_MESSAGE,
+	formatNoActivePreviewUrlsMessage,
 	patchPreviewDeploymentSecrets,
 	resolvePreviewName,
 } from "./index";
@@ -94,7 +94,7 @@ export const previewSecretDeleteCommand = createCommand({
 						? `\n➡️  Your Preview "${previewName}" is now live at ${liveUrls
 								.map((url) => chalk.bold.underline(url))
 								.join(", ")}`
-						: `\n${NO_ACTIVE_PREVIEW_URLS_MESSAGE}`)
+						: `\n${formatNoActivePreviewUrlsMessage(config)}`)
 			);
 		}
 	},

--- a/packages/wrangler/src/preview/secrets/index.ts
+++ b/packages/wrangler/src/preview/secrets/index.ts
@@ -1,4 +1,5 @@
 import {
+	formatNoActivePreviewUrlsMessage,
 	getBranchName,
 	NO_ACTIVE_PREVIEW_URLS_MESSAGE,
 	patchPreviewDeployment,
@@ -47,7 +48,7 @@ export function toSecretBindingsPatch(
 export const NO_PREVIEW_DEPLOYMENT_PATCH_ERR_CODE = 10032;
 export const NO_PREVIEW_DEPLOYMENT_GET_ERR_CODE = 10222;
 export const PREVIEW_NOT_FOUND_ERR_CODE = 10025;
-export { NO_ACTIVE_PREVIEW_URLS_MESSAGE };
+export { formatNoActivePreviewUrlsMessage, NO_ACTIVE_PREVIEW_URLS_MESSAGE };
 
 export function noPreviewDeploymentPatchMessage(previewName: string) {
 	return `There are currently no deployments for the Preview "${previewName}". Please create a Preview deployment before modifying a secret.`;

--- a/packages/wrangler/src/preview/secrets/put.ts
+++ b/packages/wrangler/src/preview/secrets/put.ts
@@ -6,7 +6,7 @@ import { logger } from "../../logger";
 import { requireAuth } from "../../user";
 import { readFromStdin, trimTrailingWhitespace } from "../../utils/std";
 import {
-	NO_ACTIVE_PREVIEW_URLS_MESSAGE,
+	formatNoActivePreviewUrlsMessage,
 	patchPreviewDeploymentSecrets,
 	resolvePreviewName,
 	toSecretBindingsPatch,
@@ -89,7 +89,7 @@ export const previewSecretPutCommand = createCommand({
 					? `\n➡️  Your Preview "${previewName}" is now live at ${liveUrls
 							.map((url) => chalk.bold.underline(url))
 							.join(", ")}`
-					: `\n${NO_ACTIVE_PREVIEW_URLS_MESSAGE}`)
+					: `\n${formatNoActivePreviewUrlsMessage(config)}`)
 		);
 	},
 });


### PR DESCRIPTION
This consolidates and closes #15434, #15522, #15523, and #15524 in three commits. The changes improve custom domain deploy feedback, clarify trigger labels, and show the required configuration when a Preview has no active URL.

| Area | Before | After |
| --- | --- | --- |
| Same Worker domains | Wrangler asked to replace a domain already attached to the Worker. | Wrangler updates it without a takeover prompt. Foreign domains still require confirmation. |
| Provisioning | A successful deploy gave no warning about pending DNS or TLS work. | Wrangler warns when a Preview domain is added, enabled, or reassigned. Stable redeploys stay quiet.<br><br>*This assumes an unchanged Custom Domains update doesn't restart provisioning.* |
| Route labels | Custom domains showed `enabled` or `disabled`. | They show `production: enabled` or `production: disabled` in CLI and `WRANGLER_OUTPUT_FILE_PATH` output. |
| Missing Preview URLs | Wrangler showed a generic documentation link. | Wrangler shows JSON, JSONC, or TOML edits for the selected environment and preserves existing routes. |

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: This improves existing Wrangler output without adding a public API or configuration option.

*A picture of a cute animal (not mandatory, but encouraged)*
<img width="545" height="545" alt="image" src="https://github.com/user-attachments/assets/13f2952e-9bdb-40a8-aaf0-bf62ee3b63d2" />


<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
