### PR TITLE
[miniflare] Await workerd exit before local container cleanup

### DIFF
--- a/.changeset/tidy-containers-rest.md
+++ b/.changeset/tidy-containers-rest.md
@@ -1,0 +1,5 @@
+---
+"miniflare": patch
+---
+
+Gracefully stop workerd when containers are configured so that runtime-owned container resources are removed during shutdown

--- a/fixtures/container-app/tests/container.test.ts
+++ b/fixtures/container-app/tests/container.test.ts
@@ -1,4 +1,5 @@
-import { execSync } from "child_process";
+import assert from "node:assert";
+import { execFileSync, spawnSync } from "node:child_process";
 import { afterAll, beforeAll, describe, test, vi } from "vitest";
 import { createTestHarness } from "wrangler";
 
@@ -6,9 +7,9 @@ const isCINonLinux = process.platform !== "linux" && process.env.CI === "true";
 
 function isDockerRunning() {
 	try {
-		execSync("docker ps", { stdio: "ignore" });
+		execFileSync("docker", ["ps"], { stdio: "ignore" });
 		return true;
-	} catch (e) {
+	} catch {
 		return false;
 	}
 }
@@ -31,6 +32,7 @@ describe.skipIf(
 	const server = createTestHarness({
 		workers: [{ configPath: "./wrangler.jsonc" }],
 	});
+	let runtimeContainerIds: string[] = [];
 
 	beforeAll(async () => {
 		await server.listen();
@@ -38,6 +40,10 @@ describe.skipIf(
 
 	afterAll(async () => {
 		await server.close();
+		const remainingIds = runtimeContainerIds.filter(
+			(id) => spawnSync("docker", ["inspect", id]).status === 0
+		);
+		assert.deepStrictEqual(remainingIds, []);
 	});
 
 	test("starts and fetches from the container", async ({ expect }) => {
@@ -56,5 +62,15 @@ describe.skipIf(
 			},
 			{ interval: 500, timeout: 30_000 }
 		);
+
+		runtimeContainerIds = execFileSync(
+			"docker",
+			["ps", "-q", "--filter", "name=workerd-container-app"],
+			{ encoding: "utf8" }
+		)
+			.trim()
+			.split("\n")
+			.filter(Boolean);
+		expect(runtimeContainerIds).toHaveLength(2);
 	});
 });

--- a/packages/miniflare/src/index.ts
+++ b/packages/miniflare/src/index.ts
@@ -2577,6 +2577,13 @@ export class Miniflare {
 			reusePorts
 		);
 		const configBuffer = serializeConfig(config);
+		const hasContainers = config.services?.some(
+			(service) =>
+				"worker" in service &&
+				service.worker?.durableObjectNamespaces?.some(
+					(namespace) => namespace.container !== undefined
+				)
+		);
 
 		// Get all socket names we expect to get ports for
 		assert(config.sockets !== undefined);
@@ -2639,6 +2646,7 @@ export class Miniflare {
 				? "127.0.0.1:0"
 				: undefined,
 			verbose: this.#sharedOpts.verbose,
+			gracefulShutdown: hasContainers,
 			handleStructuredLogs: this.#sharedOpts.handleStructuredLogs,
 			onWorkerdCrashRestart: () => this.#handleWorkerdCrash(),
 			runtimeEnv: this.#sharedOpts.unsafeRuntimeEnv,

--- a/packages/miniflare/src/runtime/index.ts
+++ b/packages/miniflare/src/runtime/index.ts
@@ -10,8 +10,8 @@ import workerdPath from "workerd";
 import { z } from "zod";
 import { SERVICE_LOOPBACK, SOCKET_ENTRY } from "../plugins";
 import { MiniflareCoreError } from "../shared";
+import { terminateRuntimeProcess } from "./shutdown";
 import { handleStructuredLogsFromStream } from "./structured-logs";
-import type { Awaitable } from "../workers";
 import type { StructuredLogsHandler } from "./structured-logs";
 import type { Abortable } from "node:events";
 
@@ -47,6 +47,7 @@ export interface RuntimeOptions {
 	// Merged on top of `process.env` and Miniflare's own defaults
 	// (e.g. `TZ=UTC`, `FORCE_COLOR`), so callers can override those defaults.
 	runtimeEnv?: Record<string, string>;
+	gracefulShutdown?: boolean;
 }
 
 async function waitForPorts(
@@ -240,6 +241,7 @@ class StartupLogBuffer {
 export class Runtime {
 	#process?: childProcess.ChildProcess;
 	#processExitPromise?: Promise<void>;
+	#gracefulShutdown = false;
 
 	async updateConfig(
 		configBuffer: Buffer,
@@ -249,6 +251,7 @@ export class Runtime {
 	): Promise<SocketPorts | undefined> {
 		// 1. Stop existing process (if any) and wait for exit
 		await this.dispose();
+		this.#gracefulShutdown = options.gracefulShutdown ?? false;
 
 		// 2. Start new process
 		const command = getRuntimeCommand();
@@ -373,11 +376,13 @@ export class Runtime {
 		return ports;
 	}
 
-	dispose(): Awaitable<void> {
+	async dispose(): Promise<void> {
 		const runtimeProcess = this.#process;
 		if (runtimeProcess === undefined) {
 			return;
 		}
+		const processExitPromise = this.#processExitPromise;
+		assert(processExitPromise !== undefined);
 
 		// Clear reference to prevent potential race conditions
 		this.#process = undefined;
@@ -395,15 +400,11 @@ export class Runtime {
 			controlPipe.destroy();
 		}
 
-		// `kill()` uses `SIGTERM` by default. In `workerd`, this waits for HTTP
-		// connections to close before exiting. Notably, Chrome sometimes keeps
-		// connections open for about 10s, blocking exit. We'd like `dispose()`/
-		// `setOptions()` to immediately terminate the existing process.
-		// Therefore, use `SIGKILL` which force closes all connections.
-		// See https://github.com/cloudflare/workerd/pull/244.
-		runtimeProcess.kill("SIGKILL");
-
-		return this.#processExitPromise;
+		await terminateRuntimeProcess(
+			runtimeProcess,
+			processExitPromise,
+			this.#gracefulShutdown
+		);
 	}
 }
 

--- a/packages/miniflare/src/runtime/shutdown.ts
+++ b/packages/miniflare/src/runtime/shutdown.ts
@@ -1,0 +1,42 @@
+import type { ChildProcess } from "node:child_process";
+
+/**
+ * Terminates a workerd process, allowing container-enabled runtimes to clean up
+ * before falling back to a forced exit.
+ *
+ * @param runtimeProcess - Spawned workerd child process.
+ * @param processExitPromise - Promise resolved when the child exits.
+ * @param gracefulShutdown - Whether workerd must be given time to clean up.
+ */
+export async function terminateRuntimeProcess(
+	runtimeProcess: ChildProcess,
+	processExitPromise: Promise<void>,
+	gracefulShutdown: boolean
+): Promise<void> {
+	if (!gracefulShutdown) {
+		// `kill()` uses `SIGTERM` by default. In `workerd`, this waits for HTTP
+		// connections to close before exiting. Notably, Chrome sometimes keeps
+		// connections open for about 10s, blocking exit. We'd like `dispose()`/
+		// `setOptions()` to immediately terminate the existing process.
+		// Therefore, use `SIGKILL` which force closes all connections.
+		// See https://github.com/cloudflare/workerd/pull/244.
+		runtimeProcess.kill("SIGKILL");
+		await processExitPromise;
+		return;
+	}
+
+	// Container cleanup is owned by workerd and requires a graceful shutdown while
+	// its Docker connection is still alive. Bound the wait so open HTTP connections
+	// cannot indefinitely block Miniflare disposal.
+	runtimeProcess.kill("SIGTERM");
+	const forceKillTimeout = setTimeout(
+		() => runtimeProcess.kill("SIGKILL"),
+		5_000
+	);
+	forceKillTimeout.unref();
+	try {
+		await processExitPromise;
+	} finally {
+		clearTimeout(forceKillTimeout);
+	}
+}

--- a/packages/miniflare/test/runtime/shutdown.spec.ts
+++ b/packages/miniflare/test/runtime/shutdown.spec.ts
@@ -1,0 +1,55 @@
+import { afterEach, test, vi } from "vitest";
+import { terminateRuntimeProcess } from "../../src/runtime/shutdown";
+import type { ChildProcess } from "node:child_process";
+
+afterEach(() => {
+	vi.useRealTimers();
+});
+
+test("forces immediate shutdown for ordinary runtimes", async ({ expect }) => {
+	const kill = vi.fn(() => true);
+	const runtimeProcess = { kill } as unknown as ChildProcess;
+
+	await terminateRuntimeProcess(runtimeProcess, Promise.resolve(), false);
+
+	expect(kill).toHaveBeenCalledOnce();
+	expect(kill).toHaveBeenCalledWith("SIGKILL");
+});
+
+test("allows container runtimes to shut down gracefully", async ({
+	expect,
+}) => {
+	vi.useFakeTimers();
+	const kill = vi.fn(() => true);
+	const runtimeProcess = { kill } as unknown as ChildProcess;
+
+	await terminateRuntimeProcess(runtimeProcess, Promise.resolve(), true);
+	await vi.advanceTimersByTimeAsync(5_000);
+
+	expect(kill).toHaveBeenCalledOnce();
+	expect(kill).toHaveBeenCalledWith("SIGTERM");
+});
+
+test("force kills a container runtime after the grace period", async ({
+	expect,
+}) => {
+	vi.useFakeTimers();
+	const kill = vi.fn(() => true);
+	const runtimeProcess = { kill } as unknown as ChildProcess;
+	let resolveExit: (() => void) | undefined;
+	const processExitPromise = new Promise<void>((resolve) => {
+		resolveExit = resolve;
+	});
+
+	const termination = terminateRuntimeProcess(
+		runtimeProcess,
+		processExitPromise,
+		true
+	);
+	await vi.advanceTimersByTimeAsync(5_000);
+
+	expect(kill).toHaveBeenNthCalledWith(1, "SIGTERM");
+	expect(kill).toHaveBeenNthCalledWith(2, "SIGKILL");
+	resolveExit?.();
+	await termination;
+});

--- a/packages/miniflare/test/teardown-lifecycle.spec.ts
+++ b/packages/miniflare/test/teardown-lifecycle.spec.ts
@@ -5,19 +5,41 @@ import { afterEach, test, vi } from "vitest";
 import { WebSocketServer } from "ws";
 import { singleModuleManifest } from "./test-shared";
 
-async function createReadyMiniflare(): Promise<Miniflare> {
+async function createReadyMiniflare(container = false): Promise<Miniflare> {
 	const mf = new Miniflare({
+		...(container
+			? {
+					containerEngine: {
+						localDocker: {
+							socketPath: "unix:///does-not-exist/miniflare-test.sock",
+						},
+					},
+				}
+			: {}),
 		workers: [
 			{
 				config: {
 					type: "worker",
 					name: "",
 					compatibilityDate: "2025-05-01",
-					manifest: singleModuleManifest(`export default {
+					manifest: singleModuleManifest(`
+						export class ContainerObject {}
+						export default {
 						fetch() {
 							return new Response("ok");
 						}
 					}`),
+					...(container
+						? {
+								exports: {
+									ContainerObject: {
+										type: "durable-object" as const,
+										storage: "sqlite" as const,
+										container: { imageName: "example:latest" },
+									},
+								},
+							}
+						: {}),
 				},
 			},
 		],
@@ -26,14 +48,15 @@ async function createReadyMiniflare(): Promise<Miniflare> {
 	return mf;
 }
 
-function findKilledWorkerd(
-	kill: ReturnType<typeof vi.spyOn>
+function findSignalledWorkerd(
+	kill: ReturnType<typeof vi.spyOn>,
+	signal: NodeJS.Signals
 ): childProcess.ChildProcess | undefined {
 	for (let index = 0; index < kill.mock.calls.length; index++) {
-		const [signal] = kill.mock.calls[index];
+		const [calledSignal] = kill.mock.calls[index];
 		const child = kill.mock.contexts[index];
 		if (
-			signal === "SIGKILL" &&
+			calledSignal === signal &&
 			child instanceof childProcess.ChildProcess &&
 			path.basename(child.spawnfile).toLowerCase().startsWith("workerd")
 		) {
@@ -69,7 +92,7 @@ test("Miniflare: dispose requests workerd termination while proxy cleanup is pen
 	const disposePromise = mf.dispose();
 	try {
 		await proxyDisposeStarted;
-		expect(findKilledWorkerd(kill)).toBeDefined();
+		expect(findSignalledWorkerd(kill, "SIGKILL")).toBeDefined();
 	} finally {
 		releaseProxyDispose();
 		proxyDispose.mockRestore();
@@ -135,7 +158,7 @@ test("Miniflare: dispose waits for workerd exit and continues cleanup before ret
 		await runtimeExitObserved;
 		await new Promise<void>((resolve) => setImmediate(resolve));
 		expect(firstDisposeSettled).toBe(false);
-		expect(findKilledWorkerd(kill)).toBeDefined();
+		expect(findSignalledWorkerd(kill, "SIGKILL")).toBeDefined();
 
 		releaseRuntimeExit();
 		runtimeExitReleased = true;
@@ -155,4 +178,16 @@ test("Miniflare: dispose waits for workerd exit and continues cleanup before ret
 		await firstDisposeResult;
 		await mf.dispose().catch(() => {});
 	}
+});
+
+test("Miniflare: gracefully terminates workerd when the serialized config contains a container", async ({
+	expect,
+}) => {
+	const mf = await createReadyMiniflare(true);
+	const kill = vi.spyOn(childProcess.ChildProcess.prototype, "kill");
+
+	await mf.dispose();
+
+	expect(findSignalledWorkerd(kill, "SIGTERM")).toBeDefined();
+	expect(findSignalledWorkerd(kill, "SIGKILL")).toBeUndefined();
 });

--- a/packages/vite-plugin-cloudflare/src/plugins/dev.ts
+++ b/packages/vite-plugin-cloudflare/src/plugins/dev.ts
@@ -76,13 +76,13 @@ export const devPlugin = createPlugin("dev", (ctx) => {
 					await closeServer();
 				} finally {
 					if (!ctx.isRestartingDevServer) {
-						if (containerImageTags.size) {
-							cleanupContainers(getDockerPath(), containerImageTags);
-						}
 						try {
 							await ctx.disposeMiniflare();
-						} catch (error) {
-							debuglog("Failed to dispose Miniflare instance:", error);
+						} finally {
+							if (containerImageTags.size) {
+								cleanupContainers(getDockerPath(), containerImageTags);
+								containerImageTags.clear();
+							}
 						}
 					}
 				}

--- a/packages/vite-plugin-cloudflare/src/plugins/preview.ts
+++ b/packages/vite-plugin-cloudflare/src/plugins/preview.ts
@@ -23,6 +23,8 @@ process.on("exit", () => {
  * Plugin to provide core preview functionality
  */
 export const previewPlugin = createPlugin("preview", (ctx) => {
+	let containerImageTags = new Set<string>();
+
 	return {
 		async configurePreviewServer(vitePreviewServer) {
 			assertIsPreview(ctx);
@@ -31,7 +33,23 @@ export const previewPlugin = createPlugin("preview", (ctx) => {
 			const closePreviewServer =
 				vitePreviewServer.close.bind(vitePreviewServer);
 			vitePreviewServer.close = async () => {
-				await Promise.all([ctx.disposeMiniflare(), closePreviewServer()]);
+				try {
+					const [disposeResult, closeResult] = await Promise.allSettled([
+						ctx.disposeMiniflare(),
+						closePreviewServer(),
+					]);
+					if (disposeResult.status === "rejected") {
+						throw disposeResult.reason;
+					}
+					if (closeResult.status === "rejected") {
+						throw closeResult.reason;
+					}
+				} finally {
+					if (containerImageTags.size) {
+						cleanupContainers(getDockerPath(), containerImageTags);
+						containerImageTags.clear();
+					}
+				}
 			};
 
 			const { miniflareOptions, containerTagToOptionsMap } =
@@ -105,7 +123,7 @@ export const previewPlugin = createPlugin("preview", (ctx) => {
 					complianceConfig: ctx.allWorkerConfigs[0],
 				});
 
-				const containerImageTags = new Set(containerTagToOptionsMap.keys());
+				containerImageTags = new Set(containerTagToOptionsMap.keys());
 				vitePreviewServer.config.logger.info(
 					colors.dim(colors.yellow("\n⚡️ Containers successfully built.\n"))
 				);

--- a/packages/wrangler/src/api/startDevWorker/LocalRuntimeController.ts
+++ b/packages/wrangler/src/api/startDevWorker/LocalRuntimeController.ts
@@ -268,6 +268,9 @@ export class LocalRuntimeController extends RuntimeController {
 	containerImageTagsSeen: Set<string> = new Set();
 	// Stored here, so it can be used in `cleanupContainers()`
 	dockerPath: string | undefined;
+	// MultiworkerRuntimeController owns a separate Miniflare instance and must
+	// defer container cleanup until that instance has shut down.
+	protected deferContainerCleanup = false;
 	// If this doesn't match what is in config, trigger a rebuild.
 	// Used for the rebuild hotkey
 	#currentContainerBuildId: string | undefined;
@@ -545,15 +548,20 @@ export class LocalRuntimeController extends RuntimeController {
 
 	#teardown = async (): Promise<void> => {
 		logger.debug("LocalRuntimeController teardown beginning...");
-		process.off("exit", this.cleanupContainers);
-		this.cleanupContainers();
 
 		if (this.#mf) {
 			logger.log(chalk.dim("⎔ Shutting down local server..."));
 		}
 
-		await this.#mf?.dispose();
-		this.#mf = undefined;
+		try {
+			await this.#mf?.dispose();
+		} finally {
+			this.#mf = undefined;
+			if (!this.deferContainerCleanup) {
+				process.off("exit", this.cleanupContainers);
+				this.cleanupContainers();
+			}
+		}
 
 		if (this.#remoteProxySessionData) {
 			logger.log(chalk.dim("⎔ Shutting down remote connection..."));

--- a/packages/wrangler/src/api/startDevWorker/MultiworkerRuntimeController.ts
+++ b/packages/wrangler/src/api/startDevWorker/MultiworkerRuntimeController.ts
@@ -51,6 +51,7 @@ export class MultiworkerRuntimeController extends LocalRuntimeController {
 		private numWorkers: number
 	) {
 		super(bus);
+		this.deferContainerCleanup = true;
 	}
 	// ******************
 	//   Event Handlers
@@ -386,8 +387,13 @@ export class MultiworkerRuntimeController extends LocalRuntimeController {
 			logger.log(chalk.dim("⎔ Shutting down local server..."));
 		}
 
-		await this.#mf?.dispose();
-		this.#mf = undefined;
+		try {
+			await this.#mf?.dispose();
+		} finally {
+			this.#mf = undefined;
+			process.off("exit", this.cleanupContainers);
+			this.cleanupContainers();
+		}
 
 		if (this.#remoteProxySessionsData.size > 0) {
 			logger.log(chalk.dim("⎔ Shutting down remote connections..."));


### PR DESCRIPTION
Miniflare currently force-kills workerd on dispose. That is the right default for ordinary Workers, because Chrome can keep HTTP connections open for about 10s. For Durable Object containers it is wrong: workerd owns the application container and the `proxy-everything` sidecar, and it can remove them only while its Docker connection is still alive.

This sends `SIGTERM` when the serialized workerd config includes a Durable Object container, waits for the process to exit, and falls back to `SIGKILL` after five seconds. Wrangler and the Vite plugin now dispose Miniflare before deleting containers by their prepared image tags.

Do not merge until workers-sdk pins a workerd release that performs that sidecar cleanup. The Docker fixture asserts that both runtime containers are gone after close; that assertion is expected to fail on the current pin.

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: this is local-dev shutdown behavior; there is no new config or public API.
