### PR TITLE
[workers-utils] Stop the update check from recommending deprecated versions

### DIFF
--- a/.changeset/quiet-deprecated-update-check.md
+++ b/.changeset/quiet-deprecated-update-check.md
@@ -1,0 +1,11 @@
+---
+"wrangler": patch
+"@cloudflare/vite-plugin": patch
+"@cloudflare/workers-utils": patch
+---
+
+Stop the update check from recommending deprecated versions
+
+Previously, the "update available" notice shown by `wrangler` and `@cloudflare/vite-plugin` always pointed at whichever version was tagged `latest` on npm, even after that version had been deprecated for shipping a bug. Deprecated versions are now never recommended: if the latest release has been deprecated, the newest non-deprecated stable release below it is suggested instead, or nothing at all if you are already on it.
+
+The check now reads the npm registry directly instead of going through the `update-check` package, which discarded the deprecation information. The on-disk cache location and one-hour refresh interval are unchanged.

--- a/packages/workers-utils/package.json
+++ b/packages/workers-utils/package.json
@@ -100,7 +100,6 @@
 		"tsdown": "^0.15.9",
 		"tsup": "8.3.0",
 		"typescript": "catalog:default",
-		"update-check": "^1.5.4",
 		"vitest": "catalog:default",
 		"xdg-app-paths": "^8.3.0",
 		"zod": "catalog:default"

--- a/packages/workers-utils/src/update-check.ts
+++ b/packages/workers-utils/src/update-check.ts
@@ -1,15 +1,20 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import * as timersPromises from "node:timers/promises";
-import checkForUpdate from "update-check";
-import type { Result } from "update-check";
+import { fetch } from "undici";
 
-// Safety-net timeout for the update check network request.
-// The `update-check` library has its own 2s socket timeout, but if the first
-// request gets a 4xx it retries with auth — potentially doubling the wait.
-// This caps the total wall-clock time for the entire operation.
+// Safety-net timeout for the update check. The registry request is aborted
+// after this long, and the whole operation (cache I/O included) is raced
+// against the same budget so that a slow disk cannot hold up the caller.
 const UPDATE_CHECK_TIMEOUT_MS = 3_000;
 
-// Sentinel value used to distinguish a timeout from the library returning null
-// (which means "already up-to-date").
+// How long a registry lookup is reused before asking npm again.
+const CACHE_TTL_MS = 60 * 60 * 1_000;
+
+const NPM_REGISTRY_URL = "https://registry.npmjs.org/";
+
+// Sentinel value used to distinguish a timeout from "nothing to recommend".
 const TIMED_OUT: unique symbol = Symbol("timed_out");
 
 export type NpmVersionCheckResult =
