### PR TITLE
Add support for reading and writing Container configs in build output

### DIFF
--- a/.changeset/container-build-output.md
+++ b/.changeset/container-build-output.md
@@ -1,0 +1,7 @@
+---
+"@cloudflare/build-output-utils": minor
+---
+
+Add support for reading and writing Container configs in build output
+
+Container configs can now be written to and read from the Build Output Specification.

--- a/packages/build-output-utils/src/__tests__/paths.test.ts
+++ b/packages/build-output-utils/src/__tests__/paths.test.ts
@@ -5,6 +5,9 @@ import {
 	BUILD_OUTPUT_VERSION,
 	CONFIG_FILENAME,
 	DEFAULT_WORKER_DIRECTORY_NAME,
+	getContainerConfigPath,
+	getContainerDir,
+	getContainersDir,
 	getSettingsConfigPath,
 	getWorkerAssetsDir,
 	getWorkerBundleDir,
@@ -33,6 +36,16 @@ describe("path resolvers", () => {
 
 	it("resolve the workers directory", ({ expect }) => {
 		expect(getWorkersDir(root)).toBe(path.join(outputDir, "workers"));
+	});
+
+	it("resolve Container paths", ({ expect }) => {
+		const containersDir = path.join(outputDir, "containers");
+		const containerDir = path.join(containersDir, "api-container");
+		expect(getContainersDir(root)).toBe(containersDir);
+		expect(getContainerDir(root, "api-container")).toBe(containerDir);
+		expect(getContainerConfigPath(root, "api-container")).toBe(
+			path.join(containerDir, "config.json")
+		);
 	});
 
 	it("resolve the Worker's config, bundle, and assets paths", ({ expect }) => {
@@ -66,6 +79,23 @@ describe("path resolvers", () => {
 		]) {
 			expect(() => getWorkerConfigPath(root, workerDirectoryName)).toThrow(
 				"Worker directory names must be non-empty, single path segments."
+			);
+		}
+	});
+
+	it("rejects invalid Container directory names", ({ expect }) => {
+		for (const containerDirectoryName of [
+			"",
+			".",
+			"..",
+			"nested/container",
+			"nested\\container",
+			"container\0name",
+		]) {
+			expect(() =>
+				getContainerConfigPath(root, containerDirectoryName)
+			).toThrow(
+				"Container directory names must be non-empty, single path segments."
 			);
 		}
 	});

--- a/packages/build-output-utils/src/__tests__/paths.test.ts
+++ b/packages/build-output-utils/src/__tests__/paths.test.ts
@@ -78,7 +78,7 @@ describe("path resolvers", () => {
 			"worker\0name",
 		]) {
 			expect(() => getWorkerConfigPath(root, workerDirectoryName)).toThrow(
-				"Worker directory names must be non-empty, single path segments."
+				`Worker directory names must be non-empty, single path segments. Received ${JSON.stringify(workerDirectoryName)}.`
 			);
 		}
 	});
@@ -95,7 +95,7 @@ describe("path resolvers", () => {
 			expect(() =>
 				getContainerConfigPath(root, containerDirectoryName)
 			).toThrow(
-				"Container directory names must be non-empty, single path segments."
+				`Container directory names must be non-empty, single path segments. Received ${JSON.stringify(containerDirectoryName)}.`
 			);
 		}
 	});

--- a/packages/build-output-utils/src/__tests__/read.test.ts
+++ b/packages/build-output-utils/src/__tests__/read.test.ts
@@ -1,17 +1,27 @@
 import * as fsp from "node:fs/promises";
 import * as path from "node:path";
-import { InputSettingsSchema, InputWorkerSchema } from "@cloudflare/config";
+import {
+	InputSettingsSchema,
+	InputWorkerSchema,
+	OutputContainerSchema,
+} from "@cloudflare/config";
 import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
 import { describe, it } from "vitest";
 import { BuildOutputError } from "../errors";
 import {
 	getSettingsConfigPath,
+	getContainerConfigPath,
+	getContainerDir,
 	getWorkerAssetsDir,
 	getWorkerBundleDir,
 	getWorkerConfigPath,
 } from "../paths";
 import { readBuildOutput } from "../read";
