### PR TITLE
[containers-shared] Stop container preparation after abort

### DIFF
--- a/.changeset/calm-containers-stop.md
+++ b/.changeset/calm-containers-stop.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Stop preparing container images after an abort
+
+Aborting local container image preparation now stops later builds and pulls and skips the egress interceptor pull instead of continuing Docker work in the background.

--- a/packages/containers-shared/src/images.ts
+++ b/packages/containers-shared/src/images.ts
@@ -184,19 +184,18 @@ export async function prepareContainerImagesForDev(args: {
 				containerOptions: options,
 			});
 		}
-		if (!aborted) {
-			// Clean up duplicate image tags. This is scoped to cloudflare-dev only
-			await cleanupDuplicateImageTags(dockerPath, options.image_tag);
-
-			await checkExposedPorts(dockerPath, options);
+		if (aborted) {
+			return;
 		}
+		// Clean up duplicate image tags. This is scoped to cloudflare-dev only
+		await cleanupDuplicateImageTags(dockerPath, options.image_tag);
+
+		await checkExposedPorts(dockerPath, options);
 	}
 
 	// Pull the egress interceptor image used to intercept outbound HTTP from
 	// containers and route it back to workerd (e.g. for interceptOutboundHttp).
-	if (!aborted) {
-		await pullEgressInterceptorImage(dockerPath);
-	}
+	await pullEgressInterceptorImage(dockerPath);
 }
 
 /**

--- a/packages/containers-shared/tests/images.test.ts
+++ b/packages/containers-shared/tests/images.test.ts
@@ -3,12 +3,22 @@ import { ExternalRegistryKind } from "../src/client/models/ExternalRegistryKind"
 import {
 	getEgressInterceptorPlatform,
 	pullEgressInterceptorImage,
+	prepareContainerImagesForDev,
 	getAndValidateRegistryType,
 	validateAndEncodeGarKey,
 } from "../src/images";
-import { runDockerCmd } from "../src/utils";
+import { dockerLoginImageRegistry } from "../src/login";
+import {
+	checkExposedPorts,
+	cleanupDuplicateImageTags,
+	runDockerCmd,
+} from "../src/utils";
+
+vi.mock("../src/login", () => ({ dockerLoginImageRegistry: vi.fn() }));
 
 vi.mock("../src/utils", () => ({
+	checkExposedPorts: vi.fn(),
+	cleanupDuplicateImageTags: vi.fn(),
 	runDockerCmd: vi.fn(() => ({
 		abort: vi.fn(),
 		ready: Promise.resolve({ aborted: false }),
@@ -16,7 +26,49 @@ vi.mock("../src/utils", () => ({
 			resolve();
 		},
 	})),
+	verifyDockerInstalled: vi.fn(),
 }));
+
+it.skipIf(process.platform === "win32")(
+	"stops preparing images after cancelling a pull",
+	async ({ expect }) => {
+		vi.clearAllMocks();
+		vi.mocked(dockerLoginImageRegistry).mockResolvedValue();
+		let finishPull = () => {};
+		const ready = new Promise<{ aborted: boolean }>((resolve) => {
+			finishPull = () => resolve({ aborted: true });
+		});
+		vi.mocked(runDockerCmd).mockReturnValueOnce({
+			abort: finishPull,
+			ready,
+			then: (resolve, reject) => void ready.then(resolve).catch(reject),
+		});
+
+		await prepareContainerImagesForDev({
+			dockerPath: "docker",
+			containerOptions: [
+				{
+					class_name: "First",
+					image_tag: "cloudflare-dev/first:build-id",
+					image_uri: "docker.io/example/first:latest",
+				},
+				{
+					class_name: "Second",
+					image_tag: "cloudflare-dev/second:build-id",
+					image_uri: "docker.io/example/second:latest",
+				},
+			],
+			onContainerImagePreparationStart: ({ abort }) => abort(),
+			onContainerImagePreparationEnd: () => {},
+			logger: console,
+		});
+
+		expect(dockerLoginImageRegistry).toHaveBeenCalledOnce();
+		expect(runDockerCmd).toHaveBeenCalledOnce();
+		expect(cleanupDuplicateImageTags).not.toHaveBeenCalled();
+		expect(checkExposedPorts).not.toHaveBeenCalled();
+	}
+);
 
 describe("getEgressInterceptorPlatform", () => {
 	beforeEach(() => {


### PR DESCRIPTION
We currently allow configuring multiple container applications per worker. During local development, Wrangler and the Vite plugin prepare the container images sequentially.

Currently, cancelling preparation only aborts the Docker command in progress. The loop then moves on to the project’s next configured image, so Docker may continue building or pulling images after wrangler dev has stopped or Vite has restarted.

This change makes `prepareContainerImagesForDev()` exit when an abort is detected. It therefore skips:
- all subsequently configured container images
- cleanup and port validation for the cancelled image
- the final egress-interceptor image pull

For example, if a project configures images A and B and preparation is cancelled while processing A, Wrangler will no longer begin preparing B. A regression test covers cancelling the first of two configured images and verifies that no later Docker or validation work runs.

No documentation change because this fixes existing cancellation behaviour and does not change configuration or public APIs.

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: this fixes existing local preparation cancellation; there is no new config or API.