@@ -18,11 +23,30 @@ export type NpmVersionCheckResult =
 	| { status: "failed" };
 
 /**
+ * The subset of npm's abbreviated packument
+ * (`application/vnd.npm.install-v1+json`) that the update check reads.
+ */
+interface AbbreviatedPackument {
+	"dist-tags": Record<string, string>;
+	versions: Record<string, { deprecated?: string }>;
+}
+
+interface UpdateCheckCache {
+	/** The version to recommend, or `null` when there is none. */
+	latest: string | null;
+	/** Epoch milliseconds of the registry lookup that produced `latest`. */
+	lastUpdate: number;
+}
+
+/**
  * Checks if a newer version of a package is available on npm.
  *
- * Uses the `update-check` library to query the npm registry for the latest
- * version. The dist tag used for comparison depends on the current version —
+ * Queries the npm registry for the version behind the relevant dist tag —
  * "beta" for pre-release versions (0.0.0-*) and "latest" for stable versions.
+ * Deprecated releases are never recommended: if the tagged version has been
+ * deprecated, the newest non-deprecated stable release below it is suggested
+ * instead (or nothing, if there isn't one). The registry lookup is cached on
+ * disk for an hour.
  *
  * @param name - The npm package name to check
  * @param version - The current version to compare against
@@ -35,17 +59,12 @@ export async function fetchLatestNpmVersion(
 	name: string,
 	version: string
 ): Promise<NpmVersionCheckResult> {
-	let result: Result | null | typeof TIMED_OUT = null;
+	const distTag = version.startsWith("0.0.0") ? "beta" : "latest";
+
+	let latest: string | null | typeof TIMED_OUT;
 	try {
-		// Race with a timeout as a safety net — the library's own 2s socket
-		// timeout handles most cases, but the auth-retry path can take up to 4s.
-		result = await Promise.race([
-			checkForUpdate(
-				{ name, version },
-				{
-					distTag: version.startsWith("0.0.0") ? "beta" : "latest",
-				}
-			),
+		latest = await Promise.race([
+			getLatestVersion(name, distTag),
 			timersPromises.setTimeout(UPDATE_CHECK_TIMEOUT_MS, TIMED_OUT, {
 				ref: false,
 			}),
@@ -54,11 +73,132 @@ export async function fetchLatestNpmVersion(
 		return { status: "failed" };
 	}
 
-	if (result === TIMED_OUT) {
+	if (latest === TIMED_OUT) {
 		return { status: "failed" };
 	}
-	if (result === null) {
+	if (latest === null || compareVersions(version, latest) >= 0) {
 		return { status: "up-to-date" };
 	}
-	return { status: "update-available", latest: result.latest };
+	return { status: "update-available", latest };
+}
+
+/**
+ * Resolve the version to recommend for `distTag`, reusing a cached answer
+ * when it is less than an hour old.
+ */
+async function getLatestVersion(
+	name: string,
+	distTag: string
+): Promise<string | null> {
+	const cacheFile = getCacheFile(name, distTag);
+	const now = Date.now();
+
+	const cached = await readCache(cacheFile);
+	if (cached !== null && cached.lastUpdate + CACHE_TTL_MS > now) {
+		return cached.latest;
+	}
+
+	const latest = pickLatestVersion(await fetchPackument(name), distTag);
+	await writeCache(cacheFile, { latest, lastUpdate: now });
+	return latest;
+}
+
+/**
+ * Pick the version to recommend from a packument.
+ *
+ * @returns The version behind `distTag`, unless it has been deprecated, in
+ *   which case the newest non-deprecated stable release below it — or `null`
+ *   when there is nothing suitable to recommend.
+ */
+function pickLatestVersion(
+	packument: AbbreviatedPackument,
+	distTag: string
+): string | null {
+	const tagged = packument["dist-tags"][distTag];
+	if (tagged === undefined) {
+		throw new Error(`Distribution tag ${distTag} is not available`);
+	}
+	if (!packument.versions[tagged]?.deprecated) {
+		return tagged;
+	}
+
+	// The tagged release has been deprecated — typically because it shipped a
+	// bug that was only found after publishing — so recommending it would
+	// point users at a known-bad version. Fall back to the newest stable
+	// release below it that has not been deprecated. Pre-releases (such as
+	// the `beta` dist tag's `0.0.0-<sha>` builds) cannot be meaningfully
+	// ordered, so nothing is recommended for them.
+	if (distTag !== "latest") {
+		return null;
+	}
+	const candidates = Object.entries(packument.versions)
+		.filter(
+			([candidate, meta]) =>
+				!meta.deprecated &&
+				!candidate.includes("-") &&
+				compareVersions(candidate, tagged) < 0
+		)
+		.map(([candidate]) => candidate)
+		.sort(compareVersions);
+	return candidates.at(-1) ?? null;
+}
+
+async function fetchPackument(name: string): Promise<AbbreviatedPackument> {
+	const packageUrl = new URL(
+		encodeURIComponent(name).replace(/^%40/, "@"),
+		NPM_REGISTRY_URL
+	);
+	const response = await fetch(packageUrl, {
+		headers: {
+			accept:
+				"application/vnd.npm.install-v1+json; q=1.0, application/json; q=0.8, */*",
+		},
+		signal: AbortSignal.timeout(UPDATE_CHECK_TIMEOUT_MS),
+	});
+	if (!response.ok) {
+		throw new Error(`Request failed with code ${response.status}`);
+	}
+	return (await response.json()) as AbbreviatedPackument;
+}
+
+function getCacheFile(name: string, distTag: string): string {
+	// Same location and naming scheme as the `update-check` package this
+	// replaced, so caches written by earlier versions carry on being honoured.
+	return path.join(
+		tmpdir(),
+		"update-check",
+		`${name.replace("/", "-")}-${distTag}.json`
+	);
+}
+
+async function readCache(file: string): Promise<UpdateCheckCache | null> {
+	try {
+		const parsed = JSON.parse(
+			await readFile(file, "utf8")
+		) as Partial<UpdateCheckCache>;
+		if (
+			typeof parsed.lastUpdate === "number" &&
+			(typeof parsed.latest === "string" || parsed.latest === null)
+		) {
+			return { latest: parsed.latest, lastUpdate: parsed.lastUpdate };
+		}
+	} catch {
+		// A missing or unreadable cache file simply means we have to ask npm.
+	}
+	return null;
+}
+
+async function writeCache(file: string, cache: UpdateCheckCache) {
+	// The cache is only an optimisation; failing to persist it must not turn
+	// a successful check into a failure.
+	try {
+		await mkdir(path.dirname(file), { recursive: true });
+		await writeFile(file, JSON.stringify(cache), "utf8");
+	} catch {
+		// Ignore write failures (read-only or full temp directory, etc.).
+	}
+}
+
+function compareVersions(a: string, b: string): number {
+	return a.localeCompare(b, "en-US", { numeric: true });
 }