-import { writeSettingsConfig, writeWorkerConfig } from "../write";
+import {
+	writeContainerConfig,
+	writeSettingsConfig,
+	writeWorkerConfig,
+} from "../write";
 import type { ParsedOutputWorkerConfig } from "@cloudflare/config";
 
 const completeManifest: ParsedOutputWorkerConfig["manifest"] = {
@@ -24,6 +34,21 @@ const parsedSettingsConfig = InputSettingsSchema.parse({
 	type: "settings",
 	accountId: "1234567890",
 	complianceRegion: "public",
+});
+
+const parsedStandardContainerConfig = OutputContainerSchema.parse({
+	type: "container",
+	name: "api-container",
+	image: { reference: "registry.example.com/api:latest" },
+});
+
+const parsedDurableObjectContainerConfig = OutputContainerSchema.parse({
+	type: "container",
+	name: "session-container",
+	schedulingPolicy: "durable-object",
+	images: {
+		default: { localReference: "session-container:latest" },
+	},
 });
 
 function inputWorkerConfig(name: string) {
@@ -76,7 +101,7 @@ async function seedWorker(
 		root,
 		config: inputWorkerConfig(name),
 		manifest: hasBundle ? completeManifest : undefined,
-		workerDirectoryName,
+		directoryName: workerDirectoryName,
 	});
 	if (bundleDir) {
 		await fsp.mkdir(getWorkerBundleDir(root, workerDirectoryName), {
@@ -126,6 +151,95 @@ describe("readBuildOutput", () => {
 		expect(workers.additional?.config.name).toBe("additional-worker");
 		expect(workers.additional?.bundleDir).toBe(
 			getWorkerBundleDir(root, "additional")
+		);
+	});
+
+	it("reads Containers keyed by directory name", async ({ expect }) => {
+		const root = process.cwd();
+		await seedWorker(root);
+		await writeContainerConfig({
+			root,
+			config: parsedDurableObjectContainerConfig,
+			directoryName: "session",
+		});
+		await writeContainerConfig({
+			root,
+			config: parsedStandardContainerConfig,
+			directoryName: "api",
+		});
+
+		const { containers } = await readBuildOutput(root);
+
+		expect(Object.keys(containers)).toEqual(["api", "session"]);
+		expect(containers.api).toEqual({
+			configPath: getContainerConfigPath(root, "api"),
+			config: parsedStandardContainerConfig,
+		});
+		expect(containers.session).toEqual({
+			configPath: getContainerConfigPath(root, "session"),
+			config: parsedDurableObjectContainerConfig,
+		});
+	});
+
+	it("returns no Containers when the Containers directory is absent", async ({
+		expect,
+	}) => {
+		const root = process.cwd();
+		await seedWorker(root);
+
+		const { containers } = await readBuildOutput(root);
+
+		expect(containers).toEqual({});
+	});
+
+	it("still requires the default Worker when Containers are present", async ({
+		expect,
+	}) => {
+		const root = process.cwd();
+		await writeContainerConfig({
+			root,
+			config: parsedStandardContainerConfig,
+			directoryName: "api",
+		});
+
+		await expect(readBuildOutput(root)).rejects.toThrow(
+			/no Worker config found/
+		);
+	});
+
+	it("throws when a Container config is missing", async ({ expect }) => {
+		const root = process.cwd();
+		await seedWorker(root);
+		await fsp.mkdir(getContainerDir(root, "api"), { recursive: true });
+
+		await expect(readBuildOutput(root)).rejects.toThrow(BuildOutputError);
+		await expect(readBuildOutput(root)).rejects.toThrow(
+			/no Container config found/
+		);
+	});
+
+	it("throws when a Container config is not valid JSON", async ({ expect }) => {
+		const root = process.cwd();
+		await seedWorker(root);
+		await fsp.mkdir(getContainerDir(root, "api"), { recursive: true });
+		await fsp.writeFile(getContainerConfigPath(root, "api"), "{ not json");
+
+		await expect(readBuildOutput(root)).rejects.toThrow(/could not parse JSON/);
+	});
+
+	it("throws when a Container config fails schema validation", async ({
+		expect,
+	}) => {
+		const root = process.cwd();
+		await seedWorker(root);
+		await fsp.mkdir(getContainerDir(root, "api"), { recursive: true });
+		await fsp.writeFile(
+			getContainerConfigPath(root, "api"),
+			JSON.stringify({ type: "container", name: "api-container" })
+		);
+
+		await expect(readBuildOutput(root)).rejects.toThrow(
+			/invalid Container config/
 		);
 	});
 

--- a/packages/build-output-utils/src/__tests__/write.test.ts
+++ b/packages/build-output-utils/src/__tests__/write.test.ts
@@ -3,17 +3,20 @@ import * as path from "node:path";
 import {
 	InputSettingsSchema,
 	InputWorkerSchema,
+	OutputContainerSchema,
 	OutputWorkerSchema,
 } from "@cloudflare/config";
 import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
 import { describe, it } from "vitest";
 import {
 	BUILD_OUTPUT_ROOT,
+	getContainerConfigPath,
 	getSettingsConfigPath,
 	getWorkerConfigPath,
 } from "../paths";
 import {
 	cleanBuildOutputDir,
+	writeContainerConfig,
 	writeSettingsConfig,
 	writeWorkerConfig,
 } from "../write";
@@ -29,6 +32,21 @@ const parsedSettingsConfig = InputSettingsSchema.parse({
 	type: "settings",
 	accountId: "1234567890",
 	complianceRegion: "public",
+});
+
+const parsedStandardContainerConfig = OutputContainerSchema.parse({
+	type: "container",
+	name: "api-container",
+	image: { reference: "registry.example.com/api:latest" },
+});
+
+const parsedDurableObjectContainerConfig = OutputContainerSchema.parse({
+	type: "container",
+	name: "session-container",
+	schedulingPolicy: "durable-object",
+	images: {
+		default: { localReference: "session-container:latest" },
+	},
 });
 
 describe("writeSettingsConfig", () => {
@@ -130,13 +148,51 @@ describe("writeWorkerConfig", () => {
 		await writeWorkerConfig({
 			root,
 			config: parsedWorkerConfig,
-			workerDirectoryName: "additional",
+			directoryName: "additional",
 		});
 
 		const contents = JSON.parse(
 			fs.readFileSync(getWorkerConfigPath(root, "additional"), "utf-8")
 		);
 		expect(contents.name).toBe("my-worker");
+	});
+});
+
+describe("writeContainerConfig", () => {
+	runInTempDir();
+
+	it("writes a standard Container config with a remote image reference", async ({
+		expect,
+	}) => {
+		const root = process.cwd();
+		await writeContainerConfig({
+			root,
+			config: parsedStandardContainerConfig,
+			directoryName: "api",
+		});
+
+		const contents = JSON.parse(
+			fs.readFileSync(getContainerConfigPath(root, "api"), "utf-8")
+		);
+		expect(contents).toEqual(parsedStandardContainerConfig);
+		expect(OutputContainerSchema.parse(contents)).toEqual(contents);
+	});
+
+	it("writes a Durable Object Container config with a local image reference", async ({
+		expect,
+	}) => {
+		const root = process.cwd();
+		await writeContainerConfig({
+			root,
+			config: parsedDurableObjectContainerConfig,
+			directoryName: "session",
+		});
+
+		const contents = JSON.parse(
+			fs.readFileSync(getContainerConfigPath(root, "session"), "utf-8")
+		);
+		expect(contents).toEqual(parsedDurableObjectContainerConfig);
+		expect(OutputContainerSchema.parse(contents)).toEqual(contents);
 	});
 });
 

--- a/packages/build-output-utils/src/index.ts
+++ b/packages/build-output-utils/src/index.ts
@@ -3,6 +3,9 @@ export {
 	BUILD_OUTPUT_VERSION,
 	CONFIG_FILENAME,
 	DEFAULT_WORKER_DIRECTORY_NAME,
+	getContainerConfigPath,
+	getContainerDir,
+	getContainersDir,
 	getSettingsConfigPath,
 	getWorkerAssetsDir,
 	getWorkerBundleDir,
@@ -12,14 +15,20 @@ export {
 } from "./paths";
 export {
 	cleanBuildOutputDir,
+	writeContainerConfig,
 	writeSettingsConfig,
 	writeWorkerConfig,
 } from "./write";
-export type { WriteWorkerConfigOptions } from "./write";
+export type {
+	WriteContainerConfigOptions,
+	WriteWorkerConfigOptions,
+} from "./write";
 export { BuildOutputError } from "./errors";
 export { readBuildOutput } from "./read";
 export type {
 	BuildOutput,
+	BuildOutputContainer,
+	BuildOutputContainers,
 	BuildOutputWorker,
 	BuildOutputWorkers,
 	ResolvedOutputWorkerConfig,

--- a/packages/build-output-utils/src/paths.ts
+++ b/packages/build-output-utils/src/paths.ts
@@ -70,7 +70,7 @@ function validateDirectoryName(name: string, resourceName: string): void {
 		name.includes("\0")
 	) {
 		throw new Error(
-			`${resourceName} directory names must be non-empty, single path segments.`
+			`${resourceName} directory names must be non-empty, single path segments. Received ${JSON.stringify(name)}.`
 		);
 	}
 }

--- a/packages/build-output-utils/src/paths.ts
+++ b/packages/build-output-utils/src/paths.ts
@@ -54,26 +54,63 @@ export function getWorkersDir(root: string): string {
 }
 
 /**
+ * Absolute path to the Containers output directory.
+ */
+export function getContainersDir(root: string): string {
+	return path.join(getBuildOutputDir(root), BUILD_OUTPUT_VERSION, "containers");
+}
+
+function validateDirectoryName(name: string, resourceName: string): void {
+	if (
+		name.length === 0 ||
+		name === "." ||
+		name === ".." ||
+		name.includes("/") ||
+		name.includes("\\") ||
+		name.includes("\0")
+	) {
+		throw new Error(
+			`${resourceName} directory names must be non-empty, single path segments.`
+		);
+	}
+}
+
+/**
  * Absolute path to a Worker's directory (`workers/<worker-directory-name>`).
  */
 export function getWorkerDir(
 	root: string,
 	workerDirectoryName = DEFAULT_WORKER_DIRECTORY_NAME
 ): string {
-	if (
-		workerDirectoryName.length === 0 ||
-		workerDirectoryName === "." ||
-		workerDirectoryName === ".." ||
-		workerDirectoryName.includes("/") ||
-		workerDirectoryName.includes("\\") ||
-		workerDirectoryName.includes("\0")
-	) {
-		throw new Error(
-			"Worker directory names must be non-empty, single path segments."
-		);
-	}
+	validateDirectoryName(workerDirectoryName, "Worker");
 
 	return path.join(getWorkersDir(root), workerDirectoryName);
+}
+
+/**
+ * Absolute path to a Container's directory
+ * (`containers/<container-directory-name>`).
+ */
+export function getContainerDir(
+	root: string,
+	containerDirectoryName: string
+): string {
+	validateDirectoryName(containerDirectoryName, "Container");
+
+	return path.join(getContainersDir(root), containerDirectoryName);
+}
+
+/**
+ * Absolute path to the Container's config file.
+ */
+export function getContainerConfigPath(
+	root: string,
+	containerDirectoryName: string
+): string {
+	return path.join(
+		getContainerDir(root, containerDirectoryName),
+		CONFIG_FILENAME
+	);
 }
 
 /**

--- a/packages/build-output-utils/src/read.ts
+++ b/packages/build-output-utils/src/read.ts
@@ -1,11 +1,17 @@
 import * as fs from "node:fs";
 import * as fsp from "node:fs/promises";
 import * as path from "node:path";
-import { OutputSettingsSchema, OutputWorkerSchema } from "@cloudflare/config";
+import {
+	OutputContainerSchema,
+	OutputSettingsSchema,
+	OutputWorkerSchema,
+} from "@cloudflare/config";
 import { BuildOutputError } from "./errors";
 import {
 	BUILD_OUTPUT_VERSION,
 	DEFAULT_WORKER_DIRECTORY_NAME,
+	getContainerConfigPath,
+	getContainersDir,
 	getSettingsConfigPath,
 	getWorkerAssetsDir,
 	getWorkerBundleDir,
@@ -14,6 +20,7 @@ import {
 } from "./paths";
 import type {
 	ModuleType,
+	ParsedOutputContainerConfig,
 	ParsedOutputSettingsConfig,
 	ParsedOutputWorkerConfig,
 } from "@cloudflare/config";
@@ -72,6 +79,17 @@ export type BuildOutputWorkers = Record<string, BuildOutputWorker> & {
 	default: BuildOutputWorker;
 };
 
+/** A Container found in the Build Output Specification tree. */
+export interface BuildOutputContainer {
+	/** Absolute path to the Container's `config.json`. */
+	configPath: string;
+	/** The parsed, schema-validated Container config. */
+	config: ParsedOutputContainerConfig;
+}
+
+/** Containers keyed by their output directory names. */
+export type BuildOutputContainers = Record<string, BuildOutputContainer>;
+
 /**
  * The result of reading a Build Output Specification tree.
  */
@@ -92,6 +110,12 @@ export interface BuildOutput {
 	 * their directory names. Guaranteed to contain the `default` Worker.
 	 */
 	workers: BuildOutputWorkers;
+	/**
+	 * The Containers found under
+	 * `<root>/.cloudflare/output/v0/containers/`, keyed by their directory
+	 * names.
+	 */
+	containers: BuildOutputContainers;
 }
 
 /**
@@ -99,12 +123,13 @@ export interface BuildOutput {
  * `<root>/.cloudflare/output/v0/`.
  *
  * Reads the optional top-level settings `config.json`, then reads and
- * schema-validates the Worker's `config.json` and resolves its
- * `bundle/` / `assets/` directories. Partial manifests are resolved into
- * complete manifests using the files in `bundle/`.
+ * schema-validates each Worker and Container `config.json`, and resolves each
+ * Worker's `bundle/` / `assets/` directories. Partial manifests are resolved
+ * into complete manifests using the files in `bundle/`.
  *
  * @throws {BuildOutputError} if the top-level `config.json` is invalid, or if
- * the Worker config is missing, is not valid JSON, or fails schema validation.
+ * a Worker or Container config is missing, is not valid JSON, or fails schema
+ * validation.
  */
 export async function readBuildOutput(root: string): Promise<BuildOutput> {
 	const settings = await readSettings(root);
@@ -133,8 +158,65 @@ export async function readBuildOutput(root: string): Promise<BuildOutput> {
 		default: defaultWorker,
 		...Object.fromEntries(additionalWorkers),
 	};
+	const containers = await readContainers(root);
 
-	return { root, version: BUILD_OUTPUT_VERSION, settings, workers };
+	return {
+		root,
+		version: BUILD_OUTPUT_VERSION,
+		settings,
+		workers,
+		containers,
+	};
+}
+
+/** Read and schema-validate all Container configs, if any. */
+async function readContainers(root: string): Promise<BuildOutputContainers> {
+	const containersDir = getContainersDir(root);
+	if (!fs.existsSync(containersDir)) {
+		return {};
+	}
+
+	const containerDirectoryNames = (
+		await fsp.readdir(containersDir, { withFileTypes: true })
+	)
+		.filter((entry) => entry.isDirectory())
+		.map((entry) => entry.name)
+		.sort();
+	const containers = await Promise.all(
+		containerDirectoryNames.map(
+			async (containerDirectoryName) =>
+				[
+					containerDirectoryName,
+					await readContainer(root, containerDirectoryName),
+				] as const
+		)
+	);
+
+	return Object.fromEntries(containers);
+}
+
+/** Read and schema-validate one Container config. */
+async function readContainer(
+	root: string,
+	containerDirectoryName: string
+): Promise<BuildOutputContainer> {
+	const configPath = getContainerConfigPath(root, containerDirectoryName);
+
+	if (!fs.existsSync(configPath)) {
+		throw new BuildOutputError(`no Container config found at ${configPath}.`);
+	}
+
+	const contents = await fsp.readFile(configPath, "utf-8");
+	const result = OutputContainerSchema.safeParse(
+		parseJson(contents, configPath)
+	);
+	if (!result.success) {
+		throw new BuildOutputError(
+			`invalid Container config at ${configPath}.\n${result.error.message}`
+		);
+	}
+
+	return { configPath, config: result.data };
 }
 
 /**

--- a/packages/build-output-utils/src/write.ts
+++ b/packages/build-output-utils/src/write.ts
@@ -4,6 +4,8 @@ import { removeDir } from "@cloudflare/workers-utils";
 import {
 	DEFAULT_WORKER_DIRECTORY_NAME,
 	getBuildOutputDir,
+	getContainerConfigPath,
+	getContainerDir,
 	getSettingsConfigPath,
 	getWorkerConfigPath,
 	getWorkerDir,
@@ -11,6 +13,7 @@ import {
 import type {
 	ParsedInputSettingsConfig,
 	ParsedInputWorkerConfig,
+	ParsedOutputContainerConfig,
 	ParsedOutputSettingsConfig,
 	ParsedOutputWorkerConfig,
 } from "@cloudflare/config";
@@ -26,7 +29,7 @@ export interface WriteWorkerConfigOptions {
 	root: string;
 	config: ParsedInputWorkerConfig;
 	manifest?: ParsedOutputWorkerConfig["manifest"];
-	workerDirectoryName?: string;
+	directoryName?: string;
 }
 
 /**
@@ -39,14 +42,41 @@ export async function writeWorkerConfig({
 	root,
 	config,
 	manifest,
-	workerDirectoryName = DEFAULT_WORKER_DIRECTORY_NAME,
+	directoryName = DEFAULT_WORKER_DIRECTORY_NAME,
 }: WriteWorkerConfigOptions): Promise<void> {
 	const { entrypoint: _entrypoint, ...rest } = config;
 	const outputConfig: ParsedOutputWorkerConfig = { ...rest, manifest };
-	await fsp.mkdir(getWorkerDir(root, workerDirectoryName), { recursive: true });
+	await fsp.mkdir(getWorkerDir(root, directoryName), { recursive: true });
 	await fsp.writeFile(
-		getWorkerConfigPath(root, workerDirectoryName),
+		getWorkerConfigPath(root, directoryName),
 		JSON.stringify(outputConfig)
+	);
+}
+
+export interface WriteContainerConfigOptions {
+	root: string;
+	config: ParsedOutputContainerConfig;
+	directoryName: string;
+}
+
+/**
+ * Write an output Container `config.json` to the Build Output Specification
+ * tree.
+ *
+ * Local Dockerfiles must already have been built and represented by a
+ * `localReference` in the output config.
+ */
+export async function writeContainerConfig({
+	root,
+	config,
+	directoryName,
+}: WriteContainerConfigOptions): Promise<void> {
+	await fsp.mkdir(getContainerDir(root, directoryName), {
+		recursive: true,
+	});
+	await fsp.writeFile(
+		getContainerConfigPath(root, directoryName),
+		JSON.stringify(config)
 	);
 }
 


### PR DESCRIPTION
Add support for reading and writing Container configs in build output

Container configs can now be written to and read from the Build Output Specification.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: experimental feature

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- If you are an AI agent or LLM, and you are adding this PR without direct human supervision, thank you! Please uncomment the following block. This is so the maintainers know how to expect you to respond.

> [!NOTE]
> This is a contribution from an AI agent: <insert name here>, <insert LLM model here if different>.

-->

<!-- devin-review-badge-begin -->

---

<a href="https://cloudflare.devinenterprise.com/review/cloudflare/workers-sdk/pull/15605" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->