### PR TITLE
[wrangler] Keep preview JSON output free of build logs

### DIFF
--- a/.changeset/quiet-preview-json.md
+++ b/.changeset/quiet-preview-json.md
@@ -1,0 +1,8 @@
+---
+"wrangler": patch
+"@cloudflare/deploy-helpers": patch
+---
+
+Keep `wrangler preview --json` stdout parseable when loading redirected configs and uploading assets
+
+The private beta preview command now suppresses informational and build-progress logs throughout its JSON-mode lifecycle, while preserving warnings and errors on stderr. Wrangler emits the preview and deployment response through its JSON logger instead of the shared preview helper's ordinary logger, so scripts can parse stdout without stripping a text preamble.

--- a/packages/deploy-helpers/src/preview/preview.ts
+++ b/packages/deploy-helpers/src/preview/preview.ts
@@ -939,11 +939,7 @@ export async function preview(
 		}
 	}
 
-	if (args.json) {
-		logger.log(
-			JSON.stringify({ preview: previewResource, deployment }, null, 2)
-		);
-	} else {
+	if (!args.json) {
 		logger.log(
 			formatPreviewDeploymentSummary(
 				config,

--- a/packages/wrangler/src/__tests__/preview.test.ts
+++ b/packages/wrangler/src/__tests__/preview.test.ts
@@ -16,6 +16,7 @@ import { defaultWranglerConfig } from "@cloudflare/workers-utils";
 import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
 import { afterAll, afterEach, beforeEach, describe, test, vi } from "vitest";
+import { logger } from "../logger";
 import { clearOutputFilePath } from "../output";
 import * as user from "../user";
 import { mockAccountId, mockApiToken } from "./helpers/mock-account-id";
@@ -1726,90 +1727,150 @@ describe("wrangler preview", () => {
 			expect(std.warn).not.toContain("ASSETS");
 		});
 
-		test("should output preview and deployment JSON with --json", async ({
+		test.for(["plain", "redirected", "assets", "redirected-assets"])(
+			"should output parseable preview and deployment JSON with --json (%s)",
+			async (project, { expect }) => {
+				const hasAssets = project.includes("assets");
+				if (hasAssets) {
+					mkdirSync("public", { recursive: true });
+					writeFileSync("public/index.html", "<h1>Hello</h1>");
+				}
+				if (project.includes("redirected")) {
+					writeRedirectedWranglerConfig({
+						name: "test-worker",
+						main: "../src/index.ts",
+						userConfigPath: "./wrangler.json",
+						assets: hasAssets ? { directory: "../public" } : undefined,
+					});
+				} else if (hasAssets) {
+					writeWranglerConfig(
+						{
+							name: "test-worker",
+							main: "src/index.ts",
+							assets: { directory: "public" },
+						},
+						"wrangler.json"
+					);
+				}
+				const configPath = project.includes("redirected")
+					? "dist/wrangler.json"
+					: "wrangler.json";
+				const config = JSON.parse(readFileSync(configPath, "utf8")) as Record<
+					string,
+					unknown
+				>;
+				writeFileSync(
+					configPath,
+					JSON.stringify({ ...config, unexpected_setting: true })
+				);
+				const outputFile = "./output.json";
+				msw.use(
+					http.post(
+						`*/accounts/:accountId/workers/scripts/:workerId/assets-upload-session`,
+						() =>
+							HttpResponse.json({
+								success: true,
+								result: { buckets: [], jwt: "assets-jwt-from-session" },
+							})
+					),
+					http.get(
+						`*/accounts/:accountId/workers/workers/:workerId/previews/:previewId`,
+						() =>
+							HttpResponse.json(
+								{
+									success: false,
+									result: null,
+									errors: [{ code: 10025, message: "Preview not found" }],
+								},
+								{ status: 404 }
+							)
+					),
+					http.post(
+						`*/accounts/:accountId/workers/workers/:workerId/previews`,
+						() =>
+							HttpResponse.json(
+								{
+									success: true,
+									result: {
+										id: "preview-id-json",
+										name: "test-preview",
+										slug: "test-preview",
+										urls: ["https://test-preview.test-worker.cloudflare.app"],
+										worker_name: "test-worker",
+										created_on: new Date().toISOString(),
+									},
+								},
+								{ status: 201 }
+							)
+					),
+					http.post(
+						`*/accounts/:accountId/workers/workers/:workerId/previews/:previewId/deployments`,
+						() =>
+							HttpResponse.json(
+								{
+									success: true,
+									result: {
+										id: "deployment-id-json",
+										preview_id: "preview-id-json",
+										preview_name: "test-preview",
+										urls: ["https://json123.test-worker.cloudflare.app"],
+										compatibility_date: "2025-01-01",
+										env: {},
+										created_on: new Date().toISOString(),
+									},
+								},
+								{ status: 201 }
+							)
+					)
+				);
+
+				await runWrangler("preview --name test-preview --json", {
+					...process.env,
+					WRANGLER_OUTPUT_FILE_PATH: outputFile,
+				});
+
+				expect(JSON.parse(std.out)).toMatchObject({
+					preview: { id: "preview-id-json" },
+					deployment: { id: "deployment-id-json" },
+				});
+				expect(std.info).toBe("");
+				expect(std.debug).toBe("");
+				expect(std.warn).toContain("unexpected_setting");
+
+				const outputEntries = readFileSync(outputFile, "utf8")
+					.split("\n")
+					.filter(Boolean)
+					.map((line) => JSON.parse(line)) as OutputEntry[];
+
+				expect(outputEntries).toContainEqual(
+					expect.objectContaining({
+						type: "preview",
+						version: 1,
+						worker_name: "test-worker",
+						preview_id: "preview-id-json",
+						preview_name: "test-preview",
+						preview_slug: "test-preview",
+						preview_urls: ["https://test-preview.test-worker.cloudflare.app"],
+						deployment_id: "deployment-id-json",
+						deployment_urls: ["https://json123.test-worker.cloudflare.app"],
+					})
+				);
+				logger.info("logging restored after preview");
+				expect(std.info).toBe("logging restored after preview");
+			}
+		);
+
+		test("should restore logging after a JSON-mode configuration failure", async ({
 			expect,
 		}) => {
-			const outputFile = "./output.json";
-			msw.use(
-				http.get(
-					`*/accounts/:accountId/workers/workers/:workerId/previews/:previewId`,
-					() =>
-						HttpResponse.json(
-							{
-								success: false,
-								result: null,
-								errors: [{ code: 10025, message: "Preview not found" }],
-							},
-							{ status: 404 }
-						)
-				),
-				http.post(
-					`*/accounts/:accountId/workers/workers/:workerId/previews`,
-					() =>
-						HttpResponse.json(
-							{
-								success: true,
-								result: {
-									id: "preview-id-json",
-									name: "test-preview",
-									slug: "test-preview",
-									urls: ["https://test-preview.test-worker.cloudflare.app"],
-									worker_name: "test-worker",
-									created_on: new Date().toISOString(),
-								},
-							},
-							{ status: 201 }
-						)
-				),
-				http.post(
-					`*/accounts/:accountId/workers/workers/:workerId/previews/:previewId/deployments`,
-					() =>
-						HttpResponse.json(
-							{
-								success: true,
-								result: {
-									id: "deployment-id-json",
-									preview_id: "preview-id-json",
-									preview_name: "test-preview",
-									urls: ["https://json123.test-worker.cloudflare.app"],
-									compatibility_date: "2025-01-01",
-									env: {},
-									created_on: new Date().toISOString(),
-								},
-							},
-							{ status: 201 }
-						)
-				)
-			);
-
-			await runWrangler("preview --name test-preview --json", {
-				...process.env,
-				WRANGLER_OUTPUT_FILE_PATH: outputFile,
-			});
-
-			expect(std.out).toContain('"preview"');
-			expect(std.out).toContain('"deployment"');
-			expect(std.out).toContain('"id": "preview-id-json"');
-			expect(std.out).toContain('"id": "deployment-id-json"');
-
-			const outputEntries = readFileSync(outputFile, "utf8")
-				.split("\n")
-				.filter(Boolean)
-				.map((line) => JSON.parse(line)) as OutputEntry[];
-
-			expect(outputEntries).toContainEqual(
-				expect.objectContaining({
-					type: "preview",
-					version: 1,
-					worker_name: "test-worker",
-					preview_id: "preview-id-json",
-					preview_name: "test-preview",
-					preview_slug: "test-preview",
-					preview_urls: ["https://test-preview.test-worker.cloudflare.app"],
-					deployment_id: "deployment-id-json",
-					deployment_urls: ["https://json123.test-worker.cloudflare.app"],
-				})
-			);
+			writeFileSync("wrangler.json", JSON.stringify({ name: 123 }));
+			await expect(
+				runWrangler("preview --name test-preview --json")
+			).rejects.toThrow();
+			expect(std.out).toBe("");
+			expect(std.err).toContain("name");
+			logger.info("logging restored after failure");
+			expect(std.info).toBe("logging restored after failure");
 		});
 
 		test("should build correctly when using a redirected config", async ({

--- a/packages/wrangler/src/core/register-yargs-command.ts
+++ b/packages/wrangler/src/core/register-yargs-command.ts
@@ -28,7 +28,7 @@ import { createCloudflareClient } from "../cfetch/internal";
 import { readConfig, readNewConfig } from "../config";
 import { confirm, prompt, select } from "../dialogs";
 import { run } from "../experimental-flags";
-import { logger } from "../logger";
+import { logger, runWithLogLevel } from "../logger";
 import { getMetricsDispatcher } from "../metrics";
 import {
 	COMMAND_ARG_ALLOW_LIST,
@@ -140,7 +140,14 @@ function createHandler(def: InternalCommandDefinition, argv: string[]) {
 	// What is left is safe to use in metrics and sentry messages as the parts of the command are taken directly from the command definition.
 	const sanitizedCommand = def.command.replace(/^wrangler\s+/, "");
 
-	return async function handler(args: HandlerArgs<NamedArgDefinitions>) {
+	return (args: HandlerArgs<NamedArgDefinitions>) => {
+		const logLevel = def.behaviour?.overrideLogLevel?.(args);
+		return logLevel === undefined
+			? handler(args)
+			: runWithLogLevel(logLevel, () => handler(args));
+	};
+
+	async function handler(args: HandlerArgs<NamedArgDefinitions>) {
 		const startTime = Date.now();
 
 		// The command definition's `command` string is safe to use in sentry messages.
@@ -452,7 +459,7 @@ function createHandler(def: InternalCommandDefinition, argv: string[]) {
 			}
 			throw err;
 		}
-	};
+	}
 }
 
 /**

--- a/packages/wrangler/src/core/types.ts
+++ b/packages/wrangler/src/core/types.ts
@@ -9,7 +9,12 @@ import type { ExperimentalFlags } from "../experimental-flags";
 import type { Logger } from "../logger";
 import type { CommonYargsOptions, RemoveIndex } from "../yargs-types";
 import type { Teams } from "./teams";
-import type { Config, FatalError, UserError } from "@cloudflare/workers-utils";
+import type {
+	Config,
+	FatalError,
+	LoggerLevel,
+	UserError,
+} from "@cloudflare/workers-utils";
 import type Cloudflare from "cloudflare";
 import type {
 	ArgumentsCamelCase,
@@ -165,6 +170,11 @@ export type CommandDefinition<
 	 * This will allow wrangler commands to remain consistent and only diverge intentionally.
 	 */
 	behaviour?: {
+		/** Override logging for the command lifecycle, including configuration loading. */
+		overrideLogLevel?: (
+			args: HandlerArgs<NamedArgDefs>
+		) => LoggerLevel | undefined;
+
 		/**
 		 * By default, wrangler's version banner will be printed before the handler is executed.
 		 * Set this value to `false` to skip printing the banner.

--- a/packages/wrangler/src/preview/preview.ts
+++ b/packages/wrangler/src/preview/preview.ts
@@ -6,6 +6,7 @@ import { createCommand } from "../core/create-command";
 import { getEntry } from "../deployment-bundle/entry";
 import { buildWorker } from "../deployment-bundle/maybe-build-worker";
 import { cleanupDestination } from "../deployment-bundle/merge-config-args";
+import { logger } from "../logger";
 import { writeOutput } from "../output";
 import { requireAuth } from "../user";
 import { deployPreviewContainers, verifyContainersScope } from "./containers";
@@ -58,6 +59,7 @@ export const previewCommand = createCommand({
 		},
 	},
 	behaviour: {
+		overrideLogLevel: (args) => (args.json ? "warn" : undefined),
 		useConfigRedirectIfAvailable: true,
 		printBanner: (args) => args.json !== true,
 		suggestSkillsAfterHandler: (args) => args.json !== true,
@@ -108,6 +110,10 @@ export const previewCommand = createCommand({
 			}
 		);
 		cleanupDestination(destination);
+
+		if (args.json) {
+			logger.json({ preview: previewResource, deployment });
+		}
 
 		writeOutput({
 			type: "preview",


### PR DESCRIPTION
## Summary

`wrangler preview --json` can emit config-redirection notices, additional-module tables, and asset-upload progress before the JSON response on stdout. This makes `JSON.parse(stdout)` fail for framework builds using redirected configs or assets. This behavior is present in 4.129.0 and 4.131.1.

- Add an opt-in, async-scoped command log-level override that covers configuration loading as well as the handler.
- Use `warn` for `preview --json`, preserving warnings and errors on stderr without changing ordinary preview logging.
- Emit the structured preview/deployment response through Wrangler's JSON logger; the shared preview helper only prints the human-readable summary in non-JSON mode.
- Preserve the existing `WRANGLER_OUTPUT_FILE_PATH` record.

The scope is the command lifecycle. Startup debug messages emitted before command registration when explicitly enabling `WRANGLER_LOG=debug` are not changed here.

## Reproduction

For a Worker with static assets or a generated `.wrangler/deploy/config.json` redirect:

```sh
pnpm exec wrangler preview --name json-output-test --json > preview.json
node -e 'JSON.parse(require("node:fs").readFileSync("preview.json", "utf8"))'
```

Before this change, the second command fails on text such as `Using redirected Wrangler configuration.` or asset-progress output. The regression tests exercise plain, redirected, asset-serving, and redirected-plus-assets projects and parse the complete JSON output. They also check separate informational/debug streams, warning preservation, output-file records, and logging restoration after success and configuration failure.

## Validation

- `bun turbo -F wrangler test:ci -- preview.test.ts register-yargs-command-skills.test.ts` — 130 tests passed.
- `bun turbo -F @cloudflare/deploy-helpers test:ci --only` — 153 tests passed.
- `bun turbo -F wrangler -F @cloudflare/deploy-helpers check:type type:tests` — passed.
- `bun turbo check:lint check:format --only -- <changed files>` — passed.
- Live validation with Railroad, a Vite/TanStack Start application: built its generated redirected Wrangler config and static assets, then deployed a named preview with the patched CLI at commit `03b8d35`. Captured stdout and stderr separately with no `WRANGLER_OUTPUT_FILE_PATH` configured. The command exited 0, all 5,202 bytes of stdout parsed directly with `JSON.parse`, the expected preview/deployment fields were present, and stderr was empty. The preview URL returned the expected Cloudflare Access login redirect; application behavior behind Access was not tested. Production was not deployed.

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: this fixes the existing `--json` output contract without adding flags or changing the response fields.

> [!NOTE]
> This contribution was prepared by Codex at jahands' request.