--- a/packages/workers-utils/tests/update-check.test.ts
+++ b/packages/workers-utils/tests/update-check.test.ts
@@ -1,0 +1,315 @@
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { getGlobalDispatcher, MockAgent, setGlobalDispatcher } from "undici";
+import { afterEach, beforeEach, describe, it, vi } from "vitest";
+import { removeDirSync } from "../src/fs-helpers";
+import { fetchLatestNpmVersion } from "../src/update-check";
+import type { Dispatcher } from "undici";
+
+const REGISTRY_ORIGIN = "https://registry.npmjs.org";
+
+type Packument = {
+	"dist-tags": Record<string, string>;
+	versions: Record<string, { deprecated?: string }>;
+};
+
+function packument(
+	distTags: Record<string, string>,
+	versions: Record<string, { deprecated?: string }>
+): Packument {
+	return { "dist-tags": distTags, versions };
+}
+
+describe("fetchLatestNpmVersion", () => {
+	let tempDir: string;
+	let mockAgent: MockAgent;
+	let originalDispatcher: Dispatcher;
+
+	beforeEach(() => {
+		tempDir = mkdtempSync(path.join(tmpdir(), "update-check-test-"));
+		// `os.tmpdir()` reads these at call time, so pointing them at a fresh
+		// directory isolates the on-disk cache between tests (and from the
+		// real cache on the developer's machine).
+		vi.stubEnv("TMPDIR", tempDir);
+		vi.stubEnv("TEMP", tempDir);
+		vi.stubEnv("TMP", tempDir);
+
+		originalDispatcher = getGlobalDispatcher();
+		mockAgent = new MockAgent();
+		mockAgent.disableNetConnect();
+		setGlobalDispatcher(mockAgent);
+	});
+
+	afterEach(async () => {
+		setGlobalDispatcher(originalDispatcher);
+		await mockAgent.close();
+		removeDirSync(tempDir);
+	});
+
+	function mockPackument(
+		name: string,
+		body: Packument,
+		{ status = 200, times = 1 } = {}
+	) {
+		mockAgent
+			.get(REGISTRY_ORIGIN)
+			.intercept({
+				path: `/${encodeURIComponent(name).replace(/^%40/, "@")}`,
+				method: "GET",
+			})
+			.reply(status, body)
+			.times(times);
+	}
+
+	function cacheFilePath(name: string, distTag = "latest") {
+		return path.join(
+			tempDir,
+			"update-check",
+			`${name.replace("/", "-")}-${distTag}.json`
+		);
+	}
+
+	it("reports an update when a newer version is tagged latest", async ({
+		expect,
+	}) => {
+		mockPackument(
+			"wrangler",
+			packument({ latest: "4.14.2" }, { "4.14.1": {}, "4.14.2": {} })
+		);
+
+		await expect(fetchLatestNpmVersion("wrangler", "4.14.1")).resolves.toEqual({
+			status: "update-available",
+			latest: "4.14.2",
+		});
+	});
+
+	it("reports up-to-date when already on the latest version", async ({
+		expect,
+	}) => {
+		mockPackument(
+			"wrangler",
+			packument({ latest: "4.14.2" }, { "4.14.1": {}, "4.14.2": {} })
+		);
+
+		await expect(fetchLatestNpmVersion("wrangler", "4.14.2")).resolves.toEqual({
+			status: "up-to-date",
+		});
+	});
+
+	it("compares versions numerically rather than lexically", async ({
+		expect,
+	}) => {
+		mockPackument(
+			"wrangler",
+			packument({ latest: "4.14.2" }, { "4.9.1": {}, "4.14.2": {} })
+		);
+
+		await expect(fetchLatestNpmVersion("wrangler", "4.9.1")).resolves.toEqual({
+			status: "update-available",
+			latest: "4.14.2",
+		});
+	});
+
+	it("does not recommend a deprecated latest version, falling back to the newest non-deprecated stable release below it", async ({
+		expect,
+	}) => {
+		mockPackument(
+			"wrangler",
+			packument(
+				{ latest: "4.14.2", next: "5.0.0" },
+				{
+					"4.14.0": {},
+					"4.14.1": {},
+					"4.14.2": { deprecated: "This version has a bug in wrangler dev" },
+					// A pre-release must never be recommended in place of `latest`.
+					"4.15.0-beta.1": {},
+					// Nor should a stable release that is newer than `latest`, as
+					// that is deliberately not what users are being pointed at.
+					"5.0.0": {},
+				}
+			)
+		);
+
+		await expect(fetchLatestNpmVersion("wrangler", "4.14.0")).resolves.toEqual({
+			status: "update-available",
+			latest: "4.14.1",
+		});
+	});
+
+	it("reports up-to-date when the only newer versions are deprecated", async ({
+		expect,
+	}) => {
+		mockPackument(
+			"wrangler",
+			packument(
+				{ latest: "4.14.2" },
+				{
+					"4.14.1": {},
+					"4.14.2": { deprecated: "This version has a bug in wrangler dev" },
+				}
+			)
+		);
+
+		await expect(fetchLatestNpmVersion("wrangler", "4.14.1")).resolves.toEqual({
+			status: "up-to-date",
+		});
+	});
+
+	it("reports up-to-date when every release has been deprecated", async ({
+		expect,
+	}) => {
+		mockPackument(
+			"wrangler",
+			packument(
+				{ latest: "4.14.2" },
+				{
+					"4.14.1": { deprecated: "broken" },
+					"4.14.2": { deprecated: "also broken" },
+				}
+			)
+		);
+
+		await expect(fetchLatestNpmVersion("wrangler", "4.14.0")).resolves.toEqual({
+			status: "up-to-date",
+		});
+	});
+
+	it("uses the beta dist tag for pre-release versions and never recommends a deprecated beta", async ({
+		expect,
+	}) => {
+		mockPackument(
+			"wrangler",
+			packument(
+				{ latest: "4.14.2", beta: "0.0.0-def456" },
+				{
+					"0.0.0-abc123": {},
+					"0.0.0-def456": { deprecated: "broken pre-release" },
+					"4.14.2": {},
+				}
+			)
+		);
+
+		await expect(
+			fetchLatestNpmVersion("wrangler", "0.0.0-abc123")
+		).resolves.toEqual({ status: "up-to-date" });
+		expect(
+			JSON.parse(readFileSync(cacheFilePath("wrangler", "beta"), "utf8"))
+		).toMatchObject({ latest: null });
+	});
+
+	it("reports a failure when the dist tag does not exist", async ({
+		expect,
+	}) => {
+		mockPackument("wrangler", packument({}, { "4.14.2": {} }));
+
+		await expect(fetchLatestNpmVersion("wrangler", "4.14.1")).resolves.toEqual({
+			status: "failed",
+		});
+	});
+
+	it("reports a failure when the registry responds with an error", async ({
+		expect,
+	}) => {
+		mockPackument("wrangler", packument({}, {}), { status: 500 });
+
+		await expect(fetchLatestNpmVersion("wrangler", "4.14.1")).resolves.toEqual({
+			status: "failed",
+		});
+	});
+
+	it("reports a failure when the registry cannot be reached", async ({
+		expect,
+	}) => {
+		// No interceptor is registered and network access is disabled, so the
+		// request is rejected outright.
+		await expect(fetchLatestNpmVersion("wrangler", "4.14.1")).resolves.toEqual({
+			status: "failed",
+		});
+	});
+
+	it("encodes scoped package names", async ({ expect }) => {
+		mockPackument(
+			"@cloudflare/vite-plugin",
+			packument({ latest: "1.2.0" }, { "1.1.0": {}, "1.2.0": {} })
+		);
+
+		await expect(
+			fetchLatestNpmVersion("@cloudflare/vite-plugin", "1.1.0")
+		).resolves.toEqual({ status: "update-available", latest: "1.2.0" });
+		expect(
+			JSON.parse(readFileSync(cacheFilePath("@cloudflare/vite-plugin"), "utf8"))
+		).toMatchObject({ latest: "1.2.0" });
+	});
+
+	it("caches the registry lookup so later checks do not hit the network", async ({
+		expect,
+	}) => {
+		// Only a single response is registered; a second request would fail.
+		mockPackument(
+			"wrangler",
+			packument({ latest: "4.14.2" }, { "4.14.1": {}, "4.14.2": {} })
+		);
+
+		await expect(fetchLatestNpmVersion("wrangler", "4.14.1")).resolves.toEqual({
+			status: "update-available",
+			latest: "4.14.2",
+		});
+		await expect(fetchLatestNpmVersion("wrangler", "4.14.1")).resolves.toEqual({
+			status: "update-available",
+			latest: "4.14.2",
+		});
+	});
+
+	it("honours a cache written before the update check learnt about deprecations", async ({
+		expect,
+	}) => {
+		await mkdir(path.dirname(cacheFilePath("wrangler")), { recursive: true });
+		writeFileSync(
+			cacheFilePath("wrangler"),
+			JSON.stringify({ latest: "4.14.2", lastUpdate: Date.now() })
+		);
+
+		await expect(fetchLatestNpmVersion("wrangler", "4.14.1")).resolves.toEqual({
+			status: "update-available",
+			latest: "4.14.2",
+		});
+	});
+
+	it("refreshes a cache entry once it is more than an hour old", async ({
+		expect,
+	}) => {
+		await mkdir(path.dirname(cacheFilePath("wrangler")), { recursive: true });
+		writeFileSync(
+			cacheFilePath("wrangler"),
+			JSON.stringify({
+				latest: "4.14.2",
+				lastUpdate: Date.now() - 2 * 60 * 60 * 1_000,
+			})
+		);
+		mockPackument(
+			"wrangler",
+			packument({ latest: "4.14.3" }, { "4.14.2": {}, "4.14.3": {} })
+		);
+
+		await expect(fetchLatestNpmVersion("wrangler", "4.14.1")).resolves.toEqual({
+			status: "update-available",
+			latest: "4.14.3",
+		});
+	});
+
+	it("ignores a corrupt cache file", async ({ expect }) => {
+		await mkdir(path.dirname(cacheFilePath("wrangler")), { recursive: true });
+		writeFileSync(cacheFilePath("wrangler"), "not json");
+		mockPackument(
+			"wrangler",
+			packument({ latest: "4.14.2" }, { "4.14.1": {}, "4.14.2": {} })
+		);
+
+		await expect(fetchLatestNpmVersion("wrangler", "4.14.1")).resolves.toEqual({
+			status: "update-available",
+			latest: "4.14.2",
+		});
+	});
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4512,9 +4512,6 @@ importers:
       typescript:
         specifier: catalog:default
         version: 5.8.3
-      update-check:
-        specifier: ^1.5.4
-        version: 1.5.4
       vitest:
         specifier: catalog:default
         version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@22.15.17)(@vitest/ui@4.1.0)(msw@2.14.6(@types/node@22.15.17)(typescript@5.8.3))(vite@8.2.0(@types/node@22.15.17)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.9.0))
