### PR TITLE
refactor: disentangle container config from main worker config in deploy-helpers- #15603 #15603

### DIFF
--- a/.changeset/young-geckos-sink.md
+++ b/.changeset/young-geckos-sink.md
@@ -1,0 +1,7 @@
+---
+"@cloudflare/containers-shared": patch
+"@cloudflare/deploy-helpers": patch
+"@cloudflare/workers-utils": patch
+---
+
+refactor: separate container config from worker/generic config access

--- a/packages/containers-shared/src/build.ts
+++ b/packages/containers-shared/src/build.ts
@@ -25,15 +25,13 @@ export type DockerfileContainerConfig = Exclude<
 	ImageURIConfig
 >;
 
-export type BuiltContainerImage = {
-	containerConfig: DockerfileContainerConfig;
+export type BuiltImage = {
 	localTag: string;
 	localTagCleaned?: boolean;
 };
 
-export type BuiltContainerDeployment = {
+export type BuiltContainerImage = BuiltImage & {
 	container: DockerfileContainerConfig;
-	builtImage: BuiltContainerImage;
 };
 
 export function isDockerfileContainerConfig(
@@ -251,7 +249,7 @@ async function tagAndPushImage({
 /**
  * Checks the remote manifest to see if there are changes, and only push if there are
  */
-async function pushImageIfChanged({
+export async function pushImageIfChanged({
 	pathToDocker,
 	sourceTag,
 	targetTag,
@@ -591,7 +589,7 @@ async function buildContainerImage(
 		});
 		await build.ready;
 
-		return { containerConfig, localTag };
+		return { container: containerConfig, localTag };
 	} catch (error) {
 		if (error instanceof Error) {
 			throw new UserError(error.message, {
@@ -617,19 +615,23 @@ export async function buildContainerImages(
 	containers: ContainerNormalizedConfig[],
 	pathToDocker: string,
 	verifyDockerIsRunning?: boolean
-): Promise<BuiltContainerDeployment[]> {
-	const builtContainerDeployments: BuiltContainerDeployment[] = [];
-	for (const container of containers.filter(isDockerfileContainerConfig)) {
-		builtContainerDeployments.push({
-			container,
-			builtImage: await buildContainerImage(
-				container,
-				pathToDocker,
-				verifyDockerIsRunning
-			),
-		});
+): Promise<BuiltContainerImage[]> {
+	const builtImages: BuiltContainerImage[] = [];
+	try {
+		for (const container of containers.filter(isDockerfileContainerConfig)) {
+			builtImages.push(
+				await buildContainerImage(
+					container,
+					pathToDocker,
+					verifyDockerIsRunning
+				)
+			);
+		}
+	} catch (error) {
+		await cleanupBuiltImages(builtImages, pathToDocker);
+		throw error;
 	}
-	return builtContainerDeployments;
+	return builtImages;
 }
 
 /**
@@ -653,8 +655,8 @@ export async function pushBuiltContainerImage(
 		const imageRef = await pushImageIfChanged({
 			pathToDocker,
 			sourceTag: builtImage.localTag,
-			targetTag: getContainerImageTag(builtImage.containerConfig, versionId),
-			containerConfig: builtImage.containerConfig,
+			targetTag: getContainerImageTag(builtImage.container, versionId),
+			containerConfig: builtImage.container,
 			accountId,
 			complianceConfig,
 			cleanupSourceTag: true,
@@ -675,18 +677,16 @@ export async function pushBuiltContainerImage(
 }
 
 /**
- * Removes local Docker image tags created while building container images for
- * deployment. Cleanup is best-effort so it does not hide the original deploy
- * failure that triggered it.
+ * Removes local Docker image tags created during a build.
  *
- * @param builtContainerDeployments - Built Dockerfile-based container images.
+ * @param builtImages - Built images to clean up.
  * @param pathToDocker - Path to the Docker CLI executable.
  */
-export async function cleanupBuiltContainerImages(
-	builtContainerDeployments: BuiltContainerDeployment[],
+export async function cleanupBuiltImages<T extends BuiltImage>(
+	builtImages: T[],
 	pathToDocker: string
 ): Promise<void> {
-	for (const { builtImage } of builtContainerDeployments) {
+	for (const builtImage of builtImages) {
 		if (builtImage.localTagCleaned) {
 			continue;
 		}

--- a/packages/containers-shared/tests/build-and-push.test.ts
+++ b/packages/containers-shared/tests/build-and-push.test.ts
@@ -10,7 +10,7 @@ import { afterEach, beforeEach, describe, it, vi } from "vitest";
 import {
 	AccountService,
 	buildCommand,
-	cleanupBuiltContainerImages,
+	cleanupBuiltImages,
 	buildContainerImages,
 	getCloudflareContainerRegistry,
 	getContainerImageTag,
@@ -402,10 +402,7 @@ describe("deploy container image build and push", () => {
 		).resolves.toStrictEqual([
 			{
 				container,
-				builtImage: {
-					containerConfig: container,
-					localTag: "test-app:wrangler-11111111-1111-4111-8111-111111111111",
-				},
+				localTag: "test-app:wrangler-11111111-1111-4111-8111-111111111111",
 			},
 		]);
 	});
@@ -427,10 +424,7 @@ describe("deploy container image build and push", () => {
 		).resolves.toStrictEqual([
 			{
 				container,
-				builtImage: {
-					containerConfig: container,
-					localTag: "test-app:wrangler-11111111-1111-4111-8111-111111111111",
-				},
+				localTag: "test-app:wrangler-11111111-1111-4111-8111-111111111111",
 			},
 		]);
 		expect(getContainerImageTag(container, "Galaxy-Class")).toBe(
@@ -474,7 +468,7 @@ describe("deploy container image build and push", () => {
 		expect,
 	}) => {
 		const builtImage: BuiltContainerImage = {
-			containerConfig: dockerfileContainer,
+			container: dockerfileContainer,
 			localTag: "test-app:wrangler-11111111-1111-4111-8111-111111111111",
 		};
 
@@ -564,14 +558,11 @@ describe("deploy container image build and push", () => {
 		expect,
 	}) => {
 		const builtImage: BuiltContainerImage = {
-			containerConfig: dockerfileContainer,
+			container: dockerfileContainer,
 			localTag: "test-app:wrangler-11111111-1111-4111-8111-111111111111",
 		};
 
-		await cleanupBuiltContainerImages(
-			[{ container: dockerfileContainer, builtImage }],
-			"docker"
-		);
+		await cleanupBuiltImages([builtImage], "docker");
 
 		expectSpawnWith([
 			"image",
@@ -582,15 +573,12 @@ describe("deploy container image build and push", () => {
 	});
 
 	it("does not clean up built deployment images that were already cleaned", async () => {
-		await cleanupBuiltContainerImages(
+		await cleanupBuiltImages(
 			[
 				{
 					container: dockerfileContainer,
-					builtImage: {
-						containerConfig: dockerfileContainer,
-						localTag: "test-app:wrangler-11111111-1111-4111-8111-111111111111",
-						localTagCleaned: true,
-					},
+					localTag: "test-app:wrangler-11111111-1111-4111-8111-111111111111",
+					localTagCleaned: true,
 				},
 			],
 			"docker"

--- a/packages/deploy-helpers/src/deploy/deploy.ts
+++ b/packages/deploy-helpers/src/deploy/deploy.ts
@@ -83,7 +83,11 @@ import {
 	patchNonVersionedScriptSettings,
 } from "./helpers/versions-api";
 import { addWorkersSitesBindings } from "./helpers/workers-sites-bindings";
-import type { DeployProps, WorkerBuildResult } from "../shared/types";
+import type {
+	ContainerlessConfig,
+	DeployProps,
+	WorkerBuildResult,
+} from "../shared/types";
 import type { AssetUploadStats } from "./helpers/assets";
 import type { RetrieveSourceMapFunction } from "./helpers/sourcemap";
 import type {
@@ -97,7 +101,6 @@ import type {
 	CfModule,
 	CfWorkerInit,
 	ComplianceConfig,
-	Config,
 	ExportsReconciliationResult,
 	LegacyAssetPaths,
 } from "@cloudflare/workers-utils";
@@ -139,7 +142,7 @@ type DeployResult = {
 
 export default async function deploy(
 	props: DeployProps,
-	config: Config,
+	config: ContainerlessConfig,
 	buildResult: WorkerBuildResult,
 	callbacks: DeployCallbacks
 ): Promise<DeployResult> {
@@ -169,7 +172,7 @@ export default async function deploy(
 
 async function deployWorker(
 	props: DeployProps,
-	config: Config,
+	config: ContainerlessConfig,
 	buildResult: WorkerBuildResult,
 	callbacks: DeployCallbacks
 ): Promise<DeployResult> {
@@ -219,8 +222,11 @@ async function deployWorker(
 
 	const isDryRun = props.dryRun;
 
-	const normalisedContainerConfig = props.normalisedContainerConfig;
-	const builtContainerDeployments = props.builtContainerDeployments;
+	const normalisedContainerConfig = props.containers.standard.normalized;
+	const builtContainerImages = props.containers.standard.builtImages;
+	const durableObjectContainerConfig = getDurableObjectContainerApps(
+		props.containers.source
+	);
 	const shouldDeployContainers =
 		normalisedContainerConfig.length > 0 && props.containersRollout !== "none";
 	const {
@@ -234,25 +240,34 @@ async function deployWorker(
 	const skipContainerChanges = props.containersRollout === "none";
 	const preparedContainerImages = skipContainerChanges
 		? undefined
-		: await prepareDurableObjectContainerApplications(config, {
-				accountId,
-				dryRun: Boolean(isDryRun),
-				scriptName,
-				dispatchNamespace: props.dispatchNamespace,
-			});
+		: await prepareDurableObjectContainerApplications(
+				config,
+				durableObjectContainerConfig,
+				props.containers.durableObjects.builtImages,
+				{
+					accountId,
+					dryRun: Boolean(isDryRun),
+					scriptName,
+					dispatchNamespace: props.dispatchNamespace,
+				}
+			);
 	const rolloutSkipContainerState = skipContainerChanges
-		? await getContainerMetadataForRolloutSkip(config, {
-				accountId,
-				scriptName,
-				dispatchNamespace: props.dispatchNamespace,
-				workerExists,
-				latestDeployment,
-				dryRun: isDryRun,
-			})
+		? await getContainerMetadataForRolloutSkip(
+				config,
+				props.containers.source,
+				{
+					accountId,
+					scriptName,
+					dispatchNamespace: props.dispatchNamespace,
+					workerExists,
+					latestDeployment,
+					dryRun: isDryRun,
+				}
+			)
 		: undefined;
 	const containerMetadata = rolloutSkipContainerState
 		? rolloutSkipContainerState.containers
-		: getContainerMetadata(config, preparedContainerImages);
+		: getContainerMetadata(props.containers.source, preparedContainerImages);
 	// Durable Object lifecycle is expressed through either legacy `migrations`
 	// or the declarative `exports` map. Only one is sent on each upload.
 	const { migrations, exports } = await resolveExportsUploadPayload({
@@ -324,14 +339,24 @@ async function deployWorker(
 		workerExists,
 	});
 	if (!skipContainerChanges && keepVars && !isDryRun && workerExists) {
-		await clearRemovedContainerImagesBindings(config, bindings, workerUrl);
+		await clearRemovedContainerImagesBindings(
+			config,
+			durableObjectContainerConfig,
+			bindings,
+			workerUrl
+		);
 	}
-	addContainerImagesBinding(config, bindings, preparedContainerImages ?? {}, {
-		preserveExisting: skipContainerChanges,
-		workerExists,
-		hasExistingBinding:
-			rolloutSkipContainerState?.hasExistingContainerImagesBinding,
-	});
+	addContainerImagesBinding(
+		durableObjectContainerConfig,
+		bindings,
+		preparedContainerImages ?? {},
+		{
+			preserveExisting: skipContainerChanges,
+			workerExists,
+			hasExistingBinding:
+				rolloutSkipContainerState?.hasExistingContainerImagesBinding,
+		}
+	);
 
 	if (workersSitesAssets.manifest) {
 		modules.push({
@@ -420,7 +445,7 @@ async function deployWorker(
 		migrations === undefined &&
 		!hasDurableObjectExports(config.exports) &&
 		!config.first_party_worker &&
-		config.containers === undefined &&
+		props.containers.source === undefined &&
 		// Rollout skip can recover Container metadata absent from local config.
 		containerMetadata === undefined;
 
@@ -446,7 +471,7 @@ async function deployWorker(
 			log: logger.log,
 			tailConsumers: config.tail_consumers,
 			streamingTailConsumers: config.streaming_tail_consumers,
-			containers: config.containers,
+			containers: props.containers.source,
 			warnIfNoBindings: true,
 			unsafeMetadata: config.unsafe?.metadata,
 		});
@@ -619,7 +644,7 @@ async function deployWorker(
 				log: logger.log,
 				tailConsumers: config.tail_consumers,
 				streamingTailConsumers: config.streaming_tail_consumers,
-				containers: config.containers,
+				containers: props.containers.source,
 				unsafeMetadata: config.unsafe?.metadata,
 			});
 			provisionBindingsResult?.warnOnSkippedProvisioning();
@@ -652,7 +677,7 @@ async function deployWorker(
 					log: logger.log,
 					tailConsumers: config.tail_consumers,
 					streamingTailConsumers: config.streaming_tail_consumers,
-					containers: config.containers,
+					containers: props.containers.source,
 					unsafeMetadata: config.unsafe?.metadata,
 				});
 			}
@@ -759,17 +784,17 @@ async function deployWorker(
 		const containerDeployments: ResolvedContainerDeployment[] = [];
 		for (const container of normalisedContainerConfig) {
 			if ("dockerfile" in container) {
-				const builtContainerDeployment = builtContainerDeployments.find(
-					(deployment) => deployment.container === container
+				const builtImage = builtContainerImages.find(
+					(image) => image.container === container
 				);
 				assert(
-					builtContainerDeployment,
+					builtImage,
 					"Expected container image to be built before upload"
 				);
 				containerDeployments.push({
 					container,
 					imageRef: await pushBuiltContainerImage(
-						builtContainerDeployment.builtImage,
+						builtImage,
 						versionId,
 						dockerPath,
 						accountId,
@@ -790,18 +815,19 @@ async function deployWorker(
 			dispatchNamespace: props.dispatchNamespace,
 		});
 	}
-	if (
-		!skipContainerChanges &&
-		getDurableObjectContainerApps(config.containers).length > 0
-	) {
+	if (!skipContainerChanges && durableObjectContainerConfig.length > 0) {
 		assert(versionId && accountId);
 		try {
-			await deployDurableObjectContainerApplications(config, {
-				versionId,
-				accountId,
-				scriptName,
-				dispatchNamespace: props.dispatchNamespace,
-			});
+			await deployDurableObjectContainerApplications(
+				config,
+				durableObjectContainerConfig,
+				{
+					versionId,
+					accountId,
+					scriptName,
+					dispatchNamespace: props.dispatchNamespace,
+				}
+			);
 		} catch (error) {
 			throw new UserError(
 				"The Worker version was deployed, but Wrangler could not finish creating its Durable Object-managed Container applications. Re-run the same `wrangler deploy` command to retry the idempotent application creation and finish deployment.",

--- a/packages/deploy-helpers/src/deploy/helpers/container-image-bindings.ts
+++ b/packages/deploy-helpers/src/deploy/helpers/container-image-bindings.ts
@@ -1,12 +1,9 @@
-import {
-	CONTAINER_IMAGES_BINDING,
-	getDurableObjectContainerApps,
-	UserError,
-} from "@cloudflare/workers-utils";
+import { CONTAINER_IMAGES_BINDING, UserError } from "@cloudflare/workers-utils";
 import { fetchResult } from "../../shared/context";
+import type { ContainerlessConfig } from "../../shared/types";
 import type {
 	Binding,
-	Config,
+	DurableObjectContainerApp,
 	WorkerMetadataBinding,
 } from "@cloudflare/workers-utils";
 
@@ -14,11 +11,12 @@ type PreparedContainerImages = Record<string, Record<string, string>>;
 
 /** Prevent keep_vars from retaining generated images when no managed Containers remain. */
 export async function clearRemovedContainerImagesBindings(
-	config: Config,
+	config: ContainerlessConfig,
+	durableObjectContainerConfig: DurableObjectContainerApp[],
 	bindings: Record<string, Binding>,
 	workerUrl: string
 ): Promise<void> {
-	if (getDurableObjectContainerApps(config.containers).length > 0) {
+	if (durableObjectContainerConfig.length > 0) {
 		return;
 	}
 	// A full upload clears Container metadata even when containers is omitted.
@@ -34,7 +32,7 @@ export async function clearRemovedContainerImagesBindings(
 }
 
 export function addContainerImagesBinding(
-	config: Config,
+	durableObjectContainerConfig: DurableObjectContainerApp[],
 	bindings: Record<string, Binding>,
 	preparedContainerImages: PreparedContainerImages,
 	options: {
@@ -43,7 +41,6 @@ export function addContainerImagesBinding(
 		hasExistingBinding?: boolean;
 	} = {}
 ): void {
-	const containers = getDurableObjectContainerApps(config.containers);
 	const shouldInheritExisting =
 		options.preserveExisting &&
 		options.workerExists &&
@@ -52,7 +49,7 @@ export function addContainerImagesBinding(
 	if (options.preserveExisting && !shouldInheritExisting) {
 		return;
 	}
-	if (containers.length === 0 && !shouldInheritExisting) {
+	if (durableObjectContainerConfig.length === 0 && !shouldInheritExisting) {
 		return;
 	}
 
@@ -74,7 +71,7 @@ export function addContainerImagesBinding(
 	bindings[CONTAINER_IMAGES_BINDING] = {
 		type: "json",
 		value: Object.fromEntries(
-			containers.map((container) => {
+			durableObjectContainerConfig.map((container) => {
 				const configuredImages = Object.keys(container.images ?? {});
 				const preparedImages = preparedContainerImages[container.class_name];
 				if (configuredImages.length > 0 && preparedImages === undefined) {

--- a/packages/deploy-helpers/src/deploy/helpers/container-metadata.ts
+++ b/packages/deploy-helpers/src/deploy/helpers/container-metadata.ts
@@ -5,50 +5,49 @@ import {
 	UserError,
 } from "@cloudflare/workers-utils";
 import { fetchVersions } from "./versions-api";
+import type { ContainerlessConfig } from "../../shared/types";
 import type { ApiDeployment } from "./versions-types";
-import type { CfWorkerInit, Config } from "@cloudflare/workers-utils";
+import type { CfWorkerInit, ContainerApp } from "@cloudflare/workers-utils";
 
 type ContainerImages = Record<string, Record<string, string>>;
 
 export function getContainerMetadata(
-	config: Config,
+	containers: ContainerApp[] | undefined,
 	preparedContainerImages: ContainerImages = {},
 	options: { allowUnprepared?: boolean } = {}
 ): CfWorkerInit["containers"] {
-	const metadata =
-		config.containers?.map((container) => {
-			if (isDurableObjectContainerApp(container)) {
-				const configuredImages = Object.keys(container.images ?? {});
-				const images = preparedContainerImages[container.class_name];
-				if (
-					configuredImages.length > 0 &&
-					images === undefined &&
-					!options.allowUnprepared
-				) {
-					throw new Error(
-						`Container images for Durable Object class "${container.class_name}" were not prepared before upload.`
-					);
-				}
-				return {
-					name: container.name,
-					class_name: container.class_name,
-					...(images !== undefined && { images }),
-				};
+	return containers?.map((container) => {
+		if (isDurableObjectContainerApp(container)) {
+			const configuredImages = Object.keys(container.images ?? {});
+			const images = preparedContainerImages[container.class_name];
+			if (
+				configuredImages.length > 0 &&
+				images === undefined &&
+				!options.allowUnprepared
+			) {
+				throw new Error(
+					`Container images for Durable Object class "${container.class_name}" were not prepared before upload.`
+				);
 			}
-
 			return {
-				...(container.name !== undefined && { name: container.name }),
-				...(container.class_name !== undefined && {
-					class_name: container.class_name,
-				}),
+				name: container.name,
+				class_name: container.class_name,
+				...(images !== undefined && { images }),
 			};
-		}) ?? [];
+		}
 
-	return config.containers === undefined ? undefined : metadata;
+		return {
+			...(container.name !== undefined && { name: container.name }),
+			...(container.class_name !== undefined && {
+				class_name: container.class_name,
+			}),
+		};
+	});
 }
 
 export async function getContainerMetadataForRolloutSkip(
-	config: Config,
+	config: ContainerlessConfig,
+	containers: ContainerApp[] | undefined,
 	{
 		accountId,
 		scriptName,
@@ -69,7 +68,7 @@ export async function getContainerMetadataForRolloutSkip(
 	hasExistingContainerImagesBinding: boolean;
 }> {
 	const configuredMetadata = getContainerMetadata(
-		config,
+		containers,
 		{},
 		{
 			allowUnprepared: true,

--- a/packages/deploy-helpers/src/deploy/helpers/durable-object-container-applications.ts
+++ b/packages/deploy-helpers/src/deploy/helpers/durable-object-container-applications.ts
@@ -4,11 +4,11 @@ import { setTimeout } from "node:timers/promises";
 import { updateStatus } from "@cloudflare/cli-shared-helpers";
 import {
 	ApplicationsService,
-	buildAndMaybePush,
 	ContainerImagePreparationsService,
 	ContainerImagePreparationStatus,
 	createDurableObjectNamespaceResolver,
 	listDurableObjects,
+	pushImageIfChanged,
 	resolveImageName,
 	SchedulingPolicy,
 } from "@cloudflare/containers-shared";
@@ -16,11 +16,13 @@ import {
 	CONTAINER_IMAGES_BINDING,
 	getDockerPath,
 	getDurableObjectClassNameToUseSQLiteMap,
-	getDurableObjectContainerApps,
 	UserError,
 	validateDurableObjectContainerApplications,
 } from "@cloudflare/workers-utils";
-import { logger } from "../../shared/context";
+import type {
+	BuiltDurableObjectContainerImage,
+	ContainerlessConfig,
+} from "../../shared/types";
 import type { ApiVersion } from "./versions-types";
 import type { CreateDurableObjectApplicationRequest } from "@cloudflare/containers-shared";
 import type {
@@ -291,24 +293,12 @@ export async function deployVersionedDurableObjectContainerApplications(
 	}
 }
 
-function buildTag(
-	scriptName: string,
-	className: string,
-	imageName: string
-): string {
-	const repository = `${scriptName}-${className}-${imageName}`
-		.toLowerCase()
-		.replace(/[^a-z0-9._-]+/g, "-")
-		.replace(/^-+|-+$/g, "");
-	return `${repository}:wrangler-${Date.now().toString(36)}`;
-}
-
 async function buildOrResolveImage(
-	config: Config,
+	config: ContainerlessConfig,
 	container: DurableObjectContainerApp,
 	imageName: string,
 	imageConfig: DurableObjectContainerImage,
-	scriptName: string,
+	builtImages: BuiltDurableObjectContainerImage[],
 	dryRun: boolean,
 	accountId: string | undefined
 ): Promise<string> {
@@ -320,27 +310,43 @@ async function buildOrResolveImage(
 		return resolveImageName(accountId, imageConfig.image, config);
 	}
 
-	const baseDir = config.configPath
-		? path.dirname(config.configPath)
-		: process.cwd();
-	const dockerfile = path.resolve(baseDir, imageConfig.dockerfile);
-	const tag = buildTag(scriptName, container.class_name, imageName);
-	logger.log("Building image", tag);
-	const imageRef = await buildAndMaybePush(
-		{
-			tag,
-			pathToDockerfile: dockerfile,
-			buildContext: path.dirname(dockerfile),
-			platform: "linux/amd64",
-		},
-		getDockerPath(),
-		!dryRun,
-		undefined,
-		true,
-		config
+	const builtImage = builtImages.find(
+		(candidate) =>
+			candidate.className === container.class_name &&
+			candidate.imageName === imageName
 	);
+	if (builtImage === undefined) {
+		throw new Error(
+			`Container image "${imageName}" for Durable Object class "${container.class_name}" was not built before upload.`
+		);
+	}
+	if (dryRun) {
+		return builtImage.localTag;
+	}
 
-	return "remoteDigest" in imageRef ? imageRef.remoteDigest : imageRef.newTag;
+	try {
+		const imageRef = await pushImageIfChanged({
+			pathToDocker: getDockerPath(),
+			sourceTag: builtImage.localTag,
+			targetTag: builtImage.localTag,
+			accountId,
+			complianceConfig: config,
+			cleanupSourceTag: true,
+		});
+		builtImage.localTagCleaned = true;
+
+		return "remoteDigest" in imageRef ? imageRef.remoteDigest : imageRef.newTag;
+	} catch (error) {
+		if (error instanceof Error) {
+			throw new UserError(error.message, {
+				cause: error,
+				telemetryMessage: "durable object container image push failed",
+			});
+		}
+		throw new UserError("An unknown error occurred", {
+			telemetryMessage: "durable object container image push failed",
+		});
+	}
 }
 
 async function waitForImagePreparation(image: string): Promise<void> {
@@ -383,7 +389,9 @@ async function waitForImagePreparation(image: string): Promise<void> {
 }
 
 export async function prepareDurableObjectContainerApplications(
-	config: Config,
+	config: ContainerlessConfig,
+	durableObjectContainerConfig: DurableObjectContainerApp[],
+	builtImages: BuiltDurableObjectContainerImage[],
 	{
 		accountId,
 		dryRun,
@@ -391,16 +399,17 @@ export async function prepareDurableObjectContainerApplications(
 		dispatchNamespace,
 	}: PrepareDurableObjectContainerApplicationsArgs
 ): Promise<PreparedContainerImages> {
-	validateDurableObjectContainerApplications(config);
+	validateDurableObjectContainerApplications(
+		config,
+		durableObjectContainerConfig
+	);
 	if (!dryRun) {
 		assert(accountId, "Expected accountId to prepare container applications");
 		const storageByClass = getDurableObjectClassNameToUseSQLiteMap(
 			config.migrations,
 			config.exports
 		);
-		const unknownStorage = getDurableObjectContainerApps(
-			config.containers
-		).filter(
+		const unknownStorage = durableObjectContainerConfig.filter(
 			(container) => storageByClass.get(container.class_name) === undefined
 		);
 		if (unknownStorage.length > 0) {
@@ -428,7 +437,7 @@ export async function prepareDurableObjectContainerApplications(
 		}
 	}
 
-	const containers = getDurableObjectContainerApps(config.containers).filter(
+	const containers = durableObjectContainerConfig.filter(
 		(container) => Object.keys(container.images ?? {}).length > 0
 	);
 	if (containers.length === 0) {
@@ -455,7 +464,7 @@ export async function prepareDurableObjectContainerApplications(
 					container,
 					imageName,
 					imageConfig,
-					scriptName,
+					builtImages,
 					dryRun,
 					accountId
 				);
@@ -480,7 +489,8 @@ export async function prepareDurableObjectContainerApplications(
 }
 
 export async function deployDurableObjectContainerApplications(
-	config: Config,
+	config: ContainerlessConfig,
+	durableObjectContainerConfig: DurableObjectContainerApp[],
 	{
 		versionId,
 		accountId,
@@ -488,7 +498,7 @@ export async function deployDurableObjectContainerApplications(
 		dispatchNamespace,
 	}: DeployDurableObjectContainerApplicationsArgs
 ): Promise<void> {
-	const containers = getDurableObjectContainerApps(config.containers);
+	const containers = durableObjectContainerConfig;
 	if (containers.length === 0) {
 		return;
 	}

--- a/packages/deploy-helpers/src/deploy/helpers/provision-bindings.ts
+++ b/packages/deploy-helpers/src/deploy/helpers/provision-bindings.ts
@@ -1225,7 +1225,6 @@ export async function provisionBindings(
 				log: logger.log,
 				tailConsumers: config.tail_consumers,
 				streamingTailConsumers: config.streaming_tail_consumers,
-				containers: config.containers,
 				provisioning: true,
 			}
 		);

--- a/packages/deploy-helpers/src/deploy/helpers/validate-worker-props.ts
+++ b/packages/deploy-helpers/src/deploy/helpers/validate-worker-props.ts
@@ -23,12 +23,12 @@ import { downloadWorkerConfig } from "./download-worker-config";
 import { verifyWorkerMatchesCITag } from "./match-tag";
 import { validateRoutes } from "./validate-routes";
 import { isWorkerNotFoundError } from "./worker-not-found-error";
-import type { DeployProps, VersionsUploadProps } from "../../shared/types";
 import type {
-	AssetsOptions,
-	Config,
-	RawConfig,
-} from "@cloudflare/workers-utils";
+	ContainerlessConfig,
+	DeployProps,
+	VersionsUploadProps,
+} from "../../shared/types";
+import type { AssetsOptions, RawConfig } from "@cloudflare/workers-utils";
 
 /**
  *
@@ -45,7 +45,7 @@ type ValidateWorkerPropsInput =
 
 export function validateWorkerProps<T extends ValidateWorkerPropsInput>(
 	props: T,
-	config: Config
+	config: ContainerlessConfig
 ): T & { name: string } {
 	const { name, compatibilityDate } = props;
 	const { format } = props.entry;
@@ -119,7 +119,7 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 		}
 	} else {
 		if (
-			config.containers?.some(
+			props.containers.source?.some(
 				(container) => !isDurableObjectContainerApp(container)
 			)
 		) {
@@ -146,7 +146,7 @@ export type PreUploadApiChecksResult = {
  */
 export async function preUploadApiChecks(
 	props: DeployProps | VersionsUploadProps,
-	config: Config
+	config: ContainerlessConfig
 ): Promise<PreUploadApiChecksResult> {
 	const { accountId, name } = props;
 

--- a/packages/deploy-helpers/src/deploy/versions-upload.ts
+++ b/packages/deploy-helpers/src/deploy/versions-upload.ts
@@ -59,11 +59,15 @@ import {
 	validateWorkerProps,
 } from "./helpers/validate-worker-props";
 import { patchNonVersionedScriptSettings } from "./helpers/versions-api";
-import type { VersionsUploadProps, WorkerBuildResult } from "../shared/types";
+import type {
+	ContainerlessConfig,
+	VersionsUploadProps,
+	WorkerBuildResult,
+} from "../shared/types";
 import type { DeployCallbacks } from "./deploy";
 import type { AssetUploadStats } from "./helpers/assets";
 import type { RetrieveSourceMapFunction } from "./helpers/sourcemap";
-import type { CfWorkerInit, Config } from "@cloudflare/workers-utils";
+import type { CfWorkerInit } from "@cloudflare/workers-utils";
 import type { FormData } from "undici";
 
 export type VersionsUploadCallbacks = Pick<DeployCallbacks, "analyseBundle">;
@@ -79,7 +83,7 @@ type VersionsUploadResult = {
 
 export default async function versionsUpload(
 	props: VersionsUploadProps,
-	config: Config,
+	config: ContainerlessConfig,
 	buildResult: WorkerBuildResult,
 	callbacks: VersionsUploadCallbacks
 ): Promise<VersionsUploadResult> {
@@ -115,7 +119,7 @@ export default async function versionsUpload(
 
 async function uploadWorkerVersion(
 	props: VersionsUploadProps,
-	config: Config,
+	config: ContainerlessConfig,
 	buildResult: WorkerBuildResult,
 	callbacks: VersionsUploadCallbacks
 ): Promise<VersionsUploadResult> {
@@ -185,13 +189,21 @@ async function uploadWorkerVersion(
 			{ telemetryMessage: "versions upload pending durable object migration" }
 		);
 	}
+	const durableObjectContainerConfig = getDurableObjectContainerApps(
+		props.containers.source
+	);
 
 	const preparedContainerImages =
-		await prepareDurableObjectContainerApplications(config, {
-			accountId,
-			dryRun: Boolean(props.dryRun),
-			scriptName,
-		});
+		await prepareDurableObjectContainerApplications(
+			config,
+			durableObjectContainerConfig,
+			props.containers.durableObjects.builtImages,
+			{
+				accountId,
+				dryRun: Boolean(props.dryRun),
+				scriptName,
+			}
+		);
 
 	// Upload assets if assets is being used
 	const assetsUploadResult =
@@ -216,9 +228,18 @@ async function uploadWorkerVersion(
 
 	addRequiredSecretsInheritBindings(config, bindings, { type: "upload" });
 	if (keepVars && !props.dryRun && workerExists) {
-		await clearRemovedContainerImagesBindings(config, bindings, workerUrl);
+		await clearRemovedContainerImagesBindings(
+			config,
+			durableObjectContainerConfig,
+			bindings,
+			workerUrl
+		);
 	}
-	addContainerImagesBinding(config, bindings, preparedContainerImages ?? {});
+	addContainerImagesBinding(
+		durableObjectContainerConfig,
+		bindings,
+		preparedContainerImages ?? {}
+	);
 
 	const placement = parseConfigPlacement(config);
 
@@ -235,7 +256,10 @@ async function uploadWorkerVersion(
 		migrations,
 		exports,
 		modules,
-		containers: getContainerMetadata(config, preparedContainerImages),
+		containers: getContainerMetadata(
+			props.containers.source,
+			preparedContainerImages
+		),
 		sourceMaps,
 		compatibility_date: compatibilityDate,
 		compatibility_flags: compatibilityFlags,
@@ -463,14 +487,18 @@ async function uploadWorkerVersion(
 	// only migration-managed namespaces can be resolved during version upload.
 	if (
 		!hasDurableObjectExports(config.exports) &&
-		getDurableObjectContainerApps(config.containers).length > 0
+		durableObjectContainerConfig.length > 0
 	) {
 		assert(versionId);
-		await deployDurableObjectContainerApplications(config, {
-			versionId,
-			accountId,
-			scriptName,
-		});
+		await deployDurableObjectContainerApplications(
+			config,
+			durableObjectContainerConfig,
+			{
+				versionId,
+				accountId,
+				scriptName,
+			}
+		);
 	}
 
 	const uploadMs = Date.now() - start;

--- a/packages/deploy-helpers/src/shared/types.ts
+++ b/packages/deploy-helpers/src/shared/types.ts
@@ -1,5 +1,6 @@
 import type {
-	BuiltContainerDeployment,
+	BuiltContainerImage,
+	BuiltImage,
 	ContainerNormalizedConfig,
 } from "@cloudflare/containers-shared";
 import type {
@@ -16,6 +17,7 @@ import type {
 	Logger,
 	Route,
 	Entry,
+	ContainerApp,
 } from "@cloudflare/workers-utils";
 
 /**
@@ -48,6 +50,28 @@ export type DeployHelpersContext = {
 			fallbackOption?: number;
 		}
 	) => Promise<Values>;
+};
+
+export type ContainerlessConfig = Omit<Config, "containers">;
+
+export type BuiltDurableObjectContainerImage = BuiltImage & {
+	className: string;
+	imageName: string;
+};
+
+export type ContainerDeployConfig = {
+	/** Original resolved container configuration. */
+	source: ContainerApp[] | undefined;
+	standard: {
+		/** Normalized non-Durable-Object container applications. */
+		normalized: ContainerNormalizedConfig[];
+		/** Locally built images awaiting deployment or cleanup. */
+		builtImages: BuiltContainerImage[];
+	};
+	durableObjects: {
+		/** Locally built named images awaiting upload or cleanup. */
+		builtImages: BuiltDurableObjectContainerImage[];
+	};
 };
 
 /**
@@ -108,6 +132,8 @@ export type SharedDeployVersionsProps = {
 	skipProvisioningConfigWriteback: boolean;
 	/** From --strict arg. In strict mode, conflicting pre-upload checks abort instead of auto-continuing. */
 	strict: boolean;
+	/** Container configuration and locally built image state. */
+	containers: ContainerDeployConfig;
 	/** Whether the resolved Worker name differs from the pre-merge config/args name. */
 	workerNameOverridden?: boolean;
 };
@@ -131,10 +157,6 @@ export type DeployProps = SharedDeployVersionsProps & {
 	oldAssetTtl: number | undefined;
 	/** From --containers-rollout arg. Deploy-only. */
 	containersRollout: "immediate" | "gradual" | "none" | undefined;
-	/** Normalized Wrangler container configuration, resolved before calling deploy-helpers. */
-	normalisedContainerConfig: ContainerNormalizedConfig[];
-	/** Dockerfile container images built by the caller before invoking deploy-helpers. */
-	builtContainerDeployments: BuiltContainerDeployment[];
 	/**
 	 * When true, an existing Worker with the same name aborts the deploy instead
 	 * of updating it, because this run cannot confirm the local project owns the

--- a/packages/deploy-helpers/tests/container-image-bindings.test.ts
+++ b/packages/deploy-helpers/tests/container-image-bindings.test.ts
@@ -4,38 +4,34 @@ import { clearRemovedContainerImagesBindings } from "../src/deploy/helpers/conta
 import { fetchResult } from "../src/shared/context";
 vi.mock("../src/shared/context", () => ({ fetchResult: vi.fn() }));
 import { addContainerImagesBinding } from "../src/deploy/helpers/container-image-bindings";
-import type { Binding, Config } from "@cloudflare/workers-utils";
+import type {
+	Binding,
+	Config,
+	DurableObjectContainerApp,
+} from "@cloudflare/workers-utils";
 
 describe("addContainerImagesBinding", () => {
 	it("adds only Durable Object-managed images to the JSON binding", ({
 		expect,
 	}) => {
-		const config = {
-			containers: [
-				{
-					name: "scheduled",
-					class_name: "Scheduled",
-					scheduling_policy: "default",
-					image: "./Dockerfile",
+		const durableObjectContainerConfig = [
+			{
+				name: "sandbox",
+				class_name: "Sandbox",
+				scheduling_policy: "durable_object",
+				images: {
+					sandbox: { dockerfile: "./container/Dockerfile" },
 				},
-				{
-					name: "sandbox",
-					class_name: "Sandbox",
-					scheduling_policy: "durable_object",
-					images: {
-						sandbox: { dockerfile: "./container/Dockerfile" },
-					},
-				},
-				{
-					name: "tools",
-					class_name: "Tools",
-					scheduling_policy: "durable_object",
-				},
-			],
-		} as unknown as Config;
+			},
+			{
+				name: "tools",
+				class_name: "Tools",
+				scheduling_policy: "durable_object",
+			},
+		] as DurableObjectContainerApp[];
 		const bindings: Record<string, Binding> = {};
 
-		addContainerImagesBinding(config, bindings, {
+		addContainerImagesBinding(durableObjectContainerConfig, bindings, {
 			Sandbox: {
 				sandbox:
 					"registry.cloudflare.com/account/sandbox@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
@@ -60,20 +56,7 @@ describe("addContainerImagesBinding", () => {
 	}) => {
 		const bindings: Record<string, Binding> = {};
 
-		addContainerImagesBinding(
-			{
-				containers: [
-					{
-						name: "scheduled",
-						class_name: "Scheduled",
-						scheduling_policy: "default",
-						image: "./Dockerfile",
-					},
-				],
-			} as unknown as Config,
-			bindings,
-			{}
-		);
+		addContainerImagesBinding([], bindings, {});
 
 		expect(bindings).toEqual({});
 	});
@@ -83,30 +66,12 @@ describe("addContainerImagesBinding", () => {
 	}) => {
 		const bindings: Record<string, Binding> = {};
 
-		addContainerImagesBinding(
-			{
-				exports: {
-					Sandbox: {
-						type: "durable-object",
-						storage: "sqlite",
-						container: {
-							images: {
-								sandbox: {
-									dockerfile: "./container/Dockerfile",
-								},
-							},
-						},
-					},
-				},
-			} as unknown as Config,
-			bindings,
-			{
-				Sandbox: {
-					sandbox:
-						"registry.cloudflare.com/account/sandbox@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-				},
-			}
-		);
+		addContainerImagesBinding([], bindings, {
+			Sandbox: {
+				sandbox:
+					"registry.cloudflare.com/account/sandbox@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			},
+		});
 
 		expect(bindings).toEqual({});
 	});
@@ -114,15 +79,13 @@ describe("addContainerImagesBinding", () => {
 	it.for([CONTAINER_IMAGES_BINDING])(
 		"rejects a user binding with the reserved name %s",
 		(bindingName, { expect }) => {
-			const config = {
-				containers: [
-					{
-						name: "sandbox",
-						class_name: "Sandbox",
-						scheduling_policy: "durable_object",
-					},
-				],
-			} as unknown as Config;
+			const durableObjectContainerConfig = [
+				{
+					name: "sandbox",
+					class_name: "Sandbox",
+					scheduling_policy: "durable_object",
+				},
+			] as DurableObjectContainerApp[];
 			const bindings: Record<string, Binding> = {
 				[bindingName]: {
 					type: "plain_text",
@@ -130,27 +93,27 @@ describe("addContainerImagesBinding", () => {
 				},
 			};
 
-			expect(() => addContainerImagesBinding(config, bindings, {})).toThrow(
-				`The binding name "${bindingName}" is reserved`
-			);
+			expect(() =>
+				addContainerImagesBinding(durableObjectContainerConfig, bindings, {})
+			).toThrow(`The binding name "${bindingName}" is reserved`);
 		}
 	);
 
 	it("rejects configured images that were not prepared", ({ expect }) => {
-		const config = {
-			containers: [
-				{
-					name: "sandbox",
-					class_name: "Sandbox",
-					scheduling_policy: "durable_object",
-					images: {
-						sandbox: { dockerfile: "./container/Dockerfile" },
-					},
+		const durableObjectContainerConfig = [
+			{
+				name: "sandbox",
+				class_name: "Sandbox",
+				scheduling_policy: "durable_object",
+				images: {
+					sandbox: { dockerfile: "./container/Dockerfile" },
 				},
-			],
-		} as unknown as Config;
+			},
+		] as DurableObjectContainerApp[];
 
-		expect(() => addContainerImagesBinding(config, {}, {})).toThrow(
+		expect(() =>
+			addContainerImagesBinding(durableObjectContainerConfig, {}, {})
+		).toThrow(
 			'Container images for Durable Object class "Sandbox" were not prepared before upload.'
 		);
 	});
@@ -158,22 +121,20 @@ describe("addContainerImagesBinding", () => {
 	it("inherits the binding when the existing image map should be preserved", ({
 		expect,
 	}) => {
-		const config = {
-			containers: [
-				{
-					name: "sandbox",
-					class_name: "Sandbox",
-					scheduling_policy: "durable_object",
-					images: {
-						sandbox: { dockerfile: "./container/Dockerfile" },
-					},
+		const durableObjectContainerConfig = [
+			{
+				name: "sandbox",
+				class_name: "Sandbox",
+				scheduling_policy: "durable_object",
+				images: {
+					sandbox: { dockerfile: "./container/Dockerfile" },
 				},
-			],
-		} as unknown as Config;
+			},
+		] as DurableObjectContainerApp[];
 		const bindings: Record<string, Binding> = {};
 
 		addContainerImagesBinding(
-			config,
+			durableObjectContainerConfig,
 			bindings,
 			{},
 			{
@@ -194,7 +155,7 @@ describe("addContainerImagesBinding", () => {
 		const bindings: Record<string, Binding> = {};
 
 		addContainerImagesBinding(
-			{ containers: [] } as unknown as Config,
+			[],
 			bindings,
 			{},
 			{
@@ -217,7 +178,7 @@ describe("addContainerImagesBinding", () => {
 		};
 		expect(() =>
 			addContainerImagesBinding(
-				{} as Config,
+				[],
 				bindings,
 				{},
 				{
@@ -232,22 +193,20 @@ describe("addContainerImagesBinding", () => {
 	it("omits the binding when preserving images for a new Worker", ({
 		expect,
 	}) => {
-		const config = {
-			containers: [
-				{
-					name: "sandbox",
-					class_name: "Sandbox",
-					scheduling_policy: "durable_object",
-					images: {
-						sandbox: { dockerfile: "./container/Dockerfile" },
-					},
+		const durableObjectContainerConfig = [
+			{
+				name: "sandbox",
+				class_name: "Sandbox",
+				scheduling_policy: "durable_object",
+				images: {
+					sandbox: { dockerfile: "./container/Dockerfile" },
 				},
-			],
-		} as unknown as Config;
+			},
+		] as DurableObjectContainerApp[];
 		const bindings: Record<string, Binding> = {};
 
 		addContainerImagesBinding(
-			config,
+			durableObjectContainerConfig,
 			bindings,
 			{},
 			{
@@ -278,6 +237,7 @@ describe("clearRemovedContainerImagesBindings", () => {
 			const bindings: Record<string, Binding> = {};
 			await clearRemovedContainerImagesBindings(
 				{ containers } as unknown as Config,
+				[],
 				bindings,
 				"/worker"
 			);
@@ -299,6 +259,7 @@ describe("clearRemovedContainerImagesBindings", () => {
 			const bindings: Record<string, Binding> = {};
 			await clearRemovedContainerImagesBindings(
 				{ containers } as unknown as Config,
+				[],
 				bindings,
 				"/worker"
 			);
@@ -314,6 +275,7 @@ describe("clearRemovedContainerImagesBindings", () => {
 			};
 			await clearRemovedContainerImagesBindings(
 				{ containers } as unknown as Config,
+				[],
 				bindings,
 				"/worker"
 			);
@@ -337,6 +299,7 @@ describe("clearRemovedContainerImagesBindings", () => {
 			const bindings: Record<string, Binding> = {};
 			await clearRemovedContainerImagesBindings(
 				{ containers } as unknown as Config,
+				containers as DurableObjectContainerApp[],
 				bindings,
 				"/worker"
 			);

--- a/packages/deploy-helpers/tests/container-metadata.test.ts
+++ b/packages/deploy-helpers/tests/container-metadata.test.ts
@@ -9,37 +9,92 @@ import type {
 	ApiDeployment,
 	ApiVersion,
 } from "../src/deploy/helpers/versions-types";
-import type { CfWorkerInit, Config } from "@cloudflare/workers-utils";
+import type {
+	CfWorkerInit,
+	Config,
+	ContainerApp,
+	DurableObjectContainerApp,
+} from "@cloudflare/workers-utils";
 
 vi.mock("../src/deploy/helpers/versions-api");
+
+function containerConfig(
+	options: {
+		containerMetadataConfig?: CfWorkerInit["containers"];
+		durableObjectContainerConfig?: DurableObjectContainerApp[];
+	} = {}
+) {
+	const metadata = Object.hasOwn(options, "containerMetadataConfig")
+		? options.containerMetadataConfig
+		: [];
+	return metadata === undefined
+		? undefined
+		: [
+				...(metadata as ContainerApp[]),
+				...(options.durableObjectContainerConfig ?? []),
+			];
+}
 
 describe("getContainerMetadata", () => {
 	it("returns undefined when container configuration is absent", ({
 		expect,
 	}) => {
-		expect(getContainerMetadata({} as Config)).toBeUndefined();
+		expect(
+			getContainerMetadata(
+				containerConfig({ containerMetadataConfig: undefined })
+			)
+		).toBeUndefined();
 	});
 
 	it("returns an empty list when container configuration is explicitly empty", ({
 		expect,
 	}) => {
-		expect(
-			getContainerMetadata({ containers: [] } as unknown as Config)
-		).toEqual([]);
+		expect(getContainerMetadata(containerConfig({}))).toEqual([]);
+	});
+
+	it("includes standard container metadata", ({ expect }) => {
+		const metadata = getContainerMetadata(
+			containerConfig({
+				containerMetadataConfig: [
+					{
+						class_name: "Scheduled",
+						name: "scheduled-app",
+					},
+				],
+			})
+		);
+
+		expect(metadata).toEqual([
+			{ name: "scheduled-app", class_name: "Scheduled" },
+		]);
+	});
+
+	it("preserves standard container metadata without an explicit class name", ({
+		expect,
+	}) => {
+		const metadata = getContainerMetadata(
+			containerConfig({
+				containerMetadataConfig: [{ name: "scheduled-app" }],
+			})
+		);
+
+		expect(metadata).toEqual([{ name: "scheduled-app" }]);
 	});
 
 	it("includes the resolved name when no Durable Object-managed images are configured", ({
 		expect,
 	}) => {
-		const metadata = getContainerMetadata({
-			containers: [
-				{
-					class_name: "Sandbox",
-					name: "sandbox-app",
-					scheduling_policy: "durable_object",
-				},
-			],
-		} as unknown as Config);
+		const metadata = getContainerMetadata(
+			containerConfig({
+				durableObjectContainerConfig: [
+					{
+						class_name: "Sandbox",
+						name: "sandbox-app",
+						scheduling_policy: "durable_object",
+					},
+				],
+			})
+		);
 
 		expect(metadata).toEqual([{ name: "sandbox-app", class_name: "Sandbox" }]);
 	});
@@ -48,8 +103,8 @@ describe("getContainerMetadata", () => {
 		expect,
 	}) => {
 		const metadata = getContainerMetadata(
-			{
-				containers: [
+			containerConfig({
+				durableObjectContainerConfig: [
 					{
 						class_name: "Sandbox",
 						name: "sandbox-app",
@@ -59,7 +114,7 @@ describe("getContainerMetadata", () => {
 						},
 					},
 				],
-			} as unknown as Config,
+			}),
 			{
 				Sandbox: {
 					sandbox:
@@ -84,8 +139,8 @@ describe("getContainerMetadata", () => {
 		expect,
 	}) => {
 		const metadata = getContainerMetadata(
-			{
-				containers: [
+			containerConfig({
+				durableObjectContainerConfig: [
 					{
 						class_name: "Sandbox",
 						name: "sandbox-app",
@@ -95,7 +150,7 @@ describe("getContainerMetadata", () => {
 						},
 					},
 				],
-			} as unknown as Config,
+			}),
 			{},
 			{ allowUnprepared: true }
 		);
@@ -153,23 +208,34 @@ describe("getContainerMetadataForRolloutSkip", () => {
 	}
 	function recover(config: Config, versions: ApiVersion[]) {
 		vi.mocked(fetchVersions).mockResolvedValue(versions);
-		return getContainerMetadataForRolloutSkip(config, {
-			accountId: "account",
-			scriptName: "worker",
-			dispatchNamespace: undefined,
-			workerExists: true,
-			latestDeployment: {
-				id: "deployment",
-				source: "api",
-				strategy: "percentage",
-				author_email: "",
-				created_on: "",
-				versions: versions.map(({ id }) => ({
-					version_id: id,
-					percentage: 100 / versions.length,
+		return getContainerMetadataForRolloutSkip(
+			config,
+			containerConfig({
+				containerMetadataConfig: config.containers?.map((container) => ({
+					...(container.name !== undefined && { name: container.name }),
+					...(container.class_name !== undefined && {
+						class_name: container.class_name,
+					}),
 				})),
-			},
-		});
+			}),
+			{
+				accountId: "account",
+				scriptName: "worker",
+				dispatchNamespace: undefined,
+				workerExists: true,
+				latestDeployment: {
+					id: "deployment",
+					source: "api",
+					strategy: "percentage",
+					author_email: "",
+					created_on: "",
+					versions: versions.map(({ id }) => ({
+						version_id: id,
+						percentage: 100 / versions.length,
+					})),
+				},
+			}
+		);
 	}
 
 	it("ignores other user variables even when their presence differs", async ({
@@ -235,13 +301,17 @@ describe("getContainerMetadataForRolloutSkip", () => {
 		"rejects an existing Worker without recoverable deployed versions: %j",
 		async (latestDeployment, { expect }) => {
 			await expect(
-				getContainerMetadataForRolloutSkip({} as Config, {
-					accountId: "account",
-					scriptName: "worker",
-					dispatchNamespace: undefined,
-					workerExists: true,
-					latestDeployment,
-				})
+				getContainerMetadataForRolloutSkip(
+					{} as Config,
+					containerConfig({ containerMetadataConfig: undefined }),
+					{
+						accountId: "account",
+						scriptName: "worker",
+						dispatchNamespace: undefined,
+						workerExists: true,
+						latestDeployment,
+					}
+				)
 			).rejects.toThrow("deployed Container metadata could not be recovered");
 			expect(fetchVersions).not.toHaveBeenCalled();
 		}
@@ -249,13 +319,17 @@ describe("getContainerMetadataForRolloutSkip", () => {
 
 	it("rejects an existing Worker without an account ID", async ({ expect }) => {
 		await expect(
-			getContainerMetadataForRolloutSkip({} as Config, {
-				accountId: undefined,
-				scriptName: "worker",
-				dispatchNamespace: undefined,
-				workerExists: true,
-				latestDeployment: undefined,
-			})
+			getContainerMetadataForRolloutSkip(
+				{} as Config,
+				containerConfig({ containerMetadataConfig: undefined }),
+				{
+					accountId: undefined,
+					scriptName: "worker",
+					dispatchNamespace: undefined,
+					workerExists: true,
+					latestDeployment: undefined,
+				}
+			)
 		).rejects.toThrow("deployed Container metadata could not be recovered");
 	});
 
@@ -267,8 +341,9 @@ describe("getContainerMetadataForRolloutSkip", () => {
 		"keeps local metadata for first deployments and dry runs: %j",
 		async (options, { expect }) => {
 			const result = await getContainerMetadataForRolloutSkip(
-				{
-					containers: [
+				{} as Config,
+				containerConfig({
+					durableObjectContainerConfig: [
 						{
 							name: "sandbox",
 							class_name: "Sandbox",
@@ -276,7 +351,7 @@ describe("getContainerMetadataForRolloutSkip", () => {
 							images: { app: { dockerfile: "./Dockerfile" } },
 						},
 					],
-				} as unknown as Config,
+				}),
 				{
 					...options,
 					scriptName: "worker",

--- a/packages/deploy-helpers/tests/durable-object-container-applications.test.ts
+++ b/packages/deploy-helpers/tests/durable-object-container-applications.test.ts
@@ -5,6 +5,7 @@ import {
 	ContainerImagePreparationStatus,
 	createDurableObjectNamespaceResolver,
 	listDurableObjects,
+	pushImageIfChanged,
 	SchedulingPolicy,
 } from "@cloudflare/containers-shared";
 import { afterEach, beforeEach, describe, it, vi } from "vitest";
@@ -13,8 +14,12 @@ import {
 	resolveVersionedDurableObjectContainerApplications,
 	prepareDurableObjectContainerApplications,
 } from "../src/deploy/helpers/durable-object-container-applications";
+import type { BuiltDurableObjectContainerImage } from "../src/shared/types";
 import type { Application } from "@cloudflare/containers-shared";
-import type { Config } from "@cloudflare/workers-utils";
+import type {
+	Config,
+	DurableObjectContainerApp,
+} from "@cloudflare/workers-utils";
 
 vi.mock("node:timers/promises", () => ({ setTimeout: vi.fn() }));
 vi.mock("@cloudflare/cli-shared-helpers", async (importOriginal) => ({
@@ -25,6 +30,7 @@ vi.mock("@cloudflare/containers-shared", async (importOriginal) => ({
 	...(await importOriginal<typeof import("@cloudflare/containers-shared")>()),
 	createDurableObjectNamespaceResolver: vi.fn(),
 	listDurableObjects: vi.fn(),
+	pushImageIfChanged: vi.fn(),
 }));
 
 const image = `registry.cloudflare.com/account/tools@sha256:${"a".repeat(64)}`;
@@ -40,6 +46,8 @@ const config = {
 		},
 	],
 } as unknown as Config;
+const durableObjectContainerConfig =
+	config.containers as DurableObjectContainerApp[];
 const args = { accountId: "account", dryRun: false, scriptName: "worker" };
 const namespace = {
 	id: "namespace",
@@ -79,15 +87,14 @@ describe("Container image preparation", () => {
 				status: ContainerImagePreparationStatus.READY,
 			});
 		const result = await prepareDurableObjectContainerApplications(
-			{
-				...config,
-				containers: [
-					{
-						...config.containers?.[0],
-						images: { tools: { image }, alias: { image } },
-					},
-				],
-			} as Config,
+			config,
+			[
+				{
+					...durableObjectContainerConfig[0],
+					images: { tools: { image }, alias: { image } },
+				},
+			],
+			[],
 			args
 		);
 		expect(result).toEqual({ Sandbox: { tools: image, alias: image } });
@@ -105,7 +112,12 @@ describe("Container image preparation", () => {
 				reason: "Image cannot be prepared",
 			});
 		await expect(
-			prepareDurableObjectContainerApplications(config, args)
+			prepareDurableObjectContainerApplications(
+				config,
+				durableObjectContainerConfig,
+				[],
+				args
+			)
 		).rejects.toThrow("Image cannot be prepared");
 		expect(prepare).toHaveBeenCalledOnce();
 		expect(setTimeout).not.toHaveBeenCalled();
@@ -124,7 +136,12 @@ describe("Container image preparation", () => {
 			.mockReturnValueOnce(0)
 			.mockReturnValue(15 * 60_000);
 		await expect(
-			prepareDurableObjectContainerApplications(config, args)
+			prepareDurableObjectContainerApplications(
+				config,
+				durableObjectContainerConfig,
+				[],
+				args
+			)
 		).rejects.toThrow("Timed out while preparing the container image");
 		expect(prepare).toHaveBeenCalledOnce();
 	});
@@ -139,12 +156,62 @@ describe("Container image preparation", () => {
 				status: ContainerImagePreparationStatus.READY,
 			});
 		await expect(
-			prepareDurableObjectContainerApplications(config, args)
+			prepareDurableObjectContainerApplications(
+				config,
+				durableObjectContainerConfig,
+				[],
+				args
+			)
 		).rejects.toThrow("connection reset");
 		await expect(
-			prepareDurableObjectContainerApplications(config, args)
+			prepareDurableObjectContainerApplications(
+				config,
+				durableObjectContainerConfig,
+				[],
+				args
+			)
 		).resolves.toEqual({ Sandbox: { tools: image } });
 		expect(prepare).toHaveBeenCalledTimes(2);
+	});
+	it("pushes a prebuilt Dockerfile image before preparing it", async ({
+		expect,
+	}) => {
+		vi.spyOn(
+			ContainerImagePreparationsService,
+			"prepareContainerImage"
+		).mockResolvedValue({
+			image,
+			status: ContainerImagePreparationStatus.READY,
+		});
+		const push = vi.mocked(pushImageIfChanged).mockResolvedValue({
+			remoteDigest: image,
+		});
+		const builtImage: BuiltDurableObjectContainerImage = {
+			className: "Sandbox",
+			imageName: "tools",
+			localTag: "worker-sandbox-tools:wrangler-test",
+		};
+		const result = await prepareDurableObjectContainerApplications(
+			config,
+			[
+				{
+					...durableObjectContainerConfig[0],
+					images: { tools: { dockerfile: "./Dockerfile" } },
+				},
+			],
+			[builtImage],
+			args
+		);
+		expect(result).toEqual({ Sandbox: { tools: image } });
+		expect(push).toHaveBeenCalledWith({
+			pathToDocker: expect.any(String),
+			sourceTag: builtImage.localTag,
+			targetTag: builtImage.localTag,
+			accountId: "account",
+			complianceConfig: config,
+			cleanupSourceTag: true,
+		});
+		expect(builtImage.localTagCleaned).toBe(true);
 	});
 });
 
@@ -160,6 +227,8 @@ describe("unknown Durable Object storage", () => {
 			},
 		],
 	} as unknown as Config;
+	const unknownStorageDurableObjectContainerConfig =
+		unknownStorageConfig.containers as DurableObjectContainerApp[];
 	it("rejects confirmed legacy storage even with no images to prepare", async ({
 		expect,
 	}) => {
@@ -167,7 +236,12 @@ describe("unknown Durable Object storage", () => {
 			{ ...namespace, use_sqlite: false },
 		]);
 		await expect(
-			prepareDurableObjectContainerApplications(unknownStorageConfig, args)
+			prepareDurableObjectContainerApplications(
+				unknownStorageConfig,
+				unknownStorageDurableObjectContainerConfig,
+				[],
+				args
+			)
 		).rejects.toThrow("legacy KV storage backend");
 	});
 	it.for([
@@ -188,7 +262,12 @@ describe("unknown Durable Object storage", () => {
 		async (namespaces, { expect }) => {
 			vi.mocked(listDurableObjects).mockResolvedValue(namespaces);
 			await expect(
-				prepareDurableObjectContainerApplications(unknownStorageConfig, args)
+				prepareDurableObjectContainerApplications(
+					unknownStorageConfig,
+					unknownStorageDurableObjectContainerConfig,
+					[],
+					args
+				)
 			).resolves.toEqual({});
 		}
 	);
@@ -199,33 +278,53 @@ describe("unknown Durable Object storage", () => {
 			{ ...namespace, dispatch_namespace: "target" },
 		]);
 		await expect(
-			prepareDurableObjectContainerApplications(unknownStorageConfig, {
-				...args,
-				dispatchNamespace: "target",
-			})
+			prepareDurableObjectContainerApplications(
+				unknownStorageConfig,
+				unknownStorageDurableObjectContainerConfig,
+				[],
+				{
+					...args,
+					dispatchNamespace: "target",
+				}
+			)
 		).resolves.toEqual({});
 		vi.mocked(listDurableObjects).mockResolvedValue([
 			{ ...namespace, dispatch_namespace: "target", use_sqlite: false },
 		]);
 		await expect(
-			prepareDurableObjectContainerApplications(unknownStorageConfig, {
-				...args,
-				dispatchNamespace: "target",
-			})
+			prepareDurableObjectContainerApplications(
+				unknownStorageConfig,
+				unknownStorageDurableObjectContainerConfig,
+				[],
+				{
+					...args,
+					dispatchNamespace: "target",
+				}
+			)
 		).rejects.toThrow("legacy KV storage backend");
 	});
 	it("does not query namespaces for a dry run", async ({ expect }) => {
-		await prepareDurableObjectContainerApplications(unknownStorageConfig, {
-			...args,
-			accountId: undefined,
-			dryRun: true,
-		});
+		await prepareDurableObjectContainerApplications(
+			unknownStorageConfig,
+			unknownStorageDurableObjectContainerConfig,
+			[],
+			{
+				...args,
+				accountId: undefined,
+				dryRun: true,
+			}
+		);
 		expect(listDurableObjects).not.toHaveBeenCalled();
 	});
 	it("propagates a namespace lookup failure", async ({ expect }) => {
 		vi.mocked(listDurableObjects).mockRejectedValue(new Error("lookup failed"));
 		await expect(
-			prepareDurableObjectContainerApplications(unknownStorageConfig, args)
+			prepareDurableObjectContainerApplications(
+				unknownStorageConfig,
+				unknownStorageDurableObjectContainerConfig,
+				[],
+				args
+			)
 		).rejects.toThrow("lookup failed");
 	});
 });
@@ -263,8 +362,16 @@ describe("Container namespace resolution", () => {
 			accountId: "account",
 			scriptName: "worker",
 		};
-		await deployDurableObjectContainerApplications(config, deployArgs);
-		await deployDurableObjectContainerApplications(config, deployArgs);
+		await deployDurableObjectContainerApplications(
+			config,
+			durableObjectContainerConfig,
+			deployArgs
+		);
+		await deployDurableObjectContainerApplications(
+			config,
+			durableObjectContainerConfig,
+			deployArgs
+		);
 
 		expect(create).toHaveBeenCalledTimes(2);
 		expect(create).toHaveBeenNthCalledWith(1, {
@@ -292,17 +399,15 @@ describe("Container namespace resolution", () => {
 		);
 		await expect(
 			deployDurableObjectContainerApplications(
-				{
-					...config,
-					containers: [
-						...(config.containers ?? []),
-						{
-							name: "other",
-							class_name: "Other",
-							scheduling_policy: "durable_object",
-						},
-					],
-				},
+				config,
+				[
+					...durableObjectContainerConfig,
+					{
+						name: "other",
+						class_name: "Other",
+						scheduling_policy: "durable_object",
+					},
+				],
 				{ versionId: "version", accountId: "account", scriptName: "worker" }
 			)
 		).rejects.toThrow("missing namespace");

--- a/packages/workers-utils/src/config/containers.ts
+++ b/packages/workers-utils/src/config/containers.ts
@@ -195,14 +195,19 @@ export function getDurableObjectClassNameToUseSQLiteMap(
  * Validate that every Durable Object-managed container belongs to this Worker.
  */
 export function validateDurableObjectContainerApplications(
-	config: Config
+	config: Pick<Config, "migrations" | "exports" | "durable_objects"> & {
+		containers?: ContainerApp[];
+	},
+	containers: DurableObjectContainerApp[] = getDurableObjectContainerApps(
+		config.containers
+	)
 ): void {
 	const allDOs = getDurableObjectClassNameToUseSQLiteMap(
 		config.migrations,
 		config.exports
 	);
 
-	for (const container of getDurableObjectContainerApps(config.containers)) {
+	for (const container of containers) {
 		const maybeBoundDO = config.durable_objects.bindings.find(
 			(durableObject) => durableObject.class_name === container.class_name
 		);

--- a/packages/wrangler/src/__tests__/deployment-bundle/build-container-images.test.ts
+++ b/packages/wrangler/src/__tests__/deployment-bundle/build-container-images.test.ts
@@ -1,0 +1,165 @@
+import {
+	buildAndMaybePush,
+	cleanupBuiltImages,
+	verifyDockerInstalled,
+} from "@cloudflare/containers-shared";
+import { beforeEach, describe, it, vi } from "vitest";
+import { buildDurableObjectContainerImages } from "../../deployment-bundle/build-container-images";
+import type { Config } from "@cloudflare/workers-utils";
+
+vi.mock("@cloudflare/containers-shared", async (importOriginal) => ({
+	...(await importOriginal<typeof import("@cloudflare/containers-shared")>()),
+	buildAndMaybePush: vi.fn().mockResolvedValue({ newTag: "local" }),
+	cleanupBuiltImages: vi.fn(),
+	verifyDockerInstalled: vi.fn(),
+}));
+
+function containerConfig(source: Config["containers"]) {
+	return {
+		source,
+		standard: { normalized: [], builtImages: [] },
+		durableObjects: { builtImages: [] },
+	};
+}
+
+describe("buildDurableObjectContainerImages", () => {
+	const config = { configPath: "/project/wrangler.toml" } as Config;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("builds Dockerfile-backed Durable Object-managed container images without pushing", async ({
+		expect,
+	}) => {
+		const props = {
+			command: "deploy" as const,
+			containersRollout: "gradual" as const,
+			dryRun: false,
+			name: "worker",
+			containers: containerConfig([
+				{
+					name: "sandbox",
+					class_name: "Sandbox",
+					scheduling_policy: "durable_object",
+					images: {
+						tools: { dockerfile: "./container/Dockerfile" },
+						base: {
+							image:
+								"registry.cloudflare.com/account/base@sha256:" + "a".repeat(64),
+						},
+					},
+				},
+			]),
+		};
+
+		const result = await buildDurableObjectContainerImages(props, config);
+
+		expect(verifyDockerInstalled).toHaveBeenCalledOnce();
+		expect(buildAndMaybePush).toHaveBeenCalledOnce();
+		expect(buildAndMaybePush).toHaveBeenCalledWith(
+			{
+				tag: expect.stringMatching(/^worker-sandbox-tools:wrangler-/),
+				pathToDockerfile: "/project/container/Dockerfile",
+				buildContext: "/project/container",
+				platform: "linux/amd64",
+			},
+			expect.any(String),
+			false,
+			undefined,
+			false
+		);
+		expect(result).toEqual([
+			{
+				className: "Sandbox",
+				imageName: "tools",
+				localTag: expect.stringMatching(/^worker-sandbox-tools:wrangler-/),
+			},
+		]);
+	});
+
+	it("skips deploy builds when container rollout is disabled", async ({
+		expect,
+	}) => {
+		const props = {
+			command: "deploy" as const,
+			containersRollout: "none" as const,
+			dryRun: false,
+			name: "worker",
+			containers: containerConfig([
+				{
+					name: "sandbox",
+					class_name: "Sandbox",
+					scheduling_policy: "durable_object",
+					images: { tools: { dockerfile: "./container/Dockerfile" } },
+				},
+			]),
+		};
+
+		await expect(
+			buildDurableObjectContainerImages(props, config)
+		).resolves.toEqual([]);
+		expect(buildAndMaybePush).not.toHaveBeenCalled();
+	});
+
+	it("builds Durable Object-managed images before versions upload", async ({
+		expect,
+	}) => {
+		const props = {
+			command: "versions upload" as const,
+			dryRun: false,
+			name: "worker",
+			containers: containerConfig([
+				{
+					name: "sandbox",
+					class_name: "Sandbox",
+					scheduling_policy: "durable_object",
+					images: { tools: { dockerfile: "./container/Dockerfile" } },
+				},
+			]),
+		};
+
+		const result = await buildDurableObjectContainerImages(props, config);
+
+		expect(result).toHaveLength(1);
+		expect(buildAndMaybePush).toHaveBeenCalledOnce();
+	});
+
+	it("cleans up earlier images when a later build fails", async ({
+		expect,
+	}) => {
+		vi.mocked(buildAndMaybePush)
+			.mockResolvedValueOnce({ newTag: "first" })
+			.mockRejectedValueOnce(new Error("build failed"));
+		const props = {
+			command: "versions upload" as const,
+			dryRun: false,
+			name: "worker",
+			containers: containerConfig([
+				{
+					name: "sandbox",
+					class_name: "Sandbox",
+					scheduling_policy: "durable_object",
+					images: {
+						first: { dockerfile: "./first/Dockerfile" },
+						second: { dockerfile: "./second/Dockerfile" },
+					},
+				},
+			]),
+		};
+
+		await expect(
+			buildDurableObjectContainerImages(props, config)
+		).rejects.toThrow("build failed");
+		expect(cleanupBuiltImages).toHaveBeenCalledWith(
+			[
+				{
+					className: "Sandbox",
+					imageName: "first",
+					localTag: expect.stringMatching(/^worker-sandbox-first:wrangler-/),
+				},
+			],
+			expect.any(String)
+		);
+	});
+});

--- a/packages/wrangler/src/__tests__/deployment-bundle/build-container-images.test.ts
+++ b/packages/wrangler/src/__tests__/deployment-bundle/build-container-images.test.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import {
 	buildAndMaybePush,
 	cleanupBuiltImages,
@@ -54,14 +55,18 @@ describe("buildDurableObjectContainerImages", () => {
 		};
 
 		const result = await buildDurableObjectContainerImages(props, config);
+		const expectedDockerfile = path.resolve(
+			"/project",
+			"./container/Dockerfile"
+		);
 
 		expect(verifyDockerInstalled).toHaveBeenCalledOnce();
 		expect(buildAndMaybePush).toHaveBeenCalledOnce();
 		expect(buildAndMaybePush).toHaveBeenCalledWith(
 			{
 				tag: expect.stringMatching(/^worker-sandbox-tools:wrangler-/),
-				pathToDockerfile: "/project/container/Dockerfile",
-				buildContext: "/project/container",
+				pathToDockerfile: expectedDockerfile,
+				buildContext: path.dirname(expectedDockerfile),
 				platform: "linux/amd64",
 			},
 			expect.any(String),

--- a/packages/wrangler/src/deploy/index.ts
+++ b/packages/wrangler/src/deploy/index.ts
@@ -1,5 +1,5 @@
 import {
-	cleanupBuiltContainerImages,
+	cleanupBuiltImages,
 	initContainersSharedContext,
 } from "@cloudflare/containers-shared";
 import { deploy } from "@cloudflare/deploy-helpers";
@@ -14,7 +14,10 @@ import { analyseBundle } from "../check/commands";
 import { fillOpenAPIConfiguration } from "../cloudchamber/common";
 import { containersScope } from "../containers";
 import { createCommand } from "../core/create-command";
-import { buildDeployContainerImages } from "../deployment-bundle/build-container-images";
+import {
+	buildDeployContainerImages,
+	buildDurableObjectContainerImages,
+} from "../deployment-bundle/build-container-images";
 import {
 	sharedDeployVersionsArgs,
 	validateDeployVersionsArgs,
@@ -206,12 +209,15 @@ export async function runDeployCommandHandler(
 			fetchPagedListResult,
 			fetchResult,
 		});
-		props.builtContainerDeployments = await buildDeployContainerImages(props);
+		props.containers.standard.builtImages =
+			await buildDeployContainerImages(props);
+		props.containers.durableObjects.builtImages =
+			await buildDurableObjectContainerImages(props, config);
 		if (
 			!props.dryRun &&
 			props.containersRollout !== "none" &&
-			(props.normalisedContainerConfig.length > 0 ||
-				getDurableObjectContainerApps(config.containers).length > 0)
+			(props.containers.standard.normalized.length > 0 ||
+				getDurableObjectContainerApps(props.containers.source).length > 0)
 		) {
 			await fillOpenAPIConfiguration(config, containersScope);
 		}
@@ -239,10 +245,17 @@ export async function runDeployCommandHandler(
 			}
 		);
 	} finally {
-		if (props.builtContainerDeployments.length > 0) {
-			await cleanupBuiltContainerImages(
-				props.builtContainerDeployments,
-				getDockerPath()
+		if (
+			props.containers.standard.builtImages.length > 0 ||
+			props.containers.durableObjects.builtImages.length > 0
+		) {
+			const dockerPath = getDockerPath();
+			await cleanupBuiltImages(
+				[
+					...props.containers.standard.builtImages,
+					...props.containers.durableObjects.builtImages,
+				],
+				dockerPath
 			);
 		}
 		cleanupDestination(buildProps.destination);

--- a/packages/wrangler/src/deployment-bundle/build-container-images.ts
+++ b/packages/wrangler/src/deployment-bundle/build-container-images.ts
@@ -1,23 +1,37 @@
+import path from "node:path";
 import {
 	buildContainerImages,
+	buildAndMaybePush,
+	cleanupBuiltImages,
 	isDockerfileContainerConfig,
 	verifyDockerInstalled,
 } from "@cloudflare/containers-shared";
-import { getDockerPath } from "@cloudflare/workers-utils";
-import type { BuiltContainerDeployment } from "@cloudflare/containers-shared";
-import type { DeployProps } from "@cloudflare/deploy-helpers";
+import {
+	getDockerPath,
+	getDurableObjectContainerApps,
+} from "@cloudflare/workers-utils";
+import type { BuiltContainerImage } from "@cloudflare/containers-shared";
+import type {
+	BuiltDurableObjectContainerImage,
+	DeployProps,
+	VersionsUploadProps,
+} from "@cloudflare/deploy-helpers";
+import type {
+	Config,
+	DurableObjectContainerImage,
+} from "@cloudflare/workers-utils";
 
 export async function buildDeployContainerImages(
-	props: DeployProps
-): Promise<BuiltContainerDeployment[]> {
+	props: Pick<DeployProps, "containers" | "containersRollout" | "dryRun">
+): Promise<BuiltContainerImage[]> {
 	if (
 		props.containersRollout === "none" ||
-		props.normalisedContainerConfig.length === 0
+		props.containers.standard.normalized.length === 0
 	) {
 		return [];
 	}
 
-	const containersWithDockerfile = props.normalisedContainerConfig.filter(
+	const containersWithDockerfile = props.containers.standard.normalized.filter(
 		isDockerfileContainerConfig
 	);
 	if (containersWithDockerfile.length === 0) {
@@ -36,4 +50,105 @@ export async function buildDeployContainerImages(
 	});
 
 	return buildContainerImages(containersWithDockerfile, dockerPath, false);
+}
+
+function isDockerfileDurableObjectContainerImage(
+	image: DurableObjectContainerImage
+): image is Extract<DurableObjectContainerImage, { dockerfile: string }> {
+	return typeof image.dockerfile === "string";
+}
+
+function buildDurableObjectImageTag(
+	scriptName: string,
+	className: string,
+	imageName: string
+): string {
+	const repository = `${scriptName}-${className}-${imageName}`
+		.toLowerCase()
+		.replace(/[^a-z0-9._-]+/g, "-")
+		.replace(/^-+|-+$/g, "");
+	return `${repository}:wrangler-${Date.now().toString(36)}`;
+}
+
+type DurableObjectContainerBuildProps =
+	| Pick<
+			DeployProps,
+			"command" | "containers" | "containersRollout" | "dryRun" | "name"
+	  >
+	| Pick<VersionsUploadProps, "command" | "containers" | "dryRun" | "name">;
+
+export async function buildDurableObjectContainerImages(
+	props: DurableObjectContainerBuildProps,
+	config: Config
+): Promise<BuiltDurableObjectContainerImage[]> {
+	const durableObjectContainerConfig = getDurableObjectContainerApps(
+		props.containers.source
+	);
+	if (
+		(props.command === "deploy" && props.containersRollout === "none") ||
+		durableObjectContainerConfig.length === 0 ||
+		props.name === undefined
+	) {
+		return [];
+	}
+
+	const imagesToBuild = durableObjectContainerConfig.flatMap((container) =>
+		Object.entries(container.images ?? {})
+			.filter((entry): entry is [string, { dockerfile: string }] =>
+				isDockerfileDurableObjectContainerImage(entry[1])
+			)
+			.map(([imageName, image]) => ({ container, imageName, image }))
+	);
+	if (imagesToBuild.length === 0) {
+		return [];
+	}
+
+	const dockerPath = getDockerPath();
+	await verifyDockerInstalled({
+		dockerPath,
+		operation: `${props.command === "deploy" ? "deploying" : "uploading"}${
+			props.dryRun ? " (even in dry-run mode)" : ""
+		}`,
+		imageNoun:
+			imagesToBuild.length !== 1
+				? "the configured images"
+				: "the configured image",
+		hint: "If you cannot run Docker locally, use a prebuilt registry image instead of a Dockerfile path for the affected Durable Object-managed Container images.",
+	});
+
+	const builtImages: BuiltDurableObjectContainerImage[] = [];
+	const baseDir = config.configPath
+		? path.dirname(config.configPath)
+		: process.cwd();
+	try {
+		for (const { container, imageName, image } of imagesToBuild) {
+			const dockerfile = path.resolve(baseDir, image.dockerfile);
+			const localTag = buildDurableObjectImageTag(
+				props.name,
+				container.class_name,
+				imageName
+			);
+			await buildAndMaybePush(
+				{
+					tag: localTag,
+					pathToDockerfile: dockerfile,
+					buildContext: path.dirname(dockerfile),
+					platform: "linux/amd64",
+				},
+				dockerPath,
+				false,
+				undefined,
+				false
+			);
+			builtImages.push({
+				className: container.class_name,
+				imageName,
+				localTag,
+			});
+		}
+	} catch (error) {
+		await cleanupBuiltImages(builtImages, dockerPath);
+		throw error;
+	}
+	return builtImages;
 }

--- a/packages/wrangler/src/deployment-bundle/merge-config-args.ts
+++ b/packages/wrangler/src/deployment-bundle/merge-config-args.ts
@@ -96,6 +96,11 @@ async function mergeSharedConfigArgs(
 		resourcesProvision: getFlag("RESOURCES_PROVISION") ?? false,
 		skipProvisioningConfigWriteback: false,
 		strict: args.strict ?? false,
+		containers: {
+			source: config.containers,
+			standard: { normalized: [], builtImages: [] },
+			durableObjects: { builtImages: [] },
+		},
 	};
 
 	const buildProps: BuildProps = {
@@ -138,7 +143,7 @@ export async function mergeDeployConfigArgs(
 	}));
 	const routes =
 		args.routes ?? config.routes ?? (config.route ? [config.route] : []);
-	const normalisedContainerConfig = await getNormalizedContainerOptions(
+	const normalizedContainerConfig = await getNormalizedContainerOptions(
 		config,
 		{
 			containersRollout: args.containersRollout,
@@ -162,8 +167,13 @@ export async function mergeDeployConfigArgs(
 			dispatchNamespace: args.dispatchNamespace,
 			oldAssetTtl: args.oldAssetTtl,
 			containersRollout: args.containersRollout,
-			normalisedContainerConfig,
-			builtContainerDeployments: [],
+			containers: {
+				...shared.containers,
+				standard: {
+					normalized: normalizedContainerConfig,
+					builtImages: [],
+				},
+			},
 		},
 		buildProps: { ...buildProps, metafile: args.metafile },
 	};

--- a/packages/wrangler/src/versions/upload.ts
+++ b/packages/wrangler/src/versions/upload.ts
@@ -90,7 +90,6 @@ export const versionsUploadCommand = createCommand({
 				await fillOpenAPIConfiguration(config, containersScope);
 			}
 			const { assetUploadStats: uploadStats } = await versionsUpload(
-
 				props,
 				config,
 				buildResult,

--- a/packages/wrangler/src/versions/upload.ts
+++ b/packages/wrangler/src/versions/upload.ts
@@ -90,6 +90,7 @@ export const versionsUploadCommand = createCommand({
 				await fillOpenAPIConfiguration(config, containersScope);
 			}
 			const { assetUploadStats: uploadStats } = await versionsUpload(
+
 				props,
 				config,
 				buildResult,

--- a/packages/wrangler/src/versions/upload.ts
+++ b/packages/wrangler/src/versions/upload.ts
@@ -1,14 +1,21 @@
-import { initContainersSharedContext } from "@cloudflare/containers-shared";
+import {
+	cleanupBuiltImages,
+	initContainersSharedContext,
+} from "@cloudflare/containers-shared";
 import {
 	versionsUpload,
 	type AssetUploadStats,
 } from "@cloudflare/deploy-helpers";
-import { getDurableObjectContainerApps } from "@cloudflare/workers-utils";
+import {
+	getDockerPath,
+	getDurableObjectContainerApps,
+} from "@cloudflare/workers-utils";
 import { fetchPagedListResult, fetchResult } from "../cfetch";
 import { analyseBundle } from "../check/commands";
 import { fillOpenAPIConfiguration } from "../cloudchamber/common";
 import { containersScope } from "../containers";
 import { createCommand } from "../core/create-command";
+import { buildDurableObjectContainerImages } from "../deployment-bundle/build-container-images";
 import {
 	sharedDeployVersionsArgs,
 	validateDeployVersionsArgs,
@@ -74,9 +81,11 @@ export const versionsUploadCommand = createCommand({
 				fetchPagedListResult,
 				fetchResult,
 			});
+			props.containers.durableObjects.builtImages =
+				await buildDurableObjectContainerImages(props, config);
 			if (
 				!props.dryRun &&
-				getDurableObjectContainerApps(config.containers).length > 0
+				getDurableObjectContainerApps(props.containers.source).length > 0
 			) {
 				await fillOpenAPIConfiguration(config, containersScope);
 			}
@@ -90,6 +99,13 @@ export const versionsUploadCommand = createCommand({
 			);
 			assetUploadStats = uploadStats;
 		} finally {
+			if (props.containers.durableObjects.builtImages.length > 0) {
+				const dockerPath = getDockerPath();
+				await cleanupBuiltImages(
+					props.containers.durableObjects.builtImages,
+					dockerPath
+				);
+			}
 			metrics.sendMetricsEvent(
 				"upload worker version",
 				{


### PR DESCRIPTION
Ensures that we do not read container config from the main wrangler config object, but rather from separate container configs (one for regular containers, one for DO-scheduled ones). deploy-helpers now gets Config<Omit, "containers">.

This is necessary to support the new programmatic container config.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: refactor

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- If you are an AI agent or LLM, and you are adding this PR without direct human supervision, thank you! Please uncomment the following block. This is so the maintainers know how to expect you to respond.

> [!NOTE]
> This is a contribution from an AI agent: <insert name here>, <insert LLM model here if different>.

-->

<!-- devin-review-badge-begin -->

---

<a href="https://cloudflare.devinenterprise.com/review/cloudflare/workers-sdk/pull/15606" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->