### PR TITLE
Bump C3 to pick up 2026-09-11 compat date.

### DIFF
--- a/.changeset/bump-c3-default-compat-date.md
+++ b/.changeset/bump-c3-default-compat-date.md
@@ -1,0 +1,7 @@
+---
+"create-cloudflare": patch
+---
+
+Update the default compatibility date for newly created projects to 2026-09-11
+
+The default compatibility date tracks the pinned `workerd` release, which was bumped to `1.20260911.1`. Releasing C3 ships the updated date to `npm create cloudflare` users, since it is bundled into the published package.


### PR DESCRIPTION
Update the default compatibility date for newly created projects to 2026-09-11
<!-- devin-review-badge-begin -->

---

<a href="https://cloudflare.devinenterprise.com/review/cloudflare/workers-sdk/pull/15604" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->