@@ -15080,16 +15077,9 @@ packages:
     resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
     engines: {node: '>= 0.4'}
 
-  registry-auth-token@3.3.2:
-    resolution: {integrity: sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==}
-
   registry-auth-token@5.0.2:
     resolution: {integrity: sha512-o/3ikDxtXaA59BmZuZrJZDJv8NMDGSj+6j6XaeBmHw8eY1i1qd9+6H+LjVvQXx3HN6aRCGa1cUdJ9RaJZUugnQ==}
     engines: {node: '>=14'}
-
-  registry-url@3.1.0:
-    resolution: {integrity: sha512-ZbgR5aZEdf4UKZVBPYIgaglBmSF2Hi94s2PcIHhRGFjKYu+chjJdYfHn4rt3hB6eCKLJ8giVIIfgMa1ehDfZKA==}
-    engines: {node: '>=0.10.0'}
 
   registry-url@6.0.1:
     resolution: {integrity: sha512-+crtS5QjFRqFCoQmvGduwYWEBng99ZvmFvF+cUJkGYF1L1BfU8C6Zp9T7f5vPAwyLkUExpvK+ANVZmGU49qi4Q==}
@@ -16342,9 +16332,6 @@ packages:
     hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
-
-  update-check@1.5.4:
-    resolution: {integrity: sha512-5YHsflzHP4t1G+8WGPlvKbJEbAJGCgw+Em+dGR1KmBUbr1J36SJBqlHLjR7oob7sco5hWHGQVcr9B2poIVDDTQ==}
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
@@ -27616,18 +27603,9 @@ snapshots:
       gopd: 1.2.0
       set-function-name: 2.0.2
 
