### PR TITLE
[wrangler] Support D1 jurisdiction in automatic provisioning

### DIFF
--- a/.changeset/tidy-dodos-provision.md
+++ b/.changeset/tidy-dodos-provision.md
@@ -1,0 +1,10 @@
+---
+"@cloudflare/config": minor
+"@cloudflare/deploy-helpers": patch
+"@cloudflare/workers-utils": patch
+"wrangler": minor
+---
+
+Support jurisdiction when automatically provisioning D1 databases
+
+Set `jurisdiction` on a D1 binding without a `database_id` to create the database in that jurisdiction during deployment. For example, `{"d1_databases":[{"binding":"DB","jurisdiction":"eu"}]}` creates an EU-jurisdiction database.

--- a/packages/config/src/__tests__/convert.test.ts
+++ b/packages/config/src/__tests__/convert.test.ts
@@ -235,15 +235,25 @@ describe("convertToWranglerConfig", () => {
 			]);
 		});
 
-		it("maps d1 with id and name", ({ expect }) => {
+		it("maps d1 with id, name, and jurisdiction", ({ expect }) => {
 			const result = convertToWranglerConfig({
 				...baseConfig,
 				env: {
-					MY_DB: { type: "d1", id: "db-id", name: "db-name" },
+					MY_DB: {
+						type: "d1",
+						id: "db-id",
+						name: "db-name",
+						jurisdiction: "eu",
+					},
 				},
 			});
 			expect(result.d1_databases).toEqual([
-				{ binding: "MY_DB", database_id: "db-id", database_name: "db-name" },
+				{
+					binding: "MY_DB",
+					database_id: "db-id",
+					database_name: "db-name",
+					jurisdiction: "eu",
+				},
 			]);
 		});
 

--- a/packages/config/src/__tests__/schema.test.ts
+++ b/packages/config/src/__tests__/schema.test.ts
@@ -70,6 +70,17 @@ describe("InputWorkerSchema", () => {
 			expect(result.success).toBe(true);
 		});
 
+		it("accepts a jurisdiction on D1 bindings", ({ expect }) => {
+			const result = InputWorkerSchema.safeParse({
+				...baseConfig,
+				env: {
+					DB: { type: "d1", jurisdiction: "eu" },
+				},
+			});
+
+			expect(result.success).toBe(true);
+		});
+
 		it("accepts multiple agent-memory bindings", ({ expect }) => {
 			const result = InputWorkerSchema.safeParse({
 				...baseConfig,

--- a/packages/config/src/bindings.ts
+++ b/packages/config/src/bindings.ts
@@ -148,6 +148,8 @@ interface D1BindingOptions {
 	id?: string;
 	/** The name of this D1 database. */
 	name?: string;
+	/** The jurisdiction where an automatically provisioned D1 database will be created. */
+	jurisdiction?: string;
 	/** Options that only apply during local development. */
 	dev?: BindingDevOptions;
 }

--- a/packages/config/src/convert.ts
+++ b/packages/config/src/convert.ts
@@ -459,6 +459,7 @@ function convertBindingsAndAssets(
 						binding: name,
 						database_id: binding.id,
 						database_name: binding.name,
+						jurisdiction: binding.jurisdiction,
 						remote: binding.dev?.remote,
 					})
 				);

--- a/packages/config/src/schema.ts
+++ b/packages/config/src/schema.ts
@@ -38,6 +38,7 @@ export const D1BindingSchema = z.strictObject({
 	type: z.literal("d1"),
 	name: z.string().optional(),
 	id: z.string().optional(),
+	jurisdiction: z.string().optional(),
 	dev: RemoteBindingDevSchema.optional(),
 });
 

--- a/packages/deploy-helpers/src/deploy/helpers/provision-bindings.ts
+++ b/packages/deploy-helpers/src/deploy/helpers/provision-bindings.ts
@@ -52,6 +52,7 @@ type ConcreteDatabase = {
 type DatabaseInfo = {
 	uuid: string;
 	name: string;
+	jurisdiction?: string;
 };
 
 type R2BucketInfo = {
@@ -647,19 +648,25 @@ class D1Handler extends ProvisionResourceHandler<
 		) as Extract<WorkerMetadataBinding, { type: "d1" }> | undefined;
 		// A D1 binding with the same binding name exists is already present on the worker...
 		if (maybeInherited) {
-			// ...and the user hasn't specified a name in their config, so we don't need to check if the database_name matches.
-			if (!this.binding.database_name) {
+			// ...and the user hasn't specified a name or jurisdiction in their config, so we don't need to check the database metadata.
+			if (!this.binding.database_name && !this.binding.jurisdiction) {
 				return true;
 			}
 
-			// ...and the user HAS specified a name in their config, so we need to check if the database_name they provided
-			// matches the database_name of the existing binding (which isn't present in settings, so we'll need to make an API call to check).
+			// ...and the user HAS specified a name or jurisdiction in their config, so we need to check if the provided values
+			// match the existing binding (which aren't present in settings, so we'll need to make an API call to check).
 			const dbFromId = await getDatabaseInfoFromIdOrName(
 				this.complianceConfig,
 				this.accountId,
 				maybeInherited.id
 			);
-			if (this.binding.database_name === dbFromId.name) {
+			const nameMatches =
+				!this.binding.database_name ||
+				this.binding.database_name === dbFromId.name;
+			const jurisdictionMatches =
+				!this.binding.jurisdiction ||
+				this.binding.jurisdiction === dbFromId.jurisdiction;
+			if (nameMatches && jurisdictionMatches) {
 				return true;
 			}
 		}

--- a/packages/deploy-helpers/src/deploy/helpers/provision-bindings.ts
+++ b/packages/deploy-helpers/src/deploy/helpers/provision-bindings.ts
@@ -620,7 +620,8 @@ class D1Handler extends ProvisionResourceHandler<
 		const db = await createD1Database(
 			this.complianceConfig,
 			this.accountId,
-			name
+			name,
+			this.binding.jurisdiction
 		);
 		return db.uuid;
 	}
@@ -1549,7 +1550,8 @@ async function listFlagshipApps(
 async function createD1Database(
 	complianceConfig: ComplianceConfig,
 	accountId: string,
-	name: string
+	name: string,
+	jurisdiction?: string
 ) {
 	try {
 		return await fetchResult<DatabaseCreationResult>(
@@ -1560,7 +1562,10 @@ async function createD1Database(
 				headers: {
 					"Content-Type": "application/json",
 				},
-				body: JSON.stringify({ name }),
+				body: JSON.stringify({
+					name,
+					...(jurisdiction && { jurisdiction }),
+				}),
 			}
 		);
 	} catch (e) {

--- a/packages/workers-utils/src/config/environment.ts
+++ b/packages/workers-utils/src/config/environment.ts
@@ -1246,6 +1246,8 @@ export interface EnvironmentNonInheritable {
 		database_name?: string;
 		/** The UUID of this D1 database (not required). */
 		database_id?: string;
+		/** The jurisdiction where an automatically provisioned D1 database will be created. */
+		jurisdiction?: string;
 		/** The UUID of this D1 database for Wrangler Dev (if specified). */
 		preview_database_id?: string;
 		/** The name of the migrations table for this D1 database (defaults to 'd1_migrations'). */

--- a/packages/workers-utils/src/config/validation.ts
+++ b/packages/workers-utils/src/config/validation.ts
@@ -4754,6 +4754,15 @@ const validateD1Binding: ValidatorFn = (diagnostics, field, value) => {
 		isValid = false;
 	}
 
+	if (!isOptionalProperty(value, "jurisdiction", "string")) {
+		diagnostics.errors.push(
+			`"${field}" bindings should, optionally, have a string "jurisdiction" field but got ${JSON.stringify(
+				value
+			)}.`
+		);
+		isValid = false;
+	}
+
 	if (!isOptionalProperty(value, "migrations_dir", "string")) {
 		diagnostics.errors.push(
 			`"${field}" bindings should, optionally, have a string "migrations_dir" field but got ${JSON.stringify(
@@ -4786,6 +4795,7 @@ const validateD1Binding: ValidatorFn = (diagnostics, field, value) => {
 		"database_id",
 		"database_internal_env",
 		"database_name",
+		"jurisdiction",
 		"migrations_dir",
 		"migrations_pattern",
 		"migrations_table",

--- a/packages/workers-utils/src/worker.ts
+++ b/packages/workers-utils/src/worker.ts
@@ -239,6 +239,7 @@ export interface CfD1Database {
 	binding: string;
 	database_id?: string | typeof INHERIT_SYMBOL;
 	database_name?: string;
+	jurisdiction?: string;
 	preview_database_id?: string;
 	database_internal_env?: string;
 	migrations_table?: string;

--- a/packages/workers-utils/tests/config/validation/normalize-and-validate-config.test.ts
+++ b/packages/workers-utils/tests/config/validation/normalize-and-validate-config.test.ts
@@ -6405,12 +6405,12 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should allow the database_id field to be omitted (resource provisioning)", ({
+			it("should allow provisioning options without a database_id", ({
 				expect,
 			}) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{
-						d1_databases: [{ binding: "VALID" }],
+						d1_databases: [{ binding: "VALID", jurisdiction: "eu" }],
 					} as unknown as RawConfig,
 					undefined,
 					undefined,
@@ -6419,6 +6419,31 @@ describe("normalizeAndValidateConfig()", () => {
 
 				expect(diagnostics.hasWarnings()).toBe(false);
 				expect(diagnostics.hasErrors()).toBe(false);
+			});
+
+			it("should error if D1 database jurisdiction has incorrect type", ({
+				expect,
+			}) => {
+				const { diagnostics } = normalizeAndValidateConfig(
+					{
+						d1_databases: [
+							{
+								binding: "DB",
+								jurisdiction: true,
+							},
+						],
+					} as unknown as RawConfig,
+					undefined,
+					undefined,
+					{ env: undefined }
+				);
+
+				expect(diagnostics.hasWarnings()).toBe(false);
+				expect(diagnostics.hasErrors()).toBe(true);
+				expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
+					"Processing wrangler configuration:
+					  - "d1_databases[0]" bindings should, optionally, have a string "jurisdiction" field but got {"binding":"DB","jurisdiction":true}."
+				`);
 			});
 
 			it("should error if D1 database database_name has incorrect type", ({

--- a/packages/wrangler/src/__tests__/provision.test.ts
+++ b/packages/wrangler/src/__tests__/provision.test.ts
@@ -1517,6 +1517,40 @@ describe("resource provisioning", () => {
 			expect(std.warn).toMatchInlineSnapshot(`""`);
 		});
 
+		it("creates an auto-provisioned D1 database in the configured jurisdiction", async ({
+			expect,
+		}) => {
+			writeWranglerConfig({
+				main: "index.js",
+				d1_databases: [{ binding: "D1", jurisdiction: "eu" }],
+			});
+			mockGetSettings();
+			msw.use(
+				http.get("*/accounts/:accountId/d1/database", () =>
+					HttpResponse.json(createFetchResult([]))
+				)
+			);
+			mockCreateD1Database(expect, {
+				assertName: "test-name-d1",
+				assertJurisdiction: "eu",
+				resultId: "new-d1-id",
+			});
+			mockUploadWorkerRequest({
+				expectedBindings: [
+					{
+						name: "D1",
+						type: "d1",
+						id: "new-d1-id",
+					},
+				],
+			});
+
+			await runWrangler("deploy");
+
+			expect(std.out).toContain('Creating new D1 Database "test-name-d1"');
+			expect(std.err).toBe("");
+		});
+
 		it("can inherit d1 binding when the database name is provided", async ({
 			expect,
 		}) => {
@@ -2048,15 +2082,21 @@ function mockCreateD1Database(
 	options: {
 		resultId?: string;
 		assertName?: string;
+		assertJurisdiction?: string;
 	} = {}
 ) {
 	msw.use(
 		http.post(
 			"*/accounts/:accountId/d1/database",
 			async ({ request }) => {
-				if (options.assertName) {
+				if (options.assertName || options.assertJurisdiction) {
 					const requestBody = await request.json();
-					expect(requestBody).toEqual({ name: options.assertName });
+					expect(requestBody).toEqual({
+						name: options.assertName,
+						...(options.assertJurisdiction && {
+							jurisdiction: options.assertJurisdiction,
+						}),
+					});
 				}
 
 				return HttpResponse.json(

--- a/packages/wrangler/src/__tests__/provision.test.ts
+++ b/packages/wrangler/src/__tests__/provision.test.ts
@@ -1551,6 +1551,85 @@ describe("resource provisioning", () => {
 			expect(std.err).toBe("");
 		});
 
+		it("can inherit a D1 binding when the jurisdiction matches", async ({
+			expect,
+		}) => {
+			writeWranglerConfig({
+				main: "index.js",
+				d1_databases: [{ binding: "D1", jurisdiction: "eu" }],
+			});
+			mockGetSettings({
+				result: {
+					bindings: [
+						{
+							type: "d1",
+							name: "D1",
+							id: "d1-id",
+						},
+					],
+				},
+			});
+			mockGetD1Database(expect, "d1-id", { jurisdiction: "eu" });
+			mockUploadWorkerRequest({
+				expectedBindings: [
+					{
+						name: "D1",
+						type: "inherit",
+					},
+				],
+			});
+
+			await runWrangler("deploy --x-auto-create=false");
+
+			expect(std.out).toContain("env.D1 (inherited)");
+			expect(std.err).toBe("");
+		});
+
+		it("will not inherit a D1 binding when the jurisdiction has changed", async ({
+			expect,
+		}) => {
+			writeWranglerConfig({
+				main: "index.js",
+				d1_databases: [{ binding: "D1", jurisdiction: "eu" }],
+			});
+			mockGetSettings({
+				result: {
+					bindings: [
+						{
+							type: "d1",
+							name: "D1",
+							id: "old-d1-id",
+						},
+					],
+				},
+			});
+			mockGetD1Database(expect, "old-d1-id", { jurisdiction: "us" });
+			msw.use(
+				http.get("*/accounts/:accountId/d1/database", () =>
+					HttpResponse.json(createFetchResult([]))
+				)
+			);
+			mockCreateD1Database(expect, {
+				assertName: "test-name-d1",
+				assertJurisdiction: "eu",
+				resultId: "new-d1-id",
+			});
+			mockUploadWorkerRequest({
+				expectedBindings: [
+					{
+						name: "D1",
+						type: "d1",
+						id: "new-d1-id",
+					},
+				],
+			});
+
+			await runWrangler("deploy");
+
+			expect(std.out).toContain('Creating new D1 Database "test-name-d1"');
+			expect(std.err).toBe("");
+		});
+
 		it("can inherit d1 binding when the database name is provided", async ({
 			expect,
 		}) => {

--- a/packages/wrangler/src/d1/types.ts
+++ b/packages/wrangler/src/d1/types.ts
@@ -50,6 +50,7 @@ export type DatabaseCreationResult = {
 export type DatabaseInfo = {
 	uuid: string;
 	name: string;
+	jurisdiction?: string;
 	version: "alpha" | "beta" | "production";
 	num_tables: number;
 	file_size: number;


### PR DESCRIPTION
No linked issue.

Add `jurisdiction` support to D1 bindings that use automatic resource provisioning.

This adds the field to Wrangler's raw config schema and the `@cloudflare/config` API, validates it, and forwards it to the D1 database creation request. For example:

```jsonc
{
  "d1_databases": [
    {
      "binding": "DB",
      "jurisdiction": "eu"
    }
  ]
}
```

The automatically provisioned database is now created in the requested jurisdiction.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: the option is exposed through Wrangler's generated configuration schema and follows the existing D1 jurisdiction behavior.
<!-- devin-review-badge-begin -->

---

<a href="https://cloudflare.devinenterprise.com/review/cloudflare/workers-sdk/pull/15615" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->