### PR TITLE
[wrangler] Allow `net.createServer` in the unenv-preset e2e test

### DIFF
--- a/packages/wrangler/e2e/unenv-preset/worker/index.ts
+++ b/packages/wrangler/e2e/unenv-preset/worker/index.ts
@@ -293,7 +293,7 @@ export const WorkerdTests: Record<string, () => Promise<void>> = {
 		const net = await import("node:net");
 		assert.strictEqual(typeof net, "object");
 		assert.strictEqual(typeof net.createConnection, "function");
-		assert.throws(() => net.createServer(), /not implemented/);
+		assert.strictEqual(typeof net.createServer, "function");
 	},
 
 	async testTls() {


### PR DESCRIPTION
This updates the unenv-preset e2e test to support cloudflare/workerd#7306, which implements `net.Server` in workerd.

This is a requirement for that to land in CI, as the current test asserts `net.createServer()` is `not implemented`. Asserting only that `createServer` is exported holds for both the current stub and the implementation, so this passes against wrangler's pinned workerd as well.

---

- Tests
  - [x] Additional testing not necessary because: this is an e2e test-only change
- Public documentation
  - [x] Documentation not necessary because: e2e test-only change, no user-facing behaviour