-  registry-auth-token@3.3.2:
-    dependencies:
-      rc: 1.2.8
-      safe-buffer: 5.2.1
-
   registry-auth-token@5.0.2:
     dependencies:
       '@pnpm/npm-conf': 2.2.2
-
-  registry-url@3.1.0:
-    dependencies:
-      rc: 1.2.8
 
   registry-url@6.0.1:
     dependencies:
@@ -29276,11 +29254,6 @@ snapshots:
       browserslist: 4.28.9
       escalade: 3.2.0
       picocolors: 1.1.1
-
-  update-check@1.5.4:
-    dependencies:
-      registry-auth-token: 3.3.2
-      registry-url: 3.1.0
 
   uri-js@4.4.1:
     dependencies:


### PR DESCRIPTION
Fixes #9154.

When a Wrangler release is deprecated on npm (e.g. `4.14.2` was deprecated for a `wrangler dev` regression), users on an older version still saw `(update available 4.14.2)` in the banner, nudging them towards a known-bad release.

The `update-check` package we used fetched the full abbreviated packument, which includes the per-version `deprecated` field, but only kept the `dist-tags` version. Fixing this on top of the library would have required a second registry request whenever an update was found, and the banner only waits ~100ms for the (normally cached) result, so that would have hidden the notice for everyone who was behind.

Instead `fetchLatestNpmVersion` in `@cloudflare/workers-utils` now queries the registry itself (via undici, which the package already depends on) and the `update-check` dependency is removed:

- If the version behind the dist tag (`latest`, or `beta` for `0.0.0-*` builds) is **not** deprecated, behaviour is unchanged.
- If it **is** deprecated, the newest non-deprecated stable release below it is recommended instead. Pre-releases and stable versions newer than `latest` (e.g. a `next` tag) are never picked. If nothing suitable exists, the check reports up-to-date.
- The on-disk cache keeps the same location (`<tmpdir>/update-check/<name>-<tag>.json`), file format and one-hour TTL, so caches written by the previous implementation continue to be honoured. Cache write failures no longer turn a successful check into a failure.
- The 3s overall timeout is kept, and the registry request itself is now aborted on that timeout instead of being left dangling.

One deliberate simplification to flag for reviewers: `update-check` resolved the registry URL from `.npmrc` and retried 4xx responses with an auth token. This implementation always uses `https://registry.npmjs.org/`, since both packages that use this check (`wrangler` and `@cloudflare/vite-plugin`) are only published there. Users whose network blocks the public registry will get the existing silent `failed` result. Happy to add `npm_config_registry` support if you'd prefer to keep that behaviour.

`wrangler`'s own tests are unaffected because they mock `updateCheck` at the wrangler layer.

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: this only changes which version the existing "update available" notice suggests; there are no new commands, flags or configuration.

<!-- devin-review-badge-begin -->

---

<a href="https://cloudflare.devinenterprise.com/review/cloudflare/workers-sdk/pull/15617" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